### PR TITLE
Add machinetranslation to revisions

### DIFF
--- a/bible_loading_test.py
+++ b/bible_loading_test.py
@@ -45,7 +45,7 @@ revision_query = queries.insert_bible_revision()
         
 cursor.execute(revision_query, (
     version_id, None,
-    revision_date, False, None
+    revision_date, False, None, True
     ))
 
 connection.commit()

--- a/bible_routes/v1/revision_routes.py
+++ b/bible_routes/v1/revision_routes.py
@@ -139,6 +139,7 @@ async def upload_revision(revision: RevisionIn = Depends(), file: UploadFile = F
         revision.version_id, name,
         revision_date, revision.published,
         revision.backTranslation,
+        revision.machineTranslation,
         ))
     except psycopg2.errors.ForeignKeyViolation:
         cursor.close()

--- a/bible_routes/v2/revision_routes.py
+++ b/bible_routes/v2/revision_routes.py
@@ -96,11 +96,12 @@ async def list_revisions(version_id: Optional[int]=None):
                     id=revision[0],
                     date=revision[1],
                     version_id=revision[2],
-                    version_abbreviation=revision[7],
+                    version_abbreviation=revision[8],
                     name=revision[4],
                     published=revision[3],
                     backTranslation=revision[5],
-                    isoLanguage=revision[6],
+                    machineTranslation=revision[6],
+                    isoLanguage=revision[7],
             )
 
             revisions_data.append(revision_data)
@@ -142,6 +143,7 @@ async def upload_revision(revision: RevisionIn = Depends(), file: UploadFile = F
         revision.version_id, name,
         revision_date, revision.published,
         revision.backTranslation,
+        revision.machineTranslation,
         ))
     except psycopg2.errors.ForeignKeyViolation:
         cursor.close()
@@ -164,6 +166,7 @@ async def upload_revision(revision: RevisionIn = Depends(), file: UploadFile = F
                 name=returned_revision[4],
                 published=returned_revision[3],
                 backTranslation=returned_revision[5],
+                machineTranslation=returned_revision[6],
         )
 
     # Parse the input Bible revision data.

--- a/models.py
+++ b/models.py
@@ -32,6 +32,7 @@ class RevisionIn(BaseModel):
     name: Optional[str] = None
     published: Optional[bool] = False
     backTranslation: Optional[int] = None
+    machineTranslation: Optional[bool] = False
 
 class RevisionOut(BaseModel):
     id: int
@@ -41,6 +42,7 @@ class RevisionOut(BaseModel):
     name: Optional[str] = None
     published: Optional[bool] = False
     backTranslation: Optional[int] = None
+    machineTranslation: Optional[bool] = False
     isoLanguage: Optional[str] = None
 
 

--- a/queries.py
+++ b/queries.py
@@ -60,11 +60,11 @@ def delete_verses_mutation():
 def insert_bible_revision():
     bible_revise = """
                 INSERT INTO "bibleRevision" (
-                    bibleversion, name, date, published, backTranslation
+                    bibleversion, name, date, published, backTranslation, machineTranslation
                     )
-                  VALUES ((%s), (%s), (%s), (%s), (%s))
+                  VALUES ((%s), (%s), (%s), (%s), (%s), (%s))
                 RETURNING 
-                  id, date, bibleversion, published, name, backTranslation
+                  id, date, bibleversion, published, name, backTranslation, machineTranslation;
                 """
  
     return bible_revise
@@ -81,7 +81,7 @@ def fetch_bible_version_by_abbreviation():
 
 def list_all_revisions_query():
     list_revisions = """
-                    SELECT br.id, br.date, br.bibleversion, br.published, br.name, br.backtranslation, bv.isoLanguage, bv.abbreviation
+                    SELECT br.id, br.date, br.bibleversion, br.published, br.name, br.backtranslation, br.machinetranslation, bv.isoLanguage, bv.abbreviation
                     FROM "bibleRevision" br
                     INNER JOIN "bibleVersion" bv ON br.bibleversion = bv.id
                     """
@@ -91,7 +91,7 @@ def list_all_revisions_query():
 
 def list_revisions_query():
     list_revisions = """
-                    SELECT br.id, br.date, br.bibleversion, br.published, br.name, br.backtranslation, bv.isoLanguage, bv.abbreviation
+                    SELECT br.id, br.date, br.bibleversion, br.published, br.name, br.backtranslation, br.machinetranslation, bv.isoLanguage, bv.abbreviation
                     FROM "bibleRevision" br
                     INNER JOIN "bibleVersion" bv ON br.bibleversion = bv.id
                       WHERE bibleversion=(%s)


### PR DESCRIPTION
I have added a `machinetranslation` field to the `bibleRevision` database tables.

This sets and returns that field via the API. This will help us (and other clients) to distinguish between human-generated and machine-generated revisions.