### PR TITLE
Add database indexes for ngrams performance optimization

### DIFF
--- a/alembic/migrations/versions/d2b0538c6bd5_add_indexes_for_ngrams_performance.py
+++ b/alembic/migrations/versions/d2b0538c6bd5_add_indexes_for_ngrams_performance.py
@@ -1,0 +1,40 @@
+"""add_indexes_for_ngrams_performance
+
+Revision ID: d2b0538c6bd5
+Revises: a022f5ed53e4
+Create Date: 2025-08-15 21:43:00.983538
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd2b0538c6bd5'
+down_revision: Union[str, None] = 'a022f5ed53e4'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add index on assessment_id in ngrams_table for faster filtering
+    op.create_index(
+        'ix_ngrams_table_assessment_id', 
+        'ngrams_table', 
+        ['assessment_id']
+    )
+    
+    # Add index on ngram_id in ngram_vref_table for faster joins
+    op.create_index(
+        'ix_ngram_vref_table_ngram_id', 
+        'ngram_vref_table', 
+        ['ngram_id']
+    )
+
+
+def downgrade() -> None:
+    # Remove the indexes in reverse order
+    op.drop_index('ix_ngram_vref_table_ngram_id', table_name='ngram_vref_table')
+    op.drop_index('ix_ngrams_table_assessment_id', table_name='ngrams_table')

--- a/database/models.py
+++ b/database/models.py
@@ -64,7 +64,7 @@ class NgramsTable(Base):
     __tablename__ = "ngrams_table"
 
     id = Column(Integer, primary_key=True)
-    assessment_id = Column(Integer, ForeignKey("assessment.id"))
+    assessment_id = Column(Integer, ForeignKey("assessment.id"), index=True)
     ngram = Column(Text)
     ngram_size = Column(Integer)
 
@@ -75,7 +75,7 @@ class NgramVrefTable(Base):
     __tablename__ = "ngram_vref_table"
 
     id = Column(Integer, primary_key=True)
-    ngram_id = Column(Integer, ForeignKey("ngrams_table.id"))
+    ngram_id = Column(Integer, ForeignKey("ngrams_table.id"), index=True)
     vref = Column(Text, ForeignKey("verse_reference.full_verse_id"))
 
     ngram = relationship("NgramsTable", back_populates="vrefs")


### PR DESCRIPTION
- Add index on NgramsTable.assessment_id for faster filtering
- Add index on NgramVrefTable.ngram_id for faster joins
- Create Alembic migration to apply indexes safely
- Improves performance for ngrams query with 3.5M+ records

Performance impact:
- Before: Full table scans on millions of rows
- After: Index lookups reducing query time from seconds to milliseconds

I've already run the migration, so this is just for approval and merging into main.