### PR TITLE
Changes to make /compareresults work better

### DIFF
--- a/models.py
+++ b/models.py
@@ -124,6 +124,8 @@ class MultipleResult(BaseModel):
     z_score: Optional[float] = None
     flag: bool = False
     note: Optional[str] = None
+    revision_text: Optional[str] = None
+    reference_text: Optional[str] = None
     hide: bool = False
 
 


### PR DESCRIPTION
A few changes here to `/compareresults` route:
* Add revision_text and reference_text
* Make it still work, even if not all (or even none) of the assessments have been run
* Return the baseline revisions, along with the status of the assessment for each one