### PR TITLE
Add grammar_sketch field to language profile

### DIFF
--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -134,7 +134,7 @@ async def _upsert_profile(
         profile = LanguageProfile(iso_639_3=iso, **payload.model_dump())
         db.add(profile)
     else:
-        for key, value in payload.model_dump().items():
+        for key, value in payload.model_dump(exclude_unset=True).items():
             setattr(profile, key, value)
         # Force the onupdate trigger to fire even when no fields changed,
         # so repeat PUTs always refresh updated_at.

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -90,6 +90,12 @@ async def upsert_language_profile(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
+    """Create or update a language profile.
+
+    On update, only fields present in the request body are modified; omitted
+    fields retain their current values.  To clear a field, send it explicitly
+    as ``null``.
+    """
     request_start = time.perf_counter()
     iso_exists = await db.execute(select(IsoLanguage).where(IsoLanguage.iso639 == iso))
     if iso_exists.scalar_one_or_none() is None:

--- a/alembic/migrations/versions/c5d9e2f3a4b5_add_grammar_sketch_to_language_profiles.py
+++ b/alembic/migrations/versions/c5d9e2f3a4b5_add_grammar_sketch_to_language_profiles.py
@@ -2,7 +2,7 @@
 
 Revision ID: c5d9e2f3a4b5
 Revises: b4c8d9e1f2a3
-Create Date: 2026-04-15
+Create Date: 2026-04-15 00:00:00.000000
 """
 
 from alembic import op

--- a/alembic/migrations/versions/c5d9e2f3a4b5_add_grammar_sketch_to_language_profiles.py
+++ b/alembic/migrations/versions/c5d9e2f3a4b5_add_grammar_sketch_to_language_profiles.py
@@ -1,0 +1,25 @@
+"""Add grammar_sketch column to language_profiles.
+
+Revision ID: c5d9e2f3a4b5
+Revises: b4c8d9e1f2a3
+Create Date: 2026-04-15
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c5d9e2f3a4b5"
+down_revision = "b4c8d9e1f2a3"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "language_profiles",
+        sa.Column("grammar_sketch", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("language_profiles", "grammar_sketch")

--- a/database/models.py
+++ b/database/models.py
@@ -854,6 +854,7 @@ class LanguageProfile(Base):
     script = Column(Text, nullable=True)
     typology_summary = Column(Text, nullable=True)
     morphology_notes = Column(Text, nullable=True)
+    grammar_sketch = Column(Text, nullable=True)
     common_affixes = Column(JSONB, nullable=True)
     sources = Column(JSONB, nullable=True)
     created_at = Column(TIMESTAMP, server_default=func.now())

--- a/models.py
+++ b/models.py
@@ -1211,6 +1211,7 @@ class LanguageProfileIn(BaseModel):
     script: Optional[str] = None
     typology_summary: Optional[str] = None
     morphology_notes: Optional[str] = None
+    grammar_sketch: Optional[str] = None
     common_affixes: Optional[List[Dict[str, Any]]] = None
     sources: Optional[List[str]] = None
 

--- a/models.py
+++ b/models.py
@@ -1211,7 +1211,7 @@ class LanguageProfileIn(BaseModel):
     script: Optional[str] = None
     typology_summary: Optional[str] = None
     morphology_notes: Optional[str] = None
-    grammar_sketch: Optional[str] = None
+    grammar_sketch: Optional[str] = Field(None, max_length=65536)
     common_affixes: Optional[List[Dict[str, Any]]] = None
     sources: Optional[List[str]] = None
 

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -973,4 +973,13 @@ def test_grammar_sketch_round_trip(
     assert resp.status_code == 200
     assert resp.json()["grammar_sketch"] == updated_sketch
 
+    # PUT without grammar_sketch should preserve existing value
+    resp = client.put(
+        f"/{prefix}/tokenizer/profile/{TEST_ISO}",
+        json={"name": "Swahili"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["grammar_sketch"] == updated_sketch
+
     _cleanup(db_session)

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -982,4 +982,17 @@ def test_grammar_sketch_round_trip(
     assert resp.status_code == 200
     assert resp.json()["grammar_sketch"] == updated_sketch
 
+    # PUT with grammar_sketch explicitly null should clear the stored value
+    resp = client.put(
+        f"/{prefix}/tokenizer/profile/{TEST_ISO}",
+        json={"name": "Swahili", "grammar_sketch": None},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["grammar_sketch"] is None
+
+    resp = client.get(f"/{prefix}/tokenizer/profile/{TEST_ISO}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["grammar_sketch"] is None
+
     _cleanup(db_session)

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -925,3 +925,52 @@ def test_nfc_normalization_on_index_and_search(
 
     _cleanup_verses(db_session, [vt])
     _cleanup(db_session)
+
+
+def test_grammar_sketch_round_trip(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Grammar sketch is stored and returned via profile endpoints."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    sketch = (
+        "## Noun Morphology\n\n"
+        "The language has a noun class system.\n"
+        "- **Class ʉ-**: ʉMlengi, ʉmsenya\n"
+    )
+    profile = {
+        "name": "Swahili",
+        "family": "Atlantic-Congo",
+        "grammar_sketch": sketch,
+    }
+    morphemes = [{"morpheme": "ki", "morpheme_class": "GRAMMATICAL"}]
+
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(test_revision_id, morphemes, profile=profile),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = client.get(f"/{prefix}/tokenizer/profile/{TEST_ISO}", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["grammar_sketch"] == sketch
+
+    # Update the sketch via PUT
+    updated_sketch = sketch + "\n## Verb Morphology\n\nSubject-verb agreement.\n"
+    resp = client.put(
+        f"/{prefix}/tokenizer/profile/{TEST_ISO}",
+        json={"name": "Swahili", "grammar_sketch": updated_sketch},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["grammar_sketch"] == updated_sketch
+
+    # Confirm GET reflects the update
+    resp = client.get(f"/{prefix}/tokenizer/profile/{TEST_ISO}", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["grammar_sketch"] == updated_sketch
+
+    _cleanup(db_session)


### PR DESCRIPTION
## Summary
- Adds `grammar_sketch` TEXT column to `language_profiles` table to persist the Grammar Discovery Agent's markdown output between assessment runs
- Exposes the field via Pydantic `LanguageProfileIn/Out` with a 64KB `max_length` limit
- Changes `_upsert_profile` to use `exclude_unset=True` on update, so PUT requests that omit optional fields preserve existing values (previously they were nulled out). To clear a field, clients send it explicitly as `null`.
- Includes alembic migration and round-trip test covering create, read, update, preserve-on-omit, and explicit-null-to-clear

Fixes #532

## Test plan
- [x] New `test_grammar_sketch_round_trip` test passes (covers full lifecycle)
- [x] All 22 existing tokenizer tests pass
- [x] Alembic migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)