### PR TITLE
textsearch: allow querying by language ISO instead of revision_id

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -25,30 +25,6 @@ logger = setup_logger(__name__, container_id=container_id)
 router = APIRouter()
 
 
-def _is_whole_word_match(text: str, search_term: str) -> bool:
-    """
-    Check if the search term appears as a whole word in the text (case-insensitive).
-
-    Parameters
-    ----------
-    text : str
-        The text to search in
-    search_term : str
-        The term to search for
-
-    Returns
-    -------
-    bool
-        True if the search term appears as a whole word in the text
-    """
-    if not text or not search_term:
-        return False
-
-    # Create a regex pattern for whole word matching (case-insensitive)
-    pattern = r"\b" + re.escape(search_term.lower()) + r"\b"
-    return bool(re.search(pattern, text.lower()))
-
-
 async def _resolve_authorized_revision_ids_for_iso(
     iso: str, user: UserModel, db: AsyncSession
 ) -> list[int]:
@@ -59,8 +35,8 @@ async def _resolve_authorized_revision_ids_for_iso(
         .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
         .where(
             BibleVersion.iso_language == iso,
-            BibleRevision.deleted == False,  # noqa: E712
-            BibleVersion.deleted == False,  # noqa: E712
+            BibleRevision.deleted.is_not(True),
+            BibleVersion.deleted.is_not(True),
         )
     )
 
@@ -235,6 +211,12 @@ async def search_revision_text(
                 vt1_alias.chapter,
                 vt1_alias.verse,
             )
+
+    # Cap the DB result set.  The Python-side whole-word filter may discard
+    # ilike matches that aren't whole words, so we overfetch by 10x to give
+    # enough headroom while still bounding the transfer from the DB.
+    sql_limit = limit * 10
+    search_query = search_query.limit(sql_limit)
 
     # Apply ordering.  DISTINCT ON requires the leading ORDER BY columns to
     # match, so when dedup is active we always order by (book, chapter, verse)

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -55,6 +55,7 @@ async def _resolve_authorized_revision_ids_for_iso(
     """Return revision IDs the user may access for a given ISO 639-3 code."""
     base_query = (
         select(BibleRevision.id)
+        .distinct()
         .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
         .where(
             BibleVersion.iso_language == iso,
@@ -78,7 +79,7 @@ async def _resolve_authorized_revision_ids_for_iso(
 
 @router.get("/textsearch")
 async def search_revision_text(
-    term: str,
+    term: str = Query(..., min_length=1, max_length=200),
     revision_id: Optional[int] = None,
     iso: Optional[str] = Query(
         default=None,
@@ -104,10 +105,12 @@ async def search_revision_text(
 
     Provide either ``revision_id`` or ``iso`` (not both).  When ``iso`` is
     given, all accessible revisions for that language are searched and results
-    are deduplicated by verse text.
+    are deduplicated by verse location (book, chapter, verse).  When multiple
+    revisions cover the same verse, one is chosen arbitrarily.
 
     Similarly, provide either ``comparison_revision_id`` or ``comparison_iso``
-    for parallel text.
+    for parallel text.  When ``comparison_iso`` resolves to multiple revisions,
+    one comparison text per verse is returned (non-deterministic choice).
     """
     request_start = time.perf_counter()
 
@@ -171,8 +174,9 @@ async def search_revision_text(
     use_comparison = comp_revision_ids is not None
     comp_dedup = comparison_iso is not None
 
-    # Validate limit
-    limit = max(1, min(limit, 1000))
+    # Escape SQL LIKE/ILIKE wildcards so % and _ in the term are literal
+    escaped_term = term.replace("%", r"\%").replace("_", r"\_")
+    like_pattern = f"%{escaped_term}%"
 
     # Build the base query
     vt1_alias = aliased(VerseText, name="vt1")
@@ -200,7 +204,7 @@ async def search_revision_text(
             )
             .where(
                 vt1_alias.revision_id.in_(main_revision_ids),
-                vt1_alias.text.ilike(f"%{term}%"),
+                vt1_alias.text.ilike(like_pattern),
                 vt1_alias.text != "",
                 vt2_alias.text != "",
             )
@@ -221,7 +225,7 @@ async def search_revision_text(
             vt1_alias.text.label("main_text"),
         ).where(
             vt1_alias.revision_id.in_(main_revision_ids),
-            vt1_alias.text.ilike(f"%{term}%"),
+            vt1_alias.text.ilike(like_pattern),
             vt1_alias.text != "",
         )
 
@@ -232,13 +236,25 @@ async def search_revision_text(
                 vt1_alias.verse,
             )
 
-    # Apply ordering based on random parameter
-    if random:
-        search_query = search_query.order_by(func.random())
-    else:
+    # Apply ordering.  DISTINCT ON requires the leading ORDER BY columns to
+    # match, so when dedup is active we always order by (book, chapter, verse)
+    # first.  For random mode with dedup, we wrap the deduped result as a
+    # subquery and randomise the outer query.
+    needs_dedup = use_dedup or comp_dedup
+    if needs_dedup:
         search_query = search_query.order_by(
             vt1_alias.book, vt1_alias.chapter, vt1_alias.verse
         )
+        if random:
+            sub = search_query.subquery()
+            search_query = select(sub).order_by(func.random())
+    else:
+        if random:
+            search_query = search_query.order_by(func.random())
+        else:
+            search_query = search_query.order_by(
+                vt1_alias.book, vt1_alias.chapter, vt1_alias.verse
+            )
 
     try:
         # Execute the query
@@ -247,8 +263,9 @@ async def search_revision_text(
 
         # Filter results to only include whole word matches, stopping at limit
         filtered_results = []
+        word_pattern = re.compile(r"\b" + re.escape(term.lower()) + r"\b")
         for row in rows:
-            if _is_whole_word_match(row.main_text, term):
+            if row.main_text and word_pattern.search(row.main_text.lower()):
                 result_dict = {
                     "book": row.book,
                     "chapter": row.chapter,
@@ -297,5 +314,5 @@ async def search_revision_text(
         )
         raise HTTPException(
             status_code=500,
-            detail=f"Error searching text: {str(e)}",
+            detail="Error searching text",
         )

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -12,8 +12,9 @@ from sqlalchemy.orm import aliased
 from sqlalchemy.sql import select
 
 from database.dependencies import get_db
+from database.models import BibleRevision, BibleVersion, BibleVersionAccess
 from database.models import UserDB as UserModel
-from database.models import VerseText
+from database.models import UserGroup, VerseText
 from security_routes.auth_routes import get_current_user
 from security_routes.utilities import is_user_authorized_for_revision
 from utils.logging_config import setup_logger
@@ -48,11 +49,50 @@ def _is_whole_word_match(text: str, search_term: str) -> bool:
     return bool(re.search(pattern, text.lower()))
 
 
+async def _resolve_authorized_revision_ids_for_iso(
+    iso: str, user: UserModel, db: AsyncSession
+) -> list[int]:
+    """Return revision IDs the user may access for a given ISO 639-3 code."""
+    base_query = (
+        select(BibleRevision.id)
+        .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
+        .where(
+            BibleVersion.iso_language == iso,
+            BibleRevision.deleted == False,  # noqa: E712
+            BibleVersion.deleted == False,  # noqa: E712
+        )
+    )
+
+    if not user.is_admin:
+        user_groups_subq = (
+            select(UserGroup.group_id).where(UserGroup.user_id == user.id)
+        ).subquery()
+        base_query = base_query.join(
+            BibleVersionAccess,
+            BibleVersionAccess.bible_version_id == BibleVersion.id,
+        ).where(BibleVersionAccess.group_id.in_(user_groups_subq))
+
+    result = await db.execute(base_query)
+    return list(result.scalars().all())
+
+
 @router.get("/textsearch")
 async def search_revision_text(
-    revision_id: int,
     term: str,
+    revision_id: Optional[int] = None,
+    iso: Optional[str] = Query(
+        default=None,
+        min_length=3,
+        max_length=3,
+        description="ISO 639-3 code; searches all accessible revisions for this language",
+    ),
     comparison_revision_id: Optional[int] = None,
+    comparison_iso: Optional[str] = Query(
+        default=None,
+        min_length=3,
+        max_length=3,
+        description="ISO 639-3 code for comparison text",
+    ),
     limit: int = Query(default=10, ge=1, le=1000),
     random: bool = False,
     db: AsyncSession = Depends(get_db),
@@ -62,36 +102,52 @@ async def search_revision_text(
     Search for verses containing a specific term in a revision text.
     Returns verses that contain the search term (case-insensitive, whole word match).
 
-    Parameters
-    ----------
-    revision_id : int
-        The ID of the revision to search in
-    term : str
-        The search term to look for
-    comparison_revision_id : int, optional
-        The ID of a comparison revision to include text from
-    limit : int, optional
-        Maximum number of results to return (default 10, max 1000)
-    random : bool, optional
-        If True, return results in random order. If False (default), return in verse order.
+    Provide either ``revision_id`` or ``iso`` (not both).  When ``iso`` is
+    given, all accessible revisions for that language are searched and results
+    are deduplicated by verse text.
 
-    Returns
-    -------
-    Dict
-        A dictionary containing:
-        - results: List of matching verses with book, chapter, verse, main_text, and optional comparison_text
-        - total_count: Number of results returned
+    Similarly, provide either ``comparison_revision_id`` or ``comparison_iso``
+    for parallel text.
     """
     request_start = time.perf_counter()
 
-    # Check authorization for the main revision
-    if not await is_user_authorized_for_revision(current_user.id, revision_id, db):
+    # --- validate parameter combinations ---------------------------------
+    if revision_id is not None and iso is not None:
         raise HTTPException(
-            status_code=403,
-            detail="User not authorized to access this revision",
+            status_code=400,
+            detail="Provide either revision_id or iso, not both",
+        )
+    if revision_id is None and iso is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Either revision_id or iso is required",
+        )
+    if comparison_revision_id is not None and comparison_iso is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="Provide either comparison_revision_id or comparison_iso, not both",
         )
 
-    # Check authorization for the comparison revision if provided
+    # --- resolve main revision IDs ---------------------------------------
+    if revision_id is not None:
+        if not await is_user_authorized_for_revision(current_user.id, revision_id, db):
+            raise HTTPException(
+                status_code=403,
+                detail="User not authorized to access this revision",
+            )
+        main_revision_ids = [revision_id]
+    else:
+        main_revision_ids = await _resolve_authorized_revision_ids_for_iso(
+            iso, current_user, db
+        )
+        if not main_revision_ids:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No accessible revisions found for iso '{iso}'",
+            )
+
+    # --- resolve comparison revision IDs ---------------------------------
+    comp_revision_ids: list[int] | None = None
     if comparison_revision_id is not None:
         if not await is_user_authorized_for_revision(
             current_user.id, comparison_revision_id, db
@@ -100,6 +156,20 @@ async def search_revision_text(
                 status_code=403,
                 detail="User not authorized to access the comparison revision",
             )
+        comp_revision_ids = [comparison_revision_id]
+    elif comparison_iso is not None:
+        comp_revision_ids = await _resolve_authorized_revision_ids_for_iso(
+            comparison_iso, current_user, db
+        )
+        if not comp_revision_ids:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No accessible revisions found for comparison iso '{comparison_iso}'",
+            )
+
+    use_dedup = iso is not None
+    use_comparison = comp_revision_ids is not None
+    comp_dedup = comparison_iso is not None
 
     # Validate limit
     limit = max(1, min(limit, 1000))
@@ -107,31 +177,41 @@ async def search_revision_text(
     # Build the base query
     vt1_alias = aliased(VerseText, name="vt1")
 
-    if comparison_revision_id:
+    if use_comparison:
         vt2_alias = aliased(VerseText, name="vt2")
+
+        select_cols = [
+            vt1_alias.id.label("id"),
+            vt1_alias.book.label("book"),
+            vt1_alias.chapter.label("chapter"),
+            vt1_alias.verse.label("verse"),
+            vt1_alias.text.label("main_text"),
+            vt2_alias.text.label("comparison_text"),
+        ]
+
         search_query = (
-            select(
-                vt1_alias.id.label("id"),
-                vt1_alias.book.label("book"),
-                vt1_alias.chapter.label("chapter"),
-                vt1_alias.verse.label("verse"),
-                vt1_alias.text.label("main_text"),
-                vt2_alias.text.label("comparison_text"),
-            )
+            select(*select_cols)
             .join(
                 vt2_alias,
                 (vt2_alias.book == vt1_alias.book)
                 & (vt2_alias.chapter == vt1_alias.chapter)
                 & (vt2_alias.verse == vt1_alias.verse)
-                & (vt2_alias.revision_id == comparison_revision_id),
+                & (vt2_alias.revision_id.in_(comp_revision_ids)),
             )
             .where(
-                vt1_alias.revision_id == revision_id,
+                vt1_alias.revision_id.in_(main_revision_ids),
                 vt1_alias.text.ilike(f"%{term}%"),
                 vt1_alias.text != "",
                 vt2_alias.text != "",
             )
         )
+
+        if use_dedup or comp_dedup:
+            search_query = search_query.distinct(
+                vt1_alias.book,
+                vt1_alias.chapter,
+                vt1_alias.verse,
+            )
     else:
         search_query = select(
             vt1_alias.id.label("id"),
@@ -140,16 +220,25 @@ async def search_revision_text(
             vt1_alias.verse.label("verse"),
             vt1_alias.text.label("main_text"),
         ).where(
-            vt1_alias.revision_id == revision_id,
+            vt1_alias.revision_id.in_(main_revision_ids),
             vt1_alias.text.ilike(f"%{term}%"),
             vt1_alias.text != "",
         )
+
+        if use_dedup:
+            search_query = search_query.distinct(
+                vt1_alias.book,
+                vt1_alias.chapter,
+                vt1_alias.verse,
+            )
 
     # Apply ordering based on random parameter
     if random:
         search_query = search_query.order_by(func.random())
     else:
-        search_query = search_query.order_by(vt1_alias.id)
+        search_query = search_query.order_by(
+            vt1_alias.book, vt1_alias.chapter, vt1_alias.verse
+        )
 
     try:
         # Execute the query
@@ -166,7 +255,7 @@ async def search_revision_text(
                     "verse": row.verse,
                     "main_text": row.main_text,
                 }
-                if comparison_revision_id:
+                if use_comparison:
                     result_dict["comparison_text"] = row.comparison_text
 
                 filtered_results.append(result_dict)
@@ -182,8 +271,10 @@ async def search_revision_text(
                 "method": "GET",
                 "path": "/textsearch",
                 "revision_id": revision_id,
+                "iso": iso,
                 "term": term,
                 "comparison_revision_id": comparison_revision_id,
+                "comparison_iso": comparison_iso,
                 "limit": limit,
                 "random": random,
                 "results_returned": len(filtered_results),
@@ -200,6 +291,7 @@ async def search_revision_text(
                 "method": "GET",
                 "path": "/textsearch",
                 "revision_id": revision_id,
+                "iso": iso,
                 "term": term,
             },
         )

--- a/security_routes/utilities.py
+++ b/security_routes/utilities.py
@@ -78,6 +78,10 @@ async def is_user_authorized_for_revision(user_id, revision_id, db):
     stmt = (
         select(BibleVersion)
         .join(BibleRevision, BibleVersion.id == BibleRevision.bible_version_id)
+        .join(
+            BibleVersionAccess,
+            BibleVersionAccess.bible_version_id == BibleVersion.id,
+        )
         .where(
             BibleRevision.id == revision_id,
             BibleVersionAccess.group_id.in_(user_groups),

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -844,3 +844,22 @@ def test_search_iso_no_accessible_revisions(client, regular_token2, test_db_sess
 
     # regular_token2 has no access to these versions
     assert response.status_code == 404
+
+
+def test_search_by_iso_random(client, regular_token1, test_db_session):
+    """Test ISO search with random=True does not crash (DISTINCT ON + random fix)."""
+    setup_iso_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"iso": "eng", "term": "God", "limit": 10, "random": True},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] > 0
+
+    # Dedup still applies — no duplicate verse locations
+    refs = [(r["book"], r["chapter"], r["verse"]) for r in data["results"]]
+    assert len(refs) == len(set(refs))

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -5,6 +5,7 @@ from database.models import (
     BibleVersion,
     BibleVersionAccess,
     Group,
+    IsoLanguage,
     UserDB,
     VerseText,
 )
@@ -574,3 +575,272 @@ def test_search_no_subword_matches(client, regular_token1, test_db_session):
         assert re.search(
             pattern, text_lower
         ), f"'love' not found as whole word in: {result['main_text']}"
+
+
+# --- ISO-based search tests ---
+
+
+def setup_iso_search_test_data(db_session):
+    """Setup test data for ISO-based search with multiple revisions per language."""
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = db_session.query(Group).filter(Group.name == "Group1").first()
+
+    # Ensure swh language exists
+    if (
+        db_session.query(IsoLanguage).filter(IsoLanguage.iso639 == "swh").first()
+        is None
+    ):
+        db_session.add(IsoLanguage(iso639="swh", name="Swahili"))
+        db_session.commit()
+
+    # --- Two English versions (same language) with overlapping verses ---
+    eng_version_a = BibleVersion(
+        name="ISO Test Eng A",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="IEA",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    eng_version_b = BibleVersion(
+        name="ISO Test Eng B",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="IEB",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    db_session.add_all([eng_version_a, eng_version_b])
+    db_session.commit()
+    db_session.refresh(eng_version_a)
+    db_session.refresh(eng_version_b)
+
+    eng_rev_a = BibleRevision(
+        date=date.today(),
+        bible_version_id=eng_version_a.id,
+        published=True,
+        machine_translation=False,
+    )
+    eng_rev_b = BibleRevision(
+        date=date.today(),
+        bible_version_id=eng_version_b.id,
+        published=True,
+        machine_translation=False,
+    )
+    db_session.add_all([eng_rev_a, eng_rev_b])
+    db_session.commit()
+    db_session.refresh(eng_rev_a)
+    db_session.refresh(eng_rev_b)
+
+    # Revision A has GEN 1:1 and GEN 1:3
+    for book, chapter, verse, text in [
+        ("GEN", 1, 1, "In the beginning God created the heaven and the earth."),
+        ("GEN", 1, 3, "And God said, Let there be light: and there was light."),
+    ]:
+        db_session.add(
+            VerseText(
+                text=text,
+                revision_id=eng_rev_a.id,
+                verse_reference=f"{book} {chapter}:{verse}",
+                book=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        )
+
+    # Revision B has the same verses (different wording) — dedup should collapse
+    for book, chapter, verse, text in [
+        ("GEN", 1, 1, "In the beginning God made the heavens and the earth."),
+        ("GEN", 1, 3, "Then God said, Let there be light, and there was light."),
+    ]:
+        db_session.add(
+            VerseText(
+                text=text,
+                revision_id=eng_rev_b.id,
+                verse_reference=f"{book} {chapter}:{verse}",
+                book=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        )
+
+    # --- Swahili version for comparison_iso ---
+    swh_version = BibleVersion(
+        name="ISO Test Swahili",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="ISW",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    db_session.add(swh_version)
+    db_session.commit()
+    db_session.refresh(swh_version)
+
+    swh_rev = BibleRevision(
+        date=date.today(),
+        bible_version_id=swh_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    db_session.add(swh_rev)
+    db_session.commit()
+    db_session.refresh(swh_rev)
+
+    for book, chapter, verse, text in [
+        ("GEN", 1, 1, "Hapo mwanzo Mungu aliumba mbingu na dunia."),
+        ("GEN", 1, 3, "Mungu akasema, Iwe nuru, ikawa nuru."),
+    ]:
+        db_session.add(
+            VerseText(
+                text=text,
+                revision_id=swh_rev.id,
+                verse_reference=f"{book} {chapter}:{verse}",
+                book=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        )
+
+    # Grant access to all versions
+    for version in [eng_version_a, eng_version_b, swh_version]:
+        db_session.add(
+            BibleVersionAccess(
+                bible_version_id=version.id,
+                group_id=group1.id,
+            )
+        )
+
+    db_session.commit()
+
+    return {
+        "eng_rev_a": eng_rev_a.id,
+        "eng_rev_b": eng_rev_b.id,
+        "swh_rev": swh_rev.id,
+    }
+
+
+def test_search_by_iso(client, regular_token1, test_db_session):
+    """Test searching by ISO code across all revisions for a language."""
+    ids = setup_iso_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"iso": "eng", "term": "God", "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] > 0
+
+    # Both revisions have GEN 1:1 and GEN 1:3 with "God" — dedup should
+    # return at most one result per (book, chapter, verse)
+    refs = [(r["book"], r["chapter"], r["verse"]) for r in data["results"]]
+    assert len(refs) == len(set(refs)), "Expected deduplicated results"
+
+
+def test_search_by_iso_with_comparison_iso(client, regular_token1, test_db_session):
+    """Test iso + comparison_iso returns parallel text."""
+    ids = setup_iso_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"iso": "eng", "comparison_iso": "swh", "term": "God", "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] > 0
+
+    for result in data["results"]:
+        assert "comparison_text" in result
+        assert result["comparison_text"], "Expected non-empty comparison text"
+
+
+def test_search_by_iso_with_comparison_revision_id(
+    client, regular_token1, test_db_session
+):
+    """Test iso for main + comparison_revision_id for comparison."""
+    ids = setup_iso_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "iso": "eng",
+            "comparison_revision_id": ids["swh_rev"],
+            "term": "God",
+            "limit": 10,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] > 0
+    assert "comparison_text" in data["results"][0]
+
+
+def test_search_iso_and_revision_id_mutually_exclusive(
+    client, regular_token1, test_db_session
+):
+    """Providing both revision_id and iso should return 400."""
+    ids = setup_iso_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": ids["eng_rev_a"],
+            "iso": "eng",
+            "term": "God",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_search_comparison_iso_and_revision_id_mutually_exclusive(
+    client, regular_token1, test_db_session
+):
+    """Providing both comparison_revision_id and comparison_iso should return 400."""
+    ids = setup_iso_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": ids["eng_rev_a"],
+            "comparison_revision_id": ids["swh_rev"],
+            "comparison_iso": "swh",
+            "term": "God",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_search_neither_revision_id_nor_iso(client, regular_token1, test_db_session):
+    """Omitting both revision_id and iso should return 400."""
+    response = client.get(
+        "/v3/textsearch",
+        params={"term": "God"},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_search_iso_no_accessible_revisions(client, regular_token2, test_db_session):
+    """Searching an ISO the user has no access to should return 404."""
+    setup_iso_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"iso": "eng", "term": "God"},
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+
+    # regular_token2 has no access to these versions
+    assert response.status_code == 404

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -722,7 +722,7 @@ def setup_iso_search_test_data(db_session):
 
 def test_search_by_iso(client, regular_token1, test_db_session):
     """Test searching by ISO code across all revisions for a language."""
-    ids = setup_iso_search_test_data(test_db_session)
+    setup_iso_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",
@@ -742,7 +742,7 @@ def test_search_by_iso(client, regular_token1, test_db_session):
 
 def test_search_by_iso_with_comparison_iso(client, regular_token1, test_db_session):
     """Test iso + comparison_iso returns parallel text."""
-    ids = setup_iso_search_test_data(test_db_session)
+    setup_iso_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",


### PR DESCRIPTION
## Summary

- Add optional `iso` parameter as alternative to `revision_id` — searches across all accessible revisions for that language with `DISTINCT ON` deduplication
- Add optional `comparison_iso` parameter as alternative to `comparison_revision_id`
- Validate mutually exclusive param combinations (400 if both or neither provided)
- Return 404 when no accessible revisions exist for the given ISO code

Fixes #540

## Test plan

- [x] All 12 existing textsearch tests still pass
- [x] 8 new tests: ISO search, ISO + comparison_iso, ISO + comparison_revision_id, mutual exclusion checks, missing params, unauthorized access
- [ ] Manual test against production DB on localhost:8000

🤖 Generated with [Claude Code](https://claude.com/claude-code)