### PR TITLE
Fix bug when no baseline assessments run

### DIFF
--- a/review_routes/v3/results_routes.py
+++ b/review_routes/v3/results_routes.py
@@ -1137,6 +1137,8 @@ async def get_missing_words(
                     "verse",
                     "source",
                     "target",
+                    "assessment_id",
+                    "baseline_score",
                 ]
             )
         df_baseline.loc[:, "baseline_id"] = df_baseline["assessment_id"].apply(


### PR DESCRIPTION
We'd previous taken care of the case when no `baseline_id`s are set, but not the case when they are set, but there are no finished assessments corresponding to those baseline ids. This fixes a bug for that case.

We should include this case in our tests.