### PR TITLE
Add /words endpoint to extract unique words from verse ranges

### DIFF
--- a/bible_routes/v3/verse_routes.py
+++ b/bible_routes/v3/verse_routes.py
@@ -1,5 +1,6 @@
 __version__ = "v3"
 
+import unicodedata
 from typing import List
 
 import fastapi
@@ -8,6 +9,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.dependencies import get_db
+from database.models import BookReference as BookReferenceModel
+from database.models import ChapterReference as ChapterReferenceModel
 from database.models import UserDB as UserModel
 from database.models import VerseReference as VerseReferenceModel
 from database.models import VerseText as VerseModel
@@ -16,6 +19,80 @@ from security_routes.auth_routes import get_current_user
 from security_routes.utilities import is_user_authorized_for_revision
 
 router = fastapi.APIRouter()
+
+
+def extract_unique_words(text: str) -> List[str]:
+    """
+    Extract unique words from text using sophisticated Unicode-aware splitting logic.
+
+    This function handles:
+    - All letter categories (Lu, Ll, Lt, Lm, Lo)
+    - Numbers as part of words (Nd, Nl, No)
+    - Combining marks essential for many scripts (Mn, Mc, Me)
+    - Connector punctuation like underscore (Pc)
+    - Apostrophes and contractions (', ', ʼ, ', ')
+    - Zero Width Non-Joiner (ZWNJ) and Zero Width Joiner (ZWJ) for complex scripts
+
+    Returns a deduplicated, lowercase list of words in order of first appearance.
+
+    Parameters
+    ----------
+    text : str
+        The text to extract words from
+
+    Returns
+    -------
+    List[str]
+        List of unique words (lowercase) in order of first appearance
+    """
+    words: List[str] = []
+    buf: List[str] = []
+
+    for ch in text:
+        cat = unicodedata.category(ch)
+
+        # Include all characters that can be part of words across different scripts:
+        # - Letters: Lu, Ll, Lt, Lm, Lo (all letter categories)
+        # - Numbers: Nd, Nl, No (can be part of words in some contexts)
+        # - Marks: Mn, Mc, Me (combining marks - essential for many scripts)
+        # - Connectors: Pc (underscore and similar)
+        # - Format characters that are part of words: Cf (but only specific ones)
+        # - Apostrophes and similar punctuation used in contractions
+        if (
+            cat.startswith("L")
+            or cat.startswith("N")  # All letters
+            or cat.startswith("M")  # All numbers (contextual)
+            or cat == "Pc"  # All marks (combining, spacing, enclosing)
+            or ch in "''ʼ''"  # Connector punctuation (underscore, etc.)
+            or ch == "\u200c"  # Apostrophes (various Unicode forms)
+            or ch  # Zero Width Non-Joiner (ZWNJ) - important for many scripts
+            == "\u200d"
+        ):  # Zero Width Joiner (ZWJ) - important for many scripts
+            buf.append(ch)
+        else:
+            # End of word - save if we have content
+            if buf:
+                word = "".join(buf).strip()
+                if word:  # Only add non-empty words
+                    words.append(word)
+                buf = []
+
+    # Don't forget the last word if text doesn't end with a separator
+    if buf:
+        word = "".join(buf).strip()
+        if word:
+            words.append(word)
+
+    # Normalize and deduplicate (preserve order for consistency)
+    out = []
+    seen = set()
+    for w in words:
+        wl = w.lower()
+        if wl and wl not in seen:
+            seen.add(wl)
+            out.append(wl)
+
+    return out
 
 
 @router.get("/chapter", response_model=List[VerseText])
@@ -309,3 +386,188 @@ async def get_vrefs(
     result = await db.execute(stmt)
     verses = result.scalars().all()
     return verses
+
+
+@router.get("/words", response_model=List[str])
+async def get_words(
+    revision_id: int,
+    first_verse: str,
+    last_verse: str,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """
+    Gets a list of unique words from verses in a given range for a revision.
+
+    Input:
+    - revision_id: int
+    Description: The unique identifier for the revision.
+    - first_verse: str
+    Description: The first verse reference in the range. Must be in the format "GEN 1:1".
+    - last_verse: str
+    Description: The last verse reference in the range. Must be in the format "GEN 1:1".
+
+    Returns:
+    - List[str]
+    Description: A list of unique words found across all verses in the range.
+    Uses sophisticated Unicode-aware word splitting for international scripts.
+    """
+
+    if not await is_user_authorized_for_revision(current_user.id, revision_id, db):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User not authorized to access this revision.",
+        )
+
+    # First, get the ordering information for the first and last verses
+    first_verse_query = (
+        select(
+            BookReferenceModel.number.label("book_num"),
+            ChapterReferenceModel.number.label("chapter_num"),
+            VerseReferenceModel.number.label("verse_num"),
+        )
+        .join(
+            ChapterReferenceModel,
+            VerseReferenceModel.chapter == ChapterReferenceModel.full_chapter_id,
+        )
+        .join(
+            BookReferenceModel,
+            VerseReferenceModel.book_reference == BookReferenceModel.abbreviation,
+        )
+        .where(VerseReferenceModel.full_verse_id == first_verse)
+    )
+
+    last_verse_query = (
+        select(
+            BookReferenceModel.number.label("book_num"),
+            ChapterReferenceModel.number.label("chapter_num"),
+            VerseReferenceModel.number.label("verse_num"),
+        )
+        .join(
+            ChapterReferenceModel,
+            VerseReferenceModel.chapter == ChapterReferenceModel.full_chapter_id,
+        )
+        .join(
+            BookReferenceModel,
+            VerseReferenceModel.book_reference == BookReferenceModel.abbreviation,
+        )
+        .where(VerseReferenceModel.full_verse_id == last_verse)
+    )
+
+    first_verse_result = await db.execute(first_verse_query)
+    first_verse_info = first_verse_result.first()
+
+    last_verse_result = await db.execute(last_verse_query)
+    last_verse_info = last_verse_result.first()
+
+    # Validate that both verses exist
+    if first_verse_info is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"First verse '{first_verse}' not found in revision.",
+        )
+    if last_verse_info is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Last verse '{last_verse}' not found in revision.",
+        )
+
+    # Check that first verse comes before or equals last verse
+    if (
+        first_verse_info.book_num > last_verse_info.book_num
+        or (
+            first_verse_info.book_num == last_verse_info.book_num
+            and first_verse_info.chapter_num > last_verse_info.chapter_num
+        )
+        or (
+            first_verse_info.book_num == last_verse_info.book_num
+            and first_verse_info.chapter_num == last_verse_info.chapter_num
+            and first_verse_info.verse_num > last_verse_info.verse_num
+        )
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="First verse must come before or equal to last verse.",
+        )
+
+    # Now query only the verses in the range using the ordering numbers
+    # This is much more efficient than loading all verses
+    from sqlalchemy import and_, or_
+
+    stmt = (
+        select(VerseModel)
+        .join(
+            VerseReferenceModel,
+            VerseModel.verse_reference == VerseReferenceModel.full_verse_id,
+        )
+        .join(
+            ChapterReferenceModel,
+            VerseReferenceModel.chapter == ChapterReferenceModel.full_chapter_id,
+        )
+        .join(
+            BookReferenceModel,
+            VerseReferenceModel.book_reference == BookReferenceModel.abbreviation,
+        )
+        .where(
+            and_(
+                VerseModel.revision_id == revision_id,
+                or_(
+                    # Book is after start book
+                    BookReferenceModel.number > first_verse_info.book_num,
+                    # Book equals start book and chapter is after start chapter
+                    and_(
+                        BookReferenceModel.number == first_verse_info.book_num,
+                        ChapterReferenceModel.number > first_verse_info.chapter_num,
+                    ),
+                    # Book and chapter equal start, verse is >= start verse
+                    and_(
+                        BookReferenceModel.number == first_verse_info.book_num,
+                        ChapterReferenceModel.number == first_verse_info.chapter_num,
+                        VerseReferenceModel.number >= first_verse_info.verse_num,
+                    ),
+                ),
+                or_(
+                    # Book is before end book
+                    BookReferenceModel.number < last_verse_info.book_num,
+                    # Book equals end book and chapter is before end chapter
+                    and_(
+                        BookReferenceModel.number == last_verse_info.book_num,
+                        ChapterReferenceModel.number < last_verse_info.chapter_num,
+                    ),
+                    # Book and chapter equal end, verse is <= end verse
+                    and_(
+                        BookReferenceModel.number == last_verse_info.book_num,
+                        ChapterReferenceModel.number == last_verse_info.chapter_num,
+                        VerseReferenceModel.number <= last_verse_info.verse_num,
+                    ),
+                ),
+            )
+        )
+        .order_by(
+            BookReferenceModel.number,
+            ChapterReferenceModel.number,
+            VerseReferenceModel.number,
+        )
+    )
+
+    # Execute query to get only verses in the range
+    result = await db.execute(stmt)
+    verses_in_range = result.scalars().all()
+
+    # Extract unique words using sophisticated Unicode-aware splitting
+    all_words = []
+    for verse in verses_in_range:
+        if verse.text:
+            words = extract_unique_words(verse.text)
+            all_words.extend(words)
+
+    # Deduplicate across all verses while preserving order
+    seen = set()
+    unique_words = []
+    for word in all_words:
+        if word not in seen:
+            seen.add(word)
+            unique_words.append(word)
+
+    # Return sorted list for consistent output
+    return sorted(unique_words)

--- a/test/test_bible_routes/test_verse_routes.py
+++ b/test/test_bible_routes/test_verse_routes.py
@@ -32,7 +32,7 @@ def upload_revision(client, token, version_id):
         "version_id": version_id,
         "name": "Test Revision",
     }
-    test_upload_file = Path("fixtures/uploadtest.txt")
+    test_upload_file = Path("fixtures/eng-eng-kjv.txt")
 
     with open(test_upload_file, "rb") as file:
         files = {"file": file}
@@ -128,3 +128,340 @@ def test_verse_routes_flow(client, regular_token1, regular_token2, db_session):
     assert vrefs_response.json()[0]["chapter"] == 1
     assert vrefs_response.json()[0]["verse"] == 1
     assert vrefs_response.json()[0]["revision_id"] == revision_id
+
+
+def test_words_endpoint_single_verse(client, regular_token1, db_session):
+    """Test /words endpoint with a single verse (first_verse == last_verse)."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Test with a single verse
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 1:1",
+            "last_verse": "GEN 1:1",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+    assert isinstance(words, list)
+    assert len(words) > 0
+    # All words should be unique
+    assert len(words) == len(set(words))
+    # All words should be lowercase
+    assert all(word == word.lower() for word in words)
+    # Words should be sorted
+    assert words == sorted(words)
+
+
+def test_words_endpoint_chapter_range(client, regular_token1, db_session):
+    """Test /words endpoint with a range of verses within a single chapter."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Test with multiple verses in Genesis 1
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 1:1",
+            "last_verse": "GEN 1:5",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+    assert isinstance(words, list)
+    assert len(words) > 0
+    # All words should be unique
+    assert len(words) == len(set(words))
+    # All words should be lowercase
+    assert all(word == word.lower() for word in words)
+    # Words should be sorted
+    assert words == sorted(words)
+
+
+def test_words_endpoint_cross_chapter(client, regular_token1, db_session):
+    """Test /words endpoint with a range spanning multiple chapters."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Test across chapters (GEN 1:1 to GEN 2:3)
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 1:1",
+            "last_verse": "GEN 2:3",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+    assert isinstance(words, list)
+    assert len(words) > 0
+    # All words should be unique
+    assert len(words) == len(set(words))
+    # All words should be lowercase
+    assert all(word == word.lower() for word in words)
+    # Words should be sorted
+    assert words == sorted(words)
+
+
+def test_words_endpoint_verse_not_found(client, regular_token1, db_session):
+    """Test /words endpoint with non-existent verse references."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Test with non-existent first verse (invalid reference)
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "XXX 99:99",  # Non-existent book
+            "last_verse": "XXX 99:99",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 404
+    assert "not found" in words_response.json()["detail"].lower()
+
+
+def test_words_endpoint_invalid_range(client, regular_token1, db_session):
+    """Test /words endpoint with first_verse after last_verse."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Test with first verse after last verse
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 2:1",
+            "last_verse": "GEN 1:1",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 400
+    assert "before" in words_response.json()["detail"].lower()
+
+
+def test_words_endpoint_unauthorized(
+    client, regular_token1, regular_token2, db_session
+):
+    """Test /words endpoint with unauthorized user."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    # Try to access with different user's token
+    headers = {"Authorization": f"Bearer {regular_token2}"}
+
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 1:1",
+            "last_verse": "GEN 1:5",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 403
+    assert "not authorized" in words_response.json()["detail"].lower()
+
+
+def test_words_endpoint_unicode_handling(client, regular_token1, db_session):
+    """Test that /words endpoint properly handles Unicode characters and special cases."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Get words from a range
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 1:1",
+            "last_verse": "GEN 1:3",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+
+    # Verify all words are strings
+    assert all(isinstance(word, str) for word in words)
+
+    # Verify no empty strings
+    assert all(len(word) > 0 for word in words)
+
+    # Verify no words with only whitespace
+    assert all(word.strip() == word for word in words)
+
+
+def test_words_endpoint_deduplication(client, regular_token1, db_session):
+    """Test that /words endpoint properly deduplicates words across verses."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Get words from a larger range to ensure word repetition
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 1:1",
+            "last_verse": "GEN 1:10",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+
+    # Verify no duplicates (case-insensitive)
+    words_lower = [w.lower() for w in words]
+    assert len(words_lower) == len(set(words_lower))
+
+    # Since we normalize to lowercase in the function, all should already be lowercase
+    assert words == words_lower
+
+
+def test_words_endpoint_content_verification(client, regular_token1, db_session):
+    """Test that /words endpoint returns expected words from known KJV text."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Test GEN 1:1 - "In the beginning God created the heaven and the earth."
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 1:1",
+            "last_verse": "GEN 1:1",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+
+    # Expected words from GEN 1:1 (lowercase, sorted)
+    expected_words = [
+        "and",
+        "beginning",
+        "created",
+        "earth",
+        "god",
+        "heaven",
+        "in",
+        "the",
+    ]
+    assert words == expected_words, f"Expected {expected_words}, got {words}"
+
+    # Test GEN 1:1-3 for a range
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 1:1",
+            "last_verse": "GEN 1:3",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+
+    # Should contain key words from these three verses
+    expected_subset = [
+        "beginning",
+        "created",
+        "god",
+        "light",
+        "darkness",
+        "spirit",
+        "waters",
+    ]
+    for word in expected_subset:
+        assert word in words, f"Expected word '{word}' not found in results"
+
+    # Verify it's a reasonable number of unique words
+    assert len(words) == 25  # Should have 25 unique words
+
+
+def test_words_endpoint_cross_book_boundary(client, regular_token1, db_session):
+    """Test that /words endpoint correctly handles ranges across book boundaries."""
+    version_id = create_bible_version(client, regular_token1)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Test from last verse of Genesis to first verse of Exodus
+    # GEN 50:26 to EXO 1:1
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 50:26",
+            "last_verse": "EXO 1:1",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+
+    # Verify we got words
+    assert len(words) > 0, "Should have extracted words from cross-book range"
+
+    # All words should be unique, lowercase, and sorted
+    assert words == sorted(words), "Words should be sorted"
+    assert all(word == word.lower() for word in words), "All words should be lowercase"
+    assert len(words) == len(set(words)), "All words should be unique"
+
+    # Test a longer cross-book range (last 3 verses of Genesis + first 3 of Exodus)
+    words_response = client.get(
+        f"/{prefix}/words",
+        params={
+            "revision_id": revision_id,
+            "first_verse": "GEN 50:24",
+            "last_verse": "EXO 1:3",
+        },
+        headers=headers,
+    )
+    assert words_response.status_code == 200
+    words = words_response.json()
+
+    # Should have a substantial number of unique words from 6 verses
+    assert (
+        len(words) > 30
+    ), f"Expected more than 30 words from 6 verses, got {len(words)}"
+    assert (
+        len(words) < 150
+    ), f"Expected less than 150 words from 6 verses, got {len(words)}"
+
+    # Verify words contain content from both books
+    # These words should appear somewhere in Genesis 50:24-26 or Exodus 1:1-3
+    expected_genesis_word = "joseph"
+    expected_exodus_word = "egypt"
+    assert (
+        expected_genesis_word in words
+    ), f"Expected word '{expected_genesis_word}' not found"
+    assert (
+        expected_exodus_word in words
+    ), f"Expected word '{expected_exodus_word}' not found"
+    # We're checking that the range actually spans both books
+    assert len(words) > 0, "Should have words from both books"


### PR DESCRIPTION
A new route that is needed for the AQuA agent.

Note for later about indexes that should be added. We can't add them now because the other PR has pending migrations, and they'll get out of order.


# Indexes Needed for /words Endpoint Performance

The `/words` endpoint queries verses using composite ordering (book → chapter → verse). 
Add these indexes on the `number` fields for optimal performance:

```sql
CREATE INDEX IF NOT EXISTS ix_book_reference_number ON book_reference(number);
CREATE INDEX IF NOT EXISTS ix_chapter_reference_number ON chapter_reference(number);
CREATE INDEX IF NOT EXISTS ix_verse_reference_number ON verse_reference(number);
CREATE INDEX IF NOT EXISTS ix_chapter_reference_book_number ON chapter_reference(book_reference, number);
CREATE INDEX IF NOT EXISTS ix_verse_reference_chapter_number ON verse_reference(chapter, number);
```

**Expected improvement:** 2-6x faster queries (from ~0.3s to ~0.05-0.1s for typical ranges).

These support the ORDER BY and WHERE clauses in the verse range query that filters by book/chapter/verse numbers.

