### PR TITLE
Remove requirement for version_abbreviation to be unique

### DIFF
--- a/app_test.py
+++ b/app_test.py
@@ -79,15 +79,8 @@ def test_add_version(client):
         )
 
     test_response = client.post("/version", params=test_version.dict())
-    fail_response = client.post("/version", params=test_version.dict())  # Push the same version a second time, which should give 400
-
-    if test_response.status_code == 400 and test_response.json()['detail'] == "Version abbreviation already in use.":
-        print("This version is already in the database")
-    else:
-        assert test_response.status_code == 200
-        assert test_response.json()['name'] == version_name
-    
-    assert fail_response.status_code == 400
+    assert test_response.status_code == 200
+    assert test_response.json()['name'] == version_name
 
 
 # Test for the List Versions endpoint

--- a/bible_routes/version_routes.py
+++ b/bible_routes/version_routes.py
@@ -98,19 +98,7 @@ async def add_version(v: VersionIn = Depends()):
     else:
         bT = v.backTranslation
 
-    check_version = queries.check_version_query()
-
     with Client(transport=transport, fetch_schema_from_transport=True) as client:
-        check_query = gql(check_version)
-        check_data = client.execute(check_query)
-
-        for version in check_data["bibleVersion"]:
-            if version['abbreviation'].lower() == v.abbreviation.lower():
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Version abbreviation already in use."
-                )
-
         new_version = queries.add_version_query(
             name_fixed, isoLang_fixed, isoScpt_fixed,
             abbv_fixed, rights_fixed, fT,


### PR DESCRIPTION
This is a request from Russell Morley, who is developing Clear Dashboard. Until now we have required that `version_abbreviation` be unique. But it is not now the primary key - the primary key is `id`. And Russell would prefer that we not require `version_abbreviation` to be unique.