### PR TITLE
Remove deprecated include_all_matches parameter

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1091,7 +1091,6 @@ async def get_lexeme_cards(
     source_word: str = None,
     target_word: str = None,
     pos: str = None,
-    include_all_matches: bool = False,
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -1109,9 +1108,6 @@ async def get_lexeme_cards(
     - target_word: str (optional) - Filter by target_lemma or surface_forms
       (case-insensitive exact match)
     - pos: str (optional) - Filter by part of speech
-    - include_all_matches: bool (deprecated, no effect) - Kept for backward
-      compatibility. Both source_word and target_word now always search lemma
-      and surface forms.
 
     Returns:
     - List[LexemeCardOut]: List of matching lexeme cards, ordered by confidence (descending).

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -2626,7 +2626,7 @@ def test_get_lexeme_cards_source_word_matches_source_surface_forms(
 def test_get_lexeme_cards_target_word_matches_target_lemma_without_flag(
     client, regular_token1, db_session, test_revision_id
 ):
-    """Test that target_word=upendo_nf finds card with target_lemma='upendo_nf' without include_all_matches."""
+    """Test that target_word=upendo_nf finds card with target_lemma='upendo_nf'."""
     client.post(
         f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -2639,7 +2639,7 @@ def test_get_lexeme_cards_target_word_matches_target_lemma_without_flag(
         },
     )
 
-    # No include_all_matches param — should still find by target_lemma
+    # Should find by target_lemma
     response = client.get(
         "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=upendo_nf",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -2703,43 +2703,6 @@ def test_get_lexeme_cards_source_word_case_insensitive_lemma(
     data = response.json()
     card = next((c for c in data if c["target_lemma"] == "upendo_ci2"), None)
     assert card is not None
-
-
-def test_get_lexeme_cards_include_all_matches_ignored(
-    client, regular_token1, db_session, test_revision_id
-):
-    """Test that include_all_matches=true and include_all_matches=false produce identical results."""
-    client.post(
-        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "source_lemma": "ignore_flag_test",
-            "target_lemma": "kupuuza_flag",
-            "source_language": "eng",
-            "target_language": "swh",
-            "surface_forms": ["kupuuza_flag_sf"],
-            "confidence": 0.80,
-        },
-    )
-
-    response_true = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=kupuuza_flag&include_all_matches=true",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-    )
-    response_false = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=kupuuza_flag&include_all_matches=false",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-    )
-
-    assert response_true.status_code == 200
-    assert response_false.status_code == 200
-    data_true = response_true.json()
-    data_false = response_false.json()
-    # Both should return the same cards
-    assert len(data_true) == len(data_false)
-    ids_true = sorted(c["id"] for c in data_true)
-    ids_false = sorted(c["id"] for c in data_false)
-    assert ids_true == ids_false
 
 
 def test_get_lexeme_cards_no_example_text_search(
@@ -4673,7 +4636,7 @@ def test_get_lexeme_cards_includes_last_user_edit(
     )
 
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=upepo_lue_test_get&include_all_matches=true",
+        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=upepo_lue_test_get",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- Remove the `include_all_matches` query parameter from `GET /v3/agent/lexeme-card` — it was already deprecated and had no effect on behavior
- Delete the `test_get_lexeme_cards_include_all_matches_ignored` test that validated the no-op parameter
- Clean up references in remaining tests and docstrings

## Test plan
- [x] All 75 lexeme card tests pass locally
- [ ] Verify no client code still passes `include_all_matches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)