### PR TITLE
feat: add language_affixes storage + upsert endpoints (#551)

### DIFF
--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -1,0 +1,267 @@
+__version__ = "v3"
+
+import socket
+import time
+import unicodedata
+from typing import Optional
+
+import fastapi
+from fastapi import Depends, HTTPException, Query, status
+from sqlalchemy import and_, or_, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.dependencies import get_db
+from database.models import (
+    BibleRevision,
+    IsoLanguage,
+    LanguageAffix,
+    LanguageProfile,
+)
+from database.models import UserDB as UserModel
+from models import (
+    AffixCommitRequest,
+    AffixCommitResponse,
+    AffixListOut,
+    AffixOut,
+)
+from security_routes.auth_routes import get_current_user
+from utils.logging_config import setup_logger
+
+container_id = socket.gethostname()
+logger = setup_logger(__name__, container_id=container_id)
+
+router = fastapi.APIRouter()
+
+
+def _normalize_form(form: str) -> str:
+    return unicodedata.normalize("NFC", form).strip()
+
+
+def _normalize_gloss(gloss: str) -> str:
+    return unicodedata.normalize("NFC", gloss).strip()
+
+
+@router.get("/affixes", response_model=AffixListOut)
+async def get_affixes(
+    iso: str = Query(..., min_length=3, max_length=3),
+    position: Optional[str] = Query(None, pattern="^(prefix|suffix|infix)$"),
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    request_start = time.perf_counter()
+
+    profile_result = await db.execute(
+        select(LanguageProfile.iso_639_3).where(LanguageProfile.iso_639_3 == iso)
+    )
+    if profile_result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No language profile for iso '{iso}'",
+        )
+
+    query = select(LanguageAffix).where(LanguageAffix.iso_639_3 == iso)
+    if position is not None:
+        query = query.where(LanguageAffix.position == position)
+    query = query.order_by(LanguageAffix.id)
+
+    result = await db.execute(query)
+    rows = result.scalars().all()
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"get_affixes completed in {duration}s",
+        extra={
+            "method": "GET",
+            "path": "/affixes",
+            "iso": iso,
+            "position": position,
+            "count": len(rows),
+            "duration_s": duration,
+        },
+    )
+    return AffixListOut(
+        iso_639_3=iso,
+        total=len(rows),
+        affixes=[AffixOut.model_validate(a) for a in rows],
+    )
+
+
+@router.post("/affixes", response_model=AffixCommitResponse)
+async def commit_affixes(
+    payload: AffixCommitRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Additive upsert of an affix inventory for a language.
+
+    Uniqueness is (iso, form, position, gloss) so polysemous affixes —
+    e.g. Bantu ``-ile`` as perfective/applicative/locative — live as
+    separate rows. On conflict, ``examples``, ``n_runs``, and
+    ``source_model`` are refreshed from the incoming payload.
+    """
+    request_start = time.perf_counter()
+    iso = payload.iso_639_3
+
+    iso_exists = await db.execute(select(IsoLanguage).where(IsoLanguage.iso639 == iso))
+    if iso_exists.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown ISO 639-3 code '{iso}'",
+        )
+
+    profile_result = await db.execute(
+        select(LanguageProfile.iso_639_3).where(LanguageProfile.iso_639_3 == iso)
+    )
+    if profile_result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                f"No language profile exists for iso '{iso}'. "
+                "Create one via the tokenizer profile endpoint first."
+            ),
+        )
+
+    if payload.revision_id is not None:
+        revision_exists = await db.execute(
+            select(BibleRevision.id).where(BibleRevision.id == payload.revision_id)
+        )
+        if revision_exists.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown revision_id {payload.revision_id}",
+            )
+
+    n_new = 0
+    n_updated = 0
+    n_unchanged = 0
+
+    try:
+        if payload.affixes:
+            incoming: dict[tuple[str, str, str], dict] = {}
+            for a in payload.affixes:
+                form = _normalize_form(a.form)
+                if not form:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail="Affix form must not be empty",
+                    )
+                gloss = _normalize_gloss(a.gloss)
+                if not gloss:
+                    raise HTTPException(
+                        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                        detail="Affix gloss must not be empty",
+                    )
+                incoming[(form, a.position, gloss)] = {
+                    "examples": a.examples,
+                    "n_runs": a.n_runs,
+                }
+
+            # Look up existing rows for the exact (form, position, gloss)
+            # tuples in the payload. One OR-of-ANDs clause per tuple is
+            # fine at the ~10-30 affix scale the comment specifies.
+            existing_map: dict[tuple[str, str, str], dict] = {}
+            if incoming:
+                clauses = [
+                    and_(
+                        LanguageAffix.form == f,
+                        LanguageAffix.position == p,
+                        LanguageAffix.gloss == g,
+                    )
+                    for (f, p, g) in incoming.keys()
+                ]
+                existing_result = await db.execute(
+                    select(
+                        LanguageAffix.form,
+                        LanguageAffix.position,
+                        LanguageAffix.gloss,
+                        LanguageAffix.examples,
+                        LanguageAffix.n_runs,
+                        LanguageAffix.source_model,
+                    ).where(
+                        LanguageAffix.iso_639_3 == iso,
+                        or_(*clauses),
+                    )
+                )
+                for row in existing_result.all():
+                    existing_map[(row.form, row.position, row.gloss)] = {
+                        "examples": row.examples,
+                        "n_runs": row.n_runs,
+                        "source_model": row.source_model,
+                    }
+
+            rows_to_write = []
+            for (form, position, gloss), fields in incoming.items():
+                key = (form, position, gloss)
+                if key in existing_map:
+                    stored = existing_map[key]
+                    if (
+                        stored["examples"] == fields["examples"]
+                        and stored["n_runs"] == fields["n_runs"]
+                        and stored["source_model"] == payload.source_model
+                    ):
+                        n_unchanged += 1
+                    else:
+                        n_updated += 1
+                else:
+                    n_new += 1
+
+                rows_to_write.append(
+                    {
+                        "iso_639_3": iso,
+                        "form": form,
+                        "position": position,
+                        "gloss": gloss,
+                        "examples": fields["examples"],
+                        "n_runs": fields["n_runs"],
+                        "source_model": payload.source_model,
+                        "first_seen_revision_id": payload.revision_id,
+                    }
+                )
+
+            if rows_to_write:
+                stmt = pg_insert(LanguageAffix).values(rows_to_write)
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["iso_639_3", "form", "position", "gloss"],
+                    set_={
+                        "examples": stmt.excluded.examples,
+                        "n_runs": stmt.excluded.n_runs,
+                        "source_model": stmt.excluded.source_model,
+                    },
+                )
+                await db.execute(stmt)
+
+        await db.commit()
+
+    except HTTPException:
+        await db.rollback()
+        raise
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error("Failed to commit affixes", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {e}",
+        ) from e
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"commit_affixes completed in {duration}s",
+        extra={
+            "method": "POST",
+            "path": "/affixes",
+            "iso": iso,
+            "source_model": payload.source_model,
+            "revision_id": payload.revision_id,
+            "n_affixes_new": n_new,
+            "n_affixes_updated": n_updated,
+            "n_affixes_unchanged": n_unchanged,
+            "duration_s": duration,
+        },
+    )
+    return AffixCommitResponse(
+        n_affixes_new=n_new,
+        n_affixes_updated=n_updated,
+        n_affixes_unchanged=n_unchanged,
+    )

--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -35,12 +35,10 @@ logger = setup_logger(__name__, container_id=container_id)
 router = fastapi.APIRouter()
 
 
-def _normalize_form(form: str) -> str:
-    return unicodedata.normalize("NFC", form).strip()
-
-
-def _normalize_gloss(gloss: str) -> str:
-    return unicodedata.normalize("NFC", gloss).strip()
+def _normalize(value: str) -> str:
+    # NFC + strip only — no casefold. Affix forms and glosses are
+    # case-sensitive linguistic annotations, unlike morphemes.
+    return unicodedata.normalize("NFC", value).strip()
 
 
 @router.get("/affixes", response_model=AffixListOut)
@@ -94,13 +92,6 @@ async def commit_affixes(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
-    """Additive upsert of an affix inventory for a language.
-
-    Uniqueness is (iso, form, position, gloss) so polysemous affixes —
-    e.g. Bantu ``-ile`` as perfective/applicative/locative — live as
-    separate rows. On conflict, ``examples``, ``n_runs``, and
-    ``source_model`` are refreshed from the incoming payload.
-    """
     request_start = time.perf_counter()
     iso = payload.iso_639_3
 
@@ -141,19 +132,26 @@ async def commit_affixes(
         if payload.affixes:
             incoming: dict[tuple[str, str, str], dict] = {}
             for a in payload.affixes:
-                form = _normalize_form(a.form)
-                if not form:
+                form = _normalize(a.form)
+                gloss = _normalize(a.gloss)
+                # Pydantic enforces min_length=1, but normalization may
+                # leave only whitespace — reject post-normalization too.
+                if not form or not gloss:
                     raise HTTPException(
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                        detail="Affix form must not be empty",
+                        detail="Affix form and gloss must not be empty",
                     )
-                gloss = _normalize_gloss(a.gloss)
-                if not gloss:
+                key = (form, a.position, gloss)
+                if key in incoming:
                     raise HTTPException(
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                        detail="Affix gloss must not be empty",
+                        detail=(
+                            f"Duplicate affix in payload: "
+                            f"form={form!r}, position={a.position!r}, "
+                            f"gloss={gloss!r}"
+                        ),
                     )
-                incoming[(form, a.position, gloss)] = {
+                incoming[key] = {
                     "examples": a.examples,
                     "n_runs": a.n_runs,
                 }
@@ -222,12 +220,15 @@ async def commit_affixes(
 
             if rows_to_write:
                 stmt = pg_insert(LanguageAffix).values(rows_to_write)
+                # updated_at is refreshed explicitly: raw pg_insert
+                # bypasses SQLAlchemy's ORM-level onupdate hook.
                 stmt = stmt.on_conflict_do_update(
                     index_elements=["iso_639_3", "form", "position", "gloss"],
                     set_={
                         "examples": stmt.excluded.examples,
                         "n_runs": stmt.excluded.n_runs,
                         "source_model": stmt.excluded.source_model,
+                        "updated_at": func.now(),
                     },
                 )
                 await db.execute(stmt)

--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -199,9 +199,11 @@ async def commit_affixes(
                         and stored["n_runs"] == fields["n_runs"]
                         and stored["source_model"] == payload.source_model
                     ):
+                        # Unchanged rows are excluded from the write batch
+                        # so updated_at isn't bumped for no-op upserts.
                         n_unchanged += 1
-                    else:
-                        n_updated += 1
+                        continue
+                    n_updated += 1
                 else:
                     n_new += 1
 

--- a/alembic/migrations/versions/b3c5e8f1a2d4_add_n_runs_check_to_language_affixes.py
+++ b/alembic/migrations/versions/b3c5e8f1a2d4_add_n_runs_check_to_language_affixes.py
@@ -1,0 +1,33 @@
+"""add n_runs check constraint to language_affixes
+
+Revision ID: b3c5e8f1a2d4
+Revises: f7a9b2c4d8e1
+Create Date: 2026-04-17 17:30:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b3c5e8f1a2d4"
+down_revision: Union[str, None] = "f7a9b2c4d8e1"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_check_constraint(
+        "ck_language_affixes_n_runs_min_1",
+        "language_affixes",
+        "n_runs >= 1",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_language_affixes_n_runs_min_1",
+        "language_affixes",
+        type_="check",
+    )

--- a/alembic/migrations/versions/f7a9b2c4d8e1_add_language_affixes_table.py
+++ b/alembic/migrations/versions/f7a9b2c4d8e1_add_language_affixes_table.py
@@ -1,0 +1,75 @@
+"""add language_affixes table
+
+Revision ID: f7a9b2c4d8e1
+Revises: 020e59f6d36a
+Create Date: 2026-04-17 16:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f7a9b2c4d8e1"
+down_revision: Union[str, None] = "020e59f6d36a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "language_affixes",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("iso_639_3", sa.String(length=3), nullable=False),
+        sa.Column("form", sa.Text(), nullable=False),
+        sa.Column("position", sa.Text(), nullable=False),
+        sa.Column("gloss", sa.Text(), nullable=False),
+        sa.Column("examples", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+        sa.Column("n_runs", sa.SmallInteger(), nullable=False, server_default="1"),
+        sa.Column("source_model", sa.Text(), nullable=True),
+        sa.Column("first_seen_revision_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "first_seen_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=True
+        ),
+        sa.Column(
+            "updated_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=True
+        ),
+        sa.CheckConstraint(
+            "position IN ('prefix', 'suffix', 'infix')",
+            name="ck_language_affixes_position",
+        ),
+        sa.ForeignKeyConstraint(
+            ["first_seen_revision_id"], ["bible_revision.id"], ondelete="SET NULL"
+        ),
+        sa.ForeignKeyConstraint(
+            ["iso_639_3"], ["language_profiles.iso_639_3"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ux_language_affixes_iso_form_position_gloss",
+        "language_affixes",
+        ["iso_639_3", "form", "position", "gloss"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_language_affixes_iso", "language_affixes", ["iso_639_3"], unique=False
+    )
+    op.create_index(
+        "ix_language_affixes_iso_position",
+        "language_affixes",
+        ["iso_639_3", "position"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_language_affixes_iso_position", table_name="language_affixes")
+    op.drop_index("ix_language_affixes_iso", table_name="language_affixes")
+    op.drop_index(
+        "ux_language_affixes_iso_form_position_gloss", table_name="language_affixes"
+    )
+    op.drop_table("language_affixes")

--- a/app.py
+++ b/app.py
@@ -5,6 +5,7 @@ import os
 import fastapi
 from fastapi.openapi.utils import get_openapi
 
+from agent_routes.v3.affix_routes import router as affix_router_v3
 from agent_routes.v3.agent_routes import router as agent_router_v3
 from agent_routes.v3.tokenizer_routes import router as tokenizer_router_v3
 from assessment_routes.v3.assessment_routes import router as assessment_router_v3
@@ -104,6 +105,7 @@ def configure_routing(app):
     app.include_router(search_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(agent_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(tokenizer_router_v3, prefix="/v3", tags=["Version 3"])
+    app.include_router(affix_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(train_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(eflomal_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(results_write_router_v3, prefix="/v3", tags=["Version 3"])
@@ -126,6 +128,7 @@ def configure_routing(app):
     app.include_router(
         tokenizer_router_v3, prefix="/latest", tags=["Version 3 / Latest"]
     )
+    app.include_router(affix_router_v3, prefix="/latest", tags=["Version 3 / Latest"])
     app.include_router(train_router_v3, prefix="/latest", tags=["Version 3 / Latest"])
     app.include_router(eflomal_router_v3, prefix="/latest", tags=["Version 3 / Latest"])
     app.include_router(

--- a/database/models.py
+++ b/database/models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Index,
     Integer,
     Numeric,
+    SmallInteger,
     String,
     Text,
     UniqueConstraint,
@@ -895,6 +896,47 @@ class LanguageMorpheme(Base):
         ),
         Index("ix_language_morphemes_iso", "iso_639_3"),
         Index("ix_language_morphemes_iso_class", "iso_639_3", "morpheme_class"),
+    )
+
+
+class LanguageAffix(Base):
+    __tablename__ = "language_affixes"
+
+    id = Column(Integer, primary_key=True)
+    iso_639_3 = Column(
+        String(3),
+        ForeignKey("language_profiles.iso_639_3", ondelete="CASCADE"),
+        nullable=False,
+    )
+    form = Column(Text, nullable=False)
+    position = Column(Text, nullable=False)
+    gloss = Column(Text, nullable=False)
+    examples = Column(JSONB, nullable=True)
+    n_runs = Column(SmallInteger, nullable=False, server_default="1")
+    source_model = Column(Text, nullable=True)
+    first_seen_revision_id = Column(
+        Integer,
+        ForeignKey("bible_revision.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    first_seen_at = Column(TIMESTAMP, server_default=func.now())
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        CheckConstraint(
+            "position IN ('prefix', 'suffix', 'infix')",
+            name="ck_language_affixes_position",
+        ),
+        Index(
+            "ux_language_affixes_iso_form_position_gloss",
+            "iso_639_3",
+            "form",
+            "position",
+            "gloss",
+            unique=True,
+        ),
+        Index("ix_language_affixes_iso", "iso_639_3"),
+        Index("ix_language_affixes_iso_position", "iso_639_3", "position"),
     )
 
 

--- a/database/models.py
+++ b/database/models.py
@@ -927,6 +927,7 @@ class LanguageAffix(Base):
             "position IN ('prefix', 'suffix', 'infix')",
             name="ck_language_affixes_position",
         ),
+        CheckConstraint("n_runs >= 1", name="ck_language_affixes_n_runs_min_1"),
         Index(
             "ux_language_affixes_iso_form_position_gloss",
             "iso_639_3",

--- a/models.py
+++ b/models.py
@@ -1302,7 +1302,7 @@ class AffixIn(BaseModel):
     position: AffixPosition
     gloss: str = Field(..., min_length=1)
     examples: Optional[List[str]] = None
-    n_runs: int = Field(default=1, ge=1)
+    n_runs: int = Field(default=1, ge=1, le=32767)
 
 
 class AffixOut(BaseModel):
@@ -1312,7 +1312,7 @@ class AffixOut(BaseModel):
     position: AffixPosition
     gloss: str
     examples: Optional[List[str]] = None
-    n_runs: int = Field(default=1, ge=1)
+    n_runs: int = Field(default=1, ge=1, le=32767)
     source_model: Optional[str] = None
     first_seen_revision_id: Optional[int] = None
 

--- a/models.py
+++ b/models.py
@@ -1294,6 +1294,48 @@ class IndexResponse(BaseModel):
     unique_morpheme_verse_pairs: int
 
 
+AffixPosition = Literal["prefix", "suffix", "infix"]
+
+
+class AffixIn(BaseModel):
+    form: str
+    position: AffixPosition
+    gloss: str
+    examples: Optional[List[str]] = None
+    n_runs: int = Field(default=1, ge=1)
+
+
+class AffixOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    form: str
+    position: AffixPosition
+    gloss: str
+    examples: Optional[List[str]] = None
+    n_runs: int = 1
+    source_model: Optional[str] = None
+    first_seen_revision_id: Optional[int] = None
+
+
+class AffixListOut(BaseModel):
+    iso_639_3: str
+    total: int
+    affixes: List[AffixOut]
+
+
+class AffixCommitRequest(BaseModel):
+    iso_639_3: str
+    revision_id: Optional[int] = None
+    source_model: Optional[str] = None
+    affixes: List[AffixIn] = Field(default_factory=list)
+
+
+class AffixCommitResponse(BaseModel):
+    n_affixes_new: int
+    n_affixes_updated: int
+    n_affixes_unchanged: int
+
+
 class WordIndexRequest(BaseModel):
     iso_639_3: str = Field(..., min_length=3, max_length=3)
     revision_id: int

--- a/models.py
+++ b/models.py
@@ -1298,9 +1298,9 @@ AffixPosition = Literal["prefix", "suffix", "infix"]
 
 
 class AffixIn(BaseModel):
-    form: str
+    form: str = Field(..., min_length=1)
     position: AffixPosition
-    gloss: str
+    gloss: str = Field(..., min_length=1)
     examples: Optional[List[str]] = None
     n_runs: int = Field(default=1, ge=1)
 
@@ -1312,7 +1312,7 @@ class AffixOut(BaseModel):
     position: AffixPosition
     gloss: str
     examples: Optional[List[str]] = None
-    n_runs: int = 1
+    n_runs: int = Field(default=1, ge=1)
     source_model: Optional[str] = None
     first_seen_revision_id: Optional[int] = None
 

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -604,3 +604,36 @@ def test_affixes_updated_at_refreshed_on_upsert(client, regular_token1, db_sessi
     )
     assert after > before
     _cleanup(db_session)
+
+
+def test_affixes_updated_at_not_bumped_on_unchanged_upsert(
+    client, regular_token1, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    payload = {
+        "iso_639_3": TEST_ISO,
+        "affixes": [{"form": "akha-", "position": "prefix", "gloss": "past"}],
+    }
+    client.post(f"/{prefix}/affixes", json=payload, headers=headers)
+    db_session.expire_all()
+    before = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .one()
+        .updated_at
+    )
+
+    resp = client.post(f"/{prefix}/affixes", json=payload, headers=headers)
+    assert resp.json()["n_affixes_unchanged"] == 1
+    db_session.expire_all()
+    after = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .one()
+        .updated_at
+    )
+    assert after == before
+    _cleanup(db_session)

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -1,0 +1,383 @@
+"""Tests for language affix storage API endpoints."""
+
+from database.models import LanguageAffix, LanguageProfile
+
+prefix = "v3"
+
+TEST_ISO = "swh"
+
+
+def _cleanup(db_session):
+    db_session.query(LanguageAffix).filter(LanguageAffix.iso_639_3 == TEST_ISO).delete()
+    db_session.query(LanguageProfile).filter(
+        LanguageProfile.iso_639_3 == TEST_ISO
+    ).delete()
+    db_session.commit()
+
+
+def _seed_profile(db_session):
+    db_session.add(LanguageProfile(iso_639_3=TEST_ISO, name="Swahili"))
+    db_session.commit()
+
+
+def test_affixes_round_trip(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    payload = {
+        "iso_639_3": TEST_ISO,
+        "source_model": "gpt-5-mini",
+        "affixes": [
+            {
+                "form": "akha-",
+                "position": "prefix",
+                "gloss": "past/perfective",
+                "examples": ["akhatenda", "akhalala"],
+                "n_runs": 3,
+            },
+            {
+                "form": "-ile",
+                "position": "suffix",
+                "gloss": "perfect",
+                "examples": ["tendile"],
+                "n_runs": 2,
+            },
+        ],
+    }
+    resp = client.post(f"/{prefix}/affixes", json=payload, headers=headers)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["n_affixes_new"] == 2
+    assert body["n_affixes_updated"] == 0
+    assert body["n_affixes_unchanged"] == 0
+
+    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["iso_639_3"] == TEST_ISO
+    assert data["total"] == 2
+    by_form = {a["form"]: a for a in data["affixes"]}
+    assert set(by_form) == {"akha-", "-ile"}
+    akha = by_form["akha-"]
+    assert akha["position"] == "prefix"
+    assert akha["gloss"] == "past/perfective"
+    assert akha["examples"] == ["akhatenda", "akhalala"]
+    assert akha["n_runs"] == 3
+    assert akha["source_model"] == "gpt-5-mini"
+
+    resp = client.get(
+        f"/{prefix}/affixes?iso={TEST_ISO}&position=prefix", headers=headers
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total"] == 1
+    assert data["affixes"][0]["form"] == "akha-"
+    _cleanup(db_session)
+
+
+def test_affixes_polysemy_same_form_position_different_gloss(
+    client, regular_token1, db_session
+):
+    """Bantu `-ile`-style polysemy: one surface form, multiple senses — must
+    be stored as distinct rows."""
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "-ile", "position": "suffix", "gloss": "perfective"},
+                {"form": "-ile", "position": "suffix", "gloss": "applicative"},
+                {"form": "-ile", "position": "suffix", "gloss": "locative"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["n_affixes_new"] == 3
+
+    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    data = resp.json()
+    assert data["total"] == 3
+    glosses = {a["gloss"] for a in data["affixes"]}
+    assert glosses == {"perfective", "applicative", "locative"}
+    _cleanup(db_session)
+
+
+def test_affixes_upsert_updates_existing(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    first = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "source_model": "gpt-5-mini",
+            "affixes": [
+                {
+                    "form": "akha-",
+                    "position": "prefix",
+                    "gloss": "past",
+                    "n_runs": 1,
+                },
+            ],
+        },
+        headers=headers,
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "source_model": "gpt-5-mini",
+            "affixes": [
+                {
+                    "form": "akha-",
+                    "position": "prefix",
+                    "gloss": "past",
+                    "examples": ["akhatenda"],
+                    "n_runs": 4,
+                },
+                {"form": "-ile", "position": "suffix", "gloss": "perfect"},
+            ],
+        },
+        headers=headers,
+    )
+    assert second.status_code == 200
+    body = second.json()
+    assert body["n_affixes_new"] == 1
+    assert body["n_affixes_updated"] == 1
+    assert body["n_affixes_unchanged"] == 0
+
+    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    data = resp.json()
+    assert data["total"] == 2
+    by_form = {a["form"]: a for a in data["affixes"]}
+    assert by_form["akha-"]["examples"] == ["akhatenda"]
+    assert by_form["akha-"]["n_runs"] == 4
+    _cleanup(db_session)
+
+
+def test_affixes_idempotent_same_payload(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    payload = {
+        "iso_639_3": TEST_ISO,
+        "source_model": "gpt-5-mini",
+        "affixes": [
+            {"form": "akha-", "position": "prefix", "gloss": "past", "n_runs": 2},
+        ],
+    }
+    first = client.post(f"/{prefix}/affixes", json=payload, headers=headers)
+    assert first.status_code == 200
+    assert first.json()["n_affixes_new"] == 1
+
+    second = client.post(f"/{prefix}/affixes", json=payload, headers=headers)
+    assert second.status_code == 200
+    body = second.json()
+    assert body["n_affixes_new"] == 0
+    assert body["n_affixes_updated"] == 0
+    assert body["n_affixes_unchanged"] == 1
+
+    rows = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .all()
+    )
+    assert len(rows) == 1
+    _cleanup(db_session)
+
+
+def test_affixes_same_form_different_positions(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "a", "position": "prefix", "gloss": "nominalizer"},
+                {"form": "a", "position": "suffix", "gloss": "final-vowel"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["n_affixes_new"] == 2
+
+    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    assert resp.json()["total"] == 2
+    _cleanup(db_session)
+
+
+def test_affixes_additive_preserves_absent_rows(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "akha-", "position": "prefix", "gloss": "past"},
+                {"form": "-ile", "position": "suffix", "gloss": "perfect"},
+            ],
+        },
+        headers=headers,
+    )
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "ku-", "position": "prefix", "gloss": "infinitive"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["n_affixes_new"] == 1
+
+    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    forms = {a["form"] for a in resp.json()["affixes"]}
+    assert forms == {"akha-", "-ile", "ku-"}
+    _cleanup(db_session)
+
+
+def test_affixes_with_revision_id(client, regular_token1, test_revision_id, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "revision_id": test_revision_id,
+            "affixes": [
+                {"form": "akha-", "position": "prefix", "gloss": "past"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    assert resp.json()["affixes"][0]["first_seen_revision_id"] == test_revision_id
+    _cleanup(db_session)
+
+
+def test_affixes_get_missing_profile(client, regular_token1, db_session):
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.get(f"/{prefix}/affixes?iso=xxx", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_affixes_post_missing_profile(client, regular_token1, db_session):
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [{"form": "akha-", "position": "prefix", "gloss": "past"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_affixes_post_unknown_iso(client, regular_token1, db_session):
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": "zzz",
+            "affixes": [{"form": "x-", "position": "prefix", "gloss": "x"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_affixes_post_invalid_position(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "akha-", "position": "circumfix", "gloss": "past"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    _cleanup(db_session)
+
+
+def test_affixes_post_missing_gloss(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [{"form": "akha-", "position": "prefix"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    _cleanup(db_session)
+
+
+def test_affixes_post_invalid_revision(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "revision_id": 999_999_999,
+            "affixes": [{"form": "akha-", "position": "prefix", "gloss": "past"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    _cleanup(db_session)
+
+
+def test_affixes_empty_post(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={"iso_639_3": TEST_ISO, "affixes": []},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {
+        "n_affixes_new": 0,
+        "n_affixes_updated": 0,
+        "n_affixes_unchanged": 0,
+    }
+    _cleanup(db_session)

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -79,8 +79,6 @@ def test_affixes_round_trip(client, regular_token1, db_session):
 def test_affixes_polysemy_same_form_position_different_gloss(
     client, regular_token1, db_session
 ):
-    """Bantu `-ile`-style polysemy: one surface form, multiple senses — must
-    be stored as distinct rows."""
     _cleanup(db_session)
     _seed_profile(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
@@ -380,4 +378,229 @@ def test_affixes_empty_post(client, regular_token1, db_session):
         "n_affixes_updated": 0,
         "n_affixes_unchanged": 0,
     }
+    _cleanup(db_session)
+
+
+def test_affixes_get_without_token(client, db_session):
+    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}")
+    assert resp.status_code == 401
+
+
+def test_affixes_post_without_token(client, db_session):
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [{"form": "akha-", "position": "prefix", "gloss": "past"}],
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_affixes_duplicate_in_payload_rejected(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "akha-", "position": "prefix", "gloss": "past"},
+                {"form": "akha-", "position": "prefix", "gloss": "past"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "duplicate" in resp.json()["detail"].lower()
+    _cleanup(db_session)
+
+
+def test_affixes_empty_form_rejected_at_pydantic(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [{"form": "", "position": "prefix", "gloss": "past"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    _cleanup(db_session)
+
+
+def test_affixes_whitespace_only_form_rejected(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [{"form": "   ", "position": "prefix", "gloss": "past"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    _cleanup(db_session)
+
+
+def test_affixes_nfc_normalization_dedupes(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # NFC-composed "é" and decomposed "e\u0301" should collapse to one row.
+    composed = "\u00e9-"
+    decomposed = "e\u0301-"
+    assert composed != decomposed  # distinct as raw strings
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [{"form": composed, "position": "prefix", "gloss": "x"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["n_affixes_new"] == 1
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "  " + decomposed + "  ", "position": "prefix", "gloss": "x"}
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["n_affixes_new"] == 0
+    assert body["n_affixes_unchanged"] == 1
+    _cleanup(db_session)
+
+
+def test_affixes_first_seen_revision_preserved_on_upsert(
+    client, regular_token1, test_revision_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "revision_id": test_revision_id,
+            "affixes": [{"form": "akha-", "position": "prefix", "gloss": "past"}],
+        },
+        headers=headers,
+    )
+
+    # Second commit with a different revision_id — should not clobber
+    # first_seen_revision_id.
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {
+                    "form": "akha-",
+                    "position": "prefix",
+                    "gloss": "past",
+                    "examples": ["new"],
+                }
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    row = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .one()
+    )
+    assert row.first_seen_revision_id == test_revision_id
+    _cleanup(db_session)
+
+
+def test_affixes_source_model_change_counts_as_updated(
+    client, regular_token1, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    body = {
+        "iso_639_3": TEST_ISO,
+        "source_model": "model-a",
+        "affixes": [{"form": "akha-", "position": "prefix", "gloss": "past"}],
+    }
+    client.post(f"/{prefix}/affixes", json=body, headers=headers)
+
+    body["source_model"] = "model-b"
+    resp = client.post(f"/{prefix}/affixes", json=body, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["n_affixes_updated"] == 1
+    assert data["n_affixes_unchanged"] == 0
+
+    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    assert resp.json()["affixes"][0]["source_model"] == "model-b"
+    _cleanup(db_session)
+
+
+def test_affixes_updated_at_refreshed_on_upsert(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [{"form": "akha-", "position": "prefix", "gloss": "past"}],
+        },
+        headers=headers,
+    )
+    db_session.expire_all()
+    before = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .one()
+        .updated_at
+    )
+
+    # Trigger an upsert that actually changes stored state.
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {
+                    "form": "akha-",
+                    "position": "prefix",
+                    "gloss": "past",
+                    "examples": ["akhatenda"],
+                }
+            ],
+        },
+        headers=headers,
+    )
+    db_session.expire_all()
+    after = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .one()
+        .updated_at
+    )
+    assert after > before
     _cleanup(db_session)


### PR DESCRIPTION
## Summary
- New `language_affixes` table with columns `iso_639_3`, `form`, `position` (prefix/suffix/infix), `gloss`, `examples` (JSONB), `n_runs`, `source_model`, `first_seen_revision_id`, audit columns. Unique index on `(iso, form, position, gloss)` so polysemous affixes (e.g. Bantu `-ile` perfective/applicative/locative) live as distinct rows.
- `POST /v3/affixes` + `/latest/affixes` — additive upsert. Existing `(iso, form, position, gloss)` rows get `examples`, `n_runs`, `source_model` refreshed; rows absent from the payload are left alone.
- `GET /v3/affixes?iso=...` + `/latest/affixes` — lists the inventory, with an optional `position` filter.
- Payload mirrors the tokenizer commit pattern: language-level `revision_id` + `source_model` alongside the per-affix list.
- `gloss` is required (NOT NULL in DB, required in schema) since it's the polysemy discriminator.

Fixes #551

## Test plan
- [x] New Alembic migration `f7a9b2c4d8e1` applies cleanly (`alembic upgrade head`)
- [x] 14 new tests in `test/test_agent_routes/test_affix_routes.py` covering round-trip, polysemy, upsert semantics, idempotency, same-form/different-positions, additive preservation, `revision_id` audit, and validation errors (unknown iso, missing profile, invalid position, missing gloss, invalid revision)
- [x] `black` + `isort` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)