### PR TITLE
Add version

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -19,6 +19,65 @@ def list_versions_query():
     return list_version
 
 
+def add_version_query(name, isoLanguage, isoScript, 
+                abbreviation, rights, forwardTranslation, 
+                backTranslation, machineTranslation):
+    
+    add_version = """
+                  mutation MyMutation {{
+                    insert_bibleVersion(objects: {{
+                      name: {}, isoLanguage: {}, isoScript: {}, 
+                      abbreviation: {}, rights: {}, 
+                      forwardTranslation: {}, backTranslation: {}, 
+                      machineTranslation: {}
+                    }}) {{
+                      returning {{
+                        id
+                        name
+                        abbreviation
+                        language {{
+                          name
+                        }}
+                        rights
+                      }}
+                    }}
+                  }}
+                  """.format(name, isoLanguage, 
+                          isoScript, abbreviation, rights, 
+                          forwardTranslation, backTranslation,
+                          machineTranslation
+                          )
+
+    return add_version
+
+def check_version_query():
+    check_version = """
+                    query MyQuery {
+                      bibleVersion {
+                        abbreviation
+                      }
+                    }
+                    """
+    
+    return check_version
+
+
+def delete_bible_version(version_abbv):
+    delete_version = """
+                     mutation MyMutation {{
+                       delete_bibleVersion(where: {{
+                         abbreviation: {{
+                           _eq: {}
+                         }}
+                       }}) {{
+                         affected_rows
+                       }}
+                     }}
+                     """.format(version_abbv)
+
+    return delete_version
+
+
 def insert_bible_revision(version, date, published):
     bible_revise = """
                 mutation MyMutation {{
@@ -39,8 +98,10 @@ def fetch_bible_version(abbreviation):
     version_id = """
                 query MyQuery {{
                   bibleVersion(where: {{
-                    abbreviation: {{_eq: {}}}
-                    }}) {{
+                    abbreviation: {{
+                      _eq: {}
+                    }}
+                  }}) {{
                     id
                     }}
                 }}
@@ -51,19 +112,25 @@ def fetch_bible_version(abbreviation):
 
 def delete_bibleRevision_text(revision_id):
     revision_delete = """
-                      mutation MyMutation {{}
+                      mutation MyMutation {{
                         delete_verseText(where: {{
                           bibleRevision: {{
                             _eq: {}
                           }}
-                        }})
+                        }}) {{
+                          affected_rows
+                        }}
                         delete_bibleRevision(where: {{
                           id: {{
                             _eq: {}
                           }}
-                        }})
+                        }}) {{
+                          affected_rows
+                        }}
                       }}
                       """.format(revision_id, revision_id)
+
+    return revision_delete
 
 
 def list_revisions_query(bibleVersion):
@@ -71,7 +138,11 @@ def list_revisions_query(bibleVersion):
                   query MyQuery {{
                     bibleRevision(where: {{
                       version: {{
-                        abbreviation: {{_eq: {}}}}}}}) {{
+                        abbreviation: {{
+                          _eq: {}
+                        }}
+                      }}
+                    }}) {{
                       id
                       date
                       version {{
@@ -87,10 +158,18 @@ def list_revisions_query(bibleVersion):
 def get_chapter_query(revision, chapterReference):
     get_chapter = """
                 query MyQuery {{
-                  verseText(where: {{bibleRevision: {{_eq: {}}}, 
+                  verseText(where: {{
+                    bibleRevision: {{
+                      _eq: {}
+                    }}, 
                     verseReferenceByVersereference: {{
                       chapterReference: {{
-                        fullChapterId: {{_eq: {}}}}}}}}}) {{
+                        fullChapterId: {{
+                          _eq: {}
+                        }}
+                      }}
+                    }}
+                  }}) {{
                     id
                     text
                     verseReference
@@ -110,8 +189,14 @@ def get_chapter_query(revision, chapterReference):
 def get_verses_query(revision, verseReference):
     get_verses = """
               query MyQuery {{
-                verseText(where: {{bibleRevision: {{_eq: {}}}, 
-                  verseReference: {{_eq: {}}}}}) {{
+                verseText(where: {{
+                  bibleRevision: {{
+                    _eq: {}
+                  }}, 
+                  verseReference: {{
+                    _eq: {}
+                  }}
+                }}) {{
                   id
                   text
                   verseReference


### PR DESCRIPTION
Added mutation for adding a `bibleVersion`, tests for failure of adding non-unique abbreviation and successful upload. Test also deletes listing uploaded in test. Also changed `bible_upload` test so that it deletes test created bible revisions and verse text associated with test revision. Closes #20 and #28.