### PR TITLE
feat: surface TrainingNotAvailableError as status=not_trained (#566)

### DIFF
--- a/models.py
+++ b/models.py
@@ -375,7 +375,7 @@ class PredictInput(BaseModel):
 
 
 class PredictAppResult(BaseModel):
-    status: Literal["ok", "error"]
+    status: Literal["ok", "error", "not_trained"]
     data: Optional[Any] = None
     error: Optional[str] = None
     duration_ms: int

--- a/predict_routes/v3/predict_routes.py
+++ b/predict_routes/v3/predict_routes.py
@@ -130,6 +130,13 @@ async def predict(
             logger.warning(
                 f"predict app {name} failed: {type(exc).__name__}", exc_info=True
             )
+            # "Training hasn't run yet" is an expected, actionable state —
+            # not an error. Match by class name because the exception class
+            # lives in aqua-assessments and can't be imported here.
+            if type(exc).__name__ == "TrainingNotAvailableError":
+                return name, PredictAppResult(
+                    status="not_trained", error=str(exc), duration_ms=duration_ms
+                )
             # Surface ValueError messages (per-app input validation is caller
             # error, e.g. "agent.predict requires vref and source_text on every
             # pair"); opaque type names for other exception classes.

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -361,6 +361,37 @@ def test_predict_surfaces_value_error_message(client, regular_token1):
     assert error == msg
 
 
+def test_predict_training_not_available_returns_not_trained_status(
+    client, regular_token1
+):
+    """A `TrainingNotAvailableError` (matched by class name) surfaces as
+    `status="not_trained"` — distinct from generic `"error"` — with the
+    exception message preserved."""
+
+    # Defined locally because the real class lives in aqua-assessments and
+    # can't be imported here; the route detects it by `__name__` match.
+    class TrainingNotAvailableError(ValueError):
+        pass
+
+    msg = "No TF-IDF artifacts found (source_language=mgq). Run tfidf assess() first."
+    results = {"tfidf": TrainingNotAvailableError(msg)}
+    with patch(
+        "predict_routes.v3.predict_routes.modal.Function",
+        _make_modal_mock(results),
+    ):
+        response = client.post(
+            f"/{prefix}/predict",
+            json=_body(apps=["tfidf"]),
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200
+    tfidf = response.json()["results"]["tfidf"]
+    assert tfidf["status"] == "not_trained"
+    assert tfidf["error"] == msg
+    assert tfidf["data"] is None
+
+
 def test_predict_unauthorized_reference_returns_403(
     client, regular_token2, test_revision_id
 ):


### PR DESCRIPTION
## Summary

- Adds a third value `not_trained` to `PredictAppResult.status` for the predict fan-out endpoint.
- In the `except Exception` branch of `call_one()` in `predict_routes/v3/predict_routes.py`, detects `TrainingNotAvailableError` by class name (`type(exc).__name__`) and returns `status=\"not_trained\"` with `str(exc)` preserved in `error`.
- Class-name match is intentional: the class is defined in `aqua-assessments/shared/predict_errors.py` (see sil-ai/aqua-assessments#173) and can't be imported across the Modal boundary. Modal may also downgrade custom exception types to plain `ValueError` on unpickling, so keying on the class name is more reliable than an `isinstance` check.

Fixes #566 — pairs with sil-ai/aqua-assessments#173.

## Behaviour

| App raises | `status` | `error` |
|---|---|---|
| `TrainingNotAvailableError` | `not_trained` | `str(exc)` — descriptive message from the assessment app |
| other `ValueError` | `error` | `str(exc)` (per-app input validation) |
| other `Exception` | `error` | `type(exc).__name__` (opaque — no message leak) |

Behaviour before and after this change for the non-`TrainingNotAvailableError` paths is unchanged.

## Test plan

- [x] `pytest test/test_predict_routes/` — 36 passing (includes new `test_predict_training_not_available_returns_not_trained_status`)
- [ ] Manual smoke once sil-ai/aqua-assessments#173 deploys: call `/v3/predict` with apps=['tfidf'] for an untrained language → expect `status=\"not_trained\"` with the \"Run tfidf assess() first\" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)