### PR TITLE
Update database assessment status on start and end of assessment

### DIFF
--- a/runner/runner/app.py
+++ b/runner/runner/app.py
@@ -1,6 +1,7 @@
 import os
 import json
 from enum import Enum
+import datetime
 
 import modal
 from fastapi import Request
@@ -12,7 +13,13 @@ if os.environ.get("MODAL_TEST") == "TRUE":
     suffix = "_test"
 
 
-stub = modal.Stub(name="runner" + suffix, image=modal.Image.debian_slim().pip_install())
+stub = modal.Stub(name="runner" + suffix, image=modal.Image.debian_slim().pip_install(
+    "pydantic",
+            "sqlalchemy==1.4.36",
+            "psycopg2-binary",
+),
+secret=modal.Secret.from_name("aqua-db"),
+)
 
 
 class AssessmentType(Enum):
@@ -27,28 +34,70 @@ for assessment_type in AssessmentType:
     )
 
 
-@stub.function(image=modal.Image.debian_slim().pip_install(
-    "pydantic",
-    "sqlalchemy==1.4.36",
-    "psycopg2-binary",
+class RunAssessment:
+    def __init__(self, config: dict):
+        self.config = config
+        from sqlalchemy.orm import declarative_base
+        from sqlalchemy import Column, Integer, Text, DateTime
+        Base = declarative_base()        
+        self.Assessment = type("Assessment", (Base,), {
+                "__tablename__": "assessment",
+                "id": Column(Integer, primary_key=True),
+                "revision": Column(Integer),
+                "reference": Column(Integer),
+                "type": Column(Text),
+                "status": Column(Text),
+                "start_time": Column(DateTime),
+                "end_time": Column(DateTime),
+                "requested_time": Column(DateTime),
+                "__repr__": lambda self: (
+                    f"Assessment({self.id}) - {self.type} "
+                    f"revision={self.revision} reference={self.reference}, status={self.status}"
+                )
+        })
 
-), timeout=7200)
-async def run_assessment_runner(config):
-    from pydantic import BaseModel
+    def yield_session(self):
+        from sqlalchemy.orm import Session
+        from sqlalchemy import create_engine
+        engine = create_engine(os.environ["AQUA_DB"], pool_size=5, pool_recycle=3600)
+
+        with Session(engine) as session:
+            yield session
+
+    def log_start(self):
+        with next(self.yield_session()) as session:
+            session.query(self.Assessment).filter(self.Assessment.id == self.config['assessment']).update({"status": "running", "start_time": datetime.datetime.utcnow()})
+            session.commit()
     
-    if config["assessment_type"] not in [e.name for e in AssessmentType]:
-        raise ValueError(f"Invalid assessment type: {config['assessment_type']}")
-    config["assessment_type"] = AssessmentType[config["assessment_type"]]
-    class AssessmentConfig(BaseModel):
-        assessment: int
-        assessment_type: AssessmentType
-        configuration: dict  # This will later be validated as a BaseModel by the specific assessment
-    assessment_config = AssessmentConfig(**config)
+    def log_end(self):
+        with next(self.yield_session()) as session:
+            session.query(self.Assessment).filter(self.Assessment.id == self.config['assessment']).update({"status": "finished", "end_time": datetime.datetime.utcnow()})
+            session.commit()
+    
+    def run_assessment(self):
+        from pydantic import BaseModel
+        self.config["assessment_type"] = AssessmentType[self.config["assessment_type"]]
+        class AssessmentConfig(BaseModel):
+            assessment: int
+            assessment_type: AssessmentType
+            configuration: dict  # This will later be validated as a BaseModel by the specific assessment
+        self.assessment_config = AssessmentConfig(**self.config)
 
-    response = modal.container_app[assessment_config.assessment_type.name].call(
-        assessment_id = assessment_config.assessment, configuration = assessment_config.configuration
-    )
-    return response
+        response = modal.container_app[self.assessment_config.assessment_type.name].call(
+            assessment_id = self.assessment_config.assessment, configuration = self.assessment_config.configuration
+        )
+        return response
+
+
+
+@stub.function(
+secret=modal.Secret.from_name("aqua-db"),
+)
+def run_assessment_runner(config):
+    assessment = RunAssessment(config=config)
+    assessment.log_start()
+    assessment.run_assessment()
+    assessment.log_end()
 
 
 @stub.webhook(method="POST")
@@ -56,10 +105,10 @@ async def assessment_runner(request: Request):
     body = await request.form()
     config_file = await body['file'].read()
     config = json.loads(config_file)
+    if config["assessment_type"] not in [e.name for e in AssessmentType]:
+        raise ValueError(f"Invalid assessment type: {config['assessment_type']}")
+    
+    #Start the assessment, while continuing on to return a response to the user
     run_assessment_runner.spawn(config)
     
     return "Assessment runner started in the background, will take approximately 20 minutes to finish."
-
-
-if __name__ == "__main__":
-    stub.serve()


### PR DESCRIPTION
Modified `runner/runner/app.py` so that it:
* Logs the start of the assessment to the database, setting the "start_time" and changing "status" to "running"
* Runs the assessment
* Logs the end of the assessment to the database, setting the "end_time" and changing "status" to "finished".

I've also put this into a RunAssessment class, so that they can easily share the Assessment base model and the yield_session() method.