### PR TITLE
Add target_words filter to GET /v3/agent/lexeme-card

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -7,8 +7,11 @@ import unicodedata
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, Request, status
+from sqlalchemy import bindparam
+from sqlalchemy.dialects.postgresql import ARRAY
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.types import Text as TextType
 
 from database.dependencies import get_db
 from database.models import (
@@ -1621,6 +1624,10 @@ async def get_lexeme_cards(
     try:
         from sqlalchemy import desc, select, text
 
+        # Normalize inputs before validation
+        source_word = source_word.strip() if source_word else None
+        target_word = target_word.strip() if target_word else None
+
         if target_word and target_words:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
@@ -1640,14 +1647,11 @@ async def get_lexeme_cards(
             conditions.append(AgentLexemeCard.pos == pos)
 
         # Word filtering: both source_word and target_word search
-        # lemma OR surface_forms (case-insensitive exact match)
+        # lemma OR surface_forms (case-insensitive exact match, NFC-normalized)
         word_conditions = []
 
-        source_word = source_word.strip() if source_word else None
-        target_word = target_word.strip() if target_word else None
-
         if source_word:
-            source_word_lower = source_word.lower()
+            source_word_lower = unicodedata.normalize("NFC", source_word).lower()
             word_conditions.append(
                 text(
                     "((LOWER(agent_lexeme_cards.source_lemma) = :source_word_lower) OR "
@@ -1658,7 +1662,7 @@ async def get_lexeme_cards(
             )
 
         if target_word:
-            target_word_lower = target_word.lower()
+            target_word_lower = unicodedata.normalize("NFC", target_word).lower()
             word_conditions.append(
                 text(
                     "((LOWER(agent_lexeme_cards.target_lemma) = :target_word_lower) OR "
@@ -1675,22 +1679,22 @@ async def get_lexeme_cards(
                 for w in target_words.split(",")
                 if w.strip()
             ]
-            if words_list:
-                from sqlalchemy import bindparam
-                from sqlalchemy.dialects.postgresql import ARRAY
-                from sqlalchemy.types import Text
-
-                tw_param = bindparam(
-                    "target_words_arr", value=words_list, type_=ARRAY(Text)
+            if not words_list:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="'target_words' parameter contains no valid words.",
                 )
-                word_conditions.append(
-                    text(
-                        "(LOWER(agent_lexeme_cards.target_lemma) = ANY(:target_words_arr) OR "
-                        "(jsonb_typeof(agent_lexeme_cards.surface_forms) = 'array' AND "
-                        "EXISTS (SELECT 1 FROM jsonb_array_elements_text(agent_lexeme_cards.surface_forms) AS elem "
-                        "WHERE LOWER(elem) = ANY(:target_words_arr))))"
-                    ).bindparams(tw_param)
-                )
+            tw_param = bindparam(
+                "target_words_arr", value=words_list, type_=ARRAY(TextType)
+            )
+            word_conditions.append(
+                text(
+                    "(LOWER(agent_lexeme_cards.target_lemma) = ANY(:target_words_arr) OR "
+                    "(jsonb_typeof(agent_lexeme_cards.surface_forms) = 'array' AND "
+                    "EXISTS (SELECT 1 FROM jsonb_array_elements_text(agent_lexeme_cards.surface_forms) AS elem "
+                    "WHERE LOWER(elem) = ANY(:target_words_arr))))"
+                ).bindparams(tw_param)
+            )
 
         query = (
             select(AgentLexemeCard)

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -3,6 +3,7 @@ __version__ = "v3"
 import datetime
 import socket
 import time
+import unicodedata
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, Request, status
@@ -1589,6 +1590,7 @@ async def get_lexeme_cards(
     target_language: str,
     source_word: str = None,
     target_word: str = None,
+    target_words: str = None,
     pos: str = None,
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
@@ -1606,6 +1608,9 @@ async def get_lexeme_cards(
       (case-insensitive exact match)
     - target_word: str (optional) - Filter by target_lemma or surface_forms
       (case-insensitive exact match)
+    - target_words: str (optional) - Comma-separated list of target words. Returns
+      cards where target_lemma or any surface_form matches any of the given words
+      (case-insensitive, NFC-normalized). Cannot be used with target_word.
     - pos: str (optional) - Filter by part of speech
 
     Returns:
@@ -1615,6 +1620,12 @@ async def get_lexeme_cards(
     request_start = time.perf_counter()
     try:
         from sqlalchemy import desc, select, text
+
+        if target_word and target_words:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot use both 'target_word' and 'target_words' parameters.",
+            )
 
         is_admin = current_user.is_admin
 
@@ -1656,6 +1667,30 @@ async def get_lexeme_cards(
                     "WHERE LOWER(elem) = :target_word_lower)))"
                 ).bindparams(target_word_lower=target_word_lower)
             )
+
+        if target_words:
+            # Parse comma-separated list, NFC-normalize and lowercase each word
+            words_list = [
+                unicodedata.normalize("NFC", w.strip()).lower()
+                for w in target_words.split(",")
+                if w.strip()
+            ]
+            if words_list:
+                from sqlalchemy import bindparam
+                from sqlalchemy.dialects.postgresql import ARRAY
+                from sqlalchemy.types import Text
+
+                tw_param = bindparam(
+                    "target_words_arr", value=words_list, type_=ARRAY(Text)
+                )
+                word_conditions.append(
+                    text(
+                        "(LOWER(agent_lexeme_cards.target_lemma) = ANY(:target_words_arr) OR "
+                        "(jsonb_typeof(agent_lexeme_cards.surface_forms) = 'array' AND "
+                        "EXISTS (SELECT 1 FROM jsonb_array_elements_text(agent_lexeme_cards.surface_forms) AS elem "
+                        "WHERE LOWER(elem) = ANY(:target_words_arr))))"
+                    ).bindparams(tw_param)
+                )
 
         query = (
             select(AgentLexemeCard)
@@ -1763,6 +1798,7 @@ async def get_lexeme_cards(
                 "target_language": target_language,
                 "source_word": source_word,
                 "target_word": target_word,
+                "target_words": target_words,
                 "pos": pos,
                 "duration_s": duration,
             },

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1628,7 +1628,7 @@ async def get_lexeme_cards(
         source_word = source_word.strip() if source_word else None
         target_word = target_word.strip() if target_word else None
 
-        if target_word and target_words:
+        if target_word and target_words is not None:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Cannot use both 'target_word' and 'target_words' parameters.",
@@ -1672,7 +1672,7 @@ async def get_lexeme_cards(
                 ).bindparams(target_word_lower=target_word_lower)
             )
 
-        if target_words:
+        if target_words is not None:
             # Parse comma-separated list, NFC-normalize and lowercase each word
             words_list = [
                 unicodedata.normalize("NFC", w.strip()).lower()

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1192,6 +1192,19 @@ def test_get_lexeme_cards_target_words_conflicts_with_target_word(
     assert "Cannot use both" in response.json()["detail"]
 
 
+def test_get_lexeme_cards_target_words_all_blank_returns_400(
+    client, regular_token1, db_session
+):
+    """Test that target_words with only blanks/commas returns 400."""
+    response = client.get(
+        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=%20,%20,",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+    assert "no valid words" in response.json()["detail"]
+
+
 def test_get_lexeme_cards_by_pos(client, regular_token1, db_session, test_revision_id):
     """Test getting lexeme cards filtered by part of speech."""
     # Add test data

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1095,6 +1095,103 @@ def test_get_lexeme_cards_by_target_lemma(
     assert all(card["target_lemma"] == "upendo" for card in data)
 
 
+def test_get_lexeme_cards_by_target_words(
+    client, regular_token1, db_session, test_revision_id
+):
+    """Test filtering lexeme cards by comma-separated target_words."""
+    # Add test data with unique lemmas for this test
+    for lemma in ["tw_maji", "tw_moto", "tw_ardhi"]:
+        client.post(
+            f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+            json={
+                "source_lemma": f"src_{lemma}",
+                "target_lemma": lemma,
+                "source_language": "eng",
+                "target_language": "swh",
+            },
+        )
+
+    # Filter by two of three target words
+    response = client.get(
+        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=tw_maji,tw_moto",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    lemmas = {card["target_lemma"] for card in data}
+    assert "tw_maji" in lemmas
+    assert "tw_moto" in lemmas
+    assert "tw_ardhi" not in lemmas
+
+
+def test_get_lexeme_cards_target_words_surface_forms(
+    client, regular_token1, db_session, test_revision_id
+):
+    """Test that target_words also matches surface_forms."""
+    client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "run_tw_sf",
+            "target_lemma": "kimbia_tw_sf",
+            "source_language": "eng",
+            "target_language": "swh",
+            "surface_forms": ["anakimbia_tw_sf", "walikimbia_tw_sf"],
+        },
+    )
+
+    # Search by a surface form, not the lemma
+    response = client.get(
+        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=anakimbia_tw_sf",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) >= 1
+    assert any(card["target_lemma"] == "kimbia_tw_sf" for card in data)
+
+
+def test_get_lexeme_cards_target_words_case_insensitive(
+    client, regular_token1, db_session, test_revision_id
+):
+    """Test that target_words matching is case-insensitive."""
+    client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "god_tw_ci",
+            "target_lemma": "tw_mungu",
+            "source_language": "eng",
+            "target_language": "swh",
+        },
+    )
+
+    response = client.get(
+        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=TW_MUNGU",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert any(card["target_lemma"] == "tw_mungu" for card in data)
+
+
+def test_get_lexeme_cards_target_words_conflicts_with_target_word(
+    client, regular_token1, db_session
+):
+    """Test that using both target_word and target_words returns 400."""
+    response = client.get(
+        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=foo&target_words=bar",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+    assert "Cannot use both" in response.json()["detail"]
+
+
 def test_get_lexeme_cards_by_pos(client, regular_token1, db_session, test_revision_id):
     """Test getting lexeme cards filtered by part of speech."""
     # Add test data

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1205,6 +1205,19 @@ def test_get_lexeme_cards_target_words_all_blank_returns_400(
     assert "no valid words" in response.json()["detail"]
 
 
+def test_get_lexeme_cards_target_words_empty_string_returns_400(
+    client, regular_token1, db_session
+):
+    """Test that target_words with an explicit empty value returns 400."""
+    response = client.get(
+        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+    assert "no valid words" in response.json()["detail"]
+
+
 def test_get_lexeme_cards_by_pos(client, regular_token1, db_session, test_revision_id):
     """Test getting lexeme cards filtered by part of speech."""
     # Add test data


### PR DESCRIPTION
## Summary
- Add optional `target_words` query parameter (comma-separated) to `GET /v3/agent/lexeme-card`
- Matches against `target_lemma` or any `surface_forms` entry (case-insensitive, NFC-normalized)
- Uses PostgreSQL `= ANY()` with typed `ARRAY(Text)` bind parameter for efficient multi-word matching
- Returns 400 if both `target_word` and `target_words` are provided

Fixes #538

## Test plan
- [x] Test filtering by multiple comma-separated lemmas
- [x] Test matching via surface_forms
- [x] Test case-insensitive matching
- [x] Test 400 error when both target_word and target_words provided
- [x] All 96 existing lexeme card tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)