### PR TITLE
Parse runner error detail for user-facing messages

### DIFF
--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -333,7 +333,9 @@ async def add_assessment(
             await db.commit()
         except SQLAlchemyError as e:
             await db.rollback()
-            logger.error(f"Failed to delete assessment {assessment.id} after runner error: {e}")
+            logger.error(
+                f"Failed to delete assessment {assessment.id} after runner error: {e}"
+            )
         raise HTTPException(status_code=response.status_code, detail=error_detail)
 
     return [AssessmentOut.model_validate(assessment)]


### PR DESCRIPTION
## Summary
- When the runner returns a non-2xx response (e.g., 422 validation error), extract the `detail` field from its JSON body instead of passing the raw JSON string as the error message
- Companion to sil-ai/aqua-assessments PR that adds input validation for agent assessments

## Test plan
- [ ] Submit an agent assessment with a multi-chapter range — should get a clean 422 error message, not double-wrapped JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)