### PR TITLE
Increase Uvicorn workers to number set by env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ADD review_routes/ /app/review_routes/
 
 WORKDIR /app
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "${WORKERS}"]


### PR DESCRIPTION
This sets the number of uvicorn workers via an env var, allowing it to be different for different deployments, and to be updated easily without changing the source code.