### PR TITLE
fix: relax 3-character minimum for wildcard textsearch queries

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -165,13 +165,6 @@ async def search_revision_text(
             detail="Term must contain at least one visible character",
         )
     has_wildcard = prefix_wildcard or suffix_wildcard
-    # Wildcard queries can explode result sets for very short cores
-    # (e.g. `*a*` matches nearly every verse). Require a reasonable floor.
-    if has_wildcard and visible_len < 3:
-        raise HTTPException(
-            status_code=400,
-            detail="Wildcard queries require at least 3 visible characters",
-        )
 
     # Build authorization subqueries (executed inline with the search query
     # so auth + search are a single DB round-trip in the success case).

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -110,8 +110,8 @@ async def search_revision_text(
     - ``*foo*``  — ``foo`` anywhere inside a word
 
     Wildcards are only accepted at the start/end of the term; a ``*`` in
-    the middle returns 400. Wildcard queries require at least 3 visible
-    (non-whitespace, non-format) characters around the ``*`` anchors.
+    the middle returns 400. The term must contain at least one visible
+    (non-whitespace, non-format) character.
 
     Provide either ``revision_id`` or ``iso`` (not both).  When ``iso`` is
     given, all accessible revisions for that language are searched and results

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -164,7 +164,6 @@ async def search_revision_text(
             status_code=400,
             detail="Term must contain at least one visible character",
         )
-    has_wildcard = prefix_wildcard or suffix_wildcard
 
     # Build authorization subqueries (executed inline with the search query
     # so auth + search are a single DB round-trip in the success case).

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1372,6 +1372,16 @@ def test_search_wildcard_short_core_allowed(client, regular_token1, test_db_sess
     data = response.json()
     assert len(data["results"]) > 0
 
+    one_char_response = client.get(
+        "/v3/textsearch",
+        params={"revision_id": revision_id, "term": "*a*"},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert one_char_response.status_code == 200
+    one_char_data = one_char_response.json()
+    assert len(one_char_data["results"]) > 0
+
 
 def test_search_wildcard_no_wildcard_allows_short_term(
     client, regular_token1, test_db_session

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1358,8 +1358,8 @@ def test_search_wildcard_suffix(client, regular_token1, test_db_session):
     assert refs == {("GEN", 1, 6), ("GEN", 1, 14)}
 
 
-def test_search_wildcard_minimum_length(client, regular_token1, test_db_session):
-    """Wildcard queries reject cores shorter than 3 characters."""
+def test_search_wildcard_short_core_allowed(client, regular_token1, test_db_session):
+    """Wildcard queries with short cores (< 3 chars) are allowed."""
     revision_id = _setup_morpheme_search_data(test_db_session)
 
     response = client.get(
@@ -1368,7 +1368,9 @@ def test_search_wildcard_minimum_length(client, regular_token1, test_db_session)
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["results"]) > 0
 
 
 def test_search_wildcard_no_wildcard_allows_short_term(
@@ -1430,7 +1432,7 @@ def test_search_wildcard_single_star_rejected(client, regular_token1, test_db_se
 def test_search_wildcard_invisible_chars_rejected(
     client, regular_token1, test_db_session
 ):
-    """Zero-width chars in the core don't count toward the 3-char floor."""
+    """Zero-width chars in the core don't count as visible characters."""
     revision_id = _setup_morpheme_search_data(test_db_session)
 
     # Three zero-width spaces — strip() leaves them alone, so a naive


### PR DESCRIPTION
## Summary
- Removes the 3-visible-character minimum for wildcard textsearch queries (#557)
- Short affix searches like `ki*` or `a*` now work — the existing `limit * 10` SQL cap already bounds DB work
- The "at least one visible character" check remains to prevent degenerate `*`-only queries

## Test plan
- [x] Updated `test_search_wildcard_minimum_length` → `test_search_wildcard_short_core_allowed` to verify `*bh*` returns 200 with results
- [x] All 41 search route tests pass
- [x] Invisible-chars-only queries still rejected (400)

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)