### PR TITLE
Refactor body headers requests/aqua217

### DIFF
--- a/models.py
+++ b/models.py
@@ -360,7 +360,6 @@ class User(BaseModel):
     username: str
     email: Optional[EmailStr] = None  # Assuming users have an email field
     is_admin: Optional[bool] = False
-    password: Optional[str] = None
 
     class Config:
         orm_mode = True
@@ -383,3 +382,8 @@ class Token(BaseModel):
 
 class TokenData(BaseModel):
     username: Optional[str] = None
+
+
+class PasswordChangeRequest(BaseModel):
+    username: str
+    new_password: str

--- a/models.py
+++ b/models.py
@@ -382,8 +382,3 @@ class Token(BaseModel):
 
 class TokenData(BaseModel):
     username: Optional[str] = None
-
-
-class PasswordChangeRequest(BaseModel):
-    username: str
-    new_password: str

--- a/notebooks/integration.ipynb
+++ b/notebooks/integration.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,16 +29,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 83,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'$2b$12$xAY0w69jWoGB.SfdcoxOGucEi0mD1n3GXFr2dVTHFcyk016d3nkUq'"
+       "'$2b$12$ZB3U/7XLwX2ZBRbsycK8qeLXQs1LJfUuW9jZfgBE/gEPx.B9f4V9i'"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 83,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 84,
    "metadata": {},
    "outputs": [
     {
@@ -58,7 +58,7 @@
        "True"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 84,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -78,7 +78,7 @@
        "True"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 87,
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +112,7 @@
        "145"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 87,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,16 +130,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Response [200]>"
+       "<Response [400]>"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -154,7 +154,7 @@
     "\n",
     "response = requests.post(\n",
     "    base_url+f\"{prefix}/users\",\n",
-    "    params=new_user_data,\n",
+    "    json=new_user_data,\n",
     "    headers={\"Authorization\": f\"Bearer {admin_token}\"},\n",
     ")\n",
     "\n",
@@ -163,16 +163,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'{\"id\":4,\"username\":\"new_user\",\"email\":\"new_user@example.com\",\"is_admin\":false,\"password\":null}'"
+       "'{\"detail\":\"Username already registered\"}'"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -183,16 +183,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 102,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Response [200]>"
+       "<Response [400]>"
       ]
      },
-     "execution_count": 102,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -204,7 +204,7 @@
     "}\n",
     "response = requests.post(\n",
     "    base_url+f\"{prefix}/groups\",\n",
-    "    params=group_data,\n",
+    "    json=group_data,\n",
     "    headers={\"Authorization\": f\"Bearer {admin_token}\"},\n",
     ")\n",
     "response"
@@ -212,16 +212,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Response [201]>"
+       "<Response [400]>"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 104,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +260,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"detail\":\"Not Found\"}'"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "response.text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -269,7 +289,7 @@
        "151"
       ]
      },
-     "execution_count": 105,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -280,13 +300,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 2,\n",
+       "{'id': 74,\n",
        " 'name': 'New Version',\n",
        " 'iso_language': 'eng',\n",
        " 'iso_script': 'Latn',\n",
@@ -295,12 +315,12 @@
        " 'forward_translation_id': None,\n",
        " 'back_translation_id': None,\n",
        " 'machineTranslation': False,\n",
-       " 'owner_id': 4,\n",
+       " 'owner_id': 104,\n",
        " 'group_ids': [],\n",
        " 'is_reference': True}"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/notebooks/integration.ipynb
+++ b/notebooks/integration.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 93,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -29,16 +29,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 94,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'$2b$12$ZB3U/7XLwX2ZBRbsycK8qeLXQs1LJfUuW9jZfgBE/gEPx.B9f4V9i'"
+       "'$2b$12$n1PNPEK.jMJyENdhBEZa2OujJ2kf3tJMq6butxP61ROWBpZ8h0HQK'"
       ]
      },
-     "execution_count": 83,
+     "execution_count": 94,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -49,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
@@ -58,7 +58,7 @@
        "True"
       ]
      },
-     "execution_count": 84,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -69,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
@@ -78,7 +78,7 @@
        "True"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 96,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 97,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +112,7 @@
        "145"
       ]
      },
-     "execution_count": 87,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,16 +130,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Response [400]>"
+       "<Response [200]>"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -148,13 +148,18 @@
     "new_user_data = {\n",
     "    \"username\": \"new_user\",\n",
     "    \"email\": \"new_user@example.com\",\n",
-    "    \"password\": \"newpassword\",\n",
     "    \"is_admin\": False,\n",
+    "}\n",
+    "\n",
+    "auth_data = {\n",
+    "    \"username\": new_user_data[\"username\"],\n",
+    "    \"password\": \"newpassword\",\n",
     "}\n",
     "\n",
     "response = requests.post(\n",
     "    base_url+f\"{prefix}/users\",\n",
-    "    json=new_user_data,\n",
+    "    params=new_user_data,\n",
+    "    data = auth_data,\n",
     "    headers={\"Authorization\": f\"Bearer {admin_token}\"},\n",
     ")\n",
     "\n",
@@ -162,23 +167,49 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Change passsword "
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 110,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'{\"detail\":\"Username already registered\"}'"
+       "<Response [200]>"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 110,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "response.text"
+    "# Change password\n",
+    "new_auth_data = {\n",
+    "    \"username\": \"new_user\",\n",
+    "    \"password\": \"newpassword1\",\n",
+    "}\n",
+    "\n",
+    "response = requests.post(\n",
+    "    base_url+f\"{prefix}/change-password\",\n",
+    "    data = new_auth_data,\n",
+    "    headers={\"Authorization\": f\"Bearer {admin_token}\"},\n",
+    ")\n",
+    "\n",
+    "response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create group"
    ]
   },
   {

--- a/notebooks/integration.ipynb
+++ b/notebooks/integration.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -17,28 +17,41 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Base URL\n",
+    "\n",
+    "You can run this notebook locally, on main runner, or development runner, please uncomment the one you are going to use, and comment the other base url's"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 93,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "#base_url = \"https://tmv9bz5v4q.us-east-1.awsapprunner.com/\"\n",
+    "# Main runner\n",
+    "# base_url = \"https://tmv9bz5v4q.us-east-1.awsapprunner.com/\"\n",
+    "# Development runner\n",
+    "# base_url = \"https://cp3by92k8p.us-east-1.awsapprunner.com/\"\n",
+    "# Local\n",
     "base_url = \"http://localhost:8000/\"\n",
     "prefix = \"latest\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 94,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'$2b$12$n1PNPEK.jMJyENdhBEZa2OujJ2kf3tJMq6butxP61ROWBpZ8h0HQK'"
+       "'$2b$12$xAY0w69jWoGB.SfdcoxOGucEi0mD1n3GXFr2dVTHFcyk016d3nkUq'"
       ]
      },
-     "execution_count": 94,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -49,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -58,7 +71,7 @@
        "True"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -69,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 86,
    "metadata": {},
    "outputs": [
     {
@@ -78,7 +91,7 @@
        "True"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 86,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -90,7 +103,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [
     {
@@ -112,7 +125,7 @@
        "145"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 100,
    "metadata": {},
    "outputs": [
     {
@@ -139,7 +152,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 106,
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -148,18 +161,13 @@
     "new_user_data = {\n",
     "    \"username\": \"new_user\",\n",
     "    \"email\": \"new_user@example.com\",\n",
-    "    \"is_admin\": False,\n",
-    "}\n",
-    "\n",
-    "auth_data = {\n",
-    "    \"username\": new_user_data[\"username\"],\n",
     "    \"password\": \"newpassword\",\n",
+    "    \"is_admin\": False,\n",
     "}\n",
     "\n",
     "response = requests.post(\n",
     "    base_url+f\"{prefix}/users\",\n",
     "    params=new_user_data,\n",
-    "    data = auth_data,\n",
     "    headers={\"Authorization\": f\"Bearer {admin_token}\"},\n",
     ")\n",
     "\n",
@@ -167,15 +175,28 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": 101,
    "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'{\"id\":4,\"username\":\"new_user\",\"email\":\"new_user@example.com\",\"is_admin\":false,\"password\":null}'"
+      ]
+     },
+     "execution_count": 101,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "Change passsword "
+    "response.text"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 102,
    "metadata": {},
    "outputs": [
     {
@@ -184,46 +205,7 @@
        "<Response [200]>"
       ]
      },
-     "execution_count": 110,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# Change password\n",
-    "new_auth_data = {\n",
-    "    \"username\": \"new_user\",\n",
-    "    \"password\": \"newpassword1\",\n",
-    "}\n",
-    "\n",
-    "response = requests.post(\n",
-    "    base_url+f\"{prefix}/change-password\",\n",
-    "    data = new_auth_data,\n",
-    "    headers={\"Authorization\": f\"Bearer {admin_token}\"},\n",
-    ")\n",
-    "\n",
-    "response"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Create group"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 90,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<Response [400]>"
-      ]
-     },
-     "execution_count": 90,
+     "execution_count": 102,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -235,7 +217,7 @@
     "}\n",
     "response = requests.post(\n",
     "    base_url+f\"{prefix}/groups\",\n",
-    "    json=group_data,\n",
+    "    params=group_data,\n",
     "    headers={\"Authorization\": f\"Bearer {admin_token}\"},\n",
     ")\n",
     "response"
@@ -243,16 +225,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<Response [400]>"
+       "<Response [201]>"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -279,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 104,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -291,27 +273,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 61,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'{\"detail\":\"Not Found\"}'"
-      ]
-     },
-     "execution_count": 61,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "response.text"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 105,
    "metadata": {},
    "outputs": [
     {
@@ -320,7 +282,7 @@
        "151"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 105,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -331,13 +293,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 106,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'id': 74,\n",
+       "{'id': 2,\n",
        " 'name': 'New Version',\n",
        " 'iso_language': 'eng',\n",
        " 'iso_script': 'Latn',\n",
@@ -346,12 +308,12 @@
        " 'forward_translation_id': None,\n",
        " 'back_translation_id': None,\n",
        " 'machineTranslation': False,\n",
-       " 'owner_id': 104,\n",
+       " 'owner_id': 4,\n",
        " 'group_ids': [],\n",
        " 'is_reference': True}"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 106,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/security_routes/admin_routes.py
+++ b/security_routes/admin_routes.py
@@ -83,7 +83,7 @@ async def create_user(
 # create group endpoint
 @router.post("/groups", response_model=Group)
 async def create_group(
-    group: Group,
+    group: Group=Depends(),
     db: AsyncSession = Depends(get_db),
     _: UserDB = Depends(get_current_admin),
 ):

--- a/security_routes/admin_routes.py
+++ b/security_routes/admin_routes.py
@@ -4,7 +4,7 @@ from jose import jwt
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from .utilities import hash_password
-from models import PasswordChangeRequest, User, Group
+from models import User, Group
 from database.models import (
     UserDB,
     UserGroup,
@@ -58,7 +58,7 @@ async def create_user(
 
     if db_user:
         raise HTTPException(status_code=400, detail="Username already registered")
-    if user.password is None:
+    if password is None:
         raise HTTPException(status_code=400, detail="Password is required")
     hashed_password = hash_password(password)
     db_user = UserDB(

--- a/security_routes/admin_routes.py
+++ b/security_routes/admin_routes.py
@@ -83,7 +83,7 @@ async def create_user(
 # create group endpoint
 @router.post("/groups", response_model=Group)
 async def create_group(
-    group: Group=Depends(),
+    group: Group = Depends(),
     db: AsyncSession = Depends(get_db),
     _: UserDB = Depends(get_current_admin),
 ):
@@ -246,7 +246,7 @@ async def change_password(
     _: UserDB = Depends(get_current_admin),
 ):
     username = form_data.username
-    new_password = form_data.password # new password
+    new_password = form_data.password  # new password
     result = await db.execute(select(UserDB).where(UserDB.username == username))
     user = result.scalars().first()
 

--- a/test/test_security_routes/test_admin_routes.py
+++ b/test/test_security_routes/test_admin_routes.py
@@ -61,7 +61,7 @@ def test_admin_flow(client, regular_token1, admin_token, test_db_session):
     response = client.post(
         f"{prefix}/users",
         params=new_user_data,
-        data = new_auth_data,
+        data=new_auth_data,
         headers={"Authorization": f"Bearer {admin_token}"},
     )
 

--- a/test/test_security_routes/test_admin_routes.py
+++ b/test/test_security_routes/test_admin_routes.py
@@ -41,14 +41,18 @@ def test_admin_flow(client, regular_token1, admin_token, test_db_session):
     new_user_data = {
         "username": "new_user",
         "email": "new_user@example.com",
-        "password": "password123",
         "is_admin": False,
     }
 
+    new_auth_data = {
+        "username": "new_user",
+        "password": "passwor123",
+    }
     # Send a POST as regular user to get a 400 error
     response = client.post(
         f"{prefix}/users",
         params=new_user_data,
+        data=new_auth_data,
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -57,6 +61,7 @@ def test_admin_flow(client, regular_token1, admin_token, test_db_session):
     response = client.post(
         f"{prefix}/users",
         params=new_user_data,
+        data = new_auth_data,
         headers={"Authorization": f"Bearer {admin_token}"},
     )
 
@@ -64,18 +69,17 @@ def test_admin_flow(client, regular_token1, admin_token, test_db_session):
     assert response.status_code == status.HTTP_200_OK
     assert response.json()["username"] == new_user_data["username"]
     assert response.json()["email"] == new_user_data["email"]
-    assert response.json()["password"] is None
     assert response.json()["is_admin"] == new_user_data["is_admin"]
     assert user_exists(test_db_session, new_user_data["username"])
 
     # send a post request to update te password to the change-password enpoint
     password_update = {
         "username": "new_user",
-        "new_password": "newpassword",
+        "password": "newpassword",
     }
     response = client.post(
         f"{prefix}/change-password",
-        params=password_update,
+        data=password_update,
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200
@@ -87,6 +91,7 @@ def test_admin_flow(client, regular_token1, admin_token, test_db_session):
     response = client.post(
         f"{prefix}/users",
         params=new_user_data,
+        data=new_auth_data,
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
- Routes /create user, and /change-password were exposing passwords as query parameters.
- Refactor User pydantic model without the password, everything else passed by query parameters, but username and password passed as OAuth2 FastAPI form data.
- This changes may affect how data in the front is passed, since we are merging this to development, changes can be tested in that aws runner.