### PR TITLE
142-changed auth type and relevant code

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,6 @@ import bible_routes.verse_routes as verse_routes
 import assessment_routes.assessment_routes as assessment_routes
 import review_routes.results_routes as results_routes
 
-
 app = fastapi.FastAPI()
 
 def my_schema():

--- a/assessment_routes/assessment_routes.py
+++ b/assessment_routes/assessment_routes.py
@@ -5,7 +5,7 @@ from typing import List
 
 import fastapi
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security.api_key import APIKeyHeader
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 import requests
@@ -31,9 +31,9 @@ api_keys = get_secret(
         os.getenv("AWS_SECRET_KEY")
         )
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+api_key_header = APIKeyHeader(name="api_key", auto_error=False)
 
-def api_key_auth(api_key: str = Depends(oauth2_scheme)):
+def api_key_auth(api_key: str = Depends(api_key_header)):
     if api_key not in api_keys:
         raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/bible_routes/language_routes.py
+++ b/bible_routes/language_routes.py
@@ -3,7 +3,7 @@ from typing import List
 
 import fastapi
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security.api_key import APIKeyHeader
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
@@ -27,9 +27,9 @@ api_keys = get_secret(
         os.getenv("AWS_SECRET_KEY")
         )
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+api_key_header = APIKeyHeader(name="api_key", auto_error=False)
 
-def api_key_auth(api_key: str = Depends(oauth2_scheme)):
+def api_key_auth(api_key: str = Depends(api_key_header)):
     if api_key not in api_keys:
         raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/bible_routes/revision_routes.py
+++ b/bible_routes/revision_routes.py
@@ -5,7 +5,7 @@ from tempfile import NamedTemporaryFile
 
 import fastapi
 from fastapi import Depends, HTTPException, status, File, UploadFile
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security.api_key import APIKeyHeader
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 import numpy as np
@@ -31,9 +31,9 @@ api_keys = get_secret(
         os.getenv("AWS_SECRET_KEY")
         )
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+api_key_header = APIKeyHeader(name="api_key", auto_error=False)
 
-def api_key_auth(api_key: str = Depends(oauth2_scheme)):
+def api_key_auth(api_key: str = Depends(api_key_header)):
     if api_key not in api_keys:
         raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/bible_routes/verse_routes.py
+++ b/bible_routes/verse_routes.py
@@ -3,7 +3,7 @@ from typing import List
 
 import fastapi
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security.api_key import APIKeyHeader
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
  
@@ -27,9 +27,9 @@ api_keys = get_secret(
         os.getenv("AWS_SECRET_KEY")
         )
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+api_key_header = APIKeyHeader(name="api_key", auto_error=False)
 
-def api_key_auth(api_key: str = Depends(oauth2_scheme)):
+def api_key_auth(api_key: str = Depends(api_key_header)):
     if api_key not in api_keys:
         raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/bible_routes/version_routes.py
+++ b/bible_routes/version_routes.py
@@ -3,7 +3,7 @@ from typing import List
 
 import fastapi
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security.api_key import APIKeyHeader
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
@@ -26,9 +26,9 @@ api_keys = get_secret(
         os.getenv("AWS_SECRET_KEY")
         )
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+api_key_header = APIKeyHeader(name="api_key", auto_error=False)
 
-def api_key_auth(api_key: str = Depends(oauth2_scheme)):
+def api_key_auth(api_key: str = Depends(api_key_header)):
     if api_key not in api_keys:
         raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,

--- a/review_routes/results_routes.py
+++ b/review_routes/results_routes.py
@@ -3,7 +3,7 @@ from typing import List
 
 import fastapi
 from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
+from fastapi.security.api_key import APIKeyHeader
 from gql import Client, gql
 from gql.transport.requests import RequestsHTTPTransport
 
@@ -27,9 +27,9 @@ api_keys = get_secret(
         os.getenv("AWS_SECRET_KEY")
         )
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+api_key_header = APIKeyHeader(name="api_key", auto_error=False)
 
-def api_key_auth(api_key: str = Depends(oauth2_scheme)):
+def api_key_auth(api_key: str = Depends(api_key_header)):
     if api_key not in api_keys:
         raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,


### PR DESCRIPTION
Switching authorization types to allow for using just api-key to authorize swagger docs. I also changed all instances using the old headers to the new ones. Closes #142.