### PR TITLE
Add english_lemma and alignment_scores to AgentLexemeCard

### DIFF
--- a/alembic/migrations/versions/b7c9d4e82f13_add_english_lemma_and_alignment_scores.py
+++ b/alembic/migrations/versions/b7c9d4e82f13_add_english_lemma_and_alignment_scores.py
@@ -1,0 +1,46 @@
+"""Add english_lemma and alignment_scores to lexeme cards
+
+Revision ID: b7c9d4e82f13
+Revises: a4e8c3f71b92
+Create Date: 2026-01-23 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = "b7c9d4e82f13"
+down_revision: Union[str, None] = "a4e8c3f71b92"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add english_lemma column to agent_lexeme_cards table
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column("english_lemma", sa.Text(), nullable=True),
+    )
+
+    # Add alignment_scores column to agent_lexeme_cards table
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column(
+            "alignment_scores",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Drop the alignment_scores column
+    op.drop_column("agent_lexeme_cards", "alignment_scores")
+
+    # Drop the english_lemma column
+    op.drop_column("agent_lexeme_cards", "english_lemma")

--- a/database/models.py
+++ b/database/models.py
@@ -392,6 +392,8 @@ class AgentLexemeCard(Base):
     senses = Column(JSONB)  # JSON array of senses
     # Note: examples are now stored in the agent_lexeme_card_examples table (see examples_rel relationship)
     confidence = Column(Numeric)
+    english_lemma = Column(Text)  # English lemma when source/target are not English
+    alignment_scores = Column(JSONB)  # Dict: {source_word: alignment_score}
     created_at = Column(TIMESTAMP, default=func.now())
     last_updated = Column(TIMESTAMP, default=func.now())
 

--- a/models.py
+++ b/models.py
@@ -1,6 +1,6 @@
 import datetime
 from enum import Enum
-from typing import List, Literal, Optional, Union
+from typing import Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
@@ -477,6 +477,8 @@ class LexemeCardIn(BaseModel):
     senses: Optional[list] = None
     examples: Optional[list] = None  # List of example dicts for the given revision_id
     confidence: Optional[float] = None
+    english_lemma: Optional[str] = None
+    alignment_scores: Optional[Dict[str, float]] = None
 
     model_config = {
         "json_schema_extra": {
@@ -492,7 +494,7 @@ class LexemeCardIn(BaseModel):
                     "amas",
                     "ama",
                     "amamos",
-                    "aman",
+                    "anan",
                 ],  # Target language surface forms
                 "source_surface_forms": [
                     "love",
@@ -512,6 +514,8 @@ class LexemeCardIn(BaseModel):
                     {"source": "They love music", "target": "Aman la música"},
                 ],
                 "confidence": 0.95,
+                "english_lemma": "love",
+                "alignment_scores": {"love": 0.92, "you": 0.88},
             }
         }
     }
@@ -529,6 +533,8 @@ class LexemeCardOut(BaseModel):
     senses: Optional[list] = None
     examples: Optional[list] = None  # Filtered list for the requested revision_id
     confidence: Optional[float] = None
+    english_lemma: Optional[str] = None
+    alignment_scores: Optional[Dict[str, float]] = None
     created_at: Optional[datetime.datetime] = None
     last_updated: Optional[datetime.datetime] = None
 
@@ -567,6 +573,8 @@ class LexemeCardOut(BaseModel):
                     {"source": "They love music", "target": "Aman la música"},
                 ],
                 "confidence": 0.95,
+                "english_lemma": "love",
+                "alignment_scores": {"love": 0.92, "you": 0.88},
                 "created_at": "2024-06-01T12:00:00",
                 "last_updated": "2024-06-01T12:00:00",
             }


### PR DESCRIPTION
## Summary
- Add `english_lemma` (Text) field to `AgentLexemeCard` for cases where source/target languages are not English
- Add `alignment_scores` (JSONB) field to store dict with source words as keys and alignment scores as values
- Include Alembic migration to add the new nullable columns

## Test plan
- [ ] Verify Alembic migration applies cleanly
- [ ] Verify existing lexeme card tests still pass
- [ ] Test creating a lexeme card with the new fields via API
- [ ] Test retrieving a lexeme card and verifying new fields are returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)