### PR TITLE
textsearch: inline auth into search query (#544 part 1)

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -18,7 +18,6 @@ from database.models import BibleRevision, BibleVersion, BibleVersionAccess
 from database.models import UserDB as UserModel
 from database.models import UserGroup, VerseText
 from security_routes.auth_routes import get_current_user
-from security_routes.utilities import is_user_authorized_for_revision
 from utils.logging_config import setup_logger
 
 container_id = socket.gethostname()
@@ -34,32 +33,41 @@ def _nfc_sql(col):
     return func.normalize(col, literal_column("NFC"))
 
 
-async def _resolve_authorized_revision_ids_for_iso(
-    iso: str, user: UserModel, db: AsyncSession
-) -> list[int]:
-    """Return revision IDs the user may access for a given ISO 639-3 code."""
-    base_query = (
+def _authorized_revisions_select(
+    user: UserModel,
+    iso: Optional[str] = None,
+    revision_id: Optional[int] = None,
+):
+    """Return a SELECT of revision IDs the user may access, optionally scoped.
+
+    Used as an inline subquery in the search WHERE clause so authorization
+    and search run as a single DB round-trip. Callers can also execute it
+    standalone to distinguish "no access" (empty) from "no text matches"
+    (non-empty) when the main search returns zero rows.
+    """
+    q = (
         select(BibleRevision.id)
-        .distinct()
         .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
         .where(
-            BibleVersion.iso_language == iso,
             BibleRevision.deleted.is_not(True),
             BibleVersion.deleted.is_not(True),
         )
     )
+    if revision_id is not None:
+        q = q.where(BibleRevision.id == revision_id)
+    elif iso is not None:
+        q = q.where(BibleVersion.iso_language == iso)
 
     if not user.is_admin:
         user_groups_subq = (
             select(UserGroup.group_id).where(UserGroup.user_id == user.id)
         ).subquery()
-        base_query = base_query.join(
+        q = q.join(
             BibleVersionAccess,
             BibleVersionAccess.bible_version_id == BibleVersion.id,
-        ).where(BibleVersionAccess.group_id.in_(user_groups_subq))
+        ).where(BibleVersionAccess.group_id.in_(select(user_groups_subq)))
 
-    result = await db.execute(base_query)
-    return list(result.scalars().all())
+    return q
 
 
 @router.get("/textsearch")
@@ -116,47 +124,21 @@ async def search_revision_text(
             detail="Provide either comparison_revision_id or comparison_iso, not both",
         )
 
-    # --- resolve main revision IDs ---------------------------------------
-    if revision_id is not None:
-        if not await is_user_authorized_for_revision(current_user.id, revision_id, db):
-            raise HTTPException(
-                status_code=403,
-                detail="User not authorized to access this revision",
-            )
-        main_revision_ids = [revision_id]
-    else:
-        main_revision_ids = await _resolve_authorized_revision_ids_for_iso(
-            iso, current_user, db
+    # Build authorization subqueries (executed inline with the search query
+    # so auth + search are a single DB round-trip in the success case).
+    main_auth_select = _authorized_revisions_select(
+        current_user, iso=iso, revision_id=revision_id
+    )
+    comp_auth_select = None
+    if comparison_revision_id is not None or comparison_iso is not None:
+        comp_auth_select = _authorized_revisions_select(
+            current_user,
+            iso=comparison_iso,
+            revision_id=comparison_revision_id,
         )
-        if not main_revision_ids:
-            raise HTTPException(
-                status_code=404,
-                detail=f"No accessible revisions found for iso '{iso}'",
-            )
-
-    # --- resolve comparison revision IDs ---------------------------------
-    comp_revision_ids: list[int] | None = None
-    if comparison_revision_id is not None:
-        if not await is_user_authorized_for_revision(
-            current_user.id, comparison_revision_id, db
-        ):
-            raise HTTPException(
-                status_code=403,
-                detail="User not authorized to access the comparison revision",
-            )
-        comp_revision_ids = [comparison_revision_id]
-    elif comparison_iso is not None:
-        comp_revision_ids = await _resolve_authorized_revision_ids_for_iso(
-            comparison_iso, current_user, db
-        )
-        if not comp_revision_ids:
-            raise HTTPException(
-                status_code=404,
-                detail=f"No accessible revisions found for comparison iso '{comparison_iso}'",
-            )
 
     use_dedup = iso is not None
-    use_comparison = comp_revision_ids is not None
+    use_comparison = comp_auth_select is not None
     comp_dedup = comparison_iso is not None
 
     # Normalize to NFC so accented characters match regardless of whether the
@@ -189,10 +171,10 @@ async def search_revision_text(
                 (vt2_alias.book == vt1_alias.book)
                 & (vt2_alias.chapter == vt1_alias.chapter)
                 & (vt2_alias.verse == vt1_alias.verse)
-                & (vt2_alias.revision_id.in_(comp_revision_ids)),
+                & (vt2_alias.revision_id.in_(comp_auth_select)),
             )
             .where(
-                vt1_alias.revision_id.in_(main_revision_ids),
+                vt1_alias.revision_id.in_(main_auth_select),
                 _nfc_sql(vt1_alias.text).ilike(like_pattern),
                 vt1_alias.text != "",
                 vt2_alias.text != "",
@@ -213,7 +195,7 @@ async def search_revision_text(
             vt1_alias.verse.label("verse"),
             vt1_alias.text.label("main_text"),
         ).where(
-            vt1_alias.revision_id.in_(main_revision_ids),
+            vt1_alias.revision_id.in_(main_auth_select),
             _nfc_sql(vt1_alias.text).ilike(like_pattern),
             vt1_alias.text != "",
         )
@@ -255,6 +237,38 @@ async def search_revision_text(
         # Execute the query
         result = await db.execute(search_query)
         rows = result.all()
+
+        # If empty, distinguish "no authorization" (403/404) from "no matches"
+        # (200 with empty results) with a single follow-up query.
+        if not rows:
+            auth_row = (await db.execute(main_auth_select.limit(1))).scalars().first()
+            if auth_row is None:
+                if revision_id is not None:
+                    raise HTTPException(
+                        status_code=403,
+                        detail="User not authorized to access this revision",
+                    )
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No accessible revisions found for iso '{iso}'",
+                )
+            if comp_auth_select is not None:
+                comp_auth_row = (
+                    (await db.execute(comp_auth_select.limit(1))).scalars().first()
+                )
+                if comp_auth_row is None:
+                    if comparison_revision_id is not None:
+                        raise HTTPException(
+                            status_code=403,
+                            detail="User not authorized to access the comparison revision",
+                        )
+                    raise HTTPException(
+                        status_code=404,
+                        detail=(
+                            f"No accessible revisions found for comparison iso "
+                            f"'{comparison_iso}'"
+                        ),
+                    )
 
         # Filter results to only include whole word matches, stopping at limit.
         # Normalize both the query and the stored text to NFC so the word
@@ -305,6 +319,8 @@ async def search_revision_text(
 
         return {"results": filtered_results, "total_count": len(filtered_results)}
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(
             f"Error in text search: {str(e)}",

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -45,9 +45,8 @@ def _authorized_revisions_select(
     standalone to distinguish "no access" (empty) from "no text matches"
     (non-empty) when the main search returns zero rows.
     """
-    assert (
-        iso is not None or revision_id is not None
-    ), "at least one of iso or revision_id must be provided"
+    if iso is None and revision_id is None:
+        raise ValueError("at least one of iso or revision_id must be provided")
     q = (
         select(BibleRevision.id)
         .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
@@ -69,6 +68,9 @@ def _authorized_revisions_select(
             BibleVersionAccess,
             BibleVersionAccess.bible_version_id == BibleVersion.id,
         ).where(BibleVersionAccess.group_id.in_(select(user_groups_subq)))
+        # An access row per group membership can duplicate the same revision;
+        # dedup so the subquery size tracks unique revisions.
+        q = q.distinct()
 
     return q
 
@@ -246,32 +248,39 @@ async def search_revision_text(
         if not rows:
             auth_row = (await db.execute(main_auth_select.limit(1))).scalars().first()
             if auth_row is None:
-                if revision_id is not None:
+                if iso is not None:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"No accessible revisions found for iso '{iso}'",
+                    )
+                # revision_id path: non-admins get 403 (unauthorized or
+                # non-existent — indistinguishable by design). Admins are
+                # always authorized, so preserve pre-refactor behavior of
+                # returning 200 with empty results when the revision id
+                # simply doesn't exist.
+                if not current_user.is_admin:
                     raise HTTPException(
                         status_code=403,
                         detail="User not authorized to access this revision",
                     )
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"No accessible revisions found for iso '{iso}'",
-                )
             if comp_auth_select is not None:
                 comp_auth_row = (
                     (await db.execute(comp_auth_select.limit(1))).scalars().first()
                 )
                 if comp_auth_row is None:
-                    if comparison_revision_id is not None:
+                    if comparison_iso is not None:
+                        raise HTTPException(
+                            status_code=404,
+                            detail=(
+                                f"No accessible revisions found for comparison iso "
+                                f"'{comparison_iso}'"
+                            ),
+                        )
+                    if not current_user.is_admin:
                         raise HTTPException(
                             status_code=403,
                             detail="User not authorized to access the comparison revision",
                         )
-                    raise HTTPException(
-                        status_code=404,
-                        detail=(
-                            f"No accessible revisions found for comparison iso "
-                            f"'{comparison_iso}'"
-                        ),
-                    )
 
         # Filter results to only include whole word matches, stopping at limit.
         # Normalize both the query and the stored text to NFC so the word

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -45,6 +45,9 @@ def _authorized_revisions_select(
     standalone to distinguish "no access" (empty) from "no text matches"
     (non-empty) when the main search returns zero rows.
     """
+    assert (
+        iso is not None or revision_id is not None
+    ), "at least one of iso or revision_id must be provided"
     q = (
         select(BibleRevision.id)
         .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -406,6 +406,26 @@ def test_search_unauthorized_comparison_with_zero_main_matches(
     assert "comparison" in response.json()["detail"].lower()
 
 
+def test_search_admin_nonexistent_revision_returns_200_empty(
+    client, admin_token, test_db_session
+):
+    """Admin querying a non-existent revision_id must get 200 with empty results.
+
+    Preserves pre-refactor behavior: is_user_authorized_for_revision returned
+    True for admins without checking revision existence, so admins got 200
+    empty rather than 403 for bad IDs.
+    """
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": 999_999_999, "term": "anything", "limit": 5},
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 0
+    assert data["results"] == []
+
+
 def test_search_limit_validation(client, regular_token1, test_db_session):
     """Test that limit parameter is properly validated."""
     main_revision_id, _ = setup_search_test_data(test_db_session)

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -312,6 +312,100 @@ def test_search_unauthorized_comparison(client, regular_token2, test_db_session)
     assert response.status_code == 403
 
 
+def test_search_unauthorized_comparison_with_zero_main_matches(
+    client, regular_token1, test_db_session
+):
+    """User authorized for main + unauthorized comparison + no main matches -> 403.
+
+    Exercises the zero-rows fallback: the combined query returns no rows
+    because the comparison JOIN rejects all verses (user lacks comp access),
+    so the fallback must detect comp-unauthorized and raise 403 rather than
+    silently returning 200 with empty results.
+    """
+    user2 = test_db_session.query(UserDB).filter(UserDB.username == "testuser2").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+    group2 = test_db_session.query(Group).filter(Group.name == "Group2").first()
+
+    # Ensure swh exists as an iso — used so this test's data doesn't interfere
+    # with other tests that assume testuser2 has no eng access.
+    if (
+        test_db_session.query(IsoLanguage).filter(IsoLanguage.iso639 == "swh").first()
+        is None
+    ):
+        test_db_session.add(IsoLanguage(iso639="swh", name="Swahili"))
+        test_db_session.commit()
+
+    main_version = BibleVersion(
+        name="Split-Auth Main",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="SAM",
+        owner_id=user2.id,
+        is_reference=False,
+    )
+    comp_version = BibleVersion(
+        name="Split-Auth Comp",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="SAC",
+        owner_id=user2.id,
+        is_reference=False,
+    )
+    test_db_session.add_all([main_version, comp_version])
+    test_db_session.commit()
+    test_db_session.refresh(main_version)
+    test_db_session.refresh(comp_version)
+
+    main_revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=main_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    comp_revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=comp_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add_all([main_revision, comp_revision])
+    test_db_session.commit()
+    test_db_session.refresh(main_revision)
+    test_db_session.refresh(comp_revision)
+
+    test_db_session.add(
+        VerseText(
+            text="Nothing in here matches the search term.",
+            revision_id=main_revision.id,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
+    # testuser1 (via Group1) has main access; only Group2 can see comp
+    test_db_session.add_all(
+        [
+            BibleVersionAccess(bible_version_id=main_version.id, group_id=group1.id),
+            BibleVersionAccess(bible_version_id=comp_version.id, group_id=group2.id),
+        ]
+    )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": main_revision.id,
+            "comparison_revision_id": comp_revision.id,
+            "term": "zyxwvu-no-match",
+            "limit": 5,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 403
+    assert "comparison" in response.json()["detail"].lower()
+
+
 def test_search_limit_validation(client, regular_token1, test_db_session):
     """Test that limit parameter is properly validated."""
     main_revision_id, _ = setup_search_test_data(test_db_session)


### PR DESCRIPTION
## Summary

Collapse the three sequential DB calls (`is_user_authorized_for_revision`, `_resolve_authorized_revision_ids_for_iso`, and the search itself) into a single query by inlining the authorization filter as a SQL subquery in the search `WHERE` clause.

## Measurement

Direct asyncpg benchmark against RDS from localhost (3 trials, median):
| | Before | After |
|---|---:|---:|
| DB-side latency | 462ms | **223ms** |

~52% reduction on the DB portion of each request. Does not address the per-query 700ms network RTT (that requires colocation, per #544 option 4) or the lack of a trigram index (#544 option 3).

## How 403/404 semantics are preserved

When the search returns zero rows, the route runs a single follow-up `SELECT ... LIMIT 1` against the same authorization subquery to distinguish:
- empty auth set → `403` (revision_id) or `404` (iso), matching previous behavior
- non-empty auth set → `200` with empty results (user had access but no text matched)

The fallback only fires when results are empty, so the happy path stays at 1 query.

## Query plan check

`EXPLAIN ANALYZE` confirms `ix_verse_text_revision_id` is still chosen as the inner index scan; the inlined subquery is resolved as a nested-loop over `bible_version` + `bible_revision` (both small, ~ms). Execution time for the mgq `ásaatile` test case: 147ms (unchanged from before the refactor).

## Stacked on #545

This branch is based on `fix/543-textsearch-unicode-normalization` (PR #545) so the diff is clean. Retarget to `main` after #545 merges.

Relates to #544.

## Test plan
- [x] `pytest test/test_assessment_routes/test_search_routes.py -v` — 26/26 pass
- [x] Auth-failure tests (`test_search_unauthorized_revision`, `test_search_unauthorized_comparison`, `test_search_iso_no_accessible_revisions`) still produce 403/404 correctly
- [x] Live RDS benchmark (above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)