### PR TITLE
218 add option to provide revision and reference texts to results downloads

### DIFF
--- a/app_test.py
+++ b/app_test.py
@@ -312,13 +312,28 @@ def test_result(client):
             "aggregate": "chapter",
     }
 
+    test_config_include_text = {
+            "assessment_id": assessment_id,
+            "include_text": True,
+    }
+
+    test_config_aggregate_and_include_text = {
+            "assessment_id": assessment_id,
+            "aggregate": "chapter",
+            "include_text": True,
+    }
+
     test_response = client.get("/result", params=test_config)
     fail_response = client.get("/result", params=fail_config)
     test_response_chapter_agg = client.get("/result", params=test_config_chapter_agg)
+    test_response_include_text = client.get("/result", params=test_config_include_text)
+    test_response_aggregate_and_include_text = client.get("/result", params=test_config_aggregate_and_include_text)
     
     assert test_response.status_code == 200
     assert fail_response.status_code == 400
     assert test_response_chapter_agg.status_code == 200
+    assert test_response_include_text.status_code == 200
+    assert test_response_aggregate_and_include_text.status_code == 400
     
 
 def test_delete_revision(client):

--- a/models.py
+++ b/models.py
@@ -90,6 +90,8 @@ class Result(BaseModel):
     score: float
     flag: bool = False
     note: Optional[str] = None
+    revision_text: Optional[str] = None
+    reference_text: Optional[str] = None
 
 # # Results model to record in the DB.
 # class MissingWord(BaseModel):

--- a/queries.py
+++ b/queries.py
@@ -464,6 +464,31 @@ def get_results_chapter_agg_query(assessment_id):
     return get_results_chapter_agg
 
 
+def get_results_with_text_query(assessment_id):
+    get_results_with_text = """
+                query {{
+                    assessment_result_with_text(
+                        where: {{assessment: {{
+                            _eq: {}
+                            }}
+                            }}
+                            ) {{
+                    score
+                    vref
+                    assessment
+                    source
+                    target
+                    note
+                    flag
+                    revisionText
+                    referenceText
+                    }}
+                }}
+                """.format(assessment_id)
+
+    return get_results_with_text
+
+
 def get_scripts_query():
     iso_scripts = """
         query list_scripts {


### PR DESCRIPTION
`GET /result` now has a `include_text` boolean parameters, which, if True, also returns the revision and reference texts.