### PR TITLE
Normalize morpheme casing: casefold on storage and search

### DIFF
--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -291,22 +291,12 @@ async def commit_tokenizer_run(
         n_conflicts = 0
 
         if payload.morphemes:
-            seen = set()
-            duplicates = set()
+            # Normalize to lowercase and deduplicate (keep first-seen class)
+            incoming: dict[str, str] = {}
             for m in payload.morphemes:
-                if m.morpheme in seen:
-                    duplicates.add(m.morpheme)
-                seen.add(m.morpheme)
-            if duplicates:
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail=(
-                        "Duplicate morphemes in payload: "
-                        + ", ".join(sorted(duplicates))
-                    ),
-                )
-
-            incoming = {m.morpheme: m.morpheme_class for m in payload.morphemes}
+                key = m.morpheme.casefold()
+                if key not in incoming:
+                    incoming[key] = m.morpheme_class
 
             existing_result = await db.execute(
                 select(
@@ -597,7 +587,7 @@ async def search_morpheme(
             LanguageMorpheme.id == VerseMorphemeIndex.morpheme_id,
         )
         .where(
-            LanguageMorpheme.morpheme == morpheme,
+            LanguageMorpheme.morpheme == morpheme.casefold(),
             LanguageMorpheme.iso_639_3 == iso,
             VerseText.revision_id == revision_id,
         )
@@ -648,7 +638,7 @@ async def search_morpheme(
         },
     )
     return MorphemeSearchResponse(
-        morpheme=morpheme,
+        morpheme=morpheme.casefold(),
         iso_639_3=iso,
         result_count=len(results),
         results=results,

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -297,13 +297,23 @@ async def commit_tokenizer_run(
                 key = m.morpheme.casefold()
                 if key not in incoming:
                     incoming[key] = m.morpheme_class
+                elif incoming[key] != m.morpheme_class:
+                    logger.warning(
+                        "Intra-payload morpheme class conflict (kept first-seen)",
+                        extra={
+                            "iso": iso,
+                            "morpheme": key,
+                            "kept_class": incoming[key],
+                            "discarded_class": m.morpheme_class,
+                        },
+                    )
 
             existing_result = await db.execute(
                 select(
                     LanguageMorpheme.morpheme, LanguageMorpheme.morpheme_class
                 ).where(
                     LanguageMorpheme.iso_639_3 == iso,
-                    LanguageMorpheme.morpheme.in_(list(incoming.keys())),
+                    LanguageMorpheme.morpheme.in_(incoming.keys()),
                 )
             )
             existing_map = {row[0]: row[1] for row in existing_result.all()}
@@ -631,7 +641,7 @@ async def search_morpheme(
             "method": "GET",
             "path": "/tokenizer/search",
             "iso": iso,
-            "morpheme": morpheme,
+            "morpheme": morpheme.casefold(),
             "revision_id": revision_id,
             "results": len(results),
             "duration_s": duration,

--- a/alembic/migrations/versions/a3b7c8d9e0f1_casefold_existing_morphemes.py
+++ b/alembic/migrations/versions/a3b7c8d9e0f1_casefold_existing_morphemes.py
@@ -1,0 +1,79 @@
+"""Casefold existing morphemes to lowercase.
+
+Normalise the language_morphemes.morpheme column so that all stored
+values are lowercase, matching the new application-level casefold
+behaviour.  If casefolding creates duplicate (iso_639_3, morpheme)
+pairs, the row with the smallest id (earliest insert) is kept and
+the others are deleted.
+
+Revision ID: a3b7c8d9e0f1
+Revises: 1fe4e7b897b4
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+
+revision = "a3b7c8d9e0f1"
+down_revision = "1fe4e7b897b4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. Re-point verse_morpheme_index rows from duplicate morphemes to the
+    #    keeper (smallest id per iso + lowered morpheme).
+    op.execute(
+        """
+        UPDATE verse_morpheme_index vmi
+        SET morpheme_id = keeper.id
+        FROM language_morphemes lm
+        JOIN (
+            SELECT iso_639_3, LOWER(morpheme) AS lowered, MIN(id) AS id
+            FROM language_morphemes
+            GROUP BY iso_639_3, LOWER(morpheme)
+        ) keeper
+          ON keeper.iso_639_3 = lm.iso_639_3
+         AND keeper.lowered = LOWER(lm.morpheme)
+        WHERE vmi.morpheme_id = lm.id
+          AND lm.id != keeper.id
+        """
+    )
+
+    # 2. Remove duplicate verse_morpheme_index rows that now share the same
+    #    (verse_text_id, morpheme_id).  Keep the row with the highest count.
+    op.execute(
+        """
+        DELETE FROM verse_morpheme_index
+        WHERE id NOT IN (
+            SELECT DISTINCT ON (verse_text_id, morpheme_id) id
+            FROM verse_morpheme_index
+            ORDER BY verse_text_id, morpheme_id, count DESC
+        )
+        """
+    )
+
+    # 3. Delete the duplicate morpheme rows (non-keeper ids).
+    op.execute(
+        """
+        DELETE FROM language_morphemes
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM language_morphemes
+            GROUP BY iso_639_3, LOWER(morpheme)
+        )
+        """
+    )
+
+    # 4. Lowercase all remaining morpheme values.
+    op.execute(
+        """
+        UPDATE language_morphemes
+        SET morpheme = LOWER(morpheme)
+        WHERE morpheme != LOWER(morpheme)
+        """
+    )
+
+
+def downgrade() -> None:
+    # Lowercasing is lossy — original casing cannot be restored.
+    pass

--- a/models.py
+++ b/models.py
@@ -1234,7 +1234,8 @@ class TokenizerRunRequest(BaseModel):
 
 class TokenizerRunCommitResponse(BaseModel):
     run_id: int
-    # n_morphemes_new + n_morphemes_existing == len(payload.morphemes).
+    # n_morphemes_new + n_morphemes_existing == unique morphemes after
+    # casefolding (may be < len(payload.morphemes) due to case dedup).
     # n_class_conflicts is a subset of n_morphemes_existing: a conflict is
     # an existing row whose stored class disagrees with the incoming class
     # (the stored class wins; the incoming class is logged and discarded).

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -239,10 +239,11 @@ def test_tokenizer_run_invalid_revision(client, regular_token1, db_session):
     _cleanup(db_session)
 
 
-def test_tokenizer_duplicate_morphemes_rejected(
+def test_tokenizer_duplicate_morphemes_deduplicated(
     client, regular_token1, test_revision_id, db_session
 ):
-    """Duplicate morphemes in a single payload should be rejected with 422."""
+    """Duplicate morphemes (including case variants) are deduplicated, keeping
+    the first-seen class."""
     _cleanup(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
@@ -251,15 +252,16 @@ def test_tokenizer_duplicate_morphemes_rejected(
         json=_run_payload(
             test_revision_id,
             [
-                {"morpheme": "dup", "morpheme_class": "LEXICAL"},
+                {"morpheme": "Dup", "morpheme_class": "LEXICAL"},
                 {"morpheme": "dup", "morpheme_class": "GRAMMATICAL"},
             ],
             profile={"name": "Swahili"},
         ),
         headers=headers,
     )
-    assert resp.status_code == 422
-    assert "dup" in resp.json()["detail"]
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["n_morphemes_new"] == 1
     _cleanup(db_session)
 
 

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -262,6 +262,65 @@ def test_tokenizer_duplicate_morphemes_deduplicated(
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["n_morphemes_new"] == 1
+    assert data["n_morphemes_existing"] == 0
+    assert data["n_class_conflicts"] == 0
+
+    # Verify exactly one row stored, casefolded, with first-seen class
+    row = (
+        db_session.query(LanguageMorpheme)
+        .filter(
+            LanguageMorpheme.iso_639_3 == TEST_ISO,
+            LanguageMorpheme.morpheme == "dup",
+        )
+        .one_or_none()
+    )
+    assert row is not None, "Expected one casefolded morpheme row"
+    assert row.morpheme_class == "LEXICAL"
+
+    total = (
+        db_session.query(LanguageMorpheme)
+        .filter(LanguageMorpheme.iso_639_3 == TEST_ISO)
+        .count()
+    )
+    assert total == 1
+
+    _cleanup(db_session)
+
+
+def test_tokenizer_cross_run_case_variant(
+    client, regular_token1, test_revision_id, db_session
+):
+    """A case variant submitted in a later run is counted as existing."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Run 1: store "hello" (lowercase)
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "hello", "morpheme_class": "LEXICAL"}],
+            profile={"name": "Swahili"},
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["n_morphemes_new"] == 1
+
+    # Run 2: submit "HELLO" — should be recognized as existing
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "HELLO", "morpheme_class": "LEXICAL"}],
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["n_morphemes_new"] == 0
+    assert data["n_morphemes_existing"] == 1
+
     _cleanup(db_session)
 
 
@@ -465,9 +524,46 @@ def test_index_surface_forms(client, regular_token1, test_revision_id, db_sessio
         headers=headers,
     )
     assert resp.status_code == 200
-    result = resp.json()["results"][0]
+    data = resp.json()
+    assert data["morpheme"] == "manyizyi"
+    result = data["results"][0]
     # surface_forms stores the original-case stripped word containing the morpheme
     assert "Umumanyizyi" in result["surface_forms"]
+
+    _cleanup_verses(db_session, vt_objs)
+    _cleanup(db_session)
+
+
+def test_search_case_insensitive(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Searching with mixed-case query finds lowercase-stored morphemes."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    verses = [
+        ("GEN 2:2", "GEN", 2, 2, "Umumanyizyi bhabhomba"),
+    ]
+    vt_objs = _setup_morphemes_and_verses(
+        db_session, client, headers, test_revision_id, verses
+    )
+
+    client.post(
+        f"/{prefix}/tokenizer/index",
+        json={"iso_639_3": INDEX_ISO, "revision_id": test_revision_id},
+        headers=headers,
+    )
+
+    # Search with uppercase — should still find results
+    resp = client.get(
+        f"/{prefix}/tokenizer/search?iso={INDEX_ISO}&morpheme=MANYIZYI&revision_id={test_revision_id}",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["morpheme"] == "manyizyi"
+    assert data["result_count"] == 1
+    assert data["results"][0]["verse_reference"] == "GEN 2:2"
 
     _cleanup_verses(db_session, vt_objs)
     _cleanup(db_session)

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -534,9 +534,7 @@ def test_index_surface_forms(client, regular_token1, test_revision_id, db_sessio
     _cleanup(db_session)
 
 
-def test_search_case_insensitive(
-    client, regular_token1, test_revision_id, db_session
-):
+def test_search_case_insensitive(client, regular_token1, test_revision_id, db_session):
     """Searching with mixed-case query finds lowercase-stored morphemes."""
     _cleanup(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}


### PR DESCRIPTION
## Summary
- **Storage**: `POST /latest/tokenizer/runs` now casefolds all morpheme strings before inserting into `language_morphemes`, and silently deduplicates case variants (keeping first-seen class) instead of returning 422
- **Search**: `GET /latest/tokenizer/search` casefolds the query parameter to match stored lowercase morphemes
- **Index**: Already used `.casefold()` — no changes needed

## Impact
- Fixes proper noun matching (Abraham, Jerusalem, etc. — previously stored capitalized, searched lowercase)
- Prevents duplicate morpheme entries from accumulating across tokenizer runs
- Aligns API behavior with the client (`MorphemeLexicon` already lowercases everything)

Closes #525

## Test plan
- [x] Updated `test_tokenizer_duplicate_morphemes_rejected` → `test_tokenizer_duplicate_morphemes_deduplicated` to verify case-variant dedup
- [x] All 16 tokenizer tests pass
- [x] All 155 agent route tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)