### PR TITLE
/revision endpoint to return all revisions is version_abbreviation is blank

### DIFF
--- a/app_test.py
+++ b/app_test.py
@@ -99,9 +99,11 @@ def test_list_revisions(client):
 
     test_response = client.get("/revision", params=test_version)
     fail_response = client.get("/revision", params=fail_version)
+    all_response = client.get("/revision")
     
     assert test_response.status_code == 200
     assert fail_response.status_code == 400
+    assert all_response.status_code == 200
 
 
 def test_get_chapter(client): 

--- a/queries.py
+++ b/queries.py
@@ -160,6 +160,22 @@ def fetch_bible_version(abbreviation):
     return version_id
 
 
+def list_all_revisions_query():
+    list_revisions = """
+                  query {
+                    bibleRevision {
+                      id
+                      date
+                      bibleVersionByBibleversion {
+                        name
+                      }
+                    }
+                  }
+                  """
+
+    return list_revisions
+
+
 def list_revisions_query(bibleVersion):
     list_revisions = """
                   query {{


### PR DESCRIPTION
I added a list_all_revisions_query to queries.py, and have `/revision` run this query if version_abbreviation is not provided.

This is helpful for the front end, so we don't have to query the API every time a version is selected, to get the revisions associated with that version.