### PR TITLE
Add agent translation storage API endpoints

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -12,10 +12,14 @@ from database.models import (
     AgentCritiqueIssue,
     AgentLexemeCard,
     AgentLexemeCardExample,
+    AgentTranslation,
     AgentWordAlignment,
 )
 from database.models import UserDB as UserModel
 from models import (
+    AgentTranslationBulkRequest,
+    AgentTranslationOut,
+    AgentTranslationStorageRequest,
     AgentWordAlignmentIn,
     AgentWordAlignmentOut,
     CritiqueIssueOut,
@@ -1032,6 +1036,374 @@ async def unresolve_critique_issue(
     except SQLAlchemyError as e:
         await db.rollback()
         logger.error(f"Error unresolving critique issue: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(e)}",
+        ) from e
+
+
+@router.post("/agent/translation", response_model=AgentTranslationOut)
+async def add_agent_translation(
+    translation: AgentTranslationStorageRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """
+    Store a single agent-generated translation for a verse.
+
+    Input:
+    - assessment_id: int - The assessment ID
+    - vref: str - Verse reference (e.g., "JHN 1:1")
+    - draft_text: str (optional) - The draft translation text
+    - hyper_literal_translation: str (optional) - The hyper-literal back-translation
+    - literal_translation: str (optional) - The literal back-translation
+
+    The version is auto-incremented for each new translation of the same assessment+vref.
+
+    Returns:
+    - AgentTranslationOut: The created translation entry with id, version, and created_at
+    """
+    try:
+        from sqlalchemy import func, select
+
+        from database.models import Assessment
+
+        # Validate assessment exists
+        assessment_query = select(Assessment).where(
+            Assessment.id == translation.assessment_id
+        )
+        assessment_result = await db.execute(assessment_query)
+        assessment = assessment_result.scalar_one_or_none()
+
+        if not assessment:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Assessment with id {translation.assessment_id} not found",
+            )
+
+        # Check user authorization for this assessment
+        if not await is_user_authorized_for_assessment(
+            current_user.id, translation.assessment_id, db
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User not authorized for this assessment",
+            )
+
+        # Get the next version number for this assessment+vref
+        version_query = select(func.max(AgentTranslation.version)).where(
+            AgentTranslation.assessment_id == translation.assessment_id,
+            AgentTranslation.vref == translation.vref,
+        )
+        version_result = await db.execute(version_query)
+        max_version = version_result.scalar()
+        next_version = (max_version or 0) + 1
+
+        # Create the translation record
+        agent_translation = AgentTranslation(
+            assessment_id=translation.assessment_id,
+            vref=translation.vref,
+            version=next_version,
+            draft_text=translation.draft_text,
+            hyper_literal_translation=translation.hyper_literal_translation,
+            literal_translation=translation.literal_translation,
+            english_translation=translation.english_translation,
+        )
+
+        db.add(agent_translation)
+        await db.commit()
+        await db.refresh(agent_translation)
+
+        return AgentTranslationOut.model_validate(agent_translation)
+
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error(f"Error adding agent translation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(e)}",
+        ) from e
+
+
+@router.post("/agent/translations", response_model=list[AgentTranslationOut])
+async def add_agent_translations_bulk(
+    request: AgentTranslationBulkRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """
+    Store multiple agent-generated translations in bulk.
+
+    All translations in a single request get the same version number, which is
+    auto-incremented based on the max existing version for the assessment.
+
+    Input:
+    - assessment_id: int - The assessment ID
+    - translations: list - List of translations, each with:
+      - vref: str - Verse reference (e.g., "JHN 1:1")
+      - draft_text: str (optional) - The draft translation text
+      - hyper_literal_translation: str (optional) - The hyper-literal back-translation
+      - literal_translation: str (optional) - The literal back-translation
+
+    Returns:
+    - List[AgentTranslationOut]: List of created translation entries
+    """
+    try:
+        from sqlalchemy import func, select
+
+        from database.models import Assessment
+
+        # Validate assessment exists
+        assessment_query = select(Assessment).where(
+            Assessment.id == request.assessment_id
+        )
+        assessment_result = await db.execute(assessment_query)
+        assessment = assessment_result.scalar_one_or_none()
+
+        if not assessment:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Assessment with id {request.assessment_id} not found",
+            )
+
+        # Check user authorization for this assessment
+        if not await is_user_authorized_for_assessment(
+            current_user.id, request.assessment_id, db
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User not authorized for this assessment",
+            )
+
+        # Get the next version number for this assessment (all translations get same version)
+        version_query = select(func.max(AgentTranslation.version)).where(
+            AgentTranslation.assessment_id == request.assessment_id
+        )
+        version_result = await db.execute(version_query)
+        max_version = version_result.scalar()
+        next_version = (max_version or 0) + 1
+
+        created_translations = []
+
+        # Create all translation records
+        for trans in request.translations:
+            agent_translation = AgentTranslation(
+                assessment_id=request.assessment_id,
+                vref=trans.vref,
+                version=next_version,
+                draft_text=trans.draft_text,
+                hyper_literal_translation=trans.hyper_literal_translation,
+                literal_translation=trans.literal_translation,
+                english_translation=trans.english_translation,
+            )
+            db.add(agent_translation)
+            created_translations.append(agent_translation)
+
+        await db.commit()
+
+        # Refresh all to get IDs and timestamps
+        for trans in created_translations:
+            await db.refresh(trans)
+
+        return [
+            AgentTranslationOut.model_validate(trans) for trans in created_translations
+        ]
+
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error(f"Error adding agent translations in bulk: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(e)}",
+        ) from e
+
+
+@router.get("/agent/translations", response_model=list[AgentTranslationOut])
+async def get_agent_translations(
+    assessment_id: int,
+    vref: str = None,
+    first_vref: str = None,
+    last_vref: str = None,
+    version: int = None,
+    all_versions: bool = False,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """
+    Get agent-generated translations for an assessment.
+
+    Query Parameters:
+    - assessment_id: int (required) - The assessment ID
+    - vref: str (optional) - Filter by specific verse reference (e.g., "JHN 1:1")
+    - first_vref: str (optional) - Start of verse range (inclusive)
+    - last_vref: str (optional) - End of verse range (inclusive)
+    - version: int (optional) - Filter by specific version number
+    - all_versions: bool (optional, default=False) - If True, return all versions;
+      if False, return only the latest version per vref
+
+    Returns:
+    - List[AgentTranslationOut]: List of matching translations, ordered by verse reference
+    """
+    try:
+        from sqlalchemy import and_, select
+
+        from database.models import Assessment, BookReference, VerseReference
+
+        # Validate assessment exists
+        assessment_query = select(Assessment).where(Assessment.id == assessment_id)
+        assessment_result = await db.execute(assessment_query)
+        assessment = assessment_result.scalar_one_or_none()
+
+        if not assessment:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Assessment with id {assessment_id} not found",
+            )
+
+        # Check user authorization for this assessment
+        if not await is_user_authorized_for_assessment(
+            current_user.id, assessment_id, db
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User not authorized for this assessment",
+            )
+
+        # Build the query
+        if all_versions or version is not None:
+            # Return all versions or a specific version
+            query = select(AgentTranslation).where(
+                AgentTranslation.assessment_id == assessment_id
+            )
+        else:
+            # Return only the latest version per vref using a subquery
+            from sqlalchemy import func
+
+            # Subquery to get max version per vref
+            latest_version_subq = (
+                select(
+                    AgentTranslation.vref,
+                    func.max(AgentTranslation.version).label("max_version"),
+                )
+                .where(AgentTranslation.assessment_id == assessment_id)
+                .group_by(AgentTranslation.vref)
+                .subquery()
+            )
+
+            query = select(AgentTranslation).join(
+                latest_version_subq,
+                and_(
+                    AgentTranslation.vref == latest_version_subq.c.vref,
+                    AgentTranslation.version == latest_version_subq.c.max_version,
+                    AgentTranslation.assessment_id == assessment_id,
+                ),
+            )
+
+        # Filter by specific vref
+        if vref:
+            query = query.where(AgentTranslation.vref == vref)
+
+        # Filter by specific version
+        if version is not None:
+            query = query.where(AgentTranslation.version == version)
+
+        # Filter by verse range
+        if first_vref or last_vref:
+            # Join with verse_reference and book_reference for canonical ordering
+            query = query.join(
+                VerseReference,
+                AgentTranslation.vref == VerseReference.full_verse_id,
+            ).join(
+                BookReference,
+                VerseReference.book_reference == BookReference.abbreviation,
+            )
+
+            if first_vref:
+                # Get the book number, chapter, and verse for first_vref
+                first_vref_query = (
+                    select(
+                        BookReference.number.label("book_num"),
+                        VerseReference.chapter,
+                        VerseReference.number.label("verse_num"),
+                    )
+                    .join(
+                        VerseReference,
+                        VerseReference.book_reference == BookReference.abbreviation,
+                    )
+                    .where(VerseReference.full_verse_id == first_vref)
+                )
+                first_result = await db.execute(first_vref_query)
+                first_row = first_result.first()
+                if first_row:
+                    # Filter: book_num > first OR (book_num == first AND chapter > first_ch) OR ...
+                    query = query.where(
+                        (BookReference.number > first_row.book_num)
+                        | (
+                            (BookReference.number == first_row.book_num)
+                            & (VerseReference.chapter > first_row.chapter)
+                        )
+                        | (
+                            (BookReference.number == first_row.book_num)
+                            & (VerseReference.chapter == first_row.chapter)
+                            & (VerseReference.number >= first_row.verse_num)
+                        )
+                    )
+
+            if last_vref:
+                # Get the book number, chapter, and verse for last_vref
+                last_vref_query = (
+                    select(
+                        BookReference.number.label("book_num"),
+                        VerseReference.chapter,
+                        VerseReference.number.label("verse_num"),
+                    )
+                    .join(
+                        VerseReference,
+                        VerseReference.book_reference == BookReference.abbreviation,
+                    )
+                    .where(VerseReference.full_verse_id == last_vref)
+                )
+                last_result = await db.execute(last_vref_query)
+                last_row = last_result.first()
+                if last_row:
+                    query = query.where(
+                        (BookReference.number < last_row.book_num)
+                        | (
+                            (BookReference.number == last_row.book_num)
+                            & (VerseReference.chapter < last_row.chapter)
+                        )
+                        | (
+                            (BookReference.number == last_row.book_num)
+                            & (VerseReference.chapter == last_row.chapter)
+                            & (VerseReference.number <= last_row.verse_num)
+                        )
+                    )
+
+            # Order by canonical verse order
+            query = query.order_by(
+                BookReference.number,
+                VerseReference.chapter,
+                VerseReference.number,
+                AgentTranslation.version,
+            )
+        else:
+            # Order by vref and version
+            query = query.order_by(AgentTranslation.vref, AgentTranslation.version)
+
+        # Execute query
+        result = await db.execute(query)
+        translations = result.scalars().all()
+
+        return [AgentTranslationOut.model_validate(t) for t in translations]
+
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        logger.error(f"Error fetching agent translations: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Database error: {str(e)}",

--- a/alembic/migrations/versions/c8d5e7f91a34_add_agent_translations_table.py
+++ b/alembic/migrations/versions/c8d5e7f91a34_add_agent_translations_table.py
@@ -1,0 +1,68 @@
+"""Add agent_translations table
+
+Revision ID: c8d5e7f91a34
+Revises: b7c9d4e82f13
+Create Date: 2026-01-24 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "c8d5e7f91a34"
+down_revision: Union[str, None] = "b7c9d4e82f13"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create agent_translations table
+    op.create_table(
+        "agent_translations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "assessment_id",
+            sa.Integer(),
+            sa.ForeignKey("assessment.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("vref", sa.String(20), nullable=False),
+        sa.Column("version", sa.Integer(), default=1, nullable=False),
+        sa.Column("draft_text", sa.Text(), nullable=True),
+        sa.Column("hyper_literal_translation", sa.Text(), nullable=True),
+        sa.Column("literal_translation", sa.Text(), nullable=True),
+        sa.Column("english_translation", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=True
+        ),
+    )
+
+    # Create unique index on (assessment_id, vref, version)
+    op.create_index(
+        "ix_agent_translations_unique",
+        "agent_translations",
+        ["assessment_id", "vref", "version"],
+        unique=True,
+    )
+
+    # Create query index on (assessment_id, vref)
+    op.create_index(
+        "ix_agent_translations_assessment_vref",
+        "agent_translations",
+        ["assessment_id", "vref"],
+    )
+
+
+def downgrade() -> None:
+    # Drop indexes
+    op.drop_index(
+        "ix_agent_translations_assessment_vref", table_name="agent_translations"
+    )
+    op.drop_index("ix_agent_translations_unique", table_name="agent_translations")
+
+    # Drop table
+    op.drop_table("agent_translations")

--- a/database/models.py
+++ b/database/models.py
@@ -553,3 +553,32 @@ class AgentCritiqueIssue(Base):
         Index("ix_agent_critique_issue_resolved", "is_resolved"),
         Index("ix_agent_critique_issue_resolved_by", "resolved_by_id"),
     )
+
+
+class AgentTranslation(Base):
+    __tablename__ = "agent_translations"
+
+    id = Column(Integer, primary_key=True)
+    assessment_id = Column(
+        Integer, ForeignKey("assessment.id", ondelete="CASCADE"), nullable=False
+    )
+    vref = Column(String(20), nullable=False)
+    version = Column(Integer, default=1, nullable=False)
+    draft_text = Column(Text, nullable=True)
+    hyper_literal_translation = Column(Text, nullable=True)
+    literal_translation = Column(Text, nullable=True)
+    english_translation = Column(Text, nullable=True)
+    created_at = Column(TIMESTAMP, default=func.now())
+
+    assessment = relationship("Assessment")
+
+    __table_args__ = (
+        Index(
+            "ix_agent_translations_unique",
+            "assessment_id",
+            "vref",
+            "version",
+            unique=True,
+        ),
+        Index("ix_agent_translations_assessment_vref", "assessment_id", "vref"),
+    )

--- a/models.py
+++ b/models.py
@@ -704,3 +704,110 @@ class RevisionChapters(BaseModel):
             }
         },
     }
+
+
+# Agent Translation models
+class AgentTranslationIn(BaseModel):
+    """Single translation input for storage."""
+
+    vref: str
+    draft_text: Optional[str] = None
+    hyper_literal_translation: Optional[str] = None
+    literal_translation: Optional[str] = None
+    english_translation: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "vref": "JHN 1:1",
+                "draft_text": "Na mwanzo kulikuwa na Neno",
+                "hyper_literal_translation": "And beginning there-was with Word",
+                "literal_translation": "In the beginning was the Word",
+                "english_translation": "In the beginning was the Word",
+            }
+        }
+    }
+
+
+class AgentTranslationStorageRequest(BaseModel):
+    """Request to store a single translation."""
+
+    assessment_id: int
+    vref: str
+    draft_text: Optional[str] = None
+    hyper_literal_translation: Optional[str] = None
+    literal_translation: Optional[str] = None
+    english_translation: Optional[str] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "assessment_id": 123,
+                "vref": "JHN 1:1",
+                "draft_text": "Na mwanzo kulikuwa na Neno",
+                "hyper_literal_translation": "And beginning there-was with Word",
+                "literal_translation": "In the beginning was the Word",
+                "english_translation": "In the beginning was the Word",
+            }
+        }
+    }
+
+
+class AgentTranslationBulkRequest(BaseModel):
+    """Request to store multiple translations in bulk."""
+
+    assessment_id: int
+    translations: List[AgentTranslationIn]
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "assessment_id": 123,
+                "translations": [
+                    {
+                        "vref": "JHN 1:1",
+                        "draft_text": "Na mwanzo kulikuwa na Neno",
+                        "hyper_literal_translation": "And beginning there-was with Word",
+                        "literal_translation": "In the beginning was the Word",
+                    },
+                    {
+                        "vref": "JHN 1:2",
+                        "draft_text": "Huyu alikuwa mwanzoni na Mungu",
+                        "hyper_literal_translation": "This-one he-was beginning with God",
+                        "literal_translation": "He was in the beginning with God",
+                    },
+                ],
+            }
+        }
+    }
+
+
+class AgentTranslationOut(BaseModel):
+    """Response model for agent translation."""
+
+    id: int
+    assessment_id: int
+    vref: str
+    version: int
+    draft_text: Optional[str] = None
+    hyper_literal_translation: Optional[str] = None
+    literal_translation: Optional[str] = None
+    english_translation: Optional[str] = None
+    created_at: Optional[datetime.datetime] = None
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "id": 1,
+                "assessment_id": 123,
+                "vref": "JHN 1:1",
+                "version": 1,
+                "draft_text": "Na mwanzo kulikuwa na Neno",
+                "hyper_literal_translation": "And beginning there-was with Word",
+                "literal_translation": "In the beginning was the Word",
+                "english_translation": "In the beginning was the Word",
+                "created_at": "2024-06-01T12:00:00",
+            }
+        },
+        "from_attributes": True,
+    }

--- a/test/test_agent_routes/test_agent_translation.py
+++ b/test/test_agent_routes/test_agent_translation.py
@@ -1,0 +1,494 @@
+# test_agent_translation.py
+"""Tests for agent translation storage API endpoints."""
+
+from database.models import AgentTranslation
+
+prefix = "v3"
+
+
+def test_add_translation_success(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test successfully adding a single translation entry."""
+    translation_data = {
+        "assessment_id": test_assessment_id,
+        "vref": "JHN 1:1",
+        "draft_text": "Na mwanzo kulikuwa na Neno",
+        "hyper_literal_translation": "And beginning there-was with Word",
+        "literal_translation": "In the beginning was the Word",
+    }
+
+    response = client.post(
+        f"{prefix}/agent/translation",
+        json=translation_data,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    assert data["assessment_id"] == test_assessment_id
+    assert data["vref"] == "JHN 1:1"
+    assert data["version"] == 1
+    assert data["draft_text"] == "Na mwanzo kulikuwa na Neno"
+    assert data["hyper_literal_translation"] == "And beginning there-was with Word"
+    assert data["literal_translation"] == "In the beginning was the Word"
+    assert data["id"] is not None
+    assert data["created_at"] is not None
+
+    # Verify in database
+    translation = (
+        db_session.query(AgentTranslation)
+        .filter(AgentTranslation.id == data["id"])
+        .first()
+    )
+    assert translation is not None
+    assert translation.vref == "JHN 1:1"
+    assert translation.version == 1
+
+
+def test_add_translation_version_auto_increment(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test that version auto-increments for same assessment+vref."""
+    translation_data = {
+        "assessment_id": test_assessment_id,
+        "vref": "JHN 1:2",
+        "draft_text": "Version 1 text",
+    }
+
+    # Add first version
+    response1 = client.post(
+        f"{prefix}/agent/translation",
+        json=translation_data,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response1.status_code == 200
+    assert response1.json()["version"] == 1
+
+    # Add second version with updated text
+    translation_data["draft_text"] = "Version 2 text"
+    response2 = client.post(
+        f"{prefix}/agent/translation",
+        json=translation_data,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response2.status_code == 200
+    assert response2.json()["version"] == 2
+
+    # Add third version
+    translation_data["draft_text"] = "Version 3 text"
+    response3 = client.post(
+        f"{prefix}/agent/translation",
+        json=translation_data,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response3.status_code == 200
+    assert response3.json()["version"] == 3
+
+
+def test_add_translation_partial_fields(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test adding translation with only some fields populated."""
+    translation_data = {
+        "assessment_id": test_assessment_id,
+        "vref": "JHN 1:3",
+        "draft_text": "Only draft text provided",
+    }
+
+    response = client.post(
+        f"{prefix}/agent/translation",
+        json=translation_data,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["draft_text"] == "Only draft text provided"
+    assert data["hyper_literal_translation"] is None
+    assert data["literal_translation"] is None
+
+
+def test_add_translation_unauthorized(client, test_assessment_id):
+    """Test that unauthorized requests are rejected."""
+    translation_data = {
+        "assessment_id": test_assessment_id,
+        "vref": "JHN 1:1",
+        "draft_text": "Test",
+    }
+
+    response = client.post(
+        f"{prefix}/agent/translation",
+        json=translation_data,
+    )
+
+    assert response.status_code == 401
+
+
+def test_add_translation_invalid_assessment(client, regular_token1):
+    """Test that invalid assessment_id returns 404."""
+    translation_data = {
+        "assessment_id": 99999,  # Non-existent assessment
+        "vref": "JHN 1:1",
+        "draft_text": "Test",
+    }
+
+    response = client.post(
+        f"{prefix}/agent/translation",
+        json=translation_data,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_add_translation_unauthorized_assessment(
+    client, regular_token2, test_assessment_id
+):
+    """Test that user cannot add translation to assessment they don't have access to."""
+    translation_data = {
+        "assessment_id": test_assessment_id,
+        "vref": "JHN 1:1",
+        "draft_text": "Test",
+    }
+
+    response = client.post(
+        f"{prefix}/agent/translation",
+        json=translation_data,
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+
+    assert response.status_code == 403
+
+
+def test_add_translations_bulk_success(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test successfully adding multiple translations in bulk."""
+    bulk_data = {
+        "assessment_id": test_assessment_id,
+        "translations": [
+            {
+                "vref": "JHN 1:4",
+                "draft_text": "Verse 4 draft",
+                "literal_translation": "Verse 4 literal",
+            },
+            {
+                "vref": "JHN 1:5",
+                "draft_text": "Verse 5 draft",
+                "hyper_literal_translation": "Verse 5 hyper-literal",
+            },
+            {
+                "vref": "JHN 1:6",
+                "draft_text": "Verse 6 draft",
+            },
+        ],
+    }
+
+    response = client.post(
+        f"{prefix}/agent/translations",
+        json=bulk_data,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+
+    # All should have the same version
+    versions = [t["version"] for t in data]
+    assert len(set(versions)) == 1  # All same version
+
+    # Check individual translations
+    vrefs = {t["vref"] for t in data}
+    assert vrefs == {"JHN 1:4", "JHN 1:5", "JHN 1:6"}
+
+
+def test_add_translations_bulk_version_increment(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test that bulk additions auto-increment version based on max existing."""
+    # First bulk upload
+    bulk_data1 = {
+        "assessment_id": test_assessment_id,
+        "translations": [
+            {"vref": "JHN 1:7", "draft_text": "Batch 1 - verse 7"},
+            {"vref": "JHN 1:8", "draft_text": "Batch 1 - verse 8"},
+        ],
+    }
+
+    response1 = client.post(
+        f"{prefix}/agent/translations",
+        json=bulk_data1,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response1.status_code == 200
+    version1 = response1.json()[0]["version"]
+
+    # Second bulk upload should have higher version
+    bulk_data2 = {
+        "assessment_id": test_assessment_id,
+        "translations": [
+            {"vref": "JHN 1:9", "draft_text": "Batch 2 - verse 9"},
+            {"vref": "JHN 1:10", "draft_text": "Batch 2 - verse 10"},
+        ],
+    }
+
+    response2 = client.post(
+        f"{prefix}/agent/translations",
+        json=bulk_data2,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response2.status_code == 200
+    version2 = response2.json()[0]["version"]
+
+    assert version2 == version1 + 1
+
+
+def test_add_translations_bulk_unauthorized(client, test_assessment_id):
+    """Test that unauthorized bulk requests are rejected."""
+    bulk_data = {
+        "assessment_id": test_assessment_id,
+        "translations": [{"vref": "JHN 1:1", "draft_text": "Test"}],
+    }
+
+    response = client.post(
+        f"{prefix}/agent/translations",
+        json=bulk_data,
+    )
+
+    assert response.status_code == 401
+
+
+def test_add_translations_bulk_invalid_assessment(client, regular_token1):
+    """Test that bulk request with invalid assessment returns 404."""
+    bulk_data = {
+        "assessment_id": 99999,
+        "translations": [{"vref": "JHN 1:1", "draft_text": "Test"}],
+    }
+
+    response = client.post(
+        f"{prefix}/agent/translations",
+        json=bulk_data,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_get_translations_success(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test getting translations for an assessment."""
+    # First add some translations
+    for i in range(11, 14):
+        client.post(
+            f"{prefix}/agent/translation",
+            json={
+                "assessment_id": test_assessment_id,
+                "vref": f"JHN 1:{i}",
+                "draft_text": f"Verse {i} draft",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    # Get translations
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 3
+
+    # Check that our added verses are present
+    vrefs = {t["vref"] for t in data}
+    assert "JHN 1:11" in vrefs
+    assert "JHN 1:12" in vrefs
+    assert "JHN 1:13" in vrefs
+
+
+def test_get_translations_filter_by_vref(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test filtering translations by specific vref."""
+    # Add a translation
+    client.post(
+        f"{prefix}/agent/translation",
+        json={
+            "assessment_id": test_assessment_id,
+            "vref": "JHN 1:14",
+            "draft_text": "Specific verse",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    # Get by specific vref
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&vref=JHN 1:14",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 1
+    assert all(t["vref"] == "JHN 1:14" for t in data)
+
+
+def test_get_translations_latest_only_default(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test that by default only latest version per vref is returned."""
+    # Add multiple versions of the same verse
+    vref = "JHN 1:15"
+    for i in range(3):
+        client.post(
+            f"{prefix}/agent/translation",
+            json={
+                "assessment_id": test_assessment_id,
+                "vref": vref,
+                "draft_text": f"Version {i + 1}",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    # Get without all_versions (should return only latest)
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&vref={vref}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["version"] == 3
+    assert data[0]["draft_text"] == "Version 3"
+
+
+def test_get_translations_all_versions(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test getting all versions when all_versions=true."""
+    # Add multiple versions of the same verse
+    vref = "JHN 1:16"
+    for i in range(3):
+        client.post(
+            f"{prefix}/agent/translation",
+            json={
+                "assessment_id": test_assessment_id,
+                "vref": vref,
+                "draft_text": f"Version {i + 1}",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    # Get with all_versions=true
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&vref={vref}&all_versions=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 3
+
+    # Check we have all versions
+    versions = sorted([t["version"] for t in data])
+    assert versions == [1, 2, 3]
+
+
+def test_get_translations_specific_version(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test filtering by specific version number."""
+    # Add multiple versions
+    vref = "JHN 1:17"
+    for i in range(3):
+        client.post(
+            f"{prefix}/agent/translation",
+            json={
+                "assessment_id": test_assessment_id,
+                "vref": vref,
+                "draft_text": f"Version {i + 1}",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    # Get specific version
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&vref={vref}&version=2",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["version"] == 2
+    assert data[0]["draft_text"] == "Version 2"
+
+
+def test_get_translations_verse_range(
+    client, regular_token1, test_assessment_id, db_session
+):
+    """Test filtering by verse range."""
+    # Add translations for a range of verses
+    for i in range(18, 22):
+        client.post(
+            f"{prefix}/agent/translation",
+            json={
+                "assessment_id": test_assessment_id,
+                "vref": f"JHN 1:{i}",
+                "draft_text": f"Verse {i}",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    # Get verse range (19-20)
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&first_vref=JHN 1:19&last_vref=JHN 1:20",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Should only include verses 19 and 20
+    vrefs = [t["vref"] for t in data]
+    assert "JHN 1:19" in vrefs
+    assert "JHN 1:20" in vrefs
+    assert "JHN 1:18" not in vrefs
+    assert "JHN 1:21" not in vrefs
+
+
+def test_get_translations_unauthorized(client, test_assessment_id):
+    """Test that unauthorized GET requests are rejected."""
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}",
+    )
+
+    assert response.status_code == 401
+
+
+def test_get_translations_invalid_assessment(client, regular_token1):
+    """Test that invalid assessment_id returns 404."""
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id=99999",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_get_translations_unauthorized_assessment(
+    client, regular_token2, test_assessment_id
+):
+    """Test that user cannot get translations from assessment they don't have access to."""
+    response = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}",
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Summary
- Add endpoints to store and retrieve agent-generated literal/hyper-literal back-translations per verse with version tracking for re-runs
- POST `/v3/agent/translation` - Store single translation with auto-versioning per assessment+vref
- POST `/v3/agent/translations` - Bulk store with same version assignment for all translations in request
- GET `/v3/agent/translations` - Retrieve with filtering by vref, version, verse range, and all_versions flag

## Changes
- **Database model**: `AgentTranslation` class with unique index on (assessment_id, vref, version)
- **Alembic migration**: Creates `agent_translations` table with CASCADE delete on assessment FK
- **Pydantic models**: `AgentTranslationIn`, `AgentTranslationStorageRequest`, `AgentTranslationBulkRequest`, `AgentTranslationOut`
- **API endpoints**: 3 new endpoints with authorization checks via `is_user_authorized_for_assessment`
- **Tests**: Comprehensive test coverage in `test_agent_translation.py`

## Test plan
- [ ] Run `alembic upgrade head` to apply migration
- [ ] Run `pytest test/test_agent_routes/test_agent_translation.py -v`
- [ ] Manual test via curl/httpie:
  ```bash
  # POST single
  http POST localhost:8000/v3/agent/translation assessment_id:=1 vref="JHN 1:1" draft_text="test"
  
  # GET
  http GET "localhost:8000/v3/agent/translations?assessment_id=1"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)