### PR TITLE
textsearch: pg_trgm index + truncated flag (#544 part 2)

### DIFF
--- a/alembic/migrations/versions/7f2e9a4b8c31_add_pg_trgm_index_on_verse_text.py
+++ b/alembic/migrations/versions/7f2e9a4b8c31_add_pg_trgm_index_on_verse_text.py
@@ -27,8 +27,24 @@ depends_on: Union[str, Sequence[str], None] = None
 def upgrade() -> None:
     # CREATE EXTENSION and CREATE INDEX CONCURRENTLY cannot run inside a
     # transaction; autocommit_block escapes Alembic's default DDL tx.
+    bind = op.get_bind()
     with op.get_context().autocommit_block():
         op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        # If a previous CONCURRENTLY build was interrupted, Postgres leaves
+        # the index in an INVALID state. IF NOT EXISTS would then skip the
+        # rebuild and the planner could still try to use the broken index.
+        # Detect and drop invalid indexes before (re)creating so this
+        # migration is safely retryable. DROP INDEX CONCURRENTLY can't run
+        # inside a DO block (requires non-transactional context), so we do
+        # the detection from Python and issue the drop as a top-level stmt.
+        is_invalid = bind.exec_driver_sql(
+            "SELECT 1 FROM pg_class c "
+            "JOIN pg_index i ON i.indexrelid = c.oid "
+            "WHERE c.relname = 'ix_verse_text_nfc_trgm' "
+            "  AND NOT i.indisvalid"
+        ).scalar()
+        if is_invalid:
+            op.execute("DROP INDEX CONCURRENTLY ix_verse_text_nfc_trgm")
         op.execute(
             "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
             "ix_verse_text_nfc_trgm "

--- a/alembic/migrations/versions/7f2e9a4b8c31_add_pg_trgm_index_on_verse_text.py
+++ b/alembic/migrations/versions/7f2e9a4b8c31_add_pg_trgm_index_on_verse_text.py
@@ -1,0 +1,44 @@
+"""Add pg_trgm index on verse_text for faster ILIKE
+
+Revision ID: 7f2e9a4b8c31
+Revises: 020e59f6d36a
+Create Date: 2026-04-17 06:00:00.000000
+
+The /v3/textsearch endpoint runs ILIKE '%...%' on verse_text.text, which
+cannot use a btree index. A GIN trigram index on NORMALIZE(text, NFC)
+lets Postgres accelerate substring matches against NFC-normalized text.
+
+Uses CREATE INDEX CONCURRENTLY to avoid blocking writes on the ~26GB
+verse_text table during the build. Expected build time on prod RDS:
+30 min – 2 hr depending on instance class.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7f2e9a4b8c31"
+down_revision: Union[str, None] = "020e59f6d36a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # CREATE EXTENSION and CREATE INDEX CONCURRENTLY cannot run inside a
+    # transaction; autocommit_block escapes Alembic's default DDL tx.
+    with op.get_context().autocommit_block():
+        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_verse_text_nfc_trgm "
+            "ON verse_text USING gin ("
+            "    NORMALIZE(text, NFC) gin_trgm_ops"
+            ")"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_verse_text_nfc_trgm")
+        # Leave pg_trgm extension installed; other features may use it.

--- a/alembic/migrations/versions/7f2e9a4b8c31_add_pg_trgm_index_on_verse_text.py
+++ b/alembic/migrations/versions/7f2e9a4b8c31_add_pg_trgm_index_on_verse_text.py
@@ -1,0 +1,63 @@
+"""Add pg_trgm index on verse_text for faster ILIKE
+
+Revision ID: 7f2e9a4b8c31
+Revises: d7e9f4c2a851
+Create Date: 2026-04-17 06:00:00.000000
+
+The /v3/textsearch endpoint runs ILIKE '%...%' on verse_text.text, which
+cannot use a btree index. A GIN trigram index on NORMALIZE(text, NFC)
+lets Postgres accelerate substring matches against NFC-normalized text
+for terms of 3+ characters. Shorter (1-2 char) terms bypass the trigram
+index and rely on the existing ix_verse_text_revision_id to stay bounded
+per revision; the Python-side overfetch cap limits worst-case work.
+
+Uses CREATE INDEX CONCURRENTLY to avoid blocking writes on the ~26GB
+verse_text table during the build. Expected build time on prod RDS:
+30 min – 2 hr depending on instance class.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7f2e9a4b8c31"
+down_revision: Union[str, None] = "d7e9f4c2a851"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # CREATE EXTENSION and CREATE INDEX CONCURRENTLY cannot run inside a
+    # transaction; autocommit_block escapes Alembic's default DDL tx.
+    bind = op.get_bind()
+    with op.get_context().autocommit_block():
+        op.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
+        # If a previous CONCURRENTLY build was interrupted, Postgres leaves
+        # the index in an INVALID state. IF NOT EXISTS would then skip the
+        # rebuild and the planner could still try to use the broken index.
+        # Detect and drop invalid indexes before (re)creating so this
+        # migration is safely retryable. DROP INDEX CONCURRENTLY can't run
+        # inside a DO block (requires non-transactional context), so we do
+        # the detection from Python and issue the drop as a top-level stmt.
+        is_invalid = bind.exec_driver_sql(
+            "SELECT 1 FROM pg_class c "
+            "JOIN pg_index i ON i.indexrelid = c.oid "
+            "WHERE c.relname = 'ix_verse_text_nfc_trgm' "
+            "  AND NOT i.indisvalid"
+        ).scalar()
+        if is_invalid:
+            op.execute("DROP INDEX CONCURRENTLY ix_verse_text_nfc_trgm")
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_verse_text_nfc_trgm "
+            "ON verse_text USING gin ("
+            "    NORMALIZE(text, NFC) gin_trgm_ops"
+            ")"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_verse_text_nfc_trgm")
+        # Leave pg_trgm extension installed; other features may use it.

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -384,6 +384,12 @@ async def search_revision_text(
                 if len(filtered_results) >= limit:
                     break
 
+        # If we hit the DB cap AND still produced fewer than the requested
+        # limit after whole-word filtering, there may be more matching verses
+        # we didn't see. Signal this so callers can widen the search or
+        # request a larger limit.
+        truncated = len(rows) >= sql_limit and len(filtered_results) < limit
+
         duration = round(time.perf_counter() - request_start, 2)
         logger.info(
             f"search_revision_text completed in {duration}s",
@@ -398,11 +404,16 @@ async def search_revision_text(
                 "limit": limit,
                 "random": random,
                 "results_returned": len(filtered_results),
+                "truncated": truncated,
                 "duration_s": duration,
             },
         )
 
-        return {"results": filtered_results, "total_count": len(filtered_results)}
+        return {
+            "results": filtered_results,
+            "total_count": len(filtered_results),
+            "truncated": truncated,
+        }
 
     except HTTPException:
         raise

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -77,7 +77,15 @@ def _authorized_revisions_select(
 
 @router.get("/textsearch")
 async def search_revision_text(
-    term: str = Query(..., min_length=1, max_length=200),
+    term: str = Query(
+        ...,
+        min_length=3,
+        max_length=200,
+        description=(
+            "Search term (minimum 3 characters). Shorter terms cannot use "
+            "the trigram index and would trigger a full table scan."
+        ),
+    ),
     revision_id: Optional[int] = None,
     iso: Optional[str] = Query(
         default=None,
@@ -314,6 +322,12 @@ async def search_revision_text(
                 if len(filtered_results) >= limit:
                     break
 
+        # If we hit the DB cap AND still produced fewer than the requested
+        # limit after whole-word filtering, there may be more matching verses
+        # we didn't see. Signal this so callers can widen the search or
+        # request a larger limit.
+        truncated = len(rows) >= sql_limit and len(filtered_results) < limit
+
         duration = round(time.perf_counter() - request_start, 2)
         logger.info(
             f"search_revision_text completed in {duration}s",
@@ -328,11 +342,16 @@ async def search_revision_text(
                 "limit": limit,
                 "random": random,
                 "results_returned": len(filtered_results),
+                "truncated": truncated,
                 "duration_s": duration,
             },
         )
 
-        return {"results": filtered_results, "total_count": len(filtered_results)}
+        return {
+            "results": filtered_results,
+            "total_count": len(filtered_results),
+            "truncated": truncated,
+        }
 
     except HTTPException:
         raise

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -213,9 +213,12 @@ async def search_revision_text(
             )
 
     # Cap the DB result set.  The Python-side whole-word filter may discard
-    # ilike matches that aren't whole words, so we overfetch by 10x to give
-    # enough headroom while still bounding the transfer from the DB.
-    sql_limit = limit * 10
+    # ilike matches that aren't whole words, so we overfetch to give headroom
+    # while still bounding the transfer from the DB.  3x is enough in practice:
+    # the common false-positive case (substring inside another word) is
+    # bounded per language, and pulling 10x rows back over the wire dominated
+    # latency for common terms (13s on mʉlʉngʉ with 100 verse texts).
+    sql_limit = limit * 3
     search_query = search_query.limit(sql_limit)
 
     # Apply ordering.  DISTINCT ON requires the leading ORDER BY columns to

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -426,6 +426,122 @@ def test_search_admin_nonexistent_revision_returns_200_empty(
     assert data["results"] == []
 
 
+def test_search_short_term_allowed(client, regular_token1, test_db_session):
+    """1-2 char terms must still be accepted.
+
+    The trigram index doesn't help for 1-2 char ILIKE, but the query is
+    bounded per revision by ix_verse_text_revision_id and by the
+    Python-side overfetch cap, so short searches remain safe. The
+    aqua-assessments agent relies on short-term searches (morphemes,
+    affixes), so validation must not reject them.
+    """
+    main_revision_id, _ = setup_search_test_data(test_db_session)
+
+    # 2-char whole word "he" appears in JHN 3:16 ("he gave his only...").
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": main_revision_id, "term": "he", "limit": 5},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert any(
+        re.search(r"\bhe\b", r["main_text"].lower()) for r in data["results"]
+    ), f"expected at least one whole-word 'he' match, got {data}"
+
+    # 1-char term: must not 422. Whole-word filter may yield zero rows
+    # (no standalone "a" in the fixture), but the endpoint must still
+    # succeed — that's the aqua-assessments requirement.
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": main_revision_id, "term": "a", "limit": 5},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+
+
+def test_search_truncated_flag_when_overfetch_insufficient(
+    client, regular_token1, test_db_session
+):
+    """When the DB cap is hit but whole-word matches are sparse, signal truncation.
+
+    sql_limit is driven by limit and piece count. Insert more rows than
+    the DB cap that ILIKE-match but fail the whole-word filter, plus zero
+    actual whole-word matches. The endpoint should return an empty result
+    set with truncated=true so the caller knows there may be more ILIKE
+    hits beyond what was examined.
+    """
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+
+    version = BibleVersion(
+        name="Trunc Test",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="TRC",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add(version)
+    test_db_session.commit()
+    test_db_session.refresh(version)
+
+    revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add(revision)
+    test_db_session.commit()
+    test_db_session.refresh(revision)
+
+    # With limit=5 and one piece, sql_limit = 5 * 10 * 1 = 50. Insert 60
+    # verses where the term appears only as a substring of a longer word,
+    # so ILIKE matches but the whole-word regex rejects every row.
+    # PSA 119 has 176 verses, so 60 consecutive refs are canonically valid.
+    for i in range(60):
+        test_db_session.add(
+            VerseText(
+                text="Sentence containing mudfoo_marker which is not a word.",
+                revision_id=revision.id,
+                verse_reference=f"PSA 119:{i + 1}",
+                book="PSA",
+                chapter=119,
+                verse=i + 1,
+            )
+        )
+    test_db_session.add(
+        BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+    )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision.id, "term": "mudfoo", "limit": 5},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 0
+    assert data["truncated"] is True, f"expected truncated=true, got {data}"
+
+
+def test_search_not_truncated_on_full_page(client, regular_token1, test_db_session):
+    """A normal full page of results must NOT be flagged as truncated."""
+    main_revision_id, _ = setup_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": main_revision_id, "term": "God", "limit": 3},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] >= 1
+    assert data["truncated"] is False
+
+
 def test_search_limit_validation(client, regular_token1, test_db_session):
     """Test that limit parameter is properly validated."""
     main_revision_id, _ = setup_search_test_data(test_db_session)

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -426,6 +426,99 @@ def test_search_admin_nonexistent_revision_returns_200_empty(
     assert data["results"] == []
 
 
+def test_search_term_too_short(client, regular_token1, test_db_session):
+    """Terms shorter than 3 chars are rejected (can't use the trigram index)."""
+    main_revision_id, _ = setup_search_test_data(test_db_session)
+
+    for short in ["a", "an"]:
+        response = client.get(
+            "/v3/textsearch",
+            params={"revision_id": main_revision_id, "term": short, "limit": 5},
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 422, f"expected 422 for term={short!r}"
+
+
+def test_search_truncated_flag_when_overfetch_insufficient(
+    client, regular_token1, test_db_session
+):
+    """When the DB cap is hit but whole-word matches are sparse, signal truncation.
+
+    sql_limit = limit * 3. Insert more than that many rows that ILIKE-match but
+    fail the whole-word filter, plus zero actual whole-word matches.  The
+    endpoint should return an empty result set with truncated=true so the
+    caller knows there may be more ILIKE hits beyond what was examined.
+    """
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+
+    version = BibleVersion(
+        name="Trunc Test",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="TRC",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add(version)
+    test_db_session.commit()
+    test_db_session.refresh(version)
+
+    revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add(revision)
+    test_db_session.commit()
+    test_db_session.refresh(revision)
+
+    # With limit=5 the endpoint fetches up to sql_limit=15 rows from the DB.
+    # Insert 20 verses where the term appears only as a substring of a longer
+    # word, so ILIKE matches but the whole-word regex rejects every row.
+    for i in range(20):
+        test_db_session.add(
+            VerseText(
+                text="Sentence containing mudfoo_marker which is not a word.",
+                revision_id=revision.id,
+                verse_reference=f"GEN {i + 1}:1",
+                book="GEN",
+                chapter=i + 1,
+                verse=1,
+            )
+        )
+    test_db_session.add(
+        BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+    )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision.id, "term": "mudfoo", "limit": 5},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 0
+    assert data["truncated"] is True, f"expected truncated=true, got {data}"
+
+
+def test_search_not_truncated_on_full_page(client, regular_token1, test_db_session):
+    """A normal full page of results must NOT be flagged as truncated."""
+    main_revision_id, _ = setup_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": main_revision_id, "term": "God", "limit": 3},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] >= 1
+    assert data["truncated"] is False
+
+
 def test_search_limit_validation(client, regular_token1, test_db_session):
     """Test that limit parameter is properly validated."""
     main_revision_id, _ = setup_search_test_data(test_db_session)
@@ -464,9 +557,10 @@ def test_search_whole_word_match(client, regular_token1, test_db_session):
     main_revision_id, _ = setup_search_test_data(test_db_session)
 
     # Search for a short word that might be part of other words
+    # ("was" also appears as a substring of e.g. "whereas", but not in our fixtures)
     params = {
         "revision_id": main_revision_id,
-        "term": "in",
+        "term": "was",
         "limit": 10,
     }
 
@@ -479,16 +573,14 @@ def test_search_whole_word_match(client, regular_token1, test_db_session):
     assert response.status_code == 200
     response_data = response.json()
 
-    # Verify that results contain "in" as a whole word
-    assert response_data["total_count"] > 0, "Expected to find verses containing 'in'"
+    assert response_data["total_count"] > 0, "Expected to find verses containing 'was'"
 
     for result in response_data["results"]:
         text_lower = result["main_text"].lower()
-        # Check that "in" appears as a whole word
-        pattern = r"\bin\b"
+        pattern = r"\bwas\b"
         assert re.search(
             pattern, text_lower
-        ), f"'in' not found as whole word in: {result['main_text']}"
+        ), f"'was' not found as whole word in: {result['main_text']}"
 
 
 def test_search_no_results(client, regular_token1, test_db_session):


### PR DESCRIPTION
## Summary

Performance + UX pass on `/v3/textsearch`, rewritten to preserve short-term (1-2 char) search support required by the aqua-assessments agent.

1. **`pg_trgm` GIN index on `NORMALIZE(verse_text.text, NFC)`** — makes `ILIKE '%...%'` index-backed for terms of 3+ characters. The 146ms filter-scan observed in #544 drops to an index lookup.
2. **`truncated: bool` in response** — set when the DB overfetch cap was hit but fewer than `limit` whole-word matches were produced, so callers know there may be more.

## Short-term queries (1-2 chars)

The aqua-assessments agent needs to search for short morphemes/affixes, so `min_length` stays at 1. Short queries bypass the trigram index but remain bounded:

- Every query filters by `revision_id IN (...)` (authorized revisions), and `ix_verse_text_revision_id` already exists — so a per-revision short-term search is ~31k rows, not 130M.
- The Python-side overfetch cap (`limit * 10 * len(pieces)`, capped at 10k rows, added for wildcards) bounds worst-case work even on broad `iso` searches.

## Migration notes

- Adds `pg_trgm` extension (`CREATE EXTENSION IF NOT EXISTS pg_trgm`).
- Builds the index with `CREATE INDEX CONCURRENTLY` inside an `autocommit_block` so writes aren't blocked.
- **Detects and drops INVALID indexes from interrupted prior builds** before retrying (`IF NOT EXISTS` alone would silently skip the rebuild).
- Expected build time on prod RDS (26 GB / 130M rows): **30 min – 2 hr** depending on instance class. Index size: ~10–15 GB.

## Deploy checklist

- [ ] Confirm `pg_trgm` is installed on RDS **or** that the migration role has `rds_superuser` — `SELECT * FROM pg_extension WHERE extname = 'pg_trgm'`
- [ ] Set `statement_timeout = 0` on the migration session (default RDS timeouts can kill a 2-hour index build)
- [ ] Run from a persistent session (tmux/screen on a jump host, not a CI runner with a connection timeout)
- [ ] Monitor build progress: `SELECT phase, blocks_done, blocks_total FROM pg_stat_progress_create_index WHERE relid = 'verse_text'::regclass`
- [ ] After completion, verify index is valid: `SELECT indisvalid FROM pg_index WHERE indexrelid = 'ix_verse_text_nfc_trgm'::regclass`
- [ ] Spot-check with `EXPLAIN` that a textsearch query uses the index

## Why `NORMALIZE(text, NFC)` in the index expression

- Postgres' `normalize()` is `IMMUTABLE` (verified on pg16), so expression indexes are allowed.
- The endpoint's `WHERE` clause uses exactly `NORMALIZE(text, NFC) ILIKE :pattern`, so the planner matches the index expression directly.

## Changes vs the original branch

This PR was rewritten after main diverged (wildcard support landed, and PR #557 explicitly removed a 3-char floor for wildcards). Two changes from the original were dropped:

- **`min_length=3` on term** — would have broken the aqua-assessments agent.
- **Overfetch reduction from 10x to 3x** — main already has a better piece-aware formula that scales with `len(pieces)` and caps the absolute sql_limit at 10k.

Relates to #544.

## Test plan
- [x] `alembic upgrade head` against localdb (pg16 + pgvector) — migration runs cleanly
- [x] `pytest test/test_assessment_routes/test_search_routes.py` — 51/51 pass
- [x] Short-term (1-2 char) search test passes: `test_search_short_term_allowed`
- [x] `truncated` flag: `test_search_truncated_flag_when_overfetch_insufficient` + `test_search_not_truncated_on_full_page`
- [ ] Post-merge: measure end-to-end latency on mgq and `eng` against RDS with the index in place