### PR TITLE
Add english_lemma and alignment_scores to lexeme card routes

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -202,6 +202,8 @@ async def add_lexeme_card(
     - senses: list (optional) - JSON array of senses with definitions and examples
     - examples: list (optional) - JSON array of usage examples for the specified revision_id
     - confidence: float (optional) - Confidence score for the lexeme card
+    - english_lemma: str (optional) - English lemma when source/target languages are not English
+    - alignment_scores: dict (optional) - Dict with source words as keys and alignment scores as values
 
     Returns:
     - LexemeCardOut: The created or updated lexeme card entry (with examples for the specified revision_id)
@@ -224,6 +226,8 @@ async def add_lexeme_card(
             # Update existing card
             existing_card.pos = card.pos
             existing_card.confidence = card.confidence
+            existing_card.english_lemma = card.english_lemma
+            existing_card.alignment_scores = card.alignment_scores
             existing_card.last_updated = func.now()
 
             # Handle list fields based on replace_existing flag
@@ -326,6 +330,8 @@ async def add_lexeme_card(
                 "senses": existing_card.senses,
                 "examples": examples_list,
                 "confidence": existing_card.confidence,
+                "english_lemma": existing_card.english_lemma,
+                "alignment_scores": existing_card.alignment_scores,
                 "created_at": existing_card.created_at,
                 "last_updated": existing_card.last_updated,
             }
@@ -342,6 +348,8 @@ async def add_lexeme_card(
                 source_surface_forms=card.source_surface_forms,
                 senses=card.senses,
                 confidence=card.confidence,
+                english_lemma=card.english_lemma,
+                alignment_scores=card.alignment_scores,
             )
 
             db.add(lexeme_card)
@@ -392,6 +400,8 @@ async def add_lexeme_card(
                 "senses": lexeme_card.senses,
                 "examples": examples_list,
                 "confidence": lexeme_card.confidence,
+                "english_lemma": lexeme_card.english_lemma,
+                "alignment_scores": lexeme_card.alignment_scores,
                 "created_at": lexeme_card.created_at,
                 "last_updated": lexeme_card.last_updated,
             }
@@ -619,6 +629,8 @@ async def get_lexeme_cards(
                 "source_surface_forms": card.source_surface_forms,
                 "senses": card.senses,
                 "confidence": card.confidence,
+                "english_lemma": card.english_lemma,
+                "alignment_scores": card.alignment_scores,
                 "created_at": card.created_at,
                 "last_updated": card.last_updated,
             }


### PR DESCRIPTION
Update add_lexeme_card and get_lexeme_cards endpoints to handle the new english_lemma and alignment_scores fields added to the AgentLexemeCard model.