### PR TITLE
Add option to return results by chapter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ADD review_routes/ /app/review_routes/
 
 WORKDIR /app
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "${WORKERS}"]
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
The previous solution didn't work, so this reverts uvicorn workers to default, and also allows for returning results by chapter, which gives a significant increase in performance.