### PR TITLE
Add structured endpoint logging with method, path, and params

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -107,7 +107,8 @@ async def add_word_alignment(
             extra={
                 "method": "POST",
                 "path": "/agent/word-alignment",
-                "revision_id": getattr(alignment, "revision_id", None),
+                "source_language": alignment.source_language,
+                "target_language": alignment.target_language,
                 "duration_s": duration,
             },
         )
@@ -164,83 +165,66 @@ async def add_word_alignments_bulk(
         from sqlalchemy.dialects.postgresql import insert
         from sqlalchemy.sql import func
 
-        if not request.alignments:
-            duration = round(time.perf_counter() - request_start, 2)
-            logger.info(
-                f"add_word_alignments_bulk completed in {duration}s",
-                extra={
-                    "method": "POST",
-                    "path": "/agent/word-alignment/bulk",
-                    "alignment_count": 0,
-                    "duration_s": duration,
+        result_list = []
+
+        if request.alignments:
+            # Prepare records for bulk upsert
+            records = [
+                {
+                    "source_word": item.source_word,
+                    "target_word": item.target_word,
+                    "source_language": request.source_language,
+                    "target_language": request.target_language,
+                    "score": item.score,
+                    "is_human_verified": item.is_human_verified,
+                }
+                for item in request.alignments
+            ]
+
+            # Use INSERT...ON CONFLICT DO UPDATE for atomic upsert
+            insert_stmt = insert(AgentWordAlignment).values(records)
+
+            upsert_stmt = insert_stmt.on_conflict_do_update(
+                index_elements=[
+                    "source_language",
+                    "target_language",
+                    "source_word",
+                    "target_word",
+                ],
+                set_={
+                    "score": insert_stmt.excluded.score,
+                    "is_human_verified": insert_stmt.excluded.is_human_verified,
+                    "last_updated": func.now(),
                 },
-            )
-            return []
+            ).returning(AgentWordAlignment.id)
 
-        # Prepare records for bulk upsert
-        records = [
-            {
-                "source_word": item.source_word,
-                "target_word": item.target_word,
-                "source_language": request.source_language,
-                "target_language": request.target_language,
-                "score": item.score,
-                "is_human_verified": item.is_human_verified,
-            }
-            for item in request.alignments
-        ]
+            result = await db.execute(upsert_stmt)
+            await db.commit()
 
-        # Use INSERT...ON CONFLICT DO UPDATE for atomic upsert
-        insert_stmt = insert(AgentWordAlignment).values(records)
-
-        upsert_stmt = insert_stmt.on_conflict_do_update(
-            index_elements=[
-                "source_language",
-                "target_language",
-                "source_word",
-                "target_word",
-            ],
-            set_={
-                "score": insert_stmt.excluded.score,
-                "is_human_verified": insert_stmt.excluded.is_human_verified,
-                "last_updated": func.now(),
-            },
-        ).returning(AgentWordAlignment.id)
-
-        result = await db.execute(upsert_stmt)
-        await db.commit()
-
-        # Fetch complete records by IDs
-        affected_ids = [row[0] for row in result.fetchall()]
-        if affected_ids:
-            fetch_result = await db.execute(
-                select(AgentWordAlignment).where(
-                    AgentWordAlignment.id.in_(affected_ids)
+            # Fetch complete records by IDs
+            affected_ids = [row[0] for row in result.fetchall()]
+            if affected_ids:
+                fetch_result = await db.execute(
+                    select(AgentWordAlignment).where(
+                        AgentWordAlignment.id.in_(affected_ids)
+                    )
                 )
-            )
-            alignments = fetch_result.scalars().all()
-            duration = round(time.perf_counter() - request_start, 2)
-            logger.info(
-                f"add_word_alignments_bulk completed in {duration}s",
-                extra={
-                    "method": "POST",
-                    "path": "/agent/word-alignment/bulk",
-                    "alignment_count": len(alignments),
-                    "duration_s": duration,
-                },
-            )
-            return [AgentWordAlignmentOut.model_validate(a) for a in alignments]
+                alignments = fetch_result.scalars().all()
+                result_list = [
+                    AgentWordAlignmentOut.model_validate(a) for a in alignments
+                ]
+
         duration = round(time.perf_counter() - request_start, 2)
         logger.info(
             f"add_word_alignments_bulk completed in {duration}s",
             extra={
                 "method": "POST",
                 "path": "/agent/word-alignment/bulk",
-                "alignment_count": 0,
+                "alignment_count": len(result_list),
                 "duration_s": duration,
             },
         )
-        return []
+        return result_list
 
     except SQLAlchemyError as e:
         await db.rollback()
@@ -1061,7 +1045,7 @@ async def patch_lexeme_card_by_id(
             f"patch_lexeme_card_by_id completed in {duration}s",
             extra={
                 "method": "PATCH",
-                "path": "/agent/lexeme-card/{card_id}",
+                "path": "/agent/lexeme-card",
                 "card_id": card_id,
                 "duration_s": duration,
             },
@@ -2001,7 +1985,7 @@ async def resolve_critique_issue(
             f"resolve_critique_issue completed in {duration}s",
             extra={
                 "method": "PATCH",
-                "path": "/agent/critique/{issue_id}/resolve",
+                "path": "/agent/critique/resolve",
                 "issue_id": issue_id,
                 "duration_s": duration,
             },
@@ -2079,7 +2063,7 @@ async def unresolve_critique_issue(
             f"unresolve_critique_issue completed in {duration}s",
             extra={
                 "method": "PATCH",
-                "path": "/agent/critique/{issue_id}/unresolve",
+                "path": "/agent/critique/unresolve",
                 "issue_id": issue_id,
                 "duration_s": duration,
             },

--- a/review_routes/v3/results_routes.py
+++ b/review_routes/v3/results_routes.py
@@ -1055,6 +1055,19 @@ async def compare_text_lengths(
 
     # Handle empty results
     if df_revision.empty or df_reference.empty:
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"compare_text_lengths completed in {duration}s (empty input)",
+            extra={
+                "method": "GET",
+                "path": "/compare_text_lengths",
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "total_count": 0,
+                "results_returned": 0,
+                "duration_s": duration,
+            },
+        )
         return {"results": [], "total_count": 0}
 
     # Determine merge strategy based on aggregation type
@@ -1092,6 +1105,19 @@ async def compare_text_lengths(
 
     # Handle empty merge result
     if merged_df.empty:
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"compare_text_lengths completed in {duration}s (empty merge)",
+            extra={
+                "method": "GET",
+                "path": "/compare_text_lengths",
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "total_count": 0,
+                "results_returned": 0,
+                "duration_s": duration,
+            },
+        )
         return {"results": [], "total_count": 0}
 
     # For verse-level data (no aggregation), apply verse range merging
@@ -2000,7 +2026,7 @@ async def get_alignment_scores(
             "page": page,
             "page_size": page_size,
             "total_count": total_count,
-            "results_returned": len(result_data),
+            "results_returned": len(result_list),
             "duration_s": duration,
         },
     )

--- a/review_routes/v3/search_routes.py
+++ b/review_routes/v3/search_routes.py
@@ -194,7 +194,15 @@ async def search_revision_text(
         return {"results": filtered_results, "total_count": len(filtered_results)}
 
     except Exception as e:
-        logger.error(f"Error in text search: {str(e)}")
+        logger.error(
+            f"Error in text search: {str(e)}",
+            extra={
+                "method": "GET",
+                "path": "/textsearch",
+                "revision_id": revision_id,
+                "term": term,
+            },
+        )
         raise HTTPException(
             status_code=500,
             detail=f"Error searching text: {str(e)}",


### PR DESCRIPTION
## Summary
- Replace granular per-step timing logs in results routes with a single structured summary log per request
- Add consistent endpoint logging to all agent routes (17 endpoints)
- Each log includes HTTP method, route path, relevant query/path parameters, result counts, and total duration
- Fix broken `logger.info("Assessment ID:", assessment_id)` call in ngrams endpoint (logger.info doesn't concatenate like print)

## Test plan
- [ ] Verify all endpoints still return correct responses
- [ ] Confirm structured logs appear in console/Loki with expected fields
- [ ] Check that no logs are emitted inside loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)