### PR TITLE
textsearch: support optional `*` wildcards for morpheme matching

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -151,18 +151,26 @@ async def search_revision_text(
             status_code=400,
             detail="`*` is only allowed at the start and/or end of the term",
         )
-    has_wildcard = prefix_wildcard or suffix_wildcard
-    # Wildcard queries can explode result sets for very short cores
-    # (e.g. `*a*` matches nearly every verse). Require a reasonable floor.
-    if has_wildcard and len(core_term.strip()) < 3:
-        raise HTTPException(
-            status_code=400,
-            detail="Wildcard queries require at least 3 non-`*` characters",
-        )
-    if not core_term:
+    # Count only visible characters — format/control chars (zero-width
+    # space, BOM, soft hyphen, ...) shouldn't satisfy the length floor.
+    visible_len = sum(
+        1
+        for c in core_term
+        if unicodedata.category(c) not in ("Cf", "Cc", "Cs", "Zl", "Zp")
+        and not c.isspace()
+    )
+    if visible_len == 0:
         raise HTTPException(
             status_code=400,
             detail="Term must contain at least one non-`*` character",
+        )
+    has_wildcard = prefix_wildcard or suffix_wildcard
+    # Wildcard queries can explode result sets for very short cores
+    # (e.g. `*a*` matches nearly every verse). Require a reasonable floor.
+    if has_wildcard and visible_len < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="Wildcard queries require at least 3 non-`*` characters",
         )
 
     # Build authorization subqueries (executed inline with the search query

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -99,7 +99,19 @@ async def search_revision_text(
 ):
     """
     Search for verses containing a specific term in a revision text.
-    Returns verses that contain the search term (case-insensitive, whole word match).
+    Returns verses that contain the search term (case-insensitive).
+
+    By default matches whole words only. A leading/trailing ``*`` in the
+    term acts as a wildcard:
+
+    - ``foo``    — whole-word match (default)
+    - ``foo*``   — words starting with ``foo``
+    - ``*foo``   — words ending with ``foo``
+    - ``*foo*``  — ``foo`` anywhere inside a word
+
+    Wildcards are only accepted at the start/end of the term; a ``*`` in
+    the middle returns 400. Wildcard queries require at least 3 non-``*``
+    characters.
 
     Provide either ``revision_id`` or ``iso`` (not both).  When ``iso`` is
     given, all accessible revisions for that language are searched and results
@@ -129,6 +141,30 @@ async def search_revision_text(
             detail="Provide either comparison_revision_id or comparison_iso, not both",
         )
 
+    # Parse leading/trailing `*` wildcards. A `*` in the middle of the
+    # term is rejected; wildcards are only anchors for the word boundary.
+    prefix_wildcard = term.startswith("*")
+    suffix_wildcard = term.endswith("*")
+    core_term = term[int(prefix_wildcard) : len(term) - int(suffix_wildcard)]
+    if "*" in core_term:
+        raise HTTPException(
+            status_code=400,
+            detail="`*` is only allowed at the start and/or end of the term",
+        )
+    has_wildcard = prefix_wildcard or suffix_wildcard
+    # Wildcard queries can explode result sets for very short cores
+    # (e.g. `*a*` matches nearly every verse). Require a reasonable floor.
+    if has_wildcard and len(core_term.strip()) < 3:
+        raise HTTPException(
+            status_code=400,
+            detail="Wildcard queries require at least 3 non-`*` characters",
+        )
+    if not core_term:
+        raise HTTPException(
+            status_code=400,
+            detail="Term must contain at least one non-`*` character",
+        )
+
     # Build authorization subqueries (executed inline with the search query
     # so auth + search are a single DB round-trip in the success case).
     main_auth_select = _authorized_revisions_select(
@@ -148,7 +184,7 @@ async def search_revision_text(
 
     # Normalize to NFC so accented characters match regardless of whether the
     # query or stored text uses composed vs decomposed forms.
-    normalized_term = unicodedata.normalize("NFC", term)
+    normalized_term = unicodedata.normalize("NFC", core_term)
 
     # Escape SQL LIKE/ILIKE wildcards so % and _ in the term are literal
     escaped_term = normalized_term.replace("%", r"\%").replace("_", r"\_")
@@ -282,11 +318,16 @@ async def search_revision_text(
                             detail="User not authorized to access the comparison revision",
                         )
 
-        # Filter results to only include whole word matches, stopping at limit.
+        # Filter results based on the wildcard anchors, stopping at limit.
         # Normalize both the query and the stored text to NFC so the word
         # boundary check behaves consistently regardless of input encoding.
+        # A leading `*` drops the left word boundary; a trailing `*` drops
+        # the right one; no `*` means a whole-word match.
+        escaped = re.escape(normalized_term.lower())
+        left = "" if prefix_wildcard else r"\b"
+        right = "" if suffix_wildcard else r"\b"
+        word_pattern = re.compile(left + escaped + right)
         filtered_results = []
-        word_pattern = re.compile(r"\b" + re.escape(normalized_term.lower()) + r"\b")
         for row in rows:
             if not row.main_text:
                 continue

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -110,8 +110,8 @@ async def search_revision_text(
     - ``*foo*``  — ``foo`` anywhere inside a word
 
     Wildcards are only accepted at the start/end of the term; a ``*`` in
-    the middle returns 400. Wildcard queries require at least 3 non-``*``
-    characters.
+    the middle returns 400. Wildcard queries require at least 3 visible
+    (non-whitespace, non-format) characters around the ``*`` anchors.
 
     Provide either ``revision_id`` or ``iso`` (not both).  When ``iso`` is
     given, all accessible revisions for that language are searched and results
@@ -162,7 +162,7 @@ async def search_revision_text(
     if visible_len == 0:
         raise HTTPException(
             status_code=400,
-            detail="Term must contain at least one non-`*` character",
+            detail="Term must contain at least one visible character",
         )
     has_wildcard = prefix_wildcard or suffix_wildcard
     # Wildcard queries can explode result sets for very short cores
@@ -170,7 +170,7 @@ async def search_revision_text(
     if has_wildcard and visible_len < 3:
         raise HTTPException(
             status_code=400,
-            detail="Wildcard queries require at least 3 non-`*` characters",
+            detail="Wildcard queries require at least 3 visible characters",
         )
 
     # Build authorization subqueries (executed inline with the search query

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1424,7 +1424,7 @@ def test_search_wildcard_single_star_rejected(client, regular_token1, test_db_se
     )
 
     assert response.status_code == 400
-    assert "non-`*`" in response.json()["detail"]
+    assert "visible character" in response.json()["detail"]
 
 
 def test_search_wildcard_invisible_chars_rejected(

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1411,3 +1411,126 @@ def test_search_wildcard_only_stars_rejected(client, regular_token1, test_db_ses
     )
 
     assert response.status_code == 400
+
+
+def test_search_wildcard_single_star_rejected(client, regular_token1, test_db_session):
+    """`term="*"` alone (core is empty) is rejected with a specific message."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "*"},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+    assert "non-`*`" in response.json()["detail"]
+
+
+def test_search_wildcard_invisible_chars_rejected(
+    client, regular_token1, test_db_session
+):
+    """Zero-width chars in the core don't count toward the 3-char floor."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    # Three zero-width spaces — strip() leaves them alone, so a naive
+    # len-based check would pass. The visible-char check must reject.
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "*\u200b\u200b\u200b*"},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_search_wildcard_via_iso(client, regular_token1, test_db_session):
+    """Wildcard parsing works on the iso= path (exercises DISTINCT ON)."""
+    _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"iso": "eng", "term": "*bhʉlany*", "limit": 20},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    refs = {(r["book"], r["chapter"], r["verse"]) for r in data["results"]}
+    assert refs == {
+        ("GEN", 1, 4),
+        ("GEN", 1, 6),
+        ("GEN", 1, 14),
+        ("GEN", 1, 20),
+        ("GEN", 2, 1),
+    }
+
+
+def test_search_wildcard_with_comparison(client, regular_token1, test_db_session):
+    """Wildcard term works with a comparison revision (JOIN path)."""
+    main_revision_id = _setup_morpheme_search_data(test_db_session)
+
+    # Add a comparison revision covering the same verses so the JOIN has rows.
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+    comp_version = BibleVersion(
+        name="Morpheme Comparison Version",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="MCV",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add(comp_version)
+    test_db_session.commit()
+    test_db_session.refresh(comp_version)
+
+    comp_revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=comp_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add(comp_revision)
+    test_db_session.commit()
+    test_db_session.refresh(comp_revision)
+
+    for book, chapter, verse, text in [
+        ("GEN", 1, 4, "and he divided the waters"),
+        ("GEN", 1, 6, "let the waters be divided"),
+        ("GEN", 1, 14, "let them divide the day"),
+    ]:
+        test_db_session.add(
+            VerseText(
+                text=text,
+                revision_id=comp_revision.id,
+                verse_reference=f"{book} {chapter}:{verse}",
+                book=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        )
+    test_db_session.add(
+        BibleVersionAccess(bible_version_id=comp_version.id, group_id=group1.id)
+    )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": main_revision_id,
+            "comparison_revision_id": comp_revision.id,
+            "term": "*bhʉlany*",
+            "limit": 20,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    refs = {(r["book"], r["chapter"], r["verse"]) for r in data["results"]}
+    # Only verses present in both revisions come back via the inner JOIN.
+    assert refs == {("GEN", 1, 4), ("GEN", 1, 6), ("GEN", 1, 14)}
+    for r in data["results"]:
+        assert "comparison_text" in r
+        assert r["comparison_text"]  # non-empty

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1193,3 +1193,221 @@ def test_search_by_iso_random(client, regular_token1, test_db_session):
     # Dedup still applies — no duplicate verse locations
     refs = [(r["book"], r["chapter"], r["verse"]) for r in data["results"]]
     assert len(refs) == len(set(refs))
+
+
+def _setup_morpheme_search_data(db_session):
+    """Seed a revision with morphologically related word forms for wildcard tests."""
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = db_session.query(Group).filter(Group.name == "Group1").first()
+
+    version = BibleVersion(
+        name="Morpheme Test Version",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="MTV",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    db_session.add(version)
+    db_session.commit()
+    db_session.refresh(version)
+
+    revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+    )
+    db_session.add(revision)
+    db_session.commit()
+    db_session.refresh(revision)
+
+    verses = [
+        ("GEN", 1, 4, "akhagabhʉlanya amatʉndʉ"),
+        ("GEN", 1, 6, "pagabhʉlanye amaazi"),
+        ("GEN", 1, 14, "zɨgabhʉlanye ɨmɨsi"),
+        ("GEN", 1, 20, "pagabhʉlanyiinye zyoonti"),
+        ("GEN", 2, 1, "bhʉlany is a standalone token here"),
+        ("GEN", 2, 2, "unrelated verse about ʉmundʉ"),
+    ]
+    for book, chapter, verse, text in verses:
+        db_session.add(
+            VerseText(
+                text=text,
+                revision_id=revision.id,
+                verse_reference=f"{book} {chapter}:{verse}",
+                book=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        )
+
+    db_session.add(BibleVersionAccess(bible_version_id=version.id, group_id=group1.id))
+    db_session.commit()
+    return revision.id
+
+
+def test_search_wildcard_no_wildcard_is_whole_word(
+    client, regular_token1, test_db_session
+):
+    """No `*` — behavior stays whole-word exact."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "bhʉlany", "limit": 20},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    # Only the standalone-token verse contains "bhʉlany" as a whole word.
+    refs = {(r["book"], r["chapter"], r["verse"]) for r in data["results"]}
+    assert refs == {("GEN", 2, 1)}
+
+
+def test_search_wildcard_contains(client, regular_token1, test_db_session):
+    """`*term*` finds the morpheme inside inflected forms."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": revision_id,
+            "term": "*bhʉlany*",
+            "limit": 20,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    refs = {(r["book"], r["chapter"], r["verse"]) for r in data["results"]}
+    assert refs == {
+        ("GEN", 1, 4),
+        ("GEN", 1, 6),
+        ("GEN", 1, 14),
+        ("GEN", 1, 20),
+        ("GEN", 2, 1),
+    }
+
+
+def test_search_wildcard_prefix(client, regular_token1, test_db_session):
+    """`term*` matches words STARTING with the term."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": revision_id,
+            "term": "pagabh*",
+            "limit": 20,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    refs = {(r["book"], r["chapter"], r["verse"]) for r in data["results"]}
+    # pagabhʉlanye (GEN 1:6) and pagabhʉlanyiinye (GEN 1:20) both start with pagabh
+    assert refs == {("GEN", 1, 6), ("GEN", 1, 20)}
+
+
+def test_search_wildcard_prefix_no_midword_match(
+    client, regular_token1, test_db_session
+):
+    """`term*` does NOT match when the term sits mid-word."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": revision_id,
+            "term": "bhʉlany*",
+            "limit": 20,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    refs = {(r["book"], r["chapter"], r["verse"]) for r in data["results"]}
+    # Only the standalone token "bhʉlany" (at start-of-word) matches
+    assert refs == {("GEN", 2, 1)}
+
+
+def test_search_wildcard_suffix(client, regular_token1, test_db_session):
+    """`*term` matches words ENDING with the term."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": revision_id,
+            "term": "*lanye",
+            "limit": 20,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    refs = {(r["book"], r["chapter"], r["verse"]) for r in data["results"]}
+    # pagabhʉlanye (1:6) and zɨgabhʉlanye (1:14) end with "lanye".
+    # pagabhʉlanyiinye (1:20) does NOT end with "lanye".
+    assert refs == {("GEN", 1, 6), ("GEN", 1, 14)}
+
+
+def test_search_wildcard_minimum_length(client, regular_token1, test_db_session):
+    """Wildcard queries reject cores shorter than 3 characters."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "*bh*"},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_search_wildcard_no_wildcard_allows_short_term(
+    client, regular_token1, test_db_session
+):
+    """Without `*`, short terms are still allowed (min-length rule doesn't apply)."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    # "is" is a whole word in GEN 2:1
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "is"},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+
+
+def test_search_wildcard_midterm_star_rejected(client, regular_token1, test_db_session):
+    """A `*` in the middle of the term is rejected (400)."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "bh*lany"},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_search_wildcard_only_stars_rejected(client, regular_token1, test_db_session):
+    """A term consisting only of `*` characters is rejected (400)."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "**"},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary
- Adds leading/trailing `*` wildcard syntax to the `/v3/textsearch` `term` parameter so callers (e.g. the translation agent) can match morphologically related word forms.
- `foo` stays whole-word (unchanged default); `foo*` = prefix, `*foo` = suffix, `*foo*` = contains.
- `*` mid-term returns 400; wildcard queries require ≥3 non-`*` characters to avoid result-set explosion.

## Design notes
- Went with inline `*` (issue's Option B) over an explicit `match=` param — one parameter, familiar syntax, and `*` doesn't appear in Bible text so literal escaping isn't a concern.
- Considered full regex; rejected because (1) user-supplied regex is a classic ReDoS vector, and (2) it would break the cheap SQL ILIKE prefilter and force a full scan.
- SQL stays `%term%` ILIKE with the existing 10x overfetch; the Python-side regex just drops the left/right `\b` anchor based on the wildcards. Single DB round-trip preserved.

## Test plan
- [x] Whole-word default (no `*`) still returns only exact matches
- [x] `*bhʉlany*` finds all inflected forms (the motivating use case)
- [x] `pagabh*` prefix matches words STARTING with `pagabh`; mid-word occurrences don't match
- [x] `*lanye` suffix matches words ENDING with `lanye`; mid-word occurrences don't match
- [x] `*bh*` (short core) returns 400
- [x] `bh*lany` (mid-term `*`) returns 400
- [x] `**` (only stars) returns 400
- [x] Short terms like `is` still allowed when no wildcard is used
- [x] All 37 existing search tests still pass

Fixes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)