### PR TITLE
fix: textsearch deleted filter includes NULL-deleted revisions

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -51,8 +51,8 @@ def _authorized_revisions_select(
         select(BibleRevision.id)
         .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
         .where(
-            BibleRevision.deleted.is_not(True),
-            BibleVersion.deleted.is_not(True),
+            BibleRevision.deleted.is_(False),
+            BibleVersion.deleted.is_(False),
         )
     )
     if revision_id is not None:


### PR DESCRIPTION
## Summary

Fixes #546.

- The textsearch auth subquery used `deleted.is_not(True)` which includes rows where `deleted` is `NULL`, while the revision/version listing endpoints use `deleted.is_(False)` (excludes `NULL`)
- This caused "ghost" revisions — those with `deleted=NULL` — to appear in textsearch results but not in version/revision listings
- A non-English revision tagged as `eng` (with `deleted=NULL`) was returning Devanagari comparison text for ~6-7% of queries using `comparison_iso=eng`

### Root cause investigation

- Confirmed the issue is reproducible on production: searching Malila terms with `comparison_iso=eng` returns Devanagari comparison text
- Checked all 71 English revisions visible in the API — none contain non-English text (all return empty at the affected verses)
- Confirmed Devanagari text IS searchable within `iso=eng` via textsearch, proving a "hidden" revision with `deleted=NULL` is leaking through

### Fix

Changed `_authorized_revisions_select` to use `is_(False)` instead of `is_not(True)` for both `BibleRevision.deleted` and `BibleVersion.deleted`, matching the behavior of the listing endpoints.

## Test plan

- [x] All 41 existing textsearch tests pass
- [ ] Deploy and verify Devanagari text no longer appears in `comparison_iso=eng` results

🤖 Generated with [Claude Code](https://claude.com/claude-code)