### PR TITLE
Add agent-critique assessment type support

### DIFF
--- a/assessment_routes/v1/assessment_routes.py
+++ b/assessment_routes/v1/assessment_routes.py
@@ -88,6 +88,7 @@ async def add_assessment(a: AssessmentIn = Depends(), modal_suffix: str = ""):
     - semantic-similarity (requires reference)
     - sentence-length
     - word-alignment (requires reference)
+    - agent-critique (requires reference)
 
     For those assessments that require a reference, the reference_id should be the id of the revision with which the revision will be compared.
 
@@ -103,7 +104,8 @@ async def add_assessment(a: AssessmentIn = Depends(), modal_suffix: str = ""):
         )  # Give the option of setting the suffix in the environment
 
     if (
-        a.type in ["missing-words", "semantic-similarity", "word-alignment"]
+        a.type
+        in ["missing-words", "semantic-similarity", "word-alignment", "agent-critique"]
         and a.reference_id is None
     ):
         raise HTTPException(

--- a/assessment_routes/v2/assessment_routes.py
+++ b/assessment_routes/v2/assessment_routes.py
@@ -97,6 +97,7 @@ async def add_assessment(
     - semantic-similarity (requires reference)
     - sentence-length
     - word-alignment (requires reference)
+    - agent-critique (requires reference)
 
     For those assessments that require a reference, the reference_id should be the id of the revision with which the revision will be compared.
 
@@ -112,7 +113,8 @@ async def add_assessment(
         )  # Give the option of setting the suffix in the environment
 
     if (
-        a.type in ["missing-words", "semantic-similarity", "word-alignment"]
+        a.type
+        in ["missing-words", "semantic-similarity", "word-alignment", "agent-critique"]
         and a.reference_id is None
     ):
         raise HTTPException(

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -51,6 +51,7 @@ async def get_assessments(
     - ngrams
     - tfidf
     - text-lengths (requires reference)
+    - agent-critique (requires reference)
 
 
     Returns:
@@ -185,6 +186,7 @@ async def add_assessment(
     - ngrams
     - tfidf
     - text-lengths
+    - agent-critique (requires reference)
 
     For those assessments that require a reference, the reference_id should be the id of the revision with which the revision will be compared.
 
@@ -212,7 +214,10 @@ async def add_assessment(
     - owner_id: int
     Description: The unique identifier for the owner of the assessment.
     """
-    if a.type in ["semantic-similarity", "word-alignment"] and a.reference_id is None:
+    if (
+        a.type in ["semantic-similarity", "word-alignment", "agent-critique"]
+        and a.reference_id is None
+    ):
         raise HTTPException(
             status_code=400, detail=f"Assessment type {a.type} requires a reference_id."
         )

--- a/models.py
+++ b/models.py
@@ -198,6 +198,7 @@ class AssessmentType(Enum):
     ngrams = "ngrams"
     tfidf = "tfidf"
     text_lengths = "text-lengths"
+    agent_critique = "agent-critique"
 
 
 class AssessmentIn(BaseModel):


### PR DESCRIPTION
- Add agent-critique to AssessmentType enum in models.py
- Add validation requiring reference_id for agent-critique assessments
- Update documentation in all API versions (v1, v2, v3) to include agent-critique
- Agent-critique compares translations against references to identify omissions and additions