### PR TITLE
Move logger.info call outside results formatting loop

### DIFF
--- a/review_routes/v3/results_routes.py
+++ b/review_routes/v3/results_routes.py
@@ -620,7 +620,8 @@ async def get_result(
             hide=row.hide if hasattr(row, "hide") else None,
         )
         result_list.append(result_obj)
-        logger.info(f"⏱️ Result formatting: {time.perf_counter() - start:.2f}s")
+
+    logger.info(f"⏱️ Result formatting: {time.perf_counter() - start:.2f}s")
 
     return {"results": result_list, "total_count": total_count}
 


### PR DESCRIPTION
## Summary
- The timing log at line 623 was inside the `for row in result_data` loop, causing a `logger.info()` call on every iteration — potentially thousands of times per request
- Each call triggers a synchronous HTTP POST to Loki (via `LokiHandler`), making the endpoint extremely slow
- Moved the log call after the loop so it logs once per request

## Note
The underlying issue — `LokiHandler.emit()` using synchronous `requests.post()` — should also be addressed in the [observability-library](https://github.com/sil-ai/observability-library) repo to prevent similar problems elsewhere.

## Test plan
- [ ] Verify get_result endpoint returns results in reasonable time with Loki enabled
- [ ] Confirm timing log still appears once per request in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)