### PR TITLE
Fix textsearch matching for accented characters (NFC normalization)

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -3,6 +3,7 @@ __version__ = "v3"
 import re
 import socket
 import time
+import unicodedata
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -10,6 +11,7 @@ from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import select
+from sqlalchemy.sql.expression import literal_column
 
 from database.dependencies import get_db
 from database.models import BibleRevision, BibleVersion, BibleVersionAccess
@@ -150,9 +152,16 @@ async def search_revision_text(
     use_comparison = comp_revision_ids is not None
     comp_dedup = comparison_iso is not None
 
+    # Normalize to NFC so accented characters match regardless of whether the
+    # query or stored text uses composed vs decomposed forms.
+    normalized_term = unicodedata.normalize("NFC", term)
+
     # Escape SQL LIKE/ILIKE wildcards so % and _ in the term are literal
-    escaped_term = term.replace("%", r"\%").replace("_", r"\_")
+    escaped_term = normalized_term.replace("%", r"\%").replace("_", r"\_")
     like_pattern = f"%{escaped_term}%"
+
+    def _nfc(col):
+        return func.normalize(col, literal_column("NFC"))
 
     # Build the base query
     vt1_alias = aliased(VerseText, name="vt1")
@@ -180,7 +189,7 @@ async def search_revision_text(
             )
             .where(
                 vt1_alias.revision_id.in_(main_revision_ids),
-                vt1_alias.text.ilike(like_pattern),
+                _nfc(vt1_alias.text).ilike(like_pattern),
                 vt1_alias.text != "",
                 vt2_alias.text != "",
             )
@@ -201,7 +210,7 @@ async def search_revision_text(
             vt1_alias.text.label("main_text"),
         ).where(
             vt1_alias.revision_id.in_(main_revision_ids),
-            vt1_alias.text.ilike(like_pattern),
+            _nfc(vt1_alias.text).ilike(like_pattern),
             vt1_alias.text != "",
         )
 
@@ -243,11 +252,15 @@ async def search_revision_text(
         result = await db.execute(search_query)
         rows = result.all()
 
-        # Filter results to only include whole word matches, stopping at limit
+        # Filter results to only include whole word matches, stopping at limit.
+        # Normalize both the query and the stored text to NFC so the word
+        # boundary check behaves consistently regardless of input encoding.
         filtered_results = []
-        word_pattern = re.compile(r"\b" + re.escape(term.lower()) + r"\b")
+        word_pattern = re.compile(r"\b" + re.escape(normalized_term.lower()) + r"\b")
         for row in rows:
-            if row.main_text and word_pattern.search(row.main_text.lower()):
+            if row.main_text and word_pattern.search(
+                unicodedata.normalize("NFC", row.main_text).lower()
+            ):
                 result_dict = {
                     "book": row.book,
                     "chapter": row.chapter,

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -27,6 +27,13 @@ logger = setup_logger(__name__, container_id=container_id)
 router = APIRouter()
 
 
+def _nfc_sql(col):
+    # NFC (canonical) only; NFKC is intentionally avoided so ligatures and
+    # fullwidth/compatibility forms are never silently conflated with their
+    # canonical counterparts.
+    return func.normalize(col, literal_column("NFC"))
+
+
 async def _resolve_authorized_revision_ids_for_iso(
     iso: str, user: UserModel, db: AsyncSession
 ) -> list[int]:
@@ -160,9 +167,6 @@ async def search_revision_text(
     escaped_term = normalized_term.replace("%", r"\%").replace("_", r"\_")
     like_pattern = f"%{escaped_term}%"
 
-    def _nfc(col):
-        return func.normalize(col, literal_column("NFC"))
-
     # Build the base query
     vt1_alias = aliased(VerseText, name="vt1")
 
@@ -189,7 +193,7 @@ async def search_revision_text(
             )
             .where(
                 vt1_alias.revision_id.in_(main_revision_ids),
-                _nfc(vt1_alias.text).ilike(like_pattern),
+                _nfc_sql(vt1_alias.text).ilike(like_pattern),
                 vt1_alias.text != "",
                 vt2_alias.text != "",
             )
@@ -210,7 +214,7 @@ async def search_revision_text(
             vt1_alias.text.label("main_text"),
         ).where(
             vt1_alias.revision_id.in_(main_revision_ids),
-            _nfc(vt1_alias.text).ilike(like_pattern),
+            _nfc_sql(vt1_alias.text).ilike(like_pattern),
             vt1_alias.text != "",
         )
 
@@ -258,17 +262,22 @@ async def search_revision_text(
         filtered_results = []
         word_pattern = re.compile(r"\b" + re.escape(normalized_term.lower()) + r"\b")
         for row in rows:
-            if row.main_text and word_pattern.search(
-                unicodedata.normalize("NFC", row.main_text).lower()
-            ):
+            if not row.main_text:
+                continue
+            main_text_nfc = unicodedata.normalize("NFC", row.main_text)
+            if word_pattern.search(main_text_nfc.lower()):
                 result_dict = {
                     "book": row.book,
                     "chapter": row.chapter,
                     "verse": row.verse,
-                    "main_text": row.main_text,
+                    "main_text": main_text_nfc,
                 }
                 if use_comparison:
-                    result_dict["comparison_text"] = row.comparison_text
+                    result_dict["comparison_text"] = (
+                        unicodedata.normalize("NFC", row.comparison_text)
+                        if row.comparison_text
+                        else row.comparison_text
+                    )
 
                 filtered_results.append(result_dict)
 

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -772,6 +772,7 @@ def test_search_accented_via_iso_multi_revision(
         )
         rev_ids.append(revision.id)
     test_db_session.commit()
+    assert len(rev_ids) == 2, f"Expected 2 revisions to be created, got {rev_ids}"
 
     nfc_query = unicodedata.normalize("NFC", "ásaatile")
     response = client.get(

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -577,6 +577,106 @@ def test_search_no_subword_matches(client, regular_token1, test_db_session):
         ), f"'love' not found as whole word in: {result['main_text']}"
 
 
+# --- Unicode normalization tests ---
+
+
+def _setup_accented_verses(db_session, verses):
+    """Create a single-revision setup with arbitrary verse texts."""
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = db_session.query(Group).filter(Group.name == "Group1").first()
+
+    version = BibleVersion(
+        name="Accent Test Version",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="ATV",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    db_session.add(version)
+    db_session.commit()
+    db_session.refresh(version)
+
+    revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+    )
+    db_session.add(revision)
+    db_session.commit()
+    db_session.refresh(revision)
+
+    for book, chapter, verse, text in verses:
+        db_session.add(
+            VerseText(
+                text=text,
+                revision_id=revision.id,
+                verse_reference=f"{book} {chapter}:{verse}",
+                book=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        )
+    db_session.add(BibleVersionAccess(bible_version_id=version.id, group_id=group1.id))
+    db_session.commit()
+    return revision.id
+
+
+def test_search_accented_nfd_stored_nfc_query(client, regular_token1, test_db_session):
+    """Accented query in NFC must match text stored in NFD (issue #543)."""
+    import unicodedata
+
+    # Stored as NFD (decomposed: 'a' + U+0301)
+    nfd_word = unicodedata.normalize("NFD", "ásaatile")
+    assert nfd_word != "ásaatile" or any(
+        unicodedata.combining(c) for c in nfd_word
+    ), "Test setup sanity: expected NFD form to differ"
+
+    revision_id = _setup_accented_verses(
+        test_db_session,
+        [("GEN", 1, 2, f"Word {nfd_word} appears here.")],
+    )
+
+    # Query in NFC (composed)
+    nfc_query = unicodedata.normalize("NFC", "ásaatile")
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": nfc_query, "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert (
+        data["total_count"] == 1
+    ), f"Expected NFC query to match NFD-stored text; got {data}"
+
+
+def test_search_accented_nfc_stored_nfd_query(client, regular_token1, test_db_session):
+    """Accented query in NFD must match text stored in NFC."""
+    import unicodedata
+
+    nfc_word = unicodedata.normalize("NFC", "ásaatile")
+    revision_id = _setup_accented_verses(
+        test_db_session,
+        [("GEN", 1, 2, f"Word {nfc_word} appears here.")],
+    )
+
+    nfd_query = unicodedata.normalize("NFD", "ásaatile")
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": nfd_query, "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 1
+
+
 # --- ISO-based search tests ---
 
 

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1,3 +1,5 @@
+import re
+import unicodedata
 from datetime import date
 
 from database.models import (
@@ -366,8 +368,6 @@ def test_search_whole_word_match(client, regular_token1, test_db_session):
     # Verify that results contain "in" as a whole word
     assert response_data["total_count"] > 0, "Expected to find verses containing 'in'"
 
-    import re
-
     for result in response_data["results"]:
         text_lower = result["main_text"].lower()
         # Check that "in" appears as a whole word
@@ -567,8 +567,6 @@ def test_search_no_subword_matches(client, regular_token1, test_db_session):
     assert response_data["total_count"] > 0, "Expected to find verses containing 'love'"
 
     # Verify that all results contain "love" as a whole word
-    import re
-
     for result in response_data["results"]:
         text_lower = result["main_text"].lower()
         pattern = r"\blove\b"
@@ -625,20 +623,16 @@ def _setup_accented_verses(db_session, verses):
 
 def test_search_accented_nfd_stored_nfc_query(client, regular_token1, test_db_session):
     """Accented query in NFC must match text stored in NFD (issue #543)."""
-    import unicodedata
-
-    # Stored as NFD (decomposed: 'a' + U+0301)
     nfd_word = unicodedata.normalize("NFD", "ásaatile")
-    assert nfd_word != "ásaatile" or any(
+    assert any(
         unicodedata.combining(c) for c in nfd_word
-    ), "Test setup sanity: expected NFD form to differ"
+    ), "Test setup sanity: expected NFD form to contain a combining mark"
 
     revision_id = _setup_accented_verses(
         test_db_session,
         [("GEN", 1, 2, f"Word {nfd_word} appears here.")],
     )
 
-    # Query in NFC (composed)
     nfc_query = unicodedata.normalize("NFC", "ásaatile")
 
     response = client.get(
@@ -652,12 +646,12 @@ def test_search_accented_nfd_stored_nfc_query(client, regular_token1, test_db_se
     assert (
         data["total_count"] == 1
     ), f"Expected NFC query to match NFD-stored text; got {data}"
+    # Response text should be NFC-normalized regardless of storage form
+    assert unicodedata.is_normalized("NFC", data["results"][0]["main_text"])
 
 
 def test_search_accented_nfc_stored_nfd_query(client, regular_token1, test_db_session):
     """Accented query in NFD must match text stored in NFC."""
-    import unicodedata
-
     nfc_word = unicodedata.normalize("NFC", "ásaatile")
     revision_id = _setup_accented_verses(
         test_db_session,
@@ -675,6 +669,127 @@ def test_search_accented_nfc_stored_nfd_query(client, regular_token1, test_db_se
     assert response.status_code == 200
     data = response.json()
     assert data["total_count"] == 1
+
+
+def test_search_accented_does_not_match_inflected_substring(
+    client, regular_token1, test_db_session
+):
+    """Whole-word search for a stem must NOT match accented-prefix inflections.
+
+    This pins the intentional behavior change from NFC normalization: before
+    the fix, `saatile` matched `gásaatile` because NFD-stored text put a
+    combining mark (non-word char) before `s`, creating a spurious word
+    boundary. After NFC, `á` is a single letter-class char and the match is
+    correctly rejected.
+    """
+    nfd_inflected = unicodedata.normalize("NFD", "gásaatile")
+    revision_id = _setup_accented_verses(
+        test_db_session,
+        [("GEN", 1, 2, f"Sentence with {nfd_inflected} inside.")],
+    )
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "saatile", "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 0, (
+        "saatile should not match inside gásaatile after NFC normalization; "
+        f"got {data}"
+    )
+
+
+def test_search_accented_uppercase_query(client, regular_token1, test_db_session):
+    """Uppercase accented query must match NFD-stored lowercase text."""
+    nfd_word = unicodedata.normalize("NFD", "ásaatile")
+    revision_id = _setup_accented_verses(
+        test_db_session,
+        [("GEN", 1, 2, f"Word {nfd_word} here.")],
+    )
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "ÁSAATILE", "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert (
+        data["total_count"] == 1
+    ), f"Expected uppercase accented query to match; got {data}"
+
+
+def test_search_accented_via_iso_multi_revision(
+    client, regular_token1, test_db_session
+):
+    """Accented search via iso= must match across NFD-stored revisions and dedup."""
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+
+    nfd_word = unicodedata.normalize("NFD", "ásaatile")
+
+    # Two eng versions, both with the same accented word on the same verse
+    rev_ids = []
+    for i, abbrev in enumerate(("IsoAccA", "IsoAccB")):
+        version = BibleVersion(
+            name=f"Iso Accent {i}",
+            iso_language="eng",
+            iso_script="Latn",
+            abbreviation=abbrev,
+            owner_id=user1.id,
+            is_reference=False,
+        )
+        test_db_session.add(version)
+        test_db_session.commit()
+        test_db_session.refresh(version)
+
+        revision = BibleRevision(
+            date=date.today(),
+            bible_version_id=version.id,
+            published=True,
+            machine_translation=False,
+        )
+        test_db_session.add(revision)
+        test_db_session.commit()
+        test_db_session.refresh(revision)
+
+        test_db_session.add(
+            VerseText(
+                text=f"The word {nfd_word} appears in verse {i}.",
+                revision_id=revision.id,
+                verse_reference="GEN 1:2",
+                book="GEN",
+                chapter=1,
+                verse=2,
+            )
+        )
+        test_db_session.add(
+            BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+        )
+        rev_ids.append(revision.id)
+    test_db_session.commit()
+
+    nfc_query = unicodedata.normalize("NFC", "ásaatile")
+    response = client.get(
+        "/v3/textsearch",
+        params={"iso": "eng", "term": nfc_query, "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    # Both revisions have the same (book, chapter, verse); dedup collapses to 1
+    refs = [(r["book"], r["chapter"], r["verse"]) for r in data["results"]]
+    assert (
+        "GEN",
+        1,
+        2,
+    ) in refs, f"Expected GEN 1:2 to match NFC query across NFD revisions; got {data}"
+    assert len(refs) == len(set(refs)), "Expected deduplicated results"
 
 
 # --- ISO-based search tests ---


### PR DESCRIPTION
## Summary
- Normalize query term and stored verse text to NFC before the ILIKE check and the Python whole-word regex, so `ásaatile` matches rows regardless of whether the DB stored the accent as composed or decomposed.
- Adds two regression tests covering both NFC-query/NFD-stored and NFD-query/NFC-stored directions.

## Why this matters
Without normalization, text stored as NFD (`a` + U+0301) silently fails to match NFC queries, breaking agent lookups for accented tokens in languages like Malila (mgq) where accents are semantically meaningful.

## Behavior change worth noting
Prior to this fix, searching for a suffix like `saatile` happened to match `ásaatile`/`gásaatile` because U+0301 created a spurious word boundary. With NFC normalization, `á` is a single letter-class char, so `\bsaatile\b` correctly rejects those — this is the whole-word filter working as designed. Substring/inflection matching (e.g. matching roots across prefixes) is tracked separately.

Fixes #543

## Test plan
- [x] `pytest test/test_assessment_routes/test_search_routes.py -v` — all 23 tests pass, including new NFC/NFD regression tests
- [x] Live smoke test against RDS via localhost:8000 — `ásaatile` now returns 1 hit in mgq (GEN 1:2); other accented mgq queries (`ápelile`, `áamɨle`, `khágubishiiye`, etc.) return expected counts
- [x] Existing non-accented behavior unchanged (case-insensitive, whole-word, subword rejection, multi-word phrase tests all pass)

## Follow-up
Perf (2s baseline, up to 13s on common terms) is pre-existing and tracked in #544.

🤖 Generated with [Claude Code](https://claude.com/claude-code)