### PR TITLE
added /result endpoint and test

### DIFF
--- a/app_test.py
+++ b/app_test.py
@@ -211,8 +211,23 @@ def test_assessment(client):
     assert id not in [assessment['id'] for assessment in response.json()['assessments']]
 
 
+def test_get_result(client): 
+    test_config = {
+            "assessment_id": 6
+            }
+
+    fail_config = {
+            "assessment_id": 0
+            }
+
+    test_response = client.get("/result", params=test_config)
+    fail_response = client.get("/result", params=fail_config)
+
+    assert test_response.status_code == 200
+    assert fail_response.status_code == 400
+
+
 def test_delete_revision(client):
-    
     test_version_abv = {
            "version_abbreviation": "DEL"
            }

--- a/queries.py
+++ b/queries.py
@@ -329,3 +329,29 @@ def delete_assessment_results_mutation(assessment):
                     """.format(assessment)
     
     return delete_assessment_results
+
+
+def get_results_query(assessment_id):
+    get_results = """
+                query {{
+                  assessmentResult(
+                    where: {{
+                      assessment: {{
+                        _eq: {}
+                      }}
+                    }}
+                  ) {{
+                    id
+                    score
+                    flag
+                    note
+                    vref
+                    assessmentByAssessment {{
+                      reference
+                      type
+                    }}
+                  }}
+                }}
+                """.format(assessment_id)
+
+    return get_results


### PR DESCRIPTION
Adds `/result` endpoint along with a test for. The `assessment_id` in the test is currently defined explicitly, which will need changing. Closes #110.