### PR TITLE
Fix 500 on duplicate lexeme card examples

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -512,6 +512,7 @@ async def add_lexeme_card(
     request_start = time.perf_counter()
     try:
         from sqlalchemy import delete, select
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
         from sqlalchemy.sql import func
 
         # Sort alignment_scores by value in descending order (highest scores first)
@@ -570,15 +571,30 @@ async def add_lexeme_card(
                     )
                     await db.execute(delete_query)
 
-                    # Add new examples
-                    for example in card.examples:
-                        example_obj = AgentLexemeCardExample(
-                            lexeme_card_id=existing_card.id,
-                            revision_id=revision_id,
-                            source_text=example.get("source", ""),
-                            target_text=example.get("target", ""),
+                    # Add new examples; ON CONFLICT DO NOTHING silently skips any
+                    # duplicate (source_text, target_text) pairs within the payload.
+                    example_records = [
+                        {
+                            "lexeme_card_id": existing_card.id,
+                            "revision_id": revision_id,
+                            "source_text": example.get("source", ""),
+                            "target_text": example.get("target", ""),
+                        }
+                        for example in card.examples
+                    ]
+                    if example_records:
+                        await db.execute(
+                            pg_insert(AgentLexemeCardExample)
+                            .values(example_records)
+                            .on_conflict_do_nothing(
+                                index_elements=[
+                                    "lexeme_card_id",
+                                    "revision_id",
+                                    "source_text",
+                                    "target_text",
+                                ],
+                            )
                         )
-                        db.add(example_obj)
                 else:
                     # If examples is None and replace_existing=True, remove this revision's examples
                     delete_query = delete(AgentLexemeCardExample).where(
@@ -608,17 +624,33 @@ async def add_lexeme_card(
                     existing_senses = existing_card.senses or []
                     existing_card.senses = existing_senses + card.senses
 
-                # For examples: append to this revision_id's examples
-                # The unique index will prevent duplicate examples automatically
+                # For examples: append to this revision_id's examples.
+                # Use ON CONFLICT DO NOTHING so duplicates (already inserted for
+                # the same lexeme_card / revision / source / target) are silently
+                # skipped instead of raising IntegrityError.
                 if card.examples:
-                    for example in card.examples:
-                        example_obj = AgentLexemeCardExample(
-                            lexeme_card_id=existing_card.id,
-                            revision_id=revision_id,
-                            source_text=example.get("source", ""),
-                            target_text=example.get("target", ""),
+                    example_records = [
+                        {
+                            "lexeme_card_id": existing_card.id,
+                            "revision_id": revision_id,
+                            "source_text": example.get("source", ""),
+                            "target_text": example.get("target", ""),
+                        }
+                        for example in card.examples
+                    ]
+                    if example_records:
+                        await db.execute(
+                            pg_insert(AgentLexemeCardExample)
+                            .values(example_records)
+                            .on_conflict_do_nothing(
+                                index_elements=[
+                                    "lexeme_card_id",
+                                    "revision_id",
+                                    "source_text",
+                                    "target_text",
+                                ],
+                            )
                         )
-                        db.add(example_obj)
 
             await db.commit()
             await db.refresh(existing_card)
@@ -691,16 +723,31 @@ async def add_lexeme_card(
             db.add(lexeme_card)
             await db.flush()  # Flush to get the ID before adding examples
 
-            # Add examples to the separate table
+            # Add examples to the separate table. Use ON CONFLICT DO NOTHING to
+            # tolerate duplicate (source_text, target_text) entries in the payload.
             if card.examples:
-                for example in card.examples:
-                    example_obj = AgentLexemeCardExample(
-                        lexeme_card_id=lexeme_card.id,
-                        revision_id=revision_id,
-                        source_text=example.get("source", ""),
-                        target_text=example.get("target", ""),
+                example_records = [
+                    {
+                        "lexeme_card_id": lexeme_card.id,
+                        "revision_id": revision_id,
+                        "source_text": example.get("source", ""),
+                        "target_text": example.get("target", ""),
+                    }
+                    for example in card.examples
+                ]
+                if example_records:
+                    await db.execute(
+                        pg_insert(AgentLexemeCardExample)
+                        .values(example_records)
+                        .on_conflict_do_nothing(
+                            index_elements=[
+                                "lexeme_card_id",
+                                "revision_id",
+                                "source_text",
+                                "target_text",
+                            ],
+                        )
                     )
-                    db.add(example_obj)
 
             await db.commit()
             await db.refresh(lexeme_card)
@@ -804,6 +851,7 @@ async def _apply_lexeme_card_patch(
 ) -> LexemeCardOut:
     """Apply patch data to a lexeme card and return the updated card."""
     from sqlalchemy import delete, select
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
     from sqlalchemy.sql import func
 
     provided_fields = patch_data.model_fields_set
@@ -924,15 +972,31 @@ async def _apply_lexeme_card_patch(
                 )
                 await db.execute(delete_query)
 
-            # Add new examples
-            for example in examples:
-                example_obj = AgentLexemeCardExample(
-                    lexeme_card_id=card.id,
-                    revision_id=revision_id,
-                    source_text=example.get("source", ""),
-                    target_text=example.get("target", ""),
+            # Add new examples. Use ON CONFLICT DO NOTHING so duplicates (either
+            # within the payload, or colliding with pre-existing rows in the
+            # append/merge case) are silently skipped instead of raising 500.
+            example_records = [
+                {
+                    "lexeme_card_id": card.id,
+                    "revision_id": revision_id,
+                    "source_text": example.get("source", ""),
+                    "target_text": example.get("target", ""),
+                }
+                for example in examples
+            ]
+            if example_records:
+                await db.execute(
+                    pg_insert(AgentLexemeCardExample)
+                    .values(example_records)
+                    .on_conflict_do_nothing(
+                        index_elements=[
+                            "lexeme_card_id",
+                            "revision_id",
+                            "source_text",
+                            "target_text",
+                        ],
+                    )
                 )
-                db.add(example_obj)
 
     # Update last_updated timestamp
     card.last_updated = func.now()

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -584,16 +584,9 @@ async def add_lexeme_card(
                     ]
                     if example_records:
                         await db.execute(
-                            pg_insert(AgentLexemeCardExample)
-                            .values(example_records)
-                            .on_conflict_do_nothing(
-                                index_elements=[
-                                    "lexeme_card_id",
-                                    "revision_id",
-                                    "source_text",
-                                    "target_text",
-                                ],
-                            )
+                            pg_insert(AgentLexemeCardExample).values(example_records)
+                            # Relies on ix_agent_lexeme_card_examples_unique
+                            .on_conflict_do_nothing()
                         )
                 else:
                     # If examples is None and replace_existing=True, remove this revision's examples
@@ -638,19 +631,11 @@ async def add_lexeme_card(
                         }
                         for example in card.examples
                     ]
-                    if example_records:
-                        await db.execute(
-                            pg_insert(AgentLexemeCardExample)
-                            .values(example_records)
-                            .on_conflict_do_nothing(
-                                index_elements=[
-                                    "lexeme_card_id",
-                                    "revision_id",
-                                    "source_text",
-                                    "target_text",
-                                ],
-                            )
-                        )
+                    await db.execute(
+                        pg_insert(AgentLexemeCardExample).values(example_records)
+                        # Relies on ix_agent_lexeme_card_examples_unique
+                        .on_conflict_do_nothing()
+                    )
 
             await db.commit()
             await db.refresh(existing_card)
@@ -735,19 +720,11 @@ async def add_lexeme_card(
                     }
                     for example in card.examples
                 ]
-                if example_records:
-                    await db.execute(
-                        pg_insert(AgentLexemeCardExample)
-                        .values(example_records)
-                        .on_conflict_do_nothing(
-                            index_elements=[
-                                "lexeme_card_id",
-                                "revision_id",
-                                "source_text",
-                                "target_text",
-                            ],
-                        )
-                    )
+                await db.execute(
+                    pg_insert(AgentLexemeCardExample).values(example_records)
+                    # Relies on ix_agent_lexeme_card_examples_unique
+                    .on_conflict_do_nothing()
+                )
 
             await db.commit()
             await db.refresh(lexeme_card)
@@ -984,19 +961,11 @@ async def _apply_lexeme_card_patch(
                 }
                 for example in examples
             ]
-            if example_records:
-                await db.execute(
-                    pg_insert(AgentLexemeCardExample)
-                    .values(example_records)
-                    .on_conflict_do_nothing(
-                        index_elements=[
-                            "lexeme_card_id",
-                            "revision_id",
-                            "source_text",
-                            "target_text",
-                        ],
-                    )
-                )
+            await db.execute(
+                pg_insert(AgentLexemeCardExample).values(example_records)
+                # Relies on ix_agent_lexeme_card_examples_unique
+                .on_conflict_do_nothing()
+            )
 
     # Update last_updated timestamp
     card.last_updated = func.now()

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1656,7 +1656,13 @@ def test_add_lexeme_card_upsert_append_duplicate_examples_no_500(
     assert response3.status_code == 200
     data3 = response3.json()
     example_pairs = {(e["source"], e["target"]) for e in data3["examples"]}
-    assert ("She runs", "Anakimbia") in example_pairs
+    assert len(data3["examples"]) == 4
+    assert example_pairs == {
+        ("I run", "Nakimbia"),
+        ("We run", "Tunakimbia"),
+        ("They run", "Wanakimbia"),
+        ("She runs", "Anakimbia"),
+    }
 
 
 def test_add_lexeme_card_upsert_append_explicit(

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1566,6 +1566,72 @@ def test_add_lexeme_card_upsert_append_default(
     assert data2["confidence"] == 0.90
 
 
+def test_add_lexeme_card_upsert_append_duplicate_examples_no_500(
+    client, regular_token1, db_session, test_revision_id
+):
+    """Regression for #517: appending examples that already exist for the same
+    (lexeme_card_id, revision_id, source_text, target_text) must not 500 on the
+    unique constraint — duplicates should be silently skipped."""
+    payload = {
+        "source_lemma": "run",
+        "target_lemma": "kimbia",
+        "source_language": "eng",
+        "target_language": "swh",
+        "pos": "verb",
+        "surface_forms": ["kimbia"],
+        "examples": [
+            {"source": "I run", "target": "Nakimbia"},
+            {"source": "We run", "target": "Tunakimbia"},
+        ],
+    }
+
+    # First POST creates the card and inserts the two examples.
+    response1 = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json=payload,
+    )
+    assert response1.status_code == 200
+    assert len(response1.json()["examples"]) == 2
+
+    # Second POST with the same examples plus a new one should NOT 500.
+    # The existing (source, target) pairs must be silently skipped.
+    payload["examples"] = [
+        {"source": "I run", "target": "Nakimbia"},  # duplicate
+        {"source": "We run", "target": "Tunakimbia"},  # duplicate
+        {"source": "They run", "target": "Wanakimbia"},  # new
+    ]
+    response2 = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json=payload,
+    )
+    assert response2.status_code == 200
+    data2 = response2.json()
+    assert len(data2["examples"]) == 3
+    example_pairs = {(e["source"], e["target"]) for e in data2["examples"]}
+    assert example_pairs == {
+        ("I run", "Nakimbia"),
+        ("We run", "Tunakimbia"),
+        ("They run", "Wanakimbia"),
+    }
+
+    # A payload containing internal duplicates must also be tolerated.
+    payload["examples"] = [
+        {"source": "She runs", "target": "Anakimbia"},
+        {"source": "She runs", "target": "Anakimbia"},
+    ]
+    response3 = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json=payload,
+    )
+    assert response3.status_code == 200
+    data3 = response3.json()
+    example_pairs = {(e["source"], e["target"]) for e in data3["examples"]}
+    assert ("She runs", "Anakimbia") in example_pairs
+
+
 def test_add_lexeme_card_upsert_append_explicit(
     client, regular_token1, db_session, test_revision_id
 ):

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1566,6 +1566,33 @@ def test_add_lexeme_card_upsert_append_default(
     assert data2["confidence"] == 0.90
 
 
+def test_add_lexeme_card_create_with_intra_payload_duplicates(
+    client, regular_token1, db_session, test_revision_id
+):
+    """Creating a new card with duplicate examples in a single payload must not 500."""
+    payload = {
+        "source_lemma": "jump",
+        "target_lemma": "ruka",
+        "source_language": "eng",
+        "target_language": "swh",
+        "pos": "verb",
+        "examples": [
+            {"source": "I jump", "target": "Naruka"},
+            {"source": "I jump", "target": "Naruka"},  # duplicate
+            {"source": "We jump", "target": "Tunaruka"},
+        ],
+    }
+    response = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json=payload,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    example_pairs = {(e["source"], e["target"]) for e in data["examples"]}
+    assert example_pairs == {("I jump", "Naruka"), ("We jump", "Tunaruka")}
+
+
 def test_add_lexeme_card_upsert_append_duplicate_examples_no_500(
     client, regular_token1, db_session, test_revision_id
 ):


### PR DESCRIPTION
## Summary
- Replace `db.add()` loops with `pg_insert(...).on_conflict_do_nothing()` for lexeme card examples in all 4 code paths (create, upsert-replace, upsert-append, patch)
- Prevents IntegrityError 500s when duplicate `(lexeme_card_id, revision_id, source_text, target_text)` examples are submitted
- Handles both re-submitted examples and internal duplicates within a single payload

Fixes #517

## Test plan
- [x] New test: `test_add_lexeme_card_upsert_append_duplicate_examples_no_500`
- [ ] Verify existing lexeme card tests still pass
- [ ] Verify no regression on lexeme card PATCH endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)