### PR TITLE
Move first_vref/last_vref to kwargs, remove unused train

### DIFF
--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -345,9 +345,23 @@ async def add_assessment(
             completed_stmt = completed_stmt.where(
                 Assessment.kwargs.op("@>")({"first_vref": parsed_kwargs["first_vref"]})
             )
+        else:
+            completed_stmt = completed_stmt.where(
+                or_(
+                    Assessment.kwargs.is_(None),
+                    ~Assessment.kwargs.has_key("first_vref"),
+                )
+            )
         if parsed_kwargs and parsed_kwargs.get("last_vref"):
             completed_stmt = completed_stmt.where(
                 Assessment.kwargs.op("@>")({"last_vref": parsed_kwargs["last_vref"]})
+            )
+        else:
+            completed_stmt = completed_stmt.where(
+                or_(
+                    Assessment.kwargs.is_(None),
+                    ~Assessment.kwargs.has_key("last_vref"),
+                )
             )
         result = await db.execute(completed_stmt)
         existing = result.scalars().first()
@@ -399,9 +413,23 @@ async def add_assessment(
             stmt = stmt.where(
                 Assessment.kwargs.op("@>")({"first_vref": parsed_kwargs["first_vref"]})
             )
+        else:
+            stmt = stmt.where(
+                or_(
+                    Assessment.kwargs.is_(None),
+                    ~Assessment.kwargs.has_key("first_vref"),
+                )
+            )
         if parsed_kwargs and parsed_kwargs.get("last_vref"):
             stmt = stmt.where(
                 Assessment.kwargs.op("@>")({"last_vref": parsed_kwargs["last_vref"]})
+            )
+        else:
+            stmt = stmt.where(
+                or_(
+                    Assessment.kwargs.is_(None),
+                    ~Assessment.kwargs.has_key("last_vref"),
+                )
             )
         result = await db.execute(stmt)
         existing_id = result.scalars().first()

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -197,6 +197,12 @@ async def call_assessment_runner(
         "runner", "run_assessment_runner", environment_name=modal_env
     )
     config = assessment.model_dump()
+    # Backward compat: copy vref range from kwargs to top-level so the
+    # runner (separate repo) can read them at either location.
+    if config.get("kwargs"):
+        for key in ("first_vref", "last_vref"):
+            if key in config["kwargs"]:
+                config[key] = config["kwargs"][key]
     config["return_all_results"] = return_all_results
     await f.spawn.aio(config, os.getenv("AQUA_DB", ""))
 
@@ -334,6 +340,15 @@ async def add_assessment(
                     ~Assessment.kwargs.op("@>")({"use_eflomal": True}),
                 )
             )
+        # Distinguish by verse range
+        if parsed_kwargs and parsed_kwargs.get("first_vref"):
+            completed_stmt = completed_stmt.where(
+                Assessment.kwargs.op("@>")({"first_vref": parsed_kwargs["first_vref"]})
+            )
+        if parsed_kwargs and parsed_kwargs.get("last_vref"):
+            completed_stmt = completed_stmt.where(
+                Assessment.kwargs.op("@>")({"last_vref": parsed_kwargs["last_vref"]})
+            )
         result = await db.execute(completed_stmt)
         existing = result.scalars().first()
         if existing is not None:
@@ -378,6 +393,15 @@ async def add_assessment(
                     Assessment.kwargs.is_(None),
                     ~Assessment.kwargs.op("@>")({"use_eflomal": True}),
                 )
+            )
+        # Distinguish by verse range
+        if parsed_kwargs and parsed_kwargs.get("first_vref"):
+            stmt = stmt.where(
+                Assessment.kwargs.op("@>")({"first_vref": parsed_kwargs["first_vref"]})
+            )
+        if parsed_kwargs and parsed_kwargs.get("last_vref"):
+            stmt = stmt.where(
+                Assessment.kwargs.op("@>")({"last_vref": parsed_kwargs["last_vref"]})
             )
         result = await db.execute(stmt)
         existing_id = result.scalars().first()

--- a/models.py
+++ b/models.py
@@ -238,11 +238,8 @@ class AssessmentIn(BaseModel):
     revision_id: int
     reference_id: Optional[int] = None
     type: AssessmentType
-    train: Optional[bool] = None
     source_language: Optional[str] = None
     target_language: Optional[str] = None
-    first_vref: Optional[str] = None
-    last_vref: Optional[str] = None
     kwargs: Optional[Dict[str, Any]] = None
 
     @field_validator("kwargs")

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -513,10 +513,10 @@ def test_duplicate_assessment_different_type_allowed(
         assert second.status_code == 200
 
 
-def test_duplicate_assessment_different_kwargs_blocked(
+def test_duplicate_in_progress_different_kwargs_blocked(
     client, regular_token1, db_session, test_db_session
 ):
-    """Different kwargs on same assessment type should still trigger 409."""
+    """In-progress check ignores kwargs differences (only vref range matters)."""
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
 
@@ -831,6 +831,147 @@ def test_completed_assessment_different_kwargs_blocked(
         )
         assert second.status_code == 409
         assert str(first_id) in second.json()["detail"]
+
+
+def test_completed_assessment_different_vref_allowed(
+    client, regular_token1, db_session, test_db_session
+):
+    """Completed assessment with different verse range should not block."""
+    from datetime import datetime
+
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+
+        first = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"first_vref": "GEN 1:1", "last_vref": "GEN 5:32"}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert first.status_code == 200
+        first_id = first.json()[0]["id"]
+
+        # Mark as finished
+        assessment = (
+            db_session.query(Assessment).filter(Assessment.id == first_id).first()
+        )
+        assessment.status = "finished"
+        assessment.end_time = datetime.now()
+        db_session.commit()
+
+        # Different verse range should succeed
+        second = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"first_vref": "GEN 6:1", "last_vref": "GEN 10:32"}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert second.status_code == 200
+
+
+def test_completed_assessment_same_vref_blocked(
+    client, regular_token1, db_session, test_db_session
+):
+    """Completed assessment with same verse range should block (409)."""
+    from datetime import datetime
+
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+
+        first = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"first_vref": "GEN 1:1", "last_vref": "GEN 5:32"}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert first.status_code == 200
+        first_id = first.json()[0]["id"]
+
+        # Mark as finished
+        assessment = (
+            db_session.query(Assessment).filter(Assessment.id == first_id).first()
+        )
+        assessment.status = "finished"
+        assessment.end_time = datetime.now()
+        db_session.commit()
+
+        # Same verse range should be blocked
+        second = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"first_vref": "GEN 1:1", "last_vref": "GEN 5:32"}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert second.status_code == 409
+        assert str(first_id) in second.json()["detail"]
+
+
+def test_completed_assessment_no_vref_not_blocked_by_vref(
+    client, regular_token1, db_session, test_db_session
+):
+    """Full-Bible run (no vref) should not be blocked by a partial-range assessment."""
+    from datetime import datetime
+
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+
+        first = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"first_vref": "GEN 1:1", "last_vref": "GEN 5:32"}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert first.status_code == 200
+        first_id = first.json()[0]["id"]
+
+        # Mark as finished
+        assessment = (
+            db_session.query(Assessment).filter(Assessment.id == first_id).first()
+        )
+        assessment.status = "finished"
+        assessment.end_time = datetime.now()
+        db_session.commit()
+
+        # Full-Bible run (no vref) should not be blocked
+        second = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert second.status_code == 200
 
 
 def test_completed_assessment_admin_also_blocked(

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -516,7 +516,7 @@ def test_duplicate_assessment_different_type_allowed(
 def test_duplicate_in_progress_different_kwargs_blocked(
     client, regular_token1, db_session, test_db_session
 ):
-    """In-progress check ignores kwargs differences (only vref range matters)."""
+    """In-progress check blocks same type+revision regardless of non-dedup kwargs like top_k."""
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
 
@@ -619,6 +619,42 @@ def test_duplicate_assessment_running_returns_409(
         )
         assert second.status_code == 409
         assert str(first_id) in second.json()["detail"]
+
+
+def test_in_progress_different_vref_allowed(
+    client, regular_token1, db_session, test_db_session
+):
+    """In-progress assessment with different verse range should not block."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+
+        first = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"first_vref": "GEN 1:1", "last_vref": "GEN 5:32"}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert first.status_code == 200
+
+        # Different verse range should succeed even while first is in-progress
+        second = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"first_vref": "GEN 6:1", "last_vref": "GEN 10:32"}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert second.status_code == 200
 
 
 def test_duplicate_assessment_admin_bypass(


### PR DESCRIPTION
## Summary
- Remove `train`, `first_vref`, `last_vref` from `AssessmentIn` top-level fields
- Users now pass `first_vref`/`last_vref` via `extra_kwargs` JSON parameter
- Both duplicate checks (completed + in-progress) now include `first_vref`/`last_vref` from kwargs, fixing false 409s when running the same assessment type with different verse ranges
- Backward compat shim copies vref keys to top-level config for the Modal runner during transition

**Prerequisite:** Modal runner must be updated to read `first_vref`/`last_vref` from `config["kwargs"]` before deploying this.

## Test plan
- [x] All 113 assessment route tests pass
- [ ] Verify assessments with different `first_vref`/`last_vref` kwargs are not blocked as duplicates
- [ ] Verify identical assessments are still blocked (409)
- [ ] Verify `force=true` still bypasses the completed check

🤖 Generated with [Claude Code](https://claude.com/claude-code)