### PR TITLE
Fix adding version to groups

### DIFF
--- a/bible_routes/v3/version_routes.py
+++ b/bible_routes/v3/version_routes.py
@@ -181,7 +181,7 @@ async def modify_version(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="User not authorized to modify this version.",
         )
-    print(f'{group_ids_to_add=} {group_ids_to_remove=}')
+    
     # Perform the updates
     if add_groups:
         for group_id in group_ids_to_add:

--- a/bible_routes/v3/version_routes.py
+++ b/bible_routes/v3/version_routes.py
@@ -88,6 +88,7 @@ async def add_version(
         back_translation_id=v.backTranslation,
         machine_translation=v.machineTranslation,
         owner_id=current_user.id,
+        is_reference=v.is_reference,
     )
 
     db.add(new_version)
@@ -172,8 +173,9 @@ async def modify_version(
     current_bible_version_access_result = await db.execute(select(BibleVersionAccess).where(BibleVersionAccess.bible_version_id == version_update.id))
     current_bible_version_access = current_bible_version_access_result.scalars().all()
     current_bible_version_access_ids = [access.group_id for access in current_bible_version_access]
-    group_ids_to_add = [group_id for group_id in add_groups if group_id not in current_bible_version_access_ids]
-    group_ids_to_remove = [group_id for group_id in current_bible_version_access_ids if group_id not in add_groups]
+    if add_groups:
+        group_ids_to_add = [group_id for group_id in add_groups if group_id not in current_bible_version_access_ids]
+        group_ids_to_remove = [group_id for group_id in current_bible_version_access_ids if group_id not in add_groups]
     
     # check if is admin or version owner
     if not current_user.is_admin and version.owner_id != current_user.id:


### PR DESCRIPTION
The `add_to_groups` parameter is all the groups that a version is currently in. The problem is that the current user may be in some of those groups and not others. Currently, this will return 403 in this case, since there are groups that this version is in, that the user is not in.

But actually, we want the user to be able to add this version to other groups, even though it is in some groups that they (the user) are not in. Similarly, we want the user to be able to remove this version from any group they are in, even if they are not in all the version's groups.