### PR TITLE
Redact credentials from alembic env.py DB URL print

### DIFF
--- a/alembic/migrations/env.py
+++ b/alembic/migrations/env.py
@@ -3,6 +3,7 @@ import os
 import sys
 from logging.config import fileConfig
 from pathlib import Path
+from urllib.parse import urlparse
 
 from dotenv import load_dotenv
 from sqlalchemy import pool
@@ -34,7 +35,8 @@ load_dotenv()
 DATABASE_URL = os.getenv("AQUA_DB")
 if DATABASE_URL.startswith("postgresql://"):
     DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
-print(DATABASE_URL)
+parsed = urlparse(DATABASE_URL)
+print(f"Database: {parsed.scheme}://{parsed.hostname}:{parsed.port}{parsed.path}")
 
 
 # this is the Alembic Config object, which provides

--- a/alembic/migrations/env.py
+++ b/alembic/migrations/env.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 import os
 import sys
 from logging.config import fileConfig
@@ -36,7 +37,8 @@ DATABASE_URL = os.getenv("AQUA_DB")
 if DATABASE_URL.startswith("postgresql://"):
     DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
 parsed = urlparse(DATABASE_URL)
-print(f"Database: {parsed.scheme}://{parsed.hostname}:{parsed.port}{parsed.path}")
+port_str = f":{parsed.port}" if parsed.port is not None else ""
+logging.info(f"Database: {parsed.scheme}://{parsed.hostname}{port_str}{parsed.path}")
 
 
 # this is the Alembic Config object, which provides


### PR DESCRIPTION
## Summary
- Replace raw `print(DATABASE_URL)` in `alembic/migrations/env.py` with a redacted form that strips credentials, printing only scheme/host/port/db name
- Prevents prod database password from leaking to terminal scrollback, CI logs, and tool transcripts

Closes #522

## Test plan
- [ ] Run `alembic current` or `alembic heads` locally and verify output shows `Database: postgresql+asyncpg://localhost:5432/dbname` without credentials
- [ ] Confirm no other files print or log the raw `AQUA_DB` value

🤖 Generated with [Claude Code](https://claude.com/claude-code)