### PR TITLE
Admin route, /create user, can only create regular users

### DIFF
--- a/security_routes/admin_routes.py
+++ b/security_routes/admin_routes.py
@@ -58,12 +58,21 @@ async def create_user(
         raise HTTPException(status_code=400, detail="Username already registered")
     if user.password is None:
         raise HTTPException(status_code=400, detail="Password is required")
+    if user.is_admin:
+        raise HTTPException(
+            status_code=400, detail="Admin users cannot be created using this endpoint"
+        )
+
     hashed_password = hash_password(user.password)
+
+
+
+    #  Ensure the user is not an admin
     db_user = UserDB(
         username=user.username,
         email=user.email,
         hashed_password=hashed_password,
-        is_admin=user.is_admin,
+        is_admin=False,
     )
     db.add(db_user)
     await db.commit()
@@ -73,7 +82,7 @@ async def create_user(
         id=db_user.id,
         username=db_user.username,
         email=db_user.email,
-        is_admin=db_user.is_admin,
+        is_admin=False,
     )
     return_user.password = None  # Ensure password is not included in the response
     return return_user

--- a/test/test_security_routes/test_admin_routes.py
+++ b/test/test_security_routes/test_admin_routes.py
@@ -68,6 +68,28 @@ def test_admin_flow(client, regular_token1, admin_token, test_db_session):
     assert response.json()["is_admin"] == new_user_data["is_admin"]
     assert user_exists(test_db_session, new_user_data["username"])
 
+    # Trying to create an admin user
+    admin_user_data = {
+        "username": "admin_user",
+        "email": "admin_user@example.com",
+        "password": "password123",
+        "is_admin": True,
+    }
+
+    # Send a POST request to create a new user
+    response = client.post(
+        f"{prefix}/users",
+        params=admin_user_data,
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+
+    # Assert the user was not created
+    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.json()["detail"] == "Admin users cannot be created using this endpoint"
+
+    # Check in the database that the user was not created
+    assert not user_exists(test_db_session, admin_user_data["username"])
+
     # send a post request to update te password to the change-password enpoint
     password_update = {
         "username": "new_user",


### PR DESCRIPTION
- Property is_admin, can only be false form the endpoint /create users
- Testing trying to create an admin, being admin, returning 400 