### PR TITLE
Normalize Unicode to NFC on storage for morphemes and lexeme cards

### DIFF
--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -567,6 +567,7 @@ async def search_morpheme(
     current_user: UserModel = Depends(get_current_user),
 ):
     request_start = time.perf_counter()
+    normalized_morpheme = unicodedata.normalize("NFC", morpheme).casefold()
 
     if not await is_user_authorized_for_revision(current_user.id, revision_id, db):
         raise HTTPException(
@@ -601,8 +602,7 @@ async def search_morpheme(
             LanguageMorpheme.id == VerseMorphemeIndex.morpheme_id,
         )
         .where(
-            LanguageMorpheme.morpheme
-            == unicodedata.normalize("NFC", morpheme).casefold(),
+            LanguageMorpheme.morpheme == normalized_morpheme,
             LanguageMorpheme.iso_639_3 == iso,
             VerseText.revision_id == revision_id,
         )
@@ -646,14 +646,14 @@ async def search_morpheme(
             "method": "GET",
             "path": "/tokenizer/search",
             "iso": iso,
-            "morpheme": unicodedata.normalize("NFC", morpheme).casefold(),
+            "morpheme": normalized_morpheme,
             "revision_id": revision_id,
             "results": len(results),
             "duration_s": duration,
         },
     )
     return MorphemeSearchResponse(
-        morpheme=unicodedata.normalize("NFC", morpheme).casefold(),
+        morpheme=normalized_morpheme,
         iso_639_3=iso,
         result_count=len(results),
         results=results,

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -3,6 +3,7 @@ __version__ = "v3"
 import datetime
 import socket
 import time
+import unicodedata
 from typing import Optional
 
 import fastapi
@@ -294,7 +295,7 @@ async def commit_tokenizer_run(
             # Normalize to lowercase and deduplicate (keep first-seen class)
             incoming: dict[str, str] = {}
             for m in payload.morphemes:
-                key = m.morpheme.casefold()
+                key = unicodedata.normalize("NFC", m.morpheme).casefold()
                 if key not in incoming:
                     incoming[key] = m.morpheme_class
                 elif incoming[key] != m.morpheme_class:
@@ -452,7 +453,10 @@ async def index_morphemes(
             detail=f"No morphemes found for iso '{iso}'",
         )
 
-    morpheme_by_text = {row.morpheme.casefold(): row.id for row in morpheme_rows}
+    morpheme_by_text = {
+        unicodedata.normalize("NFC", row.morpheme).casefold(): row.id
+        for row in morpheme_rows
+    }
     morpheme_set = set(morpheme_by_text.keys())
     max_morph_len = max(len(m) for m in morpheme_set)
 
@@ -480,7 +484,7 @@ async def index_morphemes(
             stripped = strip_punct(word)
             if not stripped:
                 continue
-            lowered = stripped.casefold()
+            lowered = unicodedata.normalize("NFC", stripped).casefold()
             segments = viterbi_segment(lowered, morpheme_set, max_morph_len)
             for kind, seg in segments:
                 if kind == "morph" and seg in morpheme_by_text:
@@ -597,7 +601,8 @@ async def search_morpheme(
             LanguageMorpheme.id == VerseMorphemeIndex.morpheme_id,
         )
         .where(
-            LanguageMorpheme.morpheme == morpheme.casefold(),
+            LanguageMorpheme.morpheme
+            == unicodedata.normalize("NFC", morpheme).casefold(),
             LanguageMorpheme.iso_639_3 == iso,
             VerseText.revision_id == revision_id,
         )
@@ -641,14 +646,14 @@ async def search_morpheme(
             "method": "GET",
             "path": "/tokenizer/search",
             "iso": iso,
-            "morpheme": morpheme.casefold(),
+            "morpheme": unicodedata.normalize("NFC", morpheme).casefold(),
             "revision_id": revision_id,
             "results": len(results),
             "duration_s": duration,
         },
     )
     return MorphemeSearchResponse(
-        morpheme=morpheme.casefold(),
+        morpheme=unicodedata.normalize("NFC", morpheme).casefold(),
         iso_639_3=iso,
         result_count=len(results),
         results=results,

--- a/alembic/migrations/versions/b4c8d9e1f2a3_nfc_normalize_existing_text.py
+++ b/alembic/migrations/versions/b4c8d9e1f2a3_nfc_normalize_existing_text.py
@@ -83,19 +83,39 @@ def upgrade() -> None:
     # NFC normalization may create duplicates against the unique index
     # on (LOWER(target_lemma), source_language, target_language).
 
-    # 2a. Delete duplicate lexeme card examples pointing to loser cards.
+    # 2a. Re-point examples from loser cards to the keeper (smallest id per
+    #     normalized lemma + language pair), preserving data instead of deleting.
+    op.execute(
+        """
+        UPDATE agent_lexeme_card_examples alce
+        SET lexeme_card_id = keeper.id
+        FROM agent_lexeme_cards lc
+        JOIN (
+            SELECT LOWER(normalize(target_lemma, NFC)) AS nfc_lemma,
+                   source_language,
+                   target_language,
+                   MIN(id) AS id
+            FROM agent_lexeme_cards
+            GROUP BY LOWER(normalize(target_lemma, NFC)),
+                     source_language, target_language
+        ) keeper
+          ON keeper.nfc_lemma = LOWER(normalize(lc.target_lemma, NFC))
+         AND keeper.source_language = lc.source_language
+         AND keeper.target_language = lc.target_language
+        WHERE alce.lexeme_card_id = lc.id
+          AND lc.id != keeper.id
+        """
+    )
+
+    # 2a-ii. Remove duplicate examples that now share the same
+    #        (lexeme_card_id, revision_id, source_text, target_text).
     op.execute(
         """
         DELETE FROM agent_lexeme_card_examples
-        WHERE lexeme_card_id IN (
-            SELECT lc.id
-            FROM agent_lexeme_cards lc
-            WHERE lc.id NOT IN (
-                SELECT MIN(id)
-                FROM agent_lexeme_cards
-                GROUP BY LOWER(normalize(target_lemma, NFC)),
-                         source_language, target_language
-            )
+        WHERE id NOT IN (
+            SELECT DISTINCT ON (lexeme_card_id, revision_id, source_text, target_text) id
+            FROM agent_lexeme_card_examples
+            ORDER BY lexeme_card_id, revision_id, source_text, target_text, id
         )
         """
     )

--- a/alembic/migrations/versions/b4c8d9e1f2a3_nfc_normalize_existing_text.py
+++ b/alembic/migrations/versions/b4c8d9e1f2a3_nfc_normalize_existing_text.py
@@ -1,0 +1,88 @@
+"""NFC-normalize existing morphemes and lexeme card text fields.
+
+Normalise Unicode to NFC (precomposed) form so that visually identical
+strings with different decompositions (NFD vs NFC) compare as equal.
+This complements the application-level NFC normalization added on ingest.
+
+PostgreSQL does not have a built-in NFC normalize function, so this
+migration uses the normalize() function available in PostgreSQL 13+.
+
+Revision ID: b4c8d9e1f2a3
+Revises: a3b7c8d9e0f1
+Create Date: 2026-04-14
+"""
+
+from alembic import op
+
+revision = "b4c8d9e1f2a3"
+down_revision = "a3b7c8d9e0f1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # 1. NFC-normalize morpheme text in language_morphemes
+    op.execute(
+        """
+        UPDATE language_morphemes
+        SET morpheme = normalize(morpheme, NFC)
+        WHERE morpheme IS NOT NULL
+          AND morpheme != normalize(morpheme, NFC)
+        """
+    )
+
+    # 2. NFC-normalize lexeme card text fields
+    op.execute(
+        """
+        UPDATE agent_lexeme_cards
+        SET target_lemma = normalize(target_lemma, NFC)
+        WHERE target_lemma IS NOT NULL
+          AND target_lemma != normalize(target_lemma, NFC)
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE agent_lexeme_cards
+        SET source_lemma = normalize(source_lemma, NFC)
+        WHERE source_lemma IS NOT NULL
+          AND source_lemma != normalize(source_lemma, NFC)
+        """
+    )
+
+    # 3. NFC-normalize surface_forms arrays (JSONB text arrays)
+    # Update each element in the surface_forms array
+    op.execute(
+        """
+        UPDATE agent_lexeme_cards
+        SET surface_forms = (
+            SELECT jsonb_agg(normalize(elem::text, NFC))
+            FROM jsonb_array_elements_text(surface_forms) AS elem
+        )
+        WHERE surface_forms IS NOT NULL
+          AND surface_forms != (
+            SELECT jsonb_agg(normalize(elem::text, NFC))
+            FROM jsonb_array_elements_text(surface_forms) AS elem
+          )
+        """
+    )
+
+    op.execute(
+        """
+        UPDATE agent_lexeme_cards
+        SET source_surface_forms = (
+            SELECT jsonb_agg(normalize(elem::text, NFC))
+            FROM jsonb_array_elements_text(source_surface_forms) AS elem
+        )
+        WHERE source_surface_forms IS NOT NULL
+          AND source_surface_forms != (
+            SELECT jsonb_agg(normalize(elem::text, NFC))
+            FROM jsonb_array_elements_text(source_surface_forms) AS elem
+          )
+        """
+    )
+
+
+def downgrade() -> None:
+    # NFC normalization is lossy — original decomposition cannot be restored.
+    pass

--- a/alembic/migrations/versions/b4c8d9e1f2a3_nfc_normalize_existing_text.py
+++ b/alembic/migrations/versions/b4c8d9e1f2a3_nfc_normalize_existing_text.py
@@ -4,8 +4,7 @@ Normalise Unicode to NFC (precomposed) form so that visually identical
 strings with different decompositions (NFD vs NFC) compare as equal.
 This complements the application-level NFC normalization added on ingest.
 
-PostgreSQL does not have a built-in NFC normalize function, so this
-migration uses the normalize() function available in PostgreSQL 13+.
+This migration requires PostgreSQL 13+ for the normalize() function.
 
 Revision ID: b4c8d9e1f2a3
 Revises: a3b7c8d9e0f1
@@ -21,7 +20,56 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # 1. NFC-normalize morpheme text in language_morphemes
+    # --- language_morphemes ---
+    # NFC normalization may merge previously-distinct byte sequences,
+    # creating duplicates against the unique index on (iso_639_3, morpheme).
+    # Follow the same deduplication pattern as a3b7c8d9e0f1.
+
+    # 1a. Re-point verse_morpheme_index rows from duplicate morphemes to the
+    #     keeper (smallest id per iso + NFC-normalized morpheme).
+    op.execute(
+        """
+        UPDATE verse_morpheme_index vmi
+        SET morpheme_id = keeper.id
+        FROM language_morphemes lm
+        JOIN (
+            SELECT iso_639_3, normalize(morpheme, NFC) AS nfc_form, MIN(id) AS id
+            FROM language_morphemes
+            GROUP BY iso_639_3, normalize(morpheme, NFC)
+        ) keeper
+          ON keeper.iso_639_3 = lm.iso_639_3
+         AND keeper.nfc_form = normalize(lm.morpheme, NFC)
+        WHERE vmi.morpheme_id = lm.id
+          AND lm.id != keeper.id
+        """
+    )
+
+    # 1b. Remove duplicate verse_morpheme_index rows that now share the same
+    #     (verse_text_id, morpheme_id).  Keep the row with the highest count.
+    op.execute(
+        """
+        DELETE FROM verse_morpheme_index
+        WHERE id NOT IN (
+            SELECT DISTINCT ON (verse_text_id, morpheme_id) id
+            FROM verse_morpheme_index
+            ORDER BY verse_text_id, morpheme_id, count DESC
+        )
+        """
+    )
+
+    # 1c. Delete the duplicate morpheme rows (non-keeper ids).
+    op.execute(
+        """
+        DELETE FROM language_morphemes
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM language_morphemes
+            GROUP BY iso_639_3, normalize(morpheme, NFC)
+        )
+        """
+    )
+
+    # 1d. NFC-normalize all remaining morpheme values.
     op.execute(
         """
         UPDATE language_morphemes
@@ -31,7 +79,41 @@ def upgrade() -> None:
         """
     )
 
-    # 2. NFC-normalize lexeme card text fields
+    # --- agent_lexeme_cards ---
+    # NFC normalization may create duplicates against the unique index
+    # on (LOWER(target_lemma), source_language, target_language).
+
+    # 2a. Delete duplicate lexeme card examples pointing to loser cards.
+    op.execute(
+        """
+        DELETE FROM agent_lexeme_card_examples
+        WHERE lexeme_card_id IN (
+            SELECT lc.id
+            FROM agent_lexeme_cards lc
+            WHERE lc.id NOT IN (
+                SELECT MIN(id)
+                FROM agent_lexeme_cards
+                GROUP BY LOWER(normalize(target_lemma, NFC)),
+                         source_language, target_language
+            )
+        )
+        """
+    )
+
+    # 2b. Delete duplicate lexeme cards (keep smallest id per group).
+    op.execute(
+        """
+        DELETE FROM agent_lexeme_cards
+        WHERE id NOT IN (
+            SELECT MIN(id)
+            FROM agent_lexeme_cards
+            GROUP BY LOWER(normalize(target_lemma, NFC)),
+                     source_language, target_language
+        )
+        """
+    )
+
+    # 2c. NFC-normalize target_lemma.
     op.execute(
         """
         UPDATE agent_lexeme_cards
@@ -41,6 +123,7 @@ def upgrade() -> None:
         """
     )
 
+    # 2d. NFC-normalize source_lemma.
     op.execute(
         """
         UPDATE agent_lexeme_cards
@@ -50,16 +133,18 @@ def upgrade() -> None:
         """
     )
 
-    # 3. NFC-normalize surface_forms arrays (JSONB text arrays)
-    # Update each element in the surface_forms array
+    # 2e. NFC-normalize surface_forms arrays (JSONB text arrays).
+    # COALESCE guards against jsonb_agg returning NULL on empty arrays.
     op.execute(
         """
         UPDATE agent_lexeme_cards
-        SET surface_forms = (
-            SELECT jsonb_agg(normalize(elem::text, NFC))
-            FROM jsonb_array_elements_text(surface_forms) AS elem
+        SET surface_forms = COALESCE(
+            (SELECT jsonb_agg(normalize(elem::text, NFC))
+             FROM jsonb_array_elements_text(surface_forms) AS elem),
+            '[]'::jsonb
         )
         WHERE surface_forms IS NOT NULL
+          AND jsonb_array_length(surface_forms) > 0
           AND surface_forms != (
             SELECT jsonb_agg(normalize(elem::text, NFC))
             FROM jsonb_array_elements_text(surface_forms) AS elem
@@ -67,14 +152,17 @@ def upgrade() -> None:
         """
     )
 
+    # 2f. NFC-normalize source_surface_forms arrays.
     op.execute(
         """
         UPDATE agent_lexeme_cards
-        SET source_surface_forms = (
-            SELECT jsonb_agg(normalize(elem::text, NFC))
-            FROM jsonb_array_elements_text(source_surface_forms) AS elem
+        SET source_surface_forms = COALESCE(
+            (SELECT jsonb_agg(normalize(elem::text, NFC))
+             FROM jsonb_array_elements_text(source_surface_forms) AS elem),
+            '[]'::jsonb
         )
         WHERE source_surface_forms IS NOT NULL
+          AND jsonb_array_length(source_surface_forms) > 0
           AND source_surface_forms != (
             SELECT jsonb_agg(normalize(elem::text, NFC))
             FROM jsonb_array_elements_text(source_surface_forms) AS elem

--- a/models.py
+++ b/models.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+import unicodedata
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 
@@ -578,7 +579,12 @@ class LexemeCardIn(BaseModel):
     @field_validator("target_lemma")
     @classmethod
     def normalize_target_lemma(cls, v):
-        return v.lower() if v else v
+        return unicodedata.normalize("NFC", v).lower() if v else v
+
+    @field_validator("source_lemma")
+    @classmethod
+    def normalize_source_lemma(cls, v):
+        return unicodedata.normalize("NFC", v) if v else v
 
     pos: Optional[str] = None
     surface_forms: Optional[list] = None
@@ -588,6 +594,20 @@ class LexemeCardIn(BaseModel):
     confidence: Optional[float] = None
     english_lemma: Optional[str] = None
     alignment_scores: Optional[Dict[str, float]] = None
+
+    @field_validator("surface_forms")
+    @classmethod
+    def normalize_surface_forms(cls, v):
+        if v is None:
+            return v
+        return [unicodedata.normalize("NFC", s) if isinstance(s, str) else s for s in v]
+
+    @field_validator("source_surface_forms")
+    @classmethod
+    def normalize_source_surface_forms(cls, v):
+        if v is None:
+            return v
+        return [unicodedata.normalize("NFC", s) if isinstance(s, str) else s for s in v]
 
     model_config = {
         "json_schema_extra": {
@@ -666,7 +686,12 @@ class LexemeCardPatch(BaseModel):
     @field_validator("target_lemma")
     @classmethod
     def normalize_target_lemma(cls, v):
-        return v.lower() if v else v
+        return unicodedata.normalize("NFC", v).lower() if v else v
+
+    @field_validator("source_lemma")
+    @classmethod
+    def normalize_source_lemma(cls, v):
+        return unicodedata.normalize("NFC", v) if v else v
 
     pos: Optional[str] = None
     confidence: Optional[float] = None
@@ -677,6 +702,20 @@ class LexemeCardPatch(BaseModel):
     examples: Optional[List[dict]] = None  # Each dict has: source, target, revision_id
     # Dict values can be float or None (None means remove that key)
     alignment_scores: Optional[Dict[str, Optional[float]]] = None
+
+    @field_validator("surface_forms")
+    @classmethod
+    def normalize_surface_forms(cls, v):
+        if v is None:
+            return v
+        return [unicodedata.normalize("NFC", s) for s in v]
+
+    @field_validator("source_surface_forms")
+    @classmethod
+    def normalize_source_surface_forms(cls, v):
+        if v is None:
+            return v
+        return [unicodedata.normalize("NFC", s) for s in v]
 
     model_config = {
         "json_schema_extra": {

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1,4 +1,6 @@
 # test_agent_routes.py
+import unicodedata
+
 from database.models import AgentCritiqueIssue, AgentWordAlignment
 
 prefix = "v3"
@@ -5217,7 +5219,6 @@ def test_post_lexeme_card_nfc_normalizes_text_fields(
     client, regular_token1, db_session, test_revision_id
 ):
     """NFD-encoded text fields are stored as NFC in lexeme cards."""
-    import unicodedata
 
     # NFD form: 'a' + combining acute accent
     nfd_lemma = "a\u0301pelile"
@@ -5256,7 +5257,6 @@ def test_patch_lexeme_card_nfc_normalizes_text_fields(
     client, regular_token1, db_session, test_revision_id
 ):
     """PATCH endpoint NFC-normalizes text fields in updates."""
-    import unicodedata
 
     # First create a card with NFC text
     response = client.post(
@@ -5292,7 +5292,6 @@ def test_post_lexeme_card_nfd_nfc_treated_as_same_lemma(
     client, regular_token1, db_session, test_revision_id
 ):
     """NFD and NFC forms of the same target_lemma should be treated as duplicates."""
-    import unicodedata
 
     nfd_lemma = "a\u0301pelile_dedup"
     nfc_lemma = unicodedata.normalize("NFC", nfd_lemma)

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -5211,3 +5211,118 @@ def test_deduplicate_no_duplicates(client, regular_token1, db_session):
     assert resp.status_code == 200
     data = resp.json()
     assert data["duplicates_found"] == 0
+
+
+def test_post_lexeme_card_nfc_normalizes_text_fields(
+    client, regular_token1, db_session, test_revision_id
+):
+    """NFD-encoded text fields are stored as NFC in lexeme cards."""
+    import unicodedata
+
+    # NFD form: 'a' + combining acute accent
+    nfd_lemma = "a\u0301pelile"
+    nfc_lemma = unicodedata.normalize("NFC", nfd_lemma)
+    assert nfd_lemma != nfc_lemma  # Different byte sequences
+
+    nfd_surface = "wa\u0301pelile"
+    nfc_surface = unicodedata.normalize("NFC", nfd_surface)
+
+    nfd_source_lemma = "cre\u0301er"
+    nfc_source_lemma = unicodedata.normalize("NFC", nfd_source_lemma)
+
+    response = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": nfd_source_lemma,
+            "target_lemma": nfd_lemma,
+            "source_language": "eng",
+            "target_language": "swh",
+            "surface_forms": [nfd_surface],
+            "source_surface_forms": [nfd_source_lemma],
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    # target_lemma is also lowercased
+    assert data["target_lemma"] == nfc_lemma.lower()
+    assert data["source_lemma"] == nfc_source_lemma
+    assert data["surface_forms"] == [nfc_surface]
+    assert data["source_surface_forms"] == [nfc_source_lemma]
+
+
+def test_patch_lexeme_card_nfc_normalizes_text_fields(
+    client, regular_token1, db_session, test_revision_id
+):
+    """PATCH endpoint NFC-normalizes text fields in updates."""
+    import unicodedata
+
+    # First create a card with NFC text
+    response = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "build",
+            "target_lemma": "nfc_patch_test",
+            "source_language": "eng",
+            "target_language": "swh",
+        },
+    )
+    assert response.status_code == 200
+    card_id = response.json()["id"]
+
+    # Patch with NFD-encoded values
+    nfd_surface = "a\u0301pelile"
+    nfc_surface = unicodedata.normalize("NFC", nfd_surface)
+
+    response = client.patch(
+        f"/v3/agent/lexeme-card/{card_id}?list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "surface_forms": [nfd_surface],
+        },
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["surface_forms"] == [nfc_surface]
+
+
+def test_post_lexeme_card_nfd_nfc_treated_as_same_lemma(
+    client, regular_token1, db_session, test_revision_id
+):
+    """NFD and NFC forms of the same target_lemma should be treated as duplicates."""
+    import unicodedata
+
+    nfd_lemma = "a\u0301pelile_dedup"
+    nfc_lemma = unicodedata.normalize("NFC", nfd_lemma)
+
+    # Create card with NFD lemma
+    response = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "create",
+            "target_lemma": nfd_lemma,
+            "source_language": "eng",
+            "target_language": "swh",
+        },
+    )
+    assert response.status_code == 200
+
+    # Create card with NFC lemma — should upsert, not create a new one
+    response = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "create",
+            "target_lemma": nfc_lemma,
+            "source_language": "eng",
+            "target_language": "swh",
+            "confidence": 0.99,
+        },
+    )
+    assert response.status_code == 200
+    data = response.json()
+    # Should have updated the existing card, not created a new one
+    assert data["confidence"] == 0.99

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -796,3 +796,133 @@ def test_index_no_morpheme_matches(
 
     _cleanup_verses(db_session, [vt])
     _cleanup(db_session)
+
+
+def test_nfc_normalization_on_morpheme_commit(
+    client, regular_token1, test_revision_id, db_session
+):
+    """NFD-encoded morphemes are stored as NFC so lookups match consistently."""
+    import unicodedata
+
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # U+0061 U+0301 = 'a' + combining acute (NFD for 'á')
+    nfd_morpheme = "a\u0301pelile"
+    assert nfd_morpheme != unicodedata.normalize("NFC", nfd_morpheme)
+
+    profile = {"name": "Swahili", "family": "Atlantic-Congo"}
+    morphemes = [{"morpheme": nfd_morpheme, "morpheme_class": "LEXICAL"}]
+
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(test_revision_id, morphemes, profile=profile),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["n_morphemes_new"] == 1
+
+    # The stored morpheme should be NFC-normalized (and casefolded)
+    row = (
+        db_session.query(LanguageMorpheme)
+        .filter(LanguageMorpheme.iso_639_3 == TEST_ISO)
+        .first()
+    )
+    expected = unicodedata.normalize("NFC", nfd_morpheme).casefold()
+    assert row.morpheme == expected
+
+    _cleanup(db_session)
+
+
+def test_nfc_normalization_deduplicates_nfd_nfc(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Submitting both NFD and NFC forms of the same morpheme results in one entry."""
+    import unicodedata
+
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    nfd = "a\u0301pelile"
+    nfc = unicodedata.normalize("NFC", nfd)
+
+    profile = {"name": "Swahili", "family": "Atlantic-Congo"}
+    morphemes = [
+        {"morpheme": nfd, "morpheme_class": "LEXICAL"},
+        {"morpheme": nfc, "morpheme_class": "LEXICAL"},
+    ]
+
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(test_revision_id, morphemes, profile=profile),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    # Both should collapse to one morpheme
+    assert resp.json()["n_morphemes_new"] == 1
+
+    count = (
+        db_session.query(LanguageMorpheme)
+        .filter(LanguageMorpheme.iso_639_3 == TEST_ISO)
+        .count()
+    )
+    assert count == 1
+
+    _cleanup(db_session)
+
+
+def test_nfc_normalization_on_index_and_search(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Verse text with NFD characters matches NFC-stored morphemes during indexing."""
+    import unicodedata
+
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    nfc_morpheme = unicodedata.normalize("NFC", "a\u0301pelile")
+
+    # Commit NFC morpheme
+    profile = {"name": "English", "family": "Indo-European"}
+    morphemes = [{"morpheme": nfc_morpheme, "morpheme_class": "LEXICAL"}]
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_index_run_payload(test_revision_id, morphemes, profile=profile),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Insert verse with NFD text (different byte representation of same characters)
+    nfd_text = "Umu" + "a\u0301pelile" + " bhomba"
+    vt = VerseText(
+        text=nfd_text,
+        revision_id=test_revision_id,
+        verse_reference="GEN 8:1",
+        book="GEN",
+        chapter=8,
+        verse=1,
+    )
+    db_session.add(vt)
+    db_session.commit()
+
+    # Index
+    resp = client.post(
+        f"/{prefix}/tokenizer/index",
+        json={"iso_639_3": INDEX_ISO, "revision_id": test_revision_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["unique_morpheme_verse_pairs"] >= 1
+
+    # Search with NFD query should also match
+    nfd_query = "a\u0301pelile"
+    resp = client.get(
+        f"/{prefix}/tokenizer/search?iso={INDEX_ISO}&morpheme={nfd_query}&revision_id={test_revision_id}",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["result_count"] == 1
+
+    _cleanup_verses(db_session, [vt])
+    _cleanup(db_session)

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -1,5 +1,7 @@
 """Tests for morpheme tokenizer storage API endpoints."""
 
+import unicodedata
+
 from database.models import (
     LanguageMorpheme,
     LanguageProfile,
@@ -802,7 +804,6 @@ def test_nfc_normalization_on_morpheme_commit(
     client, regular_token1, test_revision_id, db_session
 ):
     """NFD-encoded morphemes are stored as NFC so lookups match consistently."""
-    import unicodedata
 
     _cleanup(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
@@ -838,7 +839,6 @@ def test_nfc_normalization_deduplicates_nfd_nfc(
     client, regular_token1, test_revision_id, db_session
 ):
     """Submitting both NFD and NFC forms of the same morpheme results in one entry."""
-    import unicodedata
 
     _cleanup(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
@@ -875,7 +875,6 @@ def test_nfc_normalization_on_index_and_search(
     client, regular_token1, test_revision_id, db_session
 ):
     """Verse text with NFD characters matches NFC-stored morphemes during indexing."""
-    import unicodedata
 
     _cleanup(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}


### PR DESCRIPTION
## Summary
- Normalizes all morpheme and lexeme card text fields to NFC Unicode on ingest, fixing false negatives caused by NFD/NFC mismatches (e.g., `á` as precomposed U+00E1 vs decomposed `a` + U+0301)
- Adds NFC normalization to Pydantic validators (lexeme card fields) and tokenizer endpoints (commit, index, search)
- Includes an Alembic migration to NFC-normalize existing data in `language_morphemes` and `agent_lexeme_cards`
- Adds 6 new tests covering NFD/NFC deduplication and round-trip matching

Closes #527

## Test plan
- [x] All 179 existing tests pass (18 tokenizer + 161 agent routes)
- [x] 3 new tokenizer NFC tests pass (commit normalization, dedup, index/search round-trip)
- [x] 3 new lexeme card NFC tests pass (POST normalization, PATCH normalization, NFD/NFC dedup)
- [x] Migration tested against PostgreSQL 16 with `normalize()` function
- [x] Black and isort linting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)