### PR TITLE
Add word-level morpheme co-occurrence index and endpoint

### DIFF
--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -4,12 +4,11 @@ import datetime
 import socket
 import time
 import unicodedata
+from collections import defaultdict
 from typing import Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, status
-from collections import defaultdict
-
 from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
@@ -23,12 +22,12 @@ from database.models import (
     LanguageMorpheme,
     LanguageProfile,
     TokenizerRun,
-    WordMorphemeIndex,
 )
 from database.models import UserDB as UserModel
 from database.models import (
     VerseMorphemeIndex,
     VerseText,
+    WordMorphemeIndex,
 )
 from models import (
     CooccurrenceItem,
@@ -938,12 +937,16 @@ async def get_cooccurrences(
                 LanguageMorpheme.morpheme_class,
             ).where(LanguageMorpheme.id.in_(list(cooc_stats.keys())))
         )
-        morph_info = {row.id: (row.morpheme, row.morpheme_class) for row in morph_result.all()}
+        morph_info = {
+            row.id: (row.morpheme, row.morpheme_class) for row in morph_result.all()
+        }
     else:
         morph_info = {}
 
     # Build response, sorted by co-occurrence count descending
-    sorted_ids = sorted(cooc_stats, key=lambda mid: cooc_stats[mid]["count"], reverse=True)
+    sorted_ids = sorted(
+        cooc_stats, key=lambda mid: cooc_stats[mid]["count"], reverse=True
+    )
     cooccurrences = []
     for mid in sorted_ids[:limit]:
         stats = cooc_stats[mid]

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -893,6 +893,7 @@ async def get_cooccurrences(
 
     result = await db.execute(target_query)
     target_rows = result.all()
+    is_truncated = len(target_rows) == COOCCURRENCE_MAX_WORDS
 
     if not target_rows:
         return CooccurrenceResponse(
@@ -927,11 +928,18 @@ async def get_cooccurrences(
     )
     cooc_rows = cooc_result.all()
 
-    # Aggregate co-occurrence stats
+    # Aggregate co-occurrence stats, deduplicating by (morpheme_id, word)
+    # so a morpheme appearing at multiple positions in the same word is
+    # counted once per word token.
     # morpheme_id -> {count, example_words set, before_count, after_count}
     cooc_stats: dict[int, dict] = {}
+    seen_pairs: set[tuple[int, str]] = set()
     for row in cooc_rows:
         mid = row.morpheme_id
+        pair = (mid, row.word)
+        if pair in seen_pairs:
+            continue
+        seen_pairs.add(pair)
         if mid not in cooc_stats:
             cooc_stats[mid] = {
                 "count": 0,
@@ -1008,5 +1016,6 @@ async def get_cooccurrences(
     return CooccurrenceResponse(
         morpheme=normalized,
         total_words_containing=total_words_containing,
+        is_truncated=is_truncated,
         cooccurrences=cooccurrences,
     )

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -755,6 +755,7 @@ async def build_word_index(
 
     # Segment each unique word and build index rows
     index_rows = []
+    words_with_morphemes = 0
     for word, count in word_counts.items():
         segments = viterbi_segment(word, morpheme_set, max_morph_len)
         morphs = [
@@ -764,6 +765,7 @@ async def build_word_index(
         ]
         if not morphs:
             continue
+        words_with_morphemes += 1
         total = len(morphs)
         for pos, (seg, mid) in enumerate(morphs):
             index_rows.append(
@@ -778,7 +780,10 @@ async def build_word_index(
             )
 
     try:
-        # Delete existing word index for this language before re-indexing
+        # The word index is language-scoped (no revision_id column) — each
+        # rebuild replaces the entire language's index with data from the
+        # requested revision.  This is intentional: the index reflects the
+        # single most-recently-indexed revision for a language.
         await db.execute(
             delete(WordMorphemeIndex).where(WordMorphemeIndex.iso_639_3 == iso)
         )
@@ -801,10 +806,9 @@ async def build_word_index(
         logger.error("Failed to build word morpheme index", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Database error: {e}",
+            detail="Failed to build word morpheme index",
         ) from e
 
-    unique_words = len(word_counts)
     duration = round(time.perf_counter() - request_start, 2)
     logger.info(
         f"build_word_index completed in {duration}s",
@@ -813,21 +817,24 @@ async def build_word_index(
             "path": "/tokenizer/word-index",
             "iso": iso,
             "revision_id": revision_id,
-            "unique_words": unique_words,
+            "unique_words": words_with_morphemes,
             "pairs": len(index_rows),
             "duration_s": duration,
         },
     )
     return WordIndexResponse(
-        unique_words_indexed=unique_words,
+        unique_words_indexed=words_with_morphemes,
         word_morpheme_pairs=len(index_rows),
     )
 
 
+COOCCURRENCE_MAX_WORDS = 5000
+
+
 @router.get("/tokenizer/cooccurrences", response_model=CooccurrenceResponse)
 async def get_cooccurrences(
-    iso: str,
-    morpheme: str,
+    iso: str = Query(..., min_length=3, max_length=3),
+    morpheme: str = Query(...),
     position_filter: Optional[str] = Query(
         default=None, pattern="^(prefix|suffix|infix)$"
     ),
@@ -835,6 +842,8 @@ async def get_cooccurrences(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
+    # The word index is language-scoped shared infrastructure, so this
+    # endpoint requires authentication but not revision-level authorization.
     request_start = time.perf_counter()
     normalized = unicodedata.normalize("NFC", morpheme).casefold()
 
@@ -852,15 +861,21 @@ async def get_cooccurrences(
             detail=f"Morpheme '{morpheme}' not found for iso '{iso}'",
         )
 
-    # Find all words containing the target morpheme
-    target_query = select(
-        WordMorphemeIndex.word,
-        WordMorphemeIndex.position,
-        WordMorphemeIndex.total_morphemes,
-        WordMorphemeIndex.word_count,
-    ).where(
-        WordMorphemeIndex.iso_639_3 == iso,
-        WordMorphemeIndex.morpheme_id == target_id,
+    # Find all words containing the target morpheme, capped to bound
+    # the downstream IN() clause and in-memory aggregation.
+    target_query = (
+        select(
+            WordMorphemeIndex.word,
+            WordMorphemeIndex.position,
+            WordMorphemeIndex.total_morphemes,
+            WordMorphemeIndex.word_count,
+        )
+        .where(
+            WordMorphemeIndex.iso_639_3 == iso,
+            WordMorphemeIndex.morpheme_id == target_id,
+        )
+        .order_by(WordMorphemeIndex.word_count.desc())
+        .limit(COOCCURRENCE_MAX_WORDS)
     )
 
     # Apply position filter
@@ -887,9 +902,15 @@ async def get_cooccurrences(
         )
 
     target_words = {row.word for row in target_rows}
-    # Map word -> (target_position, word_count)
-    word_info = {row.word: (row.position, row.word_count) for row in target_rows}
-    total_words_containing = len(target_words)
+    # Map word -> (list of target positions, word_count)
+    # A morpheme can appear multiple times in one word (reduplication),
+    # so we collect all positions per word.
+    word_info: dict[str, tuple[list[int], int]] = {}
+    for row in target_rows:
+        if row.word not in word_info:
+            word_info[row.word] = ([], row.word_count)
+        word_info[row.word][0].append(row.position)
+    total_words_containing = sum(info[1] for info in word_info.values())
 
     # Find all morphemes in those same words (excluding the target)
     cooc_result = await db.execute(
@@ -922,8 +943,11 @@ async def get_cooccurrences(
         entry["count"] += row.word_count
         if len(entry["example_words"]) < 3:
             entry["example_words"].add(row.word)
-        target_pos = word_info[row.word][0]
-        if row.position < target_pos:
+        # Use the minimum target position for before/after classification.
+        # For reduplicated morphemes, the first occurrence is most relevant.
+        target_positions = word_info[row.word][0]
+        min_target_pos = min(target_positions)
+        if row.position < min_target_pos:
             entry["before"] += row.word_count
         else:
             entry["after"] += row.word_count
@@ -950,7 +974,14 @@ async def get_cooccurrences(
     cooccurrences = []
     for mid in sorted_ids[:limit]:
         stats = cooc_stats[mid]
-        text, cls = morph_info.get(mid, ("?", "UNKNOWN"))
+        morph_entry = morph_info.get(mid)
+        if morph_entry is None:
+            logger.warning(
+                f"Morpheme id {mid} in word_morpheme_index has no "
+                f"language_morphemes row — possible data integrity issue"
+            )
+            continue
+        text, cls = morph_entry
         typical = "before" if stats["before"] >= stats["after"] else "after"
         cooccurrences.append(
             CooccurrenceItem(

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -8,7 +8,9 @@ from typing import Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import delete, select
+from collections import defaultdict
+
+from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,6 +23,7 @@ from database.models import (
     LanguageMorpheme,
     LanguageProfile,
     TokenizerRun,
+    WordMorphemeIndex,
 )
 from database.models import UserDB as UserModel
 from database.models import (
@@ -28,6 +31,8 @@ from database.models import (
     VerseText,
 )
 from models import (
+    CooccurrenceItem,
+    CooccurrenceResponse,
     IndexRequest,
     IndexResponse,
     LanguageProfileIn,
@@ -40,6 +45,8 @@ from models import (
     TokenizerRunListOut,
     TokenizerRunOut,
     TokenizerRunRequest,
+    WordIndexRequest,
+    WordIndexResponse,
 )
 from security_routes.auth_routes import get_current_user
 from security_routes.utilities import is_user_authorized_for_revision
@@ -663,4 +670,309 @@ async def search_morpheme(
         iso_639_3=iso,
         result_count=len(results),
         results=results,
+    )
+
+
+@router.post("/tokenizer/word-index", response_model=WordIndexResponse)
+async def build_word_index(
+    payload: WordIndexRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    request_start = time.perf_counter()
+    iso = payload.iso_639_3
+    revision_id = payload.revision_id
+
+    if not await is_user_authorized_for_revision(current_user.id, revision_id, db):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User not authorized to access this revision",
+        )
+
+    # Validate revision exists and belongs to the given language
+    rev_result = await db.execute(
+        select(BibleVersion.iso_language)
+        .join(BibleRevision, BibleRevision.bible_version_id == BibleVersion.id)
+        .where(BibleRevision.id == revision_id)
+    )
+    rev_iso = rev_result.scalar_one_or_none()
+    if rev_iso is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown revision_id {revision_id}",
+        )
+    if rev_iso != iso:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Revision {revision_id} belongs to language '{rev_iso}', "
+                f"not '{iso}'"
+            ),
+        )
+
+    # Load morphemes for the language
+    result = await db.execute(
+        select(LanguageMorpheme.id, LanguageMorpheme.morpheme).where(
+            LanguageMorpheme.iso_639_3 == iso
+        )
+    )
+    morpheme_rows = result.all()
+    if not morpheme_rows:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No morphemes found for iso '{iso}'",
+        )
+
+    morpheme_by_text = {
+        unicodedata.normalize("NFC", row.morpheme).casefold(): row.id
+        for row in morpheme_rows
+    }
+    morpheme_set = set(morpheme_by_text.keys())
+    max_morph_len = max(len(m) for m in morpheme_set)
+
+    # Load all non-empty verses for the revision
+    result = await db.execute(
+        select(VerseText.text).where(
+            VerseText.revision_id == revision_id,
+            VerseText.text.isnot(None),
+            VerseText.text != "",
+        )
+    )
+    verses = result.all()
+    if not verses:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No verses found for revision_id {revision_id}",
+        )
+
+    # Collect unique words and their counts across the corpus
+    word_counts: dict[str, int] = defaultdict(int)
+    for verse in verses:
+        for raw_word in verse.text.split():
+            stripped = strip_punct(raw_word)
+            if stripped:
+                lowered = unicodedata.normalize("NFC", stripped).casefold()
+                word_counts[lowered] += 1
+
+    # Segment each unique word and build index rows
+    index_rows = []
+    for word, count in word_counts.items():
+        segments = viterbi_segment(word, morpheme_set, max_morph_len)
+        morphs = [
+            (seg, morpheme_by_text[seg])
+            for kind, seg in segments
+            if kind == "morph" and seg in morpheme_by_text
+        ]
+        if not morphs:
+            continue
+        total = len(morphs)
+        for pos, (seg, mid) in enumerate(morphs):
+            index_rows.append(
+                {
+                    "iso_639_3": iso,
+                    "word": word,
+                    "morpheme_id": mid,
+                    "position": pos,
+                    "total_morphemes": total,
+                    "word_count": count,
+                }
+            )
+
+    try:
+        # Delete existing word index for this language before re-indexing
+        await db.execute(
+            delete(WordMorphemeIndex).where(WordMorphemeIndex.iso_639_3 == iso)
+        )
+
+        if index_rows:
+            for i in range(0, len(index_rows), INDEX_BATCH_SIZE):
+                batch = index_rows[i : i + INDEX_BATCH_SIZE]
+                stmt = pg_insert(WordMorphemeIndex).values(batch)
+                stmt = stmt.on_conflict_do_update(
+                    constraint="uq_word_morpheme_pos",
+                    set_={
+                        "total_morphemes": stmt.excluded.total_morphemes,
+                        "word_count": stmt.excluded.word_count,
+                    },
+                )
+                await db.execute(stmt)
+        await db.commit()
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error("Failed to build word morpheme index", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {e}",
+        ) from e
+
+    unique_words = len(word_counts)
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"build_word_index completed in {duration}s",
+        extra={
+            "method": "POST",
+            "path": "/tokenizer/word-index",
+            "iso": iso,
+            "revision_id": revision_id,
+            "unique_words": unique_words,
+            "pairs": len(index_rows),
+            "duration_s": duration,
+        },
+    )
+    return WordIndexResponse(
+        unique_words_indexed=unique_words,
+        word_morpheme_pairs=len(index_rows),
+    )
+
+
+@router.get("/tokenizer/cooccurrences", response_model=CooccurrenceResponse)
+async def get_cooccurrences(
+    iso: str,
+    morpheme: str,
+    position_filter: Optional[str] = Query(
+        default=None, pattern="^(prefix|suffix|infix)$"
+    ),
+    limit: int = Query(default=20, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    request_start = time.perf_counter()
+    normalized = unicodedata.normalize("NFC", morpheme).casefold()
+
+    # Resolve the target morpheme
+    result = await db.execute(
+        select(LanguageMorpheme.id).where(
+            LanguageMorpheme.iso_639_3 == iso,
+            LanguageMorpheme.morpheme == normalized,
+        )
+    )
+    target_id = result.scalar_one_or_none()
+    if target_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Morpheme '{morpheme}' not found for iso '{iso}'",
+        )
+
+    # Find all words containing the target morpheme
+    target_query = select(
+        WordMorphemeIndex.word,
+        WordMorphemeIndex.position,
+        WordMorphemeIndex.total_morphemes,
+        WordMorphemeIndex.word_count,
+    ).where(
+        WordMorphemeIndex.iso_639_3 == iso,
+        WordMorphemeIndex.morpheme_id == target_id,
+    )
+
+    # Apply position filter
+    if position_filter == "prefix":
+        target_query = target_query.where(WordMorphemeIndex.position == 0)
+    elif position_filter == "suffix":
+        target_query = target_query.where(
+            WordMorphemeIndex.position == WordMorphemeIndex.total_morphemes - 1
+        )
+    elif position_filter == "infix":
+        target_query = target_query.where(
+            WordMorphemeIndex.position > 0,
+            WordMorphemeIndex.position < WordMorphemeIndex.total_morphemes - 1,
+        )
+
+    result = await db.execute(target_query)
+    target_rows = result.all()
+
+    if not target_rows:
+        return CooccurrenceResponse(
+            morpheme=normalized,
+            total_words_containing=0,
+            cooccurrences=[],
+        )
+
+    target_words = {row.word for row in target_rows}
+    # Map word -> (target_position, word_count)
+    word_info = {row.word: (row.position, row.word_count) for row in target_rows}
+    total_words_containing = len(target_words)
+
+    # Find all morphemes in those same words (excluding the target)
+    cooc_result = await db.execute(
+        select(
+            WordMorphemeIndex.morpheme_id,
+            WordMorphemeIndex.word,
+            WordMorphemeIndex.position,
+            WordMorphemeIndex.word_count,
+        ).where(
+            WordMorphemeIndex.iso_639_3 == iso,
+            WordMorphemeIndex.word.in_(target_words),
+            WordMorphemeIndex.morpheme_id != target_id,
+        )
+    )
+    cooc_rows = cooc_result.all()
+
+    # Aggregate co-occurrence stats
+    # morpheme_id -> {count, example_words set, before_count, after_count}
+    cooc_stats: dict[int, dict] = {}
+    for row in cooc_rows:
+        mid = row.morpheme_id
+        if mid not in cooc_stats:
+            cooc_stats[mid] = {
+                "count": 0,
+                "example_words": set(),
+                "before": 0,
+                "after": 0,
+            }
+        entry = cooc_stats[mid]
+        entry["count"] += row.word_count
+        if len(entry["example_words"]) < 3:
+            entry["example_words"].add(row.word)
+        target_pos = word_info[row.word][0]
+        if row.position < target_pos:
+            entry["before"] += row.word_count
+        else:
+            entry["after"] += row.word_count
+
+    # Look up morpheme text and class for all co-occurring morphemes
+    if cooc_stats:
+        morph_result = await db.execute(
+            select(
+                LanguageMorpheme.id,
+                LanguageMorpheme.morpheme,
+                LanguageMorpheme.morpheme_class,
+            ).where(LanguageMorpheme.id.in_(list(cooc_stats.keys())))
+        )
+        morph_info = {row.id: (row.morpheme, row.morpheme_class) for row in morph_result.all()}
+    else:
+        morph_info = {}
+
+    # Build response, sorted by co-occurrence count descending
+    sorted_ids = sorted(cooc_stats, key=lambda mid: cooc_stats[mid]["count"], reverse=True)
+    cooccurrences = []
+    for mid in sorted_ids[:limit]:
+        stats = cooc_stats[mid]
+        text, cls = morph_info.get(mid, ("?", "UNKNOWN"))
+        typical = "before" if stats["before"] >= stats["after"] else "after"
+        cooccurrences.append(
+            CooccurrenceItem(
+                morpheme=text,
+                morpheme_class=cls,
+                co_occurrence_count=stats["count"],
+                example_words=sorted(stats["example_words"]),
+                typical_position=typical,
+            )
+        )
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"get_cooccurrences completed in {duration}s",
+        extra={
+            "method": "GET",
+            "path": "/tokenizer/cooccurrences",
+            "iso": iso,
+            "morpheme": normalized,
+            "results": len(cooccurrences),
+            "duration_s": duration,
+        },
+    )
+    return CooccurrenceResponse(
+        morpheme=normalized,
+        total_words_containing=total_words_containing,
+        cooccurrences=cooccurrences,
     )

--- a/alembic/migrations/versions/d6e0f1a2b3c4_add_word_morpheme_index_table.py
+++ b/alembic/migrations/versions/d6e0f1a2b3c4_add_word_morpheme_index_table.py
@@ -1,0 +1,52 @@
+"""Add word_morpheme_index table.
+
+Revision ID: d6e0f1a2b3c4
+Revises: c5d9e2f3a4b5
+Create Date: 2026-04-15 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "d6e0f1a2b3c4"
+down_revision = "c5d9e2f3a4b5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "word_morpheme_index",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "iso_639_3",
+            sa.String(3),
+            sa.ForeignKey("language_profiles.iso_639_3", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("word", sa.Text(), nullable=False),
+        sa.Column(
+            "morpheme_id",
+            sa.Integer(),
+            sa.ForeignKey("language_morphemes.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("position", sa.Integer(), nullable=False),
+        sa.Column("total_morphemes", sa.Integer(), nullable=False),
+        sa.Column("word_count", sa.Integer(), server_default="1"),
+    )
+    op.create_unique_constraint(
+        "uq_word_morpheme_pos",
+        "word_morpheme_index",
+        ["iso_639_3", "word", "morpheme_id", "position"],
+    )
+    op.create_index(
+        "ix_word_morpheme_iso", "word_morpheme_index", ["iso_639_3"]
+    )
+    op.create_index(
+        "ix_word_morpheme_morpheme", "word_morpheme_index", ["morpheme_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("word_morpheme_index")

--- a/alembic/migrations/versions/d6e0f1a2b3c4_add_word_morpheme_index_table.py
+++ b/alembic/migrations/versions/d6e0f1a2b3c4_add_word_morpheme_index_table.py
@@ -5,8 +5,9 @@ Revises: c5d9e2f3a4b5
 Create Date: 2026-04-15 00:00:00.000000
 """
 
-from alembic import op
 import sqlalchemy as sa
+
+from alembic import op
 
 revision = "d6e0f1a2b3c4"
 down_revision = "c5d9e2f3a4b5"
@@ -40,13 +41,12 @@ def upgrade() -> None:
         "word_morpheme_index",
         ["iso_639_3", "word", "morpheme_id", "position"],
     )
-    op.create_index(
-        "ix_word_morpheme_iso", "word_morpheme_index", ["iso_639_3"]
-    )
-    op.create_index(
-        "ix_word_morpheme_morpheme", "word_morpheme_index", ["morpheme_id"]
-    )
+    op.create_index("ix_word_morpheme_iso", "word_morpheme_index", ["iso_639_3"])
+    op.create_index("ix_word_morpheme_morpheme", "word_morpheme_index", ["morpheme_id"])
 
 
 def downgrade() -> None:
+    op.drop_index("ix_word_morpheme_morpheme", table_name="word_morpheme_index")
+    op.drop_index("ix_word_morpheme_iso", table_name="word_morpheme_index")
+    op.drop_constraint("uq_word_morpheme_pos", table_name="word_morpheme_index")
     op.drop_table("word_morpheme_index")

--- a/alembic/migrations/versions/d6e0f1a2b3c4_add_word_morpheme_index_table.py
+++ b/alembic/migrations/versions/d6e0f1a2b3c4_add_word_morpheme_index_table.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
         ),
         sa.Column("position", sa.Integer(), nullable=False),
         sa.Column("total_morphemes", sa.Integer(), nullable=False),
-        sa.Column("word_count", sa.Integer(), server_default="1"),
+        sa.Column("word_count", sa.Integer(), nullable=False, server_default="1"),
     )
     op.create_unique_constraint(
         "uq_word_morpheme_pos",
@@ -48,5 +48,7 @@ def upgrade() -> None:
 def downgrade() -> None:
     op.drop_index("ix_word_morpheme_morpheme", table_name="word_morpheme_index")
     op.drop_index("ix_word_morpheme_iso", table_name="word_morpheme_index")
-    op.drop_constraint("uq_word_morpheme_pos", table_name="word_morpheme_index")
+    op.drop_constraint(
+        "uq_word_morpheme_pos", table_name="word_morpheme_index", type_="unique"
+    )
     op.drop_table("word_morpheme_index")

--- a/database/models.py
+++ b/database/models.py
@@ -940,3 +940,32 @@ class VerseMorphemeIndex(Base):
         Index("ix_verse_morpheme_index_morpheme", "morpheme_id"),
         Index("ix_verse_morpheme_index_verse", "verse_text_id"),
     )
+
+
+class WordMorphemeIndex(Base):
+    __tablename__ = "word_morpheme_index"
+
+    id = Column(Integer, primary_key=True)
+    iso_639_3 = Column(
+        String(3),
+        ForeignKey("language_profiles.iso_639_3", ondelete="CASCADE"),
+        nullable=False,
+    )
+    word = Column(Text, nullable=False)
+    morpheme_id = Column(
+        Integer,
+        ForeignKey("language_morphemes.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    position = Column(Integer, nullable=False)
+    total_morphemes = Column(Integer, nullable=False)
+    word_count = Column(Integer, server_default="1")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "iso_639_3", "word", "morpheme_id", "position",
+            name="uq_word_morpheme_pos",
+        ),
+        Index("ix_word_morpheme_iso", "iso_639_3"),
+        Index("ix_word_morpheme_morpheme", "morpheme_id"),
+    )

--- a/database/models.py
+++ b/database/models.py
@@ -959,7 +959,7 @@ class WordMorphemeIndex(Base):
     )
     position = Column(Integer, nullable=False)
     total_morphemes = Column(Integer, nullable=False)
-    word_count = Column(Integer, server_default="1")
+    word_count = Column(Integer, nullable=False, server_default="1")
 
     __table_args__ = (
         UniqueConstraint(

--- a/database/models.py
+++ b/database/models.py
@@ -963,7 +963,10 @@ class WordMorphemeIndex(Base):
 
     __table_args__ = (
         UniqueConstraint(
-            "iso_639_3", "word", "morpheme_id", "position",
+            "iso_639_3",
+            "word",
+            "morpheme_id",
+            "position",
             name="uq_word_morpheme_pos",
         ),
         Index("ix_word_morpheme_iso", "iso_639_3"),

--- a/models.py
+++ b/models.py
@@ -1295,7 +1295,7 @@ class IndexResponse(BaseModel):
 
 
 class WordIndexRequest(BaseModel):
-    iso_639_3: str
+    iso_639_3: str = Field(..., min_length=3, max_length=3)
     revision_id: int
 
 

--- a/models.py
+++ b/models.py
@@ -1294,6 +1294,30 @@ class IndexResponse(BaseModel):
     unique_morpheme_verse_pairs: int
 
 
+class WordIndexRequest(BaseModel):
+    iso_639_3: str
+    revision_id: int
+
+
+class WordIndexResponse(BaseModel):
+    unique_words_indexed: int
+    word_morpheme_pairs: int
+
+
+class CooccurrenceItem(BaseModel):
+    morpheme: str
+    morpheme_class: str
+    co_occurrence_count: int
+    example_words: List[str]
+    typical_position: str
+
+
+class CooccurrenceResponse(BaseModel):
+    morpheme: str
+    total_words_containing: int
+    cooccurrences: List[CooccurrenceItem]
+
+
 class MorphemeSearchResult(BaseModel):
     verse_reference: str
     text: str

--- a/models.py
+++ b/models.py
@@ -1315,6 +1315,7 @@ class CooccurrenceItem(BaseModel):
 class CooccurrenceResponse(BaseModel):
     morpheme: str
     total_words_containing: int
+    is_truncated: bool = False
     cooccurrences: List[CooccurrenceItem]
 
 

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -31,9 +31,6 @@ def _cleanup(db_session):
             db_session.query(VerseMorphemeIndex).filter(
                 VerseMorphemeIndex.morpheme_id.in_(mid_list)
             ).delete(synchronize_session="fetch")
-            db_session.query(WordMorphemeIndex).filter(
-                WordMorphemeIndex.morpheme_id.in_(mid_list)
-            ).delete(synchronize_session="fetch")
         db_session.query(WordMorphemeIndex).filter(
             WordMorphemeIndex.iso_639_3 == iso
         ).delete()

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -1075,11 +1075,12 @@ def test_cooccurrence_position_filter(
         db_session, client, headers, test_revision_id, verses
     )
 
-    client.post(
+    resp = client.post(
         f"/{prefix}/tokenizer/word-index",
         json={"iso_639_3": INDEX_ISO, "revision_id": test_revision_id},
         headers=headers,
     )
+    assert resp.status_code == 200, resp.text
 
     # "umu" is at position 0 in both words -> it's a prefix
     resp = client.get(

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -8,6 +8,7 @@ from database.models import (
     TokenizerRun,
     VerseMorphemeIndex,
     VerseText,
+    WordMorphemeIndex,
 )
 
 prefix = "v3"
@@ -30,6 +31,12 @@ def _cleanup(db_session):
             db_session.query(VerseMorphemeIndex).filter(
                 VerseMorphemeIndex.morpheme_id.in_(mid_list)
             ).delete(synchronize_session="fetch")
+            db_session.query(WordMorphemeIndex).filter(
+                WordMorphemeIndex.morpheme_id.in_(mid_list)
+            ).delete(synchronize_session="fetch")
+        db_session.query(WordMorphemeIndex).filter(
+            WordMorphemeIndex.iso_639_3 == iso
+        ).delete()
         db_session.query(TokenizerRun).filter(TokenizerRun.iso_639_3 == iso).delete()
         db_session.query(LanguageMorpheme).filter(
             LanguageMorpheme.iso_639_3 == iso
@@ -995,4 +1002,147 @@ def test_grammar_sketch_round_trip(
     assert resp.status_code == 200
     assert resp.json()["grammar_sketch"] is None
 
+    _cleanup(db_session)
+
+
+def test_word_index_and_cooccurrence_round_trip(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Build word index, then query co-occurrences for a morpheme."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # "umumanyizyi" segments as: umu + manyizyi
+    # "bhabhomba" segments as: bha + bhomba
+    verses = [
+        ("GEN 1:1", "GEN", 1, 1, "Umumanyizyi bhabhomba"),
+        ("GEN 1:2", "GEN", 1, 2, "Bhabhomba umumanyizyi bhabhomba"),
+    ]
+    vt_objs = _setup_morphemes_and_verses(
+        db_session, client, headers, test_revision_id, verses
+    )
+
+    # Build word index
+    resp = client.post(
+        f"/{prefix}/tokenizer/word-index",
+        json={"iso_639_3": INDEX_ISO, "revision_id": test_revision_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["unique_words_indexed"] >= 2
+    assert data["word_morpheme_pairs"] > 0
+
+    # Query co-occurrences for "umu" — should find "manyizyi" co-occurs
+    resp = client.get(
+        f"/{prefix}/tokenizer/cooccurrences?iso={INDEX_ISO}&morpheme=umu",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["morpheme"] == "umu"
+    assert data["total_words_containing"] >= 1
+    cooc_morphemes = {c["morpheme"] for c in data["cooccurrences"]}
+    assert "manyizyi" in cooc_morphemes
+
+    # Check that "manyizyi" appears after "umu" in words
+    manyizyi_cooc = next(
+        c for c in data["cooccurrences"] if c["morpheme"] == "manyizyi"
+    )
+    assert manyizyi_cooc["typical_position"] == "after"
+    assert manyizyi_cooc["co_occurrence_count"] > 0
+    assert len(manyizyi_cooc["example_words"]) > 0
+
+    _cleanup_verses(db_session, vt_objs)
+    _cleanup(db_session)
+
+
+def test_cooccurrence_position_filter(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Position filter restricts results to prefix/suffix/infix positions."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    verses = [
+        ("GEN 1:1", "GEN", 1, 1, "Umumanyizyi bhabhomba"),
+    ]
+    vt_objs = _setup_morphemes_and_verses(
+        db_session, client, headers, test_revision_id, verses
+    )
+
+    client.post(
+        f"/{prefix}/tokenizer/word-index",
+        json={"iso_639_3": INDEX_ISO, "revision_id": test_revision_id},
+        headers=headers,
+    )
+
+    # "umu" is at position 0 in "umumanyizyi" -> it's a prefix
+    resp = client.get(
+        f"/{prefix}/tokenizer/cooccurrences?iso={INDEX_ISO}&morpheme=umu&position_filter=prefix",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_words_containing"] >= 1
+
+    # "umu" as suffix should yield 0 words (it's always a prefix)
+    resp = client.get(
+        f"/{prefix}/tokenizer/cooccurrences?iso={INDEX_ISO}&morpheme=umu&position_filter=suffix",
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_words_containing"] == 0
+
+    _cleanup_verses(db_session, vt_objs)
+    _cleanup(db_session)
+
+
+def test_cooccurrence_unknown_morpheme(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Querying co-occurrences for a non-existent morpheme returns 404."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.get(
+        f"/{prefix}/tokenizer/cooccurrences?iso={INDEX_ISO}&morpheme=nonexistent",
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+    _cleanup(db_session)
+
+
+def test_word_index_idempotency(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Building word index twice yields the same result."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    verses = [
+        ("GEN 1:1", "GEN", 1, 1, "Umumanyizyi bhabhomba"),
+    ]
+    vt_objs = _setup_morphemes_and_verses(
+        db_session, client, headers, test_revision_id, verses
+    )
+
+    resp1 = client.post(
+        f"/{prefix}/tokenizer/word-index",
+        json={"iso_639_3": INDEX_ISO, "revision_id": test_revision_id},
+        headers=headers,
+    )
+    assert resp1.status_code == 200
+
+    resp2 = client.post(
+        f"/{prefix}/tokenizer/word-index",
+        json={"iso_639_3": INDEX_ISO, "revision_id": test_revision_id},
+        headers=headers,
+    )
+    assert resp2.status_code == 200
+    assert resp1.json() == resp2.json()
+
+    _cleanup_verses(db_session, vt_objs)
     _cleanup(db_session)

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -1115,9 +1115,7 @@ def test_cooccurrence_unknown_morpheme(
     _cleanup(db_session)
 
 
-def test_word_index_idempotency(
-    client, regular_token1, test_revision_id, db_session
-):
+def test_word_index_idempotency(client, regular_token1, test_revision_id, db_session):
     """Building word index twice yields the same result."""
     _cleanup(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -1012,8 +1012,8 @@ def test_word_index_and_cooccurrence_round_trip(
     _cleanup(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
-    # "umumanyizyi" segments as: umu + manyizyi
-    # "bhabhomba" segments as: bha + bhomba
+    # "umumanyizyi" segments as: umu + manyizyi (2 morphemes)
+    # "bhabhomba" segments as: bha + bhomba (2 morphemes)
     verses = [
         ("GEN 1:1", "GEN", 1, 1, "Umumanyizyi bhabhomba"),
         ("GEN 1:2", "GEN", 1, 2, "Bhabhomba umumanyizyi bhabhomba"),
@@ -1030,8 +1030,10 @@ def test_word_index_and_cooccurrence_round_trip(
     )
     assert resp.status_code == 200, resp.text
     data = resp.json()
-    assert data["unique_words_indexed"] >= 2
-    assert data["word_morpheme_pairs"] > 0
+    # 2 unique words with morphemes: "umumanyizyi" and "bhabhomba"
+    assert data["unique_words_indexed"] == 2
+    # 4 pairs: umu+manyizyi in word 1, bha+bhomba in word 2
+    assert data["word_morpheme_pairs"] == 4
 
     # Query co-occurrences for "umu" — should find "manyizyi" co-occurs
     resp = client.get(
@@ -1041,17 +1043,17 @@ def test_word_index_and_cooccurrence_round_trip(
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["morpheme"] == "umu"
-    assert data["total_words_containing"] >= 1
+    # "umumanyizyi" appears in 2 verses = word_count 2
+    assert data["total_words_containing"] == 2
     cooc_morphemes = {c["morpheme"] for c in data["cooccurrences"]}
-    assert "manyizyi" in cooc_morphemes
+    assert cooc_morphemes == {"manyizyi"}
 
     # Check that "manyizyi" appears after "umu" in words
-    manyizyi_cooc = next(
-        c for c in data["cooccurrences"] if c["morpheme"] == "manyizyi"
-    )
+    manyizyi_cooc = data["cooccurrences"][0]
+    assert manyizyi_cooc["morpheme"] == "manyizyi"
     assert manyizyi_cooc["typical_position"] == "after"
-    assert manyizyi_cooc["co_occurrence_count"] > 0
-    assert len(manyizyi_cooc["example_words"]) > 0
+    assert manyizyi_cooc["co_occurrence_count"] == 2
+    assert "umumanyizyi" in manyizyi_cooc["example_words"]
 
     _cleanup_verses(db_session, vt_objs)
     _cleanup(db_session)
@@ -1064,8 +1066,10 @@ def test_cooccurrence_position_filter(
     _cleanup(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
+    # "umubhabhomba" segments as: umu + bha + bhomba (3 morphemes)
+    # This gives us an infix ("bha" at position 1 of 3)
     verses = [
-        ("GEN 1:1", "GEN", 1, 1, "Umumanyizyi bhabhomba"),
+        ("GEN 1:1", "GEN", 1, 1, "Umumanyizyi umubhabhomba"),
     ]
     vt_objs = _setup_morphemes_and_verses(
         db_session, client, headers, test_revision_id, verses
@@ -1077,14 +1081,14 @@ def test_cooccurrence_position_filter(
         headers=headers,
     )
 
-    # "umu" is at position 0 in "umumanyizyi" -> it's a prefix
+    # "umu" is at position 0 in both words -> it's a prefix
     resp = client.get(
         f"/{prefix}/tokenizer/cooccurrences?iso={INDEX_ISO}&morpheme=umu&position_filter=prefix",
         headers=headers,
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["total_words_containing"] >= 1
+    assert data["total_words_containing"] == 2  # umumanyizyi + umubhabhomba
 
     # "umu" as suffix should yield 0 words (it's always a prefix)
     resp = client.get(
@@ -1092,8 +1096,19 @@ def test_cooccurrence_position_filter(
         headers=headers,
     )
     assert resp.status_code == 200
+    assert resp.json()["total_words_containing"] == 0
+
+    # "bha" is at position 1 of 3 in "umubhabhomba" -> it's an infix
+    resp = client.get(
+        f"/{prefix}/tokenizer/cooccurrences?iso={INDEX_ISO}&morpheme=bha&position_filter=infix",
+        headers=headers,
+    )
+    assert resp.status_code == 200
     data = resp.json()
-    assert data["total_words_containing"] == 0
+    assert data["total_words_containing"] == 1
+    cooc_morphemes = {c["morpheme"] for c in data["cooccurrences"]}
+    assert "umu" in cooc_morphemes
+    assert "bhomba" in cooc_morphemes
 
     _cleanup_verses(db_session, vt_objs)
     _cleanup(db_session)
@@ -1133,6 +1148,9 @@ def test_word_index_idempotency(client, regular_token1, test_revision_id, db_ses
         headers=headers,
     )
     assert resp1.status_code == 200
+    data1 = resp1.json()
+    assert data1["unique_words_indexed"] == 2
+    assert data1["word_morpheme_pairs"] == 4
 
     resp2 = client.post(
         f"/{prefix}/tokenizer/word-index",
@@ -1140,7 +1158,7 @@ def test_word_index_idempotency(client, regular_token1, test_revision_id, db_ses
         headers=headers,
     )
     assert resp2.status_code == 200
-    assert resp1.json() == resp2.json()
+    assert resp2.json() == data1
 
     _cleanup_verses(db_session, vt_objs)
     _cleanup(db_session)


### PR DESCRIPTION
## Summary
- Add `word_morpheme_index` table tracking morpheme positions within individual words and word frequencies across the corpus
- Add `POST /tokenizer/word-index` endpoint to build the word-level index via Viterbi segmentation of all unique words in a revision
- Add `GET /tokenizer/cooccurrences` endpoint to query morphemes that co-occur within the same words, with optional position filtering (prefix/suffix/infix)
- Includes Alembic migration, Pydantic schemas, and 4 new tests

Fixes #534

## Test plan
- [x] `test_word_index_and_cooccurrence_round_trip` — builds index, queries co-occurrences, verifies morpheme positions
- [x] `test_cooccurrence_position_filter` — prefix/suffix filtering works correctly
- [x] `test_cooccurrence_unknown_morpheme` — returns 404 for non-existent morphemes
- [x] `test_word_index_idempotency` — re-indexing produces identical results
- [x] All 26 tokenizer tests pass (existing + new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)