### PR TITLE
Add DELETE endpoint for lexeme cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,18 @@ The application uses async SQLAlchemy with asyncpg. The database URL must use th
 
 Tests use `eng` (English) and `swh` (Swahili) as language codes since these are set up in the test fixtures' `iso_language` table. Other language codes (like `fra`, `deu`) will cause foreign key constraint errors.
 
+## GitHub CLI
+
+`gh issue view` and `gh pr view` fail with a "Projects (classic) is being deprecated" error. Use `--json` to work around it:
+
+```bash
+# View an issue
+gh issue view 123 --json title,body,labels,state
+
+# View a PR
+gh pr view 123 --json title,body,state,mergeStateStatus
+```
+
 ## Pre-commit Hooks
 
 The project uses pre-commit hooks for:

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1181,6 +1181,48 @@ async def patch_lexeme_card_by_lemma(
         ) from e
 
 
+@router.delete(
+    "/agent/lexeme-card/{card_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_lexeme_card(
+    card_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """
+    Delete a lexeme card by ID.
+
+    Associated examples are deleted automatically via cascade.
+
+    Returns 204 No Content on success, 404 if card not found.
+    """
+    try:
+        from sqlalchemy import select
+
+        query = select(AgentLexemeCard).where(AgentLexemeCard.id == card_id)
+        result = await db.execute(query)
+        card = result.scalar_one_or_none()
+
+        if not card:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Lexeme card with id {card_id} not found",
+            )
+
+        await db.delete(card)
+        await db.commit()
+
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error(f"Error deleting lexeme card: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(e)}",
+        ) from e
+
+
 @router.post("/agent/lexeme-card/deduplicate")
 async def deduplicate_lexeme_cards(
     source_language: str,

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1181,9 +1181,7 @@ async def patch_lexeme_card_by_lemma(
         ) from e
 
 
-@router.delete(
-    "/agent/lexeme-card/{card_id}", status_code=status.HTTP_204_NO_CONTENT
-)
+@router.delete("/agent/lexeme-card/{card_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_lexeme_card(
     card_id: int,
     db: AsyncSession = Depends(get_db),
@@ -1192,7 +1190,11 @@ async def delete_lexeme_card(
     """
     Delete a lexeme card by ID.
 
-    Associated examples are deleted automatically via cascade.
+    Associated examples are deleted automatically via cascade
+    (both ORM-level cascade="all, delete-orphan" and DB-level ondelete="CASCADE").
+
+    This endpoint is used by aqua-assessments during card consolidation.
+    Any authenticated user can delete any card (consistent with other card endpoints).
 
     Returns 204 No Content on success, 404 if card not found.
     """

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1,7 +1,12 @@
 # test_agent_routes.py
 import unicodedata
 
-from database.models import AgentCritiqueIssue, AgentWordAlignment
+from database.models import (
+    AgentCritiqueIssue,
+    AgentLexemeCard,
+    AgentLexemeCardExample,
+    AgentWordAlignment,
+)
 
 prefix = "v3"
 
@@ -5330,7 +5335,7 @@ def test_post_lexeme_card_nfd_nfc_treated_as_same_lemma(
 def test_delete_lexeme_card_success(
     client, regular_token1, db_session, test_revision_id
 ):
-    """Test DELETE removes a lexeme card and its examples."""
+    """Test DELETE removes a lexeme card and its examples via cascade."""
     # Create a card with examples
     response = client.post(
         f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
@@ -5348,6 +5353,14 @@ def test_delete_lexeme_card_success(
     assert response.status_code == 200
     card_id = response.json()["id"]
 
+    # Verify examples exist in DB before delete
+    examples_before = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .all()
+    )
+    assert len(examples_before) > 0
+
     # Delete the card
     delete_response = client.delete(
         f"/v3/agent/lexeme-card/{card_id}",
@@ -5355,16 +5368,23 @@ def test_delete_lexeme_card_success(
     )
     assert delete_response.status_code == 204
 
-    # Verify card is gone
-    get_response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_lemma=delete_test_target",
-        headers={"Authorization": f"Bearer {regular_token1}"},
+    # Verify card is gone from DB
+    db_session.expire_all()
+    card = (
+        db_session.query(AgentLexemeCard).filter(AgentLexemeCard.id == card_id).first()
     )
-    assert get_response.status_code == 200
-    assert len(get_response.json()) == 0
+    assert card is None
+
+    # Verify examples were cascade-deleted
+    examples_after = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .all()
+    )
+    assert len(examples_after) == 0
 
 
-def test_delete_lexeme_card_not_found(client, regular_token1, db_session):
+def test_delete_lexeme_card_not_found(client, regular_token1):
     """Test DELETE returns 404 for non-existent card."""
     response = client.delete(
         "/v3/agent/lexeme-card/999999",

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -5325,3 +5325,55 @@ def test_post_lexeme_card_nfd_nfc_treated_as_same_lemma(
     data = response.json()
     # Should have updated the existing card, not created a new one
     assert data["confidence"] == 0.99
+
+
+def test_delete_lexeme_card_success(
+    client, regular_token1, db_session, test_revision_id
+):
+    """Test DELETE removes a lexeme card and its examples."""
+    # Create a card with examples
+    response = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "remove",
+            "target_lemma": "delete_test_target",
+            "source_language": "eng",
+            "target_language": "swh",
+            "examples": [
+                {"source_text": "remove this", "target_text": "ondoa hii"},
+            ],
+        },
+    )
+    assert response.status_code == 200
+    card_id = response.json()["id"]
+
+    # Delete the card
+    delete_response = client.delete(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert delete_response.status_code == 204
+
+    # Verify card is gone
+    get_response = client.get(
+        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_lemma=delete_test_target",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert get_response.status_code == 200
+    assert len(get_response.json()) == 0
+
+
+def test_delete_lexeme_card_not_found(client, regular_token1, db_session):
+    """Test DELETE returns 404 for non-existent card."""
+    response = client.delete(
+        "/v3/agent/lexeme-card/999999",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 404
+
+
+def test_delete_lexeme_card_unauthorized(client):
+    """Test DELETE requires authentication."""
+    response = client.delete("/v3/agent/lexeme-card/1")
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- Adds `DELETE /v3/agent/lexeme-card/{card_id}` endpoint (returns 204/404)
- Associated examples are cascade-deleted via SQLAlchemy relationship
- Adds tests for success, not-found, and unauthorized cases
- Documents `gh` CLI `--json` workaround in CLAUDE.md

Closes #528

## Test plan
- [x] `test_delete_lexeme_card_success` — create card with examples, delete, verify gone
- [x] `test_delete_lexeme_card_not_found` — 404 for non-existent ID
- [x] `test_delete_lexeme_card_unauthorized` — 401 without auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)