### PR TITLE
Add eflomal verse scores to assessment_results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,5 @@ Scripts
 
 # GitHub Copilot
 .github/copilot-instructions.md
+
+temp/

--- a/alembic/migrations/versions/020e59f6d36a_add_lightweight_card_revision_index_on_.py
+++ b/alembic/migrations/versions/020e59f6d36a_add_lightweight_card_revision_index_on_.py
@@ -5,6 +5,7 @@ Revises: d6e0f1a2b3c4
 Create Date: 2026-04-16 16:03:29.193554
 
 """
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa

--- a/alembic/migrations/versions/15a13c99aaf1_add_morpheme_tokenizer_tables.py
+++ b/alembic/migrations/versions/15a13c99aaf1_add_morpheme_tokenizer_tables.py
@@ -5,6 +5,7 @@ Revises: b4e7f2a91c53
 Create Date: 2026-04-11 18:52:45.953213
 
 """
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa

--- a/alembic/migrations/versions/1fe4e7b897b4_add_verse_morpheme_index_table.py
+++ b/alembic/migrations/versions/1fe4e7b897b4_add_verse_morpheme_index_table.py
@@ -5,6 +5,7 @@ Revises: 15a13c99aaf1
 Create Date: 2026-04-13 14:35:08.538829
 
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/alembic/migrations/versions/b3c5e8f1a2d4_add_n_runs_check_to_language_affixes.py
+++ b/alembic/migrations/versions/b3c5e8f1a2d4_add_n_runs_check_to_language_affixes.py
@@ -5,6 +5,7 @@ Revises: f7a9b2c4d8e1
 Create Date: 2026-04-17 17:30:00.000000
 
 """
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa

--- a/alembic/migrations/versions/f7a9b2c4d8e1_add_language_affixes_table.py
+++ b/alembic/migrations/versions/f7a9b2c4d8e1_add_language_affixes_table.py
@@ -5,6 +5,7 @@ Revises: 020e59f6d36a
 Create Date: 2026-04-17 16:00:00.000000
 
 """
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -11,6 +11,7 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from assessment_routes.v3.eflomal_scoring_service import (
+    get_missing_words_for_assessment,
     score_verses_for_assessment,
 )
 from database.dependencies import get_db
@@ -28,6 +29,7 @@ from models import (
     EflomalAssessmentOut,
     EflomalCooccurrenceItem,
     EflomalDictionaryItem,
+    EflomalMissingWordsResponse,
     EflomalResultsPullResponse,
     EflomalResultsPushRequest,
     EflomalTargetWordCountItem,
@@ -561,6 +563,81 @@ async def score_eflomal_verses(
         raise HTTPException(
             status_code=500,
             detail=f"Unexpected error scoring verses for assessment {assessment_id}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET endpoint — compute missing words from stored artifacts
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/assessment/{assessment_id}/eflomal/missing-words",
+    response_model=EflomalMissingWordsResponse,
+)
+async def get_eflomal_missing_words(
+    assessment_id: int,
+    min_alignment_count: int = 10,
+    min_frequency: float = 0.5,
+    min_word_len: int = 3,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Detect missing words for every verse pair using stored eflomal artifacts.
+
+    A target word is flagged as potentially missing if it was not aligned to
+    any source word AND its known corpus-level source equivalents are absent
+    from the current source verse.  The intuition is: if the model knows this
+    target word normally translates word X, but word X doesn't appear in the
+    source verse, the target word is unexpectedly present — a possible
+    translation mistake.
+
+    Requires the dictionary and target-word-count artifacts to have been
+    pushed for this assessment.
+
+    Query params:
+     - min_alignment_count: minimum total alignment count across the corpus
+       for a target word to be considered (default 10).
+     - min_frequency: minimum alignment_frequency (aligned / total appearances)
+       required to flag a word (default 0.5).
+     - min_word_len: minimum normalized word length to consider (default 3).
+    """
+    if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
+        raise HTTPException(
+            status_code=403, detail="Not authorized for this assessment"
+        )
+
+    try:
+        results = await get_missing_words_for_assessment(
+            db,
+            assessment_id,
+            min_alignment_count=min_alignment_count,
+            min_frequency=min_frequency,
+            min_word_len=min_word_len,
+        )
+        return EflomalMissingWordsResponse(
+            assessment_id=assessment_id,
+            results=results,
+            total_count=len(results),
+        )
+    except HTTPException:
+        raise
+    except SQLAlchemyError:
+        logger.exception(
+            "Eflomal missing-words query failed, assessment_id=%s", assessment_id
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Database error computing missing words for assessment {assessment_id}",
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected error in eflomal missing-words, assessment_id=%s",
+            assessment_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error computing missing words for assessment {assessment_id}",
         )
 
 

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -527,10 +527,16 @@ async def score_eflomal_verses(
                         f"{assessment.status!r}; expected 'running' or 'finished'"
                     ),
                 )
+            was_running = assessment.status == "running"
             assessment.status = "finished"
             if assessment.start_time is None:
                 assessment.start_time = datetime.utcnow()
-            assessment.end_time = datetime.utcnow()
+            # Only stamp end_time on the running→finished transition (or if a
+            # prior finalize somehow left it null). Retries on an already-
+            # finished assessment must not mutate end_time — downstream
+            # "latest finished" queries sort on it.
+            if was_running or assessment.end_time is None:
+                assessment.end_time = datetime.utcnow()
 
         await db.commit()
         return InsertResponse(ids=inserted_ids)

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -491,9 +491,10 @@ async def score_eflomal_verses(
     flag=False, note=null). On success, also transitions the assessment's
     status to 'finished'.
 
-    Call this after metadata / dictionary / cooccurrences / target-word-counts
-    have all been pushed; this replaces the runner's previous PATCH-to-
-    finished at the end of the eflomal push flow.
+    Call this after metadata + dictionary + cooccurrences have been pushed —
+    target-word-counts are not consulted by the scoring path. This replaces
+    the runner's previous PATCH-to-finished at the end of the eflomal push
+    flow.
 
     The operation is idempotent: any pre-existing assessment_result rows for
     this assessment are deleted before insert, so retries after a partial

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -512,10 +512,10 @@ async def score_eflomal_verses(
         # 'finished' (idempotent retry). Anything else is a caller bug — fail
         # loudly so the runner can surface it.
         assessment = (
-            await db.execute(
-                select(Assessment).where(Assessment.id == assessment_id)
-            )
-        ).scalars().first()
+            (await db.execute(select(Assessment).where(Assessment.id == assessment_id)))
+            .scalars()
+            .first()
+        )
         if assessment is not None:
             if assessment.status not in ("running", "finished"):
                 await db.rollback()

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -1,6 +1,7 @@
 __version__ = "v3"
 
 import socket
+from datetime import datetime
 from typing import List
 
 import fastapi
@@ -9,6 +10,9 @@ from sqlalchemy import desc, insert, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from assessment_routes.v3.eflomal_scoring_service import (
+    score_verses_for_assessment,
+)
 from database.dependencies import get_db
 from database.models import (
     Assessment,
@@ -462,6 +466,94 @@ async def push_eflomal_target_word_counts(
         raise HTTPException(
             status_code=500,
             detail=f"Unexpected error inserting {len(rows)} target word counts for assessment {assessment_id}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# POST endpoint — compute verse scores from stored artifacts
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/assessment/{assessment_id}/eflomal/score-verses",
+    response_model=InsertResponse,
+)
+async def score_eflomal_verses(
+    assessment_id: int,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Compute per-verse scores from stored eflomal artifacts.
+
+    Loads the dictionary + cooccurrence artifacts for this assessment, scores
+    every verse pair where both the revision and reference have non-empty
+    text, and writes one row per verse into assessment_result (score ∈ [0, 1],
+    flag=False, note=null). On success, also transitions the assessment's
+    status to 'finished'.
+
+    Call this after metadata / dictionary / cooccurrences / target-word-counts
+    have all been pushed; this replaces the runner's previous PATCH-to-
+    finished at the end of the eflomal push flow.
+
+    The operation is idempotent: any pre-existing assessment_result rows for
+    this assessment are deleted before insert, so retries after a partial
+    failure produce a clean, non-duplicated result set.
+    """
+    if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
+        raise HTTPException(
+            status_code=403, detail="Not authorized for this assessment"
+        )
+
+    try:
+        inserted_ids = await score_verses_for_assessment(db, assessment_id)
+
+        # Transition to 'finished' in the same transaction as the inserts.
+        # Only two prior statuses are valid here: 'running' (normal path) and
+        # 'finished' (idempotent retry). Anything else is a caller bug — fail
+        # loudly so the runner can surface it.
+        assessment = (
+            await db.execute(
+                select(Assessment).where(Assessment.id == assessment_id)
+            )
+        ).scalars().first()
+        if assessment is not None:
+            if assessment.status not in ("running", "finished"):
+                await db.rollback()
+                raise HTTPException(
+                    status_code=409,
+                    detail=(
+                        f"Cannot finalize assessment in status "
+                        f"{assessment.status!r}; expected 'running' or 'finished'"
+                    ),
+                )
+            assessment.status = "finished"
+            if assessment.start_time is None:
+                assessment.start_time = datetime.utcnow()
+            assessment.end_time = datetime.utcnow()
+
+        await db.commit()
+        return InsertResponse(ids=inserted_ids)
+    except HTTPException:
+        await db.rollback()
+        raise
+    except SQLAlchemyError:
+        logger.exception(
+            "Eflomal verse scoring failed, assessment_id=%s", assessment_id
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Database error scoring verses for assessment {assessment_id}",
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected error scoring eflomal verses, assessment_id=%s",
+            assessment_id,
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error scoring verses for assessment {assessment_id}",
         )
 
 

--- a/assessment_routes/v3/eflomal_scoring_service.py
+++ b/assessment_routes/v3/eflomal_scoring_service.py
@@ -1,0 +1,251 @@
+"""Server-side eflomal verse-scoring orchestration.
+
+Reads the three eflomal artifact tables (dictionary, cooccurrence — we don't
+need target_word_counts for per-verse scoring) plus the source/target verse
+text, then scores every verse pair that has text on both sides and writes one
+row per verse into assessment_result.
+
+Kept separate from eflomal_routes.py so it stays independently testable.
+"""
+
+import re
+from typing import Dict, List, Tuple
+
+from fastapi import HTTPException
+from sqlalchemy import delete, insert, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from database.models import (
+    Assessment,
+    AssessmentResult,
+    EflomalAssessment,
+    EflomalCooccurrence,
+    EflomalDictionary,
+    VerseText,
+)
+from utils.eflomal_scoring import (
+    build_src_to_translations,
+    compute_link_score,
+    normalize_dictionary_list,
+    normalize_word,
+    score_verse_pair,
+)
+
+# Mirror results_push_routes.py's regex so vrefs stored here parse the same.
+_VREF_RE = re.compile(r"^([A-Z0-9]+)\s+(\d+):(\d+)$")
+
+# Mirror the batching strategy used by other push endpoints in this module:
+# cap per-batch at 5,000 rows and respect asyncpg's 32,767-parameter limit.
+_BATCH_SIZE = 5_000
+_PG_MAX_PARAMS = 32_767
+
+
+def _parse_vref(vref: str) -> Tuple[str, int, int]:
+    m = _VREF_RE.match(vref)
+    if not m:
+        raise HTTPException(status_code=400, detail=f"Invalid vref format: {vref!r}")
+    return m.group(1), int(m.group(2)), int(m.group(3))
+
+
+async def _load_artifacts(
+    db: AsyncSession, eflomal_assessment_id: int
+) -> Tuple[Dict, Dict, Dict]:
+    """Fetch dictionary + cooccurrence rows and build the in-memory lookup
+    structures score_verse_pair expects.
+
+    Returns (dictionary, src_to_translations, cooccurrence).
+    """
+    dict_rows = (
+        await db.execute(
+            select(EflomalDictionary).where(
+                EflomalDictionary.assessment_id == eflomal_assessment_id
+            )
+        )
+    ).scalars().all()
+    cooc_rows = (
+        await db.execute(
+            select(EflomalCooccurrence).where(
+                EflomalCooccurrence.assessment_id == eflomal_assessment_id
+            )
+        )
+    ).scalars().all()
+
+    raw_dict_list = [
+        {
+            "source": r.source_word,
+            "target": r.target_word,
+            "count": r.count,
+            "probability": r.probability,
+        }
+        for r in dict_rows
+    ]
+    dictionary = normalize_dictionary_list(raw_dict_list)
+    src_to_translations = build_src_to_translations(dictionary, min_count=3)
+
+    # EflomalCooccurrence rows already store normalized words (per the
+    # training pipeline's normalize_word() output), so no further
+    # normalization is needed on key construction.
+    cooccurrence: Dict[Tuple[str, str], Dict] = {}
+    for r in cooc_rows:
+        key = (r.source_word, r.target_word)
+        cooccurrence[key] = {
+            "co_occur": r.co_occur_count,
+            "aligned": r.aligned_count,
+        }
+
+    return dictionary, src_to_translations, cooccurrence
+
+
+async def _load_verse_pairs(
+    db: AsyncSession, revision_id: int, reference_id: int
+) -> List[Tuple[str, str, str]]:
+    """Return (vref, source_text, target_text) for every vref where both
+    revisions have non-empty text.
+
+    source_text = reference (reference_id), target_text = revision (revision_id) —
+    matches the eflomal training convention where the reference language is
+    the source and the revision being assessed is the target.
+
+    Executes a single self-join on verse_text so we avoid pulling the full
+    revision into Python just to intersect with the reference's vrefs.
+    """
+    src = aliased(VerseText, name="src")
+    tgt = aliased(VerseText, name="tgt")
+    stmt = (
+        select(src.verse_reference, src.text, tgt.text)
+        .join(tgt, tgt.verse_reference == src.verse_reference)
+        .where(
+            src.revision_id == reference_id,
+            tgt.revision_id == revision_id,
+            src.text.isnot(None),
+            tgt.text.isnot(None),
+            src.text != "",
+            tgt.text != "",
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    return [(r[0], r[1], r[2]) for r in rows]
+
+
+async def score_verses_for_assessment(
+    db: AsyncSession, assessment_id: int
+) -> List[int]:
+    """Score every valid verse pair for the assessment and bulk-insert the
+    results into assessment_result.
+
+    Returns the list of inserted assessment_result row IDs. Raises
+    HTTPException on validation errors (unknown assessment, wrong type,
+    missing artifacts) so callers can propagate the status code directly.
+
+    Idempotency: any existing assessment_result rows for the assessment are
+    deleted before insert, so re-running this function overwrites cleanly
+    without leaving orphaned rows.
+    """
+    # Resolve Assessment and sanity-check the type.
+    assessment = (
+        await db.execute(
+            select(Assessment).where(Assessment.id == assessment_id)
+        )
+    ).scalars().first()
+    if assessment is None or assessment.deleted:
+        raise HTTPException(status_code=404, detail="Assessment not found")
+    if assessment.type != "word-alignment":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Assessment type must be 'word-alignment' for eflomal scoring, "
+                f"got {assessment.type!r}"
+            ),
+        )
+    if assessment.revision_id is None or assessment.reference_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Eflomal scoring requires both revision_id and reference_id",
+        )
+
+    # Resolve the EflomalAssessment row; its id is the FK target for the
+    # artifact tables (not assessment.id).
+    eflomal = (
+        await db.execute(
+            select(EflomalAssessment).where(
+                EflomalAssessment.assessment_id == assessment_id
+            )
+        )
+    ).scalars().first()
+    if eflomal is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "No eflomal artifacts found — push metadata, dictionary, "
+                "cooccurrences, and target-word-counts first"
+            ),
+        )
+
+    dictionary, src_to_translations, cooccurrence = await _load_artifacts(
+        db, eflomal.id
+    )
+    pairs = await _load_verse_pairs(
+        db, assessment.revision_id, assessment.reference_id
+    )
+
+    # Build insert rows. Leave note/source/target null per plan.
+    rows = []
+    for vref, src_text, tgt_text in pairs:
+        metrics = score_verse_pair(
+            src_text,
+            tgt_text,
+            dictionary,
+            src_to_translations,
+            cooccurrence,
+        )
+        book, chapter, verse = _parse_vref(vref)
+        rows.append(
+            {
+                "assessment_id": assessment_id,
+                "vref": vref,
+                "score": metrics["verse_score"],
+                "flag": False,
+                "source": None,
+                "target": None,
+                "note": None,
+                "book": book,
+                "chapter": chapter,
+                "verse": verse,
+            }
+        )
+
+    # Idempotency: clear any prior rows for this assessment before inserting.
+    await db.execute(
+        delete(AssessmentResult).where(
+            AssessmentResult.assessment_id == assessment_id
+        )
+    )
+
+    if not rows:
+        return []
+
+    cols_per_row = len(AssessmentResult.__table__.columns)
+    batch_size = min(_BATCH_SIZE, _PG_MAX_PARAMS // cols_per_row)
+    inserted_ids: List[int] = []
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i : i + batch_size]
+        stmt = insert(AssessmentResult).values(batch).returning(AssessmentResult.id)
+        result = await db.execute(stmt)
+        inserted_ids.extend(r[0] for r in result.fetchall())
+    return inserted_ids
+
+
+__all__ = [
+    "score_verses_for_assessment",
+    # Exported for tests; not called directly by route handlers.
+    "_load_artifacts",
+    "_load_verse_pairs",
+    "_parse_vref",
+    # Re-exports for convenience in tests that want to build artifacts inline.
+    "normalize_dictionary_list",
+    "build_src_to_translations",
+    "compute_link_score",
+    "normalize_word",
+    "score_verse_pair",
+]

--- a/assessment_routes/v3/eflomal_scoring_service.py
+++ b/assessment_routes/v3/eflomal_scoring_service.py
@@ -89,7 +89,9 @@ async def _load_artifacts(
         for r in dict_rows
     ]
     dictionary = normalize_dictionary_list(raw_dict_list)
-    src_to_translations = build_src_to_translations(dictionary, min_count=3)
+    # No min_count cutoff — match the reference _realtime_dictionary's
+    # alignment behavior (every stored dictionary pair is eligible).
+    src_to_translations = build_src_to_translations(dictionary)
 
     # EflomalCooccurrence rows already store normalized words (per the
     # training pipeline's normalize_word() output), so no further
@@ -190,7 +192,7 @@ async def score_verses_for_assessment(
             status_code=404,
             detail=(
                 "No eflomal artifacts found — push metadata, dictionary, "
-                "cooccurrences, and target-word-counts first"
+                "and cooccurrences first"
             ),
         )
 

--- a/assessment_routes/v3/eflomal_scoring_service.py
+++ b/assessment_routes/v3/eflomal_scoring_service.py
@@ -67,6 +67,14 @@ async def _load_artifacts(
         .scalars()
         .all()
     )
+    if not dict_rows:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Eflomal dictionary is empty for this assessment; "
+                "push dictionary entries before scoring"
+            ),
+        )
     cooc_rows = (
         (
             await db.execute(

--- a/assessment_routes/v3/eflomal_scoring_service.py
+++ b/assessment_routes/v3/eflomal_scoring_service.py
@@ -57,19 +57,27 @@ async def _load_artifacts(
     Returns (dictionary, src_to_translations, cooccurrence).
     """
     dict_rows = (
-        await db.execute(
-            select(EflomalDictionary).where(
-                EflomalDictionary.assessment_id == eflomal_assessment_id
+        (
+            await db.execute(
+                select(EflomalDictionary).where(
+                    EflomalDictionary.assessment_id == eflomal_assessment_id
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     cooc_rows = (
-        await db.execute(
-            select(EflomalCooccurrence).where(
-                EflomalCooccurrence.assessment_id == eflomal_assessment_id
+        (
+            await db.execute(
+                select(EflomalCooccurrence).where(
+                    EflomalCooccurrence.assessment_id == eflomal_assessment_id
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
 
     raw_dict_list = [
         {
@@ -144,10 +152,10 @@ async def score_verses_for_assessment(
     """
     # Resolve Assessment and sanity-check the type.
     assessment = (
-        await db.execute(
-            select(Assessment).where(Assessment.id == assessment_id)
-        )
-    ).scalars().first()
+        (await db.execute(select(Assessment).where(Assessment.id == assessment_id)))
+        .scalars()
+        .first()
+    )
     if assessment is None or assessment.deleted:
         raise HTTPException(status_code=404, detail="Assessment not found")
     if assessment.type != "word-alignment":
@@ -167,12 +175,16 @@ async def score_verses_for_assessment(
     # Resolve the EflomalAssessment row; its id is the FK target for the
     # artifact tables (not assessment.id).
     eflomal = (
-        await db.execute(
-            select(EflomalAssessment).where(
-                EflomalAssessment.assessment_id == assessment_id
+        (
+            await db.execute(
+                select(EflomalAssessment).where(
+                    EflomalAssessment.assessment_id == assessment_id
+                )
             )
         )
-    ).scalars().first()
+        .scalars()
+        .first()
+    )
     if eflomal is None:
         raise HTTPException(
             status_code=404,
@@ -185,9 +197,7 @@ async def score_verses_for_assessment(
     dictionary, src_to_translations, cooccurrence = await _load_artifacts(
         db, eflomal.id
     )
-    pairs = await _load_verse_pairs(
-        db, assessment.revision_id, assessment.reference_id
-    )
+    pairs = await _load_verse_pairs(db, assessment.revision_id, assessment.reference_id)
 
     # Build insert rows. Leave note/source/target null per plan.
     rows = []
@@ -217,9 +227,7 @@ async def score_verses_for_assessment(
 
     # Idempotency: clear any prior rows for this assessment before inserting.
     await db.execute(
-        delete(AssessmentResult).where(
-            AssessmentResult.assessment_id == assessment_id
-        )
+        delete(AssessmentResult).where(AssessmentResult.assessment_id == assessment_id)
     )
 
     if not rows:

--- a/assessment_routes/v3/eflomal_scoring_service.py
+++ b/assessment_routes/v3/eflomal_scoring_service.py
@@ -22,11 +22,14 @@ from database.models import (
     EflomalAssessment,
     EflomalCooccurrence,
     EflomalDictionary,
+    EflomalTargetWordCount,
     VerseText,
 )
 from utils.eflomal_scoring import (
+    build_reverse_dictionary,
     build_src_to_translations,
     compute_link_score,
+    detect_missing_words_for_verse,
     normalize_dictionary_list,
     normalize_word,
     score_verse_pair,
@@ -254,16 +257,126 @@ async def score_verses_for_assessment(
     return inserted_ids
 
 
+async def get_missing_words_for_assessment(
+    db: AsyncSession,
+    assessment_id: int,
+    min_alignment_count: int = 10,
+    min_frequency: float = 0.5,
+    min_word_len: int = 3,
+) -> List[Dict]:
+    """Return per-verse missing-word detections from stored eflomal artifacts.
+
+    For every verse pair where both the revision and reference have text,
+    runs detect_missing_words_for_verse using the stored dictionary and
+    target-word-count artifacts.  Returns a flat list of dicts, one entry per
+    flagged target word, each tagged with its vref.
+
+    Raises HTTPException on the same validation errors as
+    score_verses_for_assessment (404 / 400).
+    """
+    assessment = (
+        (await db.execute(select(Assessment).where(Assessment.id == assessment_id)))
+        .scalars()
+        .first()
+    )
+    if assessment is None or assessment.deleted:
+        raise HTTPException(status_code=404, detail="Assessment not found")
+    if assessment.type != "word-alignment":
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Assessment type must be 'word-alignment' for eflomal scoring, "
+                f"got {assessment.type!r}"
+            ),
+        )
+    if assessment.revision_id is None or assessment.reference_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Eflomal scoring requires both revision_id and reference_id",
+        )
+
+    eflomal = (
+        (
+            await db.execute(
+                select(EflomalAssessment).where(
+                    EflomalAssessment.assessment_id == assessment_id
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if eflomal is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "No eflomal artifacts found — push metadata, dictionary, "
+                "and cooccurrences first"
+            ),
+        )
+
+    dictionary, _src_to_translations, _cooccurrence = await _load_artifacts(
+        db, eflomal.id
+    )
+    if not dictionary:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                "Eflomal dictionary is empty for this assessment; "
+                "push dictionary entries before requesting missing words"
+            ),
+        )
+
+    # Build reverse dictionary (tgt -> known sources) with min_count=3 to
+    # match the aqua-assessments reference implementation.
+    reverse_dict = build_reverse_dictionary(dictionary, min_count=3)
+
+    # Load target word counts from DB.
+    twc_rows = (
+        (
+            await db.execute(
+                select(EflomalTargetWordCount).where(
+                    EflomalTargetWordCount.assessment_id == eflomal.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    tgt_word_counts = {r.word: r.count for r in twc_rows}
+
+    pairs = await _load_verse_pairs(db, assessment.revision_id, assessment.reference_id)
+
+    results: List[Dict] = []
+    for vref, src_text, tgt_text in pairs:
+        verse_missing = detect_missing_words_for_verse(
+            src_text,
+            tgt_text,
+            reverse_dict,
+            tgt_word_counts,
+            min_alignment_count=min_alignment_count,
+            min_frequency=min_frequency,
+            min_word_len=min_word_len,
+        )
+        for entry in verse_missing:
+            results.append({"vref": vref, **entry})
+
+    return results
+
+
 __all__ = [
     "score_verses_for_assessment",
+    "get_missing_words_for_assessment",
     # Exported for tests; not called directly by route handlers.
     "_load_artifacts",
     "_load_verse_pairs",
     "_parse_vref",
     # Re-exports for convenience in tests that want to build artifacts inline.
     "normalize_dictionary_list",
+    "build_reverse_dictionary",
     "build_src_to_translations",
     "compute_link_score",
     "normalize_word",
     "score_verse_pair",
+    "detect_missing_words_for_verse",
 ]

--- a/models.py
+++ b/models.py
@@ -1177,6 +1177,23 @@ class EflomalAssessmentOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class EflomalMissingWordItem(BaseModel):
+    """One flagged target word from the eflomal missing-words detection."""
+
+    vref: str
+    target_word: str
+    known_sources: str
+    score: float
+
+
+class EflomalMissingWordsResponse(BaseModel):
+    """Response from GET /assessment/{id}/eflomal/missing-words."""
+
+    assessment_id: int
+    results: List[EflomalMissingWordItem]
+    total_count: int
+
+
 class EflomalResultsPullResponse(BaseModel):
     """Full eflomal training artifacts for inference consumption.
 

--- a/test/test_assessment_routes/test_eflomal_scoring.py
+++ b/test/test_assessment_routes/test_eflomal_scoring.py
@@ -8,12 +8,10 @@ is exercised end-to-end against the local test Postgres set up in conftest.
 import math
 
 import pytest
-from sqlalchemy import select
 
 from database.models import (
     Assessment,
     AssessmentResult,
-    EflomalAssessment,
     VerseText,
 )
 from utils.eflomal_scoring import (
@@ -191,9 +189,7 @@ def eflomal_scoring_assessment_id(
 
 
 @pytest.fixture(scope="module")
-def scoring_verse_text(
-    test_db_session, test_revision_id, test_revision_id_2
-):
+def scoring_verse_text(test_db_session, test_revision_id, test_revision_id_2):
     """Seed three matching vrefs on both revisions with text the artifacts
     below will actually align."""
     # revision (target): simple aligned text
@@ -267,8 +263,18 @@ def _push_scoring_artifacts(client, token, assessment_id):
     dict_items = [
         {"source_word": "god", "target_word": "dios", "count": 10, "probability": 0.9},
         {"source_word": "made", "target_word": "hizo", "count": 10, "probability": 0.8},
-        {"source_word": "heaven", "target_word": "cielo", "count": 10, "probability": 0.7},
-        {"source_word": "earth", "target_word": "tierra", "count": 10, "probability": 0.7},
+        {
+            "source_word": "heaven",
+            "target_word": "cielo",
+            "count": 10,
+            "probability": 0.7,
+        },
+        {
+            "source_word": "earth",
+            "target_word": "tierra",
+            "count": 10,
+            "probability": 0.7,
+        },
         {"source_word": "light", "target_word": "luz", "count": 10, "probability": 0.7},
     ]
     resp = client.post(

--- a/test/test_assessment_routes/test_eflomal_scoring.py
+++ b/test/test_assessment_routes/test_eflomal_scoring.py
@@ -391,7 +391,18 @@ def test_score_eflomal_verses_is_idempotent_on_retry(
     eflomal_scoring_assessment_id,
 ):
     """Calling the endpoint a second time should not double-insert rows;
-    existing assessment_result rows are cleared before each scoring pass."""
+    existing assessment_result rows are cleared before each scoring pass.
+    end_time must also be stable across retries — "latest finished"
+    queries sort on it, so a moving timestamp breaks ordering."""
+    test_db_session.expire_all()
+    first_end_time = (
+        test_db_session.query(Assessment)
+        .filter(Assessment.id == eflomal_scoring_assessment_id)
+        .one()
+        .end_time
+    )
+    assert first_end_time is not None
+
     resp = client.post(
         f"{prefix}/assessment/{eflomal_scoring_assessment_id}/eflomal/score-verses",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -406,6 +417,14 @@ def test_score_eflomal_verses_is_idempotent_on_retry(
     )
     assert len(rows) == len(SCORING_VREFS)
 
+    second_end_time = (
+        test_db_session.query(Assessment)
+        .filter(Assessment.id == eflomal_scoring_assessment_id)
+        .one()
+        .end_time
+    )
+    assert second_end_time == first_end_time
+
 
 def test_score_eflomal_verses_missing_artifacts_returns_404(
     client,
@@ -419,6 +438,50 @@ def test_score_eflomal_verses_missing_artifacts_returns_404(
     )
     assert resp.status_code == 404
     assert "eflomal" in resp.json()["detail"].lower()
+
+
+def test_score_eflomal_verses_empty_dictionary_returns_422(
+    client,
+    regular_token1,
+    test_db_session,
+    test_revision_id,
+    test_revision_id_2,
+):
+    """Metadata pushed but no dictionary rows → scoring must reject with 422
+    rather than silently finalize an all-zero assessment."""
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="word-alignment",
+        status="running",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+    assessment_id = assessment.id
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    meta = client.post(
+        f"{prefix}/assessment/eflomal/results",
+        json={
+            "assessment_id": assessment_id,
+            "source_language": "eng",
+            "target_language": "spa",
+            "num_verse_pairs": 0,
+            "num_alignment_links": 0,
+            "num_dictionary_entries": 0,
+            "num_missing_words": 0,
+        },
+        headers=headers,
+    )
+    assert meta.status_code == 200, meta.text
+
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal/score-verses",
+        headers=headers,
+    )
+    assert resp.status_code == 422, resp.text
+    assert "dictionary" in resp.json()["detail"].lower()
 
 
 def test_score_eflomal_verses_unauthorized(

--- a/test/test_assessment_routes/test_eflomal_scoring.py
+++ b/test/test_assessment_routes/test_eflomal_scoring.py
@@ -1,0 +1,394 @@
+"""Tests for eflomal verse-level scoring (utils + endpoint).
+
+The scoring primitives (`utils/eflomal_scoring.py`) are tested in isolation
+as pure functions. The endpoint (`POST /v3/assessment/{id}/eflomal/score-verses`)
+is exercised end-to-end against the local test Postgres set up in conftest.
+"""
+
+import math
+
+import pytest
+from sqlalchemy import select
+
+from database.models import (
+    Assessment,
+    AssessmentResult,
+    EflomalAssessment,
+    VerseText,
+)
+from utils.eflomal_scoring import (
+    build_src_to_translations,
+    compute_link_score,
+    normalize_dictionary_list,
+    normalize_word,
+    score_verse_pair,
+)
+
+prefix = "v3"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: utils/eflomal_scoring.py
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_word_basic():
+    assert normalize_word("God") == "god"
+    assert normalize_word("God's") == "gods"
+    assert normalize_word("«Licht!»") == "licht"
+    # Punctuation-only collapses to empty — callers must skip these.
+    assert normalize_word("...") == ""
+    assert normalize_word("") == ""
+
+
+def test_normalize_dictionary_list_merges_case_insensitive():
+    raw = [
+        {"source": "God", "target": "Dios", "count": 10, "probability": 0.8},
+        {"source": "god", "target": "dios", "count": 30, "probability": 0.4},
+    ]
+    d = normalize_dictionary_list(raw)
+    assert list(d.keys()) == [("god", "dios")]
+    entry = d[("god", "dios")]
+    # Counts sum; probability is a count-weighted average:
+    #   (0.8 * 10 + 0.4 * 30) / 40 = 20 / 40 = 0.5
+    assert entry["count"] == 40
+    assert math.isclose(entry["probability"], 0.5)
+
+
+def test_normalize_dictionary_list_drops_empty_normalized_entries():
+    raw = [
+        {"source": "...", "target": "amor", "count": 5, "probability": 0.9},
+        {"source": "love", "target": "???", "count": 5, "probability": 0.9},
+        {"source": "love", "target": "amor", "count": 7, "probability": 0.9},
+    ]
+    d = normalize_dictionary_list(raw)
+    assert list(d.keys()) == [("love", "amor")]
+
+
+def test_build_src_to_translations_sorts_desc_and_applies_min_count():
+    dictionary = {
+        ("run", "corre"): {"count": 15, "probability": 0.9},
+        ("run", "corren"): {"count": 3, "probability": 0.6},
+        ("run", "correr"): {"count": 2, "probability": 0.4},  # below default min_count
+    }
+    out = build_src_to_translations(dictionary, min_count=3)
+    assert out["run"] == [("corre", 15), ("corren", 3)]
+
+
+def test_compute_link_score_uses_stored_probability_when_no_cooccurrence():
+    dictionary = {("love", "amor"): {"count": 10, "probability": 0.75}}
+    cooc = {}  # no cooccurrence → co_occur_count=0, falls back to probability
+    score = compute_link_score("Love", "Amor!", dictionary, cooc)
+    assert math.isclose(score, 0.75)
+
+
+def test_compute_link_score_weighted_geomean_when_enough_cooccurrence():
+    dictionary = {("love", "amor"): {"count": 10, "probability": 0.8}}
+    cooc = {("love", "amor"): {"co_occur": 10, "aligned": 5}}  # ratio = 0.5
+    # Expected: exp((2*ln(0.8) + ln(0.5)) / 3) = 0.8^(2/3) * 0.5^(1/3)
+    expected = math.exp((2 * math.log(0.8) + math.log(0.5)) / 3)
+    score = compute_link_score("love", "amor", dictionary, cooc)
+    assert math.isclose(score, expected)
+
+
+def test_score_verse_pair_empty_text_returns_zeros():
+    out = score_verse_pair("", "something", {}, {}, {})
+    assert out == {
+        "verse_score": 0.0,
+        "avg_link_score": 0.0,
+        "coverage": 0.0,
+        "num_links": 0,
+    }
+    out2 = score_verse_pair("something", "   ", {}, {}, {})
+    assert out2["num_links"] == 0
+
+
+def test_score_verse_pair_no_dictionary_match_scores_zero():
+    dictionary = {("love", "amor"): {"count": 10, "probability": 0.9}}
+    src_to_tr = build_src_to_translations(dictionary)
+    out = score_verse_pair(
+        "the quick fox",
+        "el rapido zorro",
+        dictionary,
+        src_to_tr,
+        {},
+    )
+    assert out["num_links"] == 0
+    assert out["verse_score"] == 0.0
+
+
+def test_score_verse_pair_basic_alignment_produces_expected_score():
+    # Three source words, three target words, all three pairs in the
+    # dictionary — 100% coverage on both sides.
+    dictionary = {
+        ("god", "dios"): {"count": 10, "probability": 0.9},
+        ("loves", "ama"): {"count": 10, "probability": 0.8},
+        ("us", "nos"): {"count": 10, "probability": 0.7},
+    }
+    src_to_tr = build_src_to_translations(dictionary)
+    out = score_verse_pair(
+        "God loves us",
+        "Dios ama nos",
+        dictionary,
+        src_to_tr,
+        {},
+    )
+    assert out["num_links"] == 3
+    assert out["coverage"] == 1.0
+    expected_avg = (0.9 + 0.8 + 0.7) / 3  # 0.8
+    assert math.isclose(out["avg_link_score"], round(expected_avg, 4))
+    # verse_score = avg_link_score * coverage = 0.8 * 1.0 = 0.8
+    assert math.isclose(out["verse_score"], round(expected_avg, 4))
+
+
+def test_score_verse_pair_partial_coverage_bottlenecks_on_min():
+    # Source has 3 words, target has 6; only one pair matches.
+    # src_coverage = 1/3, tgt_coverage = 1/6 → coverage = min = 1/6.
+    dictionary = {("god", "dios"): {"count": 10, "probability": 0.6}}
+    src_to_tr = build_src_to_translations(dictionary)
+    out = score_verse_pair(
+        "god rules all",
+        "dios manda en todo el mundo",
+        dictionary,
+        src_to_tr,
+        {},
+    )
+    assert out["num_links"] == 1
+    assert math.isclose(out["coverage"], round(1 / 6, 4))
+    assert math.isclose(out["avg_link_score"], 0.6)
+    # rounded to 4 decimals
+    assert math.isclose(out["verse_score"], round(0.6 * (1 / 6), 4))
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: POST /v3/assessment/{id}/eflomal/score-verses
+# ---------------------------------------------------------------------------
+
+
+SCORING_VREFS = ["GEN 1:1", "GEN 1:2", "GEN 1:3"]
+
+
+@pytest.fixture(scope="module")
+def eflomal_scoring_assessment_id(
+    test_db_session, test_revision_id, test_revision_id_2
+):
+    """A fresh word-alignment assessment in 'running' state for scoring tests.
+
+    Separate from the module-scope `test_eflomal_assessment_id` fixture used
+    by the push tests so those don't interfere with the status-transition
+    assertions here.
+    """
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="word-alignment",
+        status="running",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+    return assessment.id
+
+
+@pytest.fixture(scope="module")
+def scoring_verse_text(
+    test_db_session, test_revision_id, test_revision_id_2
+):
+    """Seed three matching vrefs on both revisions with text the artifacts
+    below will actually align."""
+    # revision (target): simple aligned text
+    # reference (source): same three words, one-to-one aligned with target
+    text_pairs = {
+        "GEN 1:1": ("god made heaven", "dios hizo cielo"),
+        "GEN 1:2": ("god made earth", "dios hizo tierra"),
+        "GEN 1:3": ("god made light", "dios hizo luz"),
+    }
+    for vref, (ref_text, tgt_text) in text_pairs.items():
+        # reference (source language) lives on revision_id_2
+        if not (
+            test_db_session.query(VerseText)
+            .filter(
+                VerseText.revision_id == test_revision_id_2,
+                VerseText.verse_reference == vref,
+            )
+            .first()
+        ):
+            test_db_session.add(
+                VerseText(
+                    text=ref_text,
+                    revision_id=test_revision_id_2,
+                    verse_reference=vref,
+                )
+            )
+        # revision (target language) lives on revision_id
+        if not (
+            test_db_session.query(VerseText)
+            .filter(
+                VerseText.revision_id == test_revision_id,
+                VerseText.verse_reference == vref,
+            )
+            .first()
+        ):
+            test_db_session.add(
+                VerseText(
+                    text=tgt_text,
+                    revision_id=test_revision_id,
+                    verse_reference=vref,
+                )
+            )
+    test_db_session.commit()
+    return text_pairs
+
+
+def _push_scoring_artifacts(client, token, assessment_id):
+    """Push the minimum artifacts needed for the scoring endpoint to work.
+
+    Uses the existing push endpoints so we exercise the same path a real
+    runner would — no direct DB seeding of eflomal_* tables.
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    meta = client.post(
+        f"{prefix}/assessment/eflomal/results",
+        json={
+            "assessment_id": assessment_id,
+            "source_language": "eng",
+            "target_language": "spa",
+            "num_verse_pairs": 3,
+            "num_alignment_links": 9,
+            "num_dictionary_entries": 3,
+            "num_missing_words": 0,
+        },
+        headers=headers,
+    )
+    assert meta.status_code == 200, meta.text
+
+    # Dictionary: three src→tgt pairs. count=10 >= min_count=3 so they pass
+    # the build_src_to_translations filter.
+    dict_items = [
+        {"source_word": "god", "target_word": "dios", "count": 10, "probability": 0.9},
+        {"source_word": "made", "target_word": "hizo", "count": 10, "probability": 0.8},
+        {"source_word": "heaven", "target_word": "cielo", "count": 10, "probability": 0.7},
+        {"source_word": "earth", "target_word": "tierra", "count": 10, "probability": 0.7},
+        {"source_word": "light", "target_word": "luz", "count": 10, "probability": 0.7},
+    ]
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal-dictionary",
+        json=dict_items,
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Empty cooccurrence list is valid; the scoring function falls back to
+    # stored probability when co_occur_count < 2 anyway.
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal-cooccurrences",
+        json=[],
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal-target-word-counts",
+        json=[],
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_score_eflomal_verses_end_to_end(
+    client,
+    regular_token1,
+    test_db_session,
+    eflomal_scoring_assessment_id,
+    scoring_verse_text,
+):
+    _push_scoring_artifacts(client, regular_token1, eflomal_scoring_assessment_id)
+
+    resp = client.post(
+        f"{prefix}/assessment/{eflomal_scoring_assessment_id}/eflomal/score-verses",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert len(body["ids"]) == len(SCORING_VREFS)
+
+    # Verify rows ended up in assessment_result with plausible shape.
+    test_db_session.expire_all()
+    rows = (
+        test_db_session.query(AssessmentResult)
+        .filter(AssessmentResult.assessment_id == eflomal_scoring_assessment_id)
+        .all()
+    )
+    assert len(rows) == len(SCORING_VREFS)
+    vrefs_seen = {r.vref for r in rows}
+    assert vrefs_seen == set(SCORING_VREFS)
+    for r in rows:
+        assert r.flag is False
+        assert r.note is None
+        assert r.source is None
+        assert r.target is None
+        assert r.book == "GEN"
+        assert r.chapter == 1
+        # With 3/3 aligned on each side and stored probabilities 0.9/0.8/0.7,
+        # avg_link_score = 0.8, coverage = 1.0 → verse_score = 0.8.
+        assert math.isclose(float(r.score), 0.8, abs_tol=1e-4)
+
+    # Status must have flipped to 'finished' with end_time set.
+    test_db_session.expire_all()
+    assessment = (
+        test_db_session.query(Assessment)
+        .filter(Assessment.id == eflomal_scoring_assessment_id)
+        .one()
+    )
+    assert assessment.status == "finished"
+    assert assessment.end_time is not None
+
+
+def test_score_eflomal_verses_is_idempotent_on_retry(
+    client,
+    regular_token1,
+    test_db_session,
+    eflomal_scoring_assessment_id,
+):
+    """Calling the endpoint a second time should not double-insert rows;
+    existing assessment_result rows are cleared before each scoring pass."""
+    resp = client.post(
+        f"{prefix}/assessment/{eflomal_scoring_assessment_id}/eflomal/score-verses",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    test_db_session.expire_all()
+    rows = (
+        test_db_session.query(AssessmentResult)
+        .filter(AssessmentResult.assessment_id == eflomal_scoring_assessment_id)
+        .all()
+    )
+    assert len(rows) == len(SCORING_VREFS)
+
+
+def test_score_eflomal_verses_missing_artifacts_returns_404(
+    client,
+    regular_token1,
+    test_eflomal_assessment_unpushed_id,
+):
+    """If metadata/artifacts were never pushed, scoring returns 404."""
+    resp = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_unpushed_id}/eflomal/score-verses",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 404
+    assert "eflomal" in resp.json()["detail"].lower()
+
+
+def test_score_eflomal_verses_unauthorized(
+    client,
+    regular_token2,
+    eflomal_scoring_assessment_id,
+):
+    """A user without group access to the assessment's bible version is denied."""
+    resp = client.post(
+        f"{prefix}/assessment/{eflomal_scoring_assessment_id}/eflomal/score-verses",
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert resp.status_code == 403

--- a/test/test_assessment_routes/test_eflomal_scoring.py
+++ b/test/test_assessment_routes/test_eflomal_scoring.py
@@ -63,11 +63,23 @@ def test_normalize_dictionary_list_drops_empty_normalized_entries():
     assert list(d.keys()) == [("love", "amor")]
 
 
-def test_build_src_to_translations_sorts_desc_and_applies_min_count():
+def test_build_src_to_translations_default_keeps_all_pairs():
+    # Default min_count=1 — every stored pair stays in the index. Mirrors
+    # the reference _realtime_dictionary's inline index.
     dictionary = {
         ("run", "corre"): {"count": 15, "probability": 0.9},
         ("run", "corren"): {"count": 3, "probability": 0.6},
-        ("run", "correr"): {"count": 2, "probability": 0.4},  # below default min_count
+        ("run", "correr"): {"count": 1, "probability": 0.4},
+    }
+    out = build_src_to_translations(dictionary)
+    assert out["run"] == [("corre", 15), ("corren", 3), ("correr", 1)]
+
+
+def test_build_src_to_translations_explicit_min_count_filters_and_sorts():
+    dictionary = {
+        ("run", "corre"): {"count": 15, "probability": 0.9},
+        ("run", "corren"): {"count": 3, "probability": 0.6},
+        ("run", "correr"): {"count": 2, "probability": 0.4},  # dropped at min_count=3
     }
     out = build_src_to_translations(dictionary, min_count=3)
     assert out["run"] == [("corre", 15), ("corren", 3)]
@@ -137,6 +149,29 @@ def test_score_verse_pair_basic_alignment_produces_expected_score():
     assert math.isclose(out["avg_link_score"], round(expected_avg, 4))
     # verse_score = avg_link_score * coverage = 0.8 * 1.0 = 0.8
     assert math.isclose(out["verse_score"], round(expected_avg, 4))
+
+
+def test_score_verse_pair_coverage_ignores_punctuation_tokens():
+    # Punctuation-only tokens (",", "!", ".") normalize to "" and can't be
+    # aligned. Coverage should be computed over alignable tokens only, so
+    # both sides here are effectively 3/3 — coverage == 1.0, not 3/5 or 3/4.
+    dictionary = {
+        ("god", "dios"): {"count": 10, "probability": 0.9},
+        ("loves", "ama"): {"count": 10, "probability": 0.9},
+        ("us", "nos"): {"count": 10, "probability": 0.9},
+    }
+    src_to_tr = build_src_to_translations(dictionary)
+    out = score_verse_pair(
+        "God , loves us !",
+        "Dios ama nos .",
+        dictionary,
+        src_to_tr,
+        {},
+    )
+    assert out["num_links"] == 3
+    assert math.isclose(out["coverage"], 1.0)
+    assert math.isclose(out["avg_link_score"], 0.9)
+    assert math.isclose(out["verse_score"], 0.9)
 
 
 def test_score_verse_pair_partial_coverage_bottlenecks_on_min():
@@ -251,15 +286,14 @@ def _push_scoring_artifacts(client, token, assessment_id):
             "target_language": "spa",
             "num_verse_pairs": 3,
             "num_alignment_links": 9,
-            "num_dictionary_entries": 3,
+            "num_dictionary_entries": 5,
             "num_missing_words": 0,
         },
         headers=headers,
     )
     assert meta.status_code == 200, meta.text
 
-    # Dictionary: three src→tgt pairs. count=10 >= min_count=3 so they pass
-    # the build_src_to_translations filter.
+    # Dictionary: five src→tgt pairs with count=10 each.
     dict_items = [
         {"source_word": "god", "target_word": "dios", "count": 10, "probability": 0.9},
         {"source_word": "made", "target_word": "hizo", "count": 10, "probability": 0.8},

--- a/test/test_assessment_routes/test_eflomal_scoring.py
+++ b/test/test_assessment_routes/test_eflomal_scoring.py
@@ -194,6 +194,126 @@ def test_score_verse_pair_partial_coverage_bottlenecks_on_min():
 
 
 # ---------------------------------------------------------------------------
+# Unit tests: build_reverse_dictionary + detect_missing_words_for_verse
+# ---------------------------------------------------------------------------
+
+
+def test_build_reverse_dictionary_basic():
+    from utils.eflomal_scoring import build_reverse_dictionary
+
+    dictionary = {
+        ("god", "dios"): {"count": 20, "probability": 0.9},
+        ("lord", "dios"): {"count": 5, "probability": 0.4},  # below default min_count=3
+        ("heaven", "cielo"): {"count": 2, "probability": 0.7},  # below min_count=3
+    }
+    reverse = build_reverse_dictionary(dictionary, min_count=3)
+    # "dios" has two sources above cutoff; "cielo" is below
+    assert "dios" in reverse
+    assert "cielo" not in reverse
+    src_words = [s for s, _ in reverse["dios"]]
+    assert "god" in src_words
+    assert "lord" in src_words
+    # sorted descending by count
+    assert reverse["dios"][0][0] == "god"
+
+
+def test_detect_missing_words_flags_unexpected_target_word():
+    from utils.eflomal_scoring import (
+        build_reverse_dictionary,
+        detect_missing_words_for_verse,
+    )
+
+    # "gracia" normally translates "grace" (count=20, freq=1.0) but "grace"
+    # is absent from the source verse — so "gracia" should be flagged.
+    dictionary = {("grace", "gracia"): {"count": 20, "probability": 0.9}}
+    reverse = build_reverse_dictionary(dictionary, min_count=3)
+    # tgt_word_counts: "gracia" appears 20 times in corpus
+    tgt_word_counts = {"gracia": 20}
+
+    results = detect_missing_words_for_verse(
+        src_text="god made the world",
+        tgt_text="dios hizo gracia mundo",
+        reverse_dict=reverse,
+        tgt_word_counts=tgt_word_counts,
+        min_alignment_count=10,
+        min_frequency=0.5,
+        min_word_len=3,
+    )
+    assert len(results) == 1
+    assert results[0]["target_word"] == "gracia"
+    assert "grace" in results[0]["known_sources"]
+    assert math.isclose(results[0]["score"], 1.0)
+
+
+def test_detect_missing_words_excludes_aligned_indices():
+    from utils.eflomal_scoring import (
+        build_reverse_dictionary,
+        detect_missing_words_for_verse,
+    )
+
+    dictionary = {("grace", "gracia"): {"count": 20, "probability": 0.9}}
+    reverse = build_reverse_dictionary(dictionary, min_count=3)
+    tgt_word_counts = {"gracia": 20}
+
+    # "gracia" is at index 2; mark it as already aligned
+    results = detect_missing_words_for_verse(
+        src_text="god made the world",
+        tgt_text="dios hizo gracia mundo",
+        reverse_dict=reverse,
+        tgt_word_counts=tgt_word_counts,
+        min_alignment_count=10,
+        min_frequency=0.5,
+        aligned_tgt_indices={2},
+    )
+    assert results == []
+
+
+def test_detect_missing_words_skips_when_source_present():
+    from utils.eflomal_scoring import (
+        build_reverse_dictionary,
+        detect_missing_words_for_verse,
+    )
+
+    # "gracia" normally translates "grace"; "grace" IS in the source verse —
+    # the word is not missing, just unaligned by the greedy algorithm.
+    dictionary = {("grace", "gracia"): {"count": 20, "probability": 0.9}}
+    reverse = build_reverse_dictionary(dictionary, min_count=3)
+    tgt_word_counts = {"gracia": 20}
+
+    results = detect_missing_words_for_verse(
+        src_text="god showed grace to all",
+        tgt_text="dios mostro gracia",
+        reverse_dict=reverse,
+        tgt_word_counts=tgt_word_counts,
+        min_alignment_count=10,
+        min_frequency=0.5,
+    )
+    assert results == []
+
+
+def test_detect_missing_words_respects_min_frequency():
+    from utils.eflomal_scoring import (
+        build_reverse_dictionary,
+        detect_missing_words_for_verse,
+    )
+
+    dictionary = {("grace", "gracia"): {"count": 5, "probability": 0.4}}
+    reverse = build_reverse_dictionary(dictionary, min_count=3)
+    # frequency = 5 / 20 = 0.25, below default min_frequency=0.5
+    tgt_word_counts = {"gracia": 20}
+
+    results = detect_missing_words_for_verse(
+        src_text="god made the world",
+        tgt_text="dios hizo gracia mundo",
+        reverse_dict=reverse,
+        tgt_word_counts=tgt_word_counts,
+        min_alignment_count=3,
+        min_frequency=0.5,
+    )
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
 # Integration tests: POST /v3/assessment/{id}/eflomal/score-verses
 # ---------------------------------------------------------------------------
 
@@ -492,6 +612,174 @@ def test_score_eflomal_verses_unauthorized(
     """A user without group access to the assessment's bible version is denied."""
     resp = client.post(
         f"{prefix}/assessment/{eflomal_scoring_assessment_id}/eflomal/score-verses",
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: GET /v3/assessment/{id}/eflomal/missing-words
+# ---------------------------------------------------------------------------
+
+
+def test_get_eflomal_missing_words_end_to_end(
+    client,
+    regular_token1,
+    test_db_session,
+    test_revision_id,
+    test_revision_id_2,
+    scoring_verse_text,
+):
+    """Happy path: a target word whose known sources are absent from the source
+    verse is returned by the endpoint.
+
+    Verse data: GEN 1:1 source="god made heaven", target="dios hizo cielo extra"
+    Dictionary: extra→bonus (count=15), so "extra" should appear as missing
+    because "bonus" is not in the source verse "god made heaven".
+    """
+    # Create a fresh assessment for this test.
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="word-alignment",
+        status="finished",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+    assessment_id = assessment.id
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Push metadata.
+    meta = client.post(
+        f"{prefix}/assessment/eflomal/results",
+        json={
+            "assessment_id": assessment_id,
+            "source_language": "eng",
+            "target_language": "spa",
+            "num_verse_pairs": 1,
+            "num_alignment_links": 3,
+            "num_dictionary_entries": 4,
+            "num_missing_words": 1,
+        },
+        headers=headers,
+    )
+    assert meta.status_code == 200, meta.text
+
+    # Dictionary: known pairs plus "extra"→"bonus" (count=15) so "extra" has
+    # a known source that is absent from the source verse.
+    dict_items = [
+        {"source_word": "god", "target_word": "dios", "count": 10, "probability": 0.9},
+        {"source_word": "made", "target_word": "hizo", "count": 10, "probability": 0.8},
+        {
+            "source_word": "heaven",
+            "target_word": "cielo",
+            "count": 10,
+            "probability": 0.7,
+        },
+        # "bonus" is the known source for "extra" but does not appear in the
+        # source verse "god made heaven".
+        {
+            "source_word": "bonus",
+            "target_word": "extra",
+            "count": 15,
+            "probability": 0.9,
+        },
+    ]
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal-dictionary",
+        json=dict_items,
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal-cooccurrences",
+        json=[],
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Target word counts: "extra" appears 15 times → alignment_frequency=1.0.
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal-target-word-counts",
+        json=[{"word": "extra", "count": 15}],
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Patch the verse text for GEN 1:1 on the target revision to include "extra".
+    from database.models import VerseText as VerseTextModel
+
+    tgt_vt = (
+        test_db_session.query(VerseTextModel)
+        .filter(
+            VerseTextModel.revision_id == test_revision_id,
+            VerseTextModel.verse_reference == "GEN 1:1",
+        )
+        .first()
+    )
+    original_text = tgt_vt.text
+    tgt_vt.text = original_text + " extra"
+    test_db_session.commit()
+
+    try:
+        resp = client.get(
+            f"{prefix}/assessment/{assessment_id}/eflomal/missing-words",
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["assessment_id"] == assessment_id
+        assert body["total_count"] >= 1
+        vrefs_with_missing = [r["vref"] for r in body["results"]]
+        assert "GEN 1:1" in vrefs_with_missing
+        gen_1_1_results = [r for r in body["results"] if r["vref"] == "GEN 1:1"]
+        target_words = [r["target_word"] for r in gen_1_1_results]
+        assert "extra" in target_words
+        extra_result = next(r for r in gen_1_1_results if r["target_word"] == "extra")
+        assert "bonus" in extra_result["known_sources"]
+        assert extra_result["score"] >= 0.5
+    finally:
+        # Restore original text so other tests are not affected.
+        tgt_vt.text = original_text
+        test_db_session.commit()
+
+
+def test_get_eflomal_missing_words_no_artifacts_returns_404(
+    client,
+    regular_token1,
+    test_db_session,
+    test_revision_id,
+    test_revision_id_2,
+):
+    """Returns 404 when no eflomal artifacts have been pushed."""
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="word-alignment",
+        status="finished",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+
+    resp = client.get(
+        f"{prefix}/assessment/{assessment.id}/eflomal/missing-words",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_get_eflomal_missing_words_unauthorized(
+    client,
+    regular_token2,
+    eflomal_scoring_assessment_id,
+):
+    """A user without group access is denied."""
+    resp = client.get(
+        f"{prefix}/assessment/{eflomal_scoring_assessment_id}/eflomal/missing-words",
         headers={"Authorization": f"Bearer {regular_token2}"},
     )
     assert resp.status_code == 403

--- a/utils/eflomal_scoring.py
+++ b/utils/eflomal_scoring.py
@@ -206,3 +206,115 @@ def score_verse_pair(
         "coverage": round(coverage, 4),
         "num_links": len(links),
     }
+
+
+def build_reverse_dictionary(
+    dictionary: Dict[Tuple[str, str], Dict],
+    min_count: int = 3,
+) -> Dict[str, List[Tuple[str, int]]]:
+    """Index the dictionary by target word: tgt_norm -> [(src_norm, count), ...]
+    sorted by count descending.
+
+    Only pairs with count >= min_count are kept to filter low-signal noise.
+    Used by detect_missing_words_for_verse to find whether a target word has
+    known source equivalents that are absent from the current verse.
+    """
+    result: Dict[str, List[Tuple[str, int]]] = defaultdict(list)
+    for (src_norm, tgt_norm), info in dictionary.items():
+        if info["count"] >= min_count:
+            result[tgt_norm].append((src_norm, info["count"]))
+    for tgt in result:
+        result[tgt].sort(key=lambda pair: pair[1], reverse=True)
+    return dict(result)
+
+
+def detect_missing_words_for_verse(
+    src_text: str,
+    tgt_text: str,
+    reverse_dict: Dict[str, List[Tuple[str, int]]],
+    tgt_word_counts: Dict[str, int],
+    min_alignment_count: int = 10,
+    min_frequency: float = 0.5,
+    min_word_len: int = 3,
+    aligned_tgt_indices: set = None,
+) -> List[Dict]:
+    """Detect target words that are likely missing translations.
+
+    A target word is flagged as potentially missing if:
+      1. It was not aligned to any source word in this verse.
+      2. The dictionary contains known source equivalents for it
+         (reverse_dict lookup).
+      3. None of those known source equivalents appear in the source verse —
+         i.e. the source side of the "usual translation" is absent, so the
+         target word is unexpectedly present without a counterpart.
+      4. The word meets minimum corpus frequency and alignment-frequency
+         thresholds to filter noise.
+
+    Port of detect_missing_words_single from aqua-assessments scoring.py.
+
+    Args:
+        src_text: Source (reference) verse text.
+        tgt_text: Target (revision) verse text.
+        reverse_dict: tgt_norm -> [(src_norm, count), ...] (see
+            build_reverse_dictionary).
+        tgt_word_counts: Corpus-wide normalized target word counts from
+            EflomalTargetWordCount (used to compute alignment_frequency).
+        min_alignment_count: Minimum total alignment count across the corpus
+            for the target word to be considered signal-rich enough to flag.
+        min_frequency: Minimum alignment_frequency (aligned_count /
+            total_appearances) required to flag a word.
+        min_word_len: Minimum normalized word length to consider.
+        aligned_tgt_indices: Set of target word indices that were already
+            aligned by score_verse_pair. Defaults to empty set (treat
+            all target words as unaligned).
+
+    Returns:
+        List of dicts with keys: target_word, known_sources (str),
+        score (float, rounded to 4 dp).
+    """
+    if aligned_tgt_indices is None:
+        aligned_tgt_indices = set()
+
+    tgt_words = tgt_text.strip().split() if tgt_text else []
+    src_words = src_text.strip().split() if src_text else []
+    src_norms = {normalize_word(w) for w in src_words if normalize_word(w)}
+
+    missing: List[Dict] = []
+    for j, tgt_word in enumerate(tgt_words):
+        if j in aligned_tgt_indices:
+            continue
+
+        tgt_norm = normalize_word(tgt_word)
+        if not tgt_norm or len(tgt_norm) < min_word_len:
+            continue
+
+        known_sources = reverse_dict.get(tgt_norm, [])
+        if not known_sources:
+            continue
+
+        # If any known source equivalent is present in the source verse,
+        # the word is not "missing" — it just wasn't aligned.
+        if any(s in src_norms for s, _ in known_sources):
+            continue
+
+        total_count = sum(c for _, c in known_sources)
+        if total_count < min_alignment_count:
+            continue
+
+        total_appearances = tgt_word_counts.get(tgt_norm, 0)
+        if total_appearances == 0:
+            continue
+        alignment_frequency = total_count / total_appearances
+        if alignment_frequency < min_frequency:
+            continue
+
+        known_str = "; ".join(f"{s}({c})" for s, c in known_sources[:5])
+        missing.append(
+            {
+                "target_word": tgt_word,
+                "known_sources": known_str,
+                "score": round(min(alignment_frequency, 1.0), 4),
+            }
+        )
+
+    return missing

--- a/utils/eflomal_scoring.py
+++ b/utils/eflomal_scoring.py
@@ -28,11 +28,13 @@ def normalize_dictionary_list(
 ) -> Dict[Tuple[str, str], Dict]:
     """Fold raw dictionary rows into a lookup keyed by (src_norm, tgt_norm).
 
-    Input rows look like {"source": str, "target": str, "count": int,
-    "probability": float}. Different original casings that normalize to the
-    same pair are merged: counts are summed and probability is averaged
-    weighted by count. Rows whose normalized form is empty on either side
-    are dropped.
+    Input rows must have {"source": str, "target": str, "count": int,
+    "probability": float}. `probability` is required — the aqua-api
+    EflomalDictionary column is NOT NULL and EflomalDictionaryItem requires
+    it at push time — so this function does not handle rows without it.
+    Different original casings that normalize to the same pair are merged:
+    counts are summed and probability is the count-weighted average. Rows
+    whose normalized form is empty on either side are dropped.
     """
     dictionary: Dict[Tuple[str, str], Dict] = {}
     for entry in dict_list:
@@ -42,20 +44,17 @@ def normalize_dictionary_list(
             continue
         key = (src_norm, tgt_norm)
         entry_count = entry["count"]
-        entry_prob = entry.get("probability")
+        entry_prob = entry["probability"]
         if key in dictionary:
             existing = dictionary[key]
             old_count = existing["count"]
             combined_count = old_count + entry_count
-            if entry_prob is not None and "probability" in existing:
-                existing["probability"] = (
-                    existing["probability"] * old_count + entry_prob * entry_count
-                ) / combined_count
+            existing["probability"] = (
+                existing["probability"] * old_count + entry_prob * entry_count
+            ) / combined_count
             existing["count"] = combined_count
         else:
-            dictionary[key] = {"count": entry_count}
-            if entry_prob is not None:
-                dictionary[key]["probability"] = entry_prob
+            dictionary[key] = {"count": entry_count, "probability": entry_prob}
     return dictionary
 
 

--- a/utils/eflomal_scoring.py
+++ b/utils/eflomal_scoring.py
@@ -1,0 +1,200 @@
+"""Pure-Python eflomal verse-scoring primitives.
+
+Ported from aqua-assessments (eflomal_steps/scoring.py and _realtime_dictionary
+in assessments/word_alignment/app.py) so aqua-api can score verse pairs
+server-side from stored eflomal artifacts (dictionary + cooccurrence) without
+running eflomal itself. Stdlib-only (math + collections).
+
+The same primitives will drive real-time verse-level prediction when that
+endpoint is added later.
+"""
+
+import math
+from collections import defaultdict
+from typing import Dict, List, Tuple
+
+
+def normalize_word(word: str) -> str:
+    """Lowercase + keep only alphanumeric characters.
+
+    Punctuation-only tokens collapse to the empty string; callers must skip
+    those (keying dictionaries by '' would collide).
+    """
+    return "".join(c for c in word.lower() if c.isalnum())
+
+
+def normalize_dictionary_list(
+    dict_list: List[Dict],
+) -> Dict[Tuple[str, str], Dict]:
+    """Fold raw dictionary rows into a lookup keyed by (src_norm, tgt_norm).
+
+    Input rows look like {"source": str, "target": str, "count": int,
+    "probability": float}. Different original casings that normalize to the
+    same pair are merged: counts are summed and probability is averaged
+    weighted by count. Rows whose normalized form is empty on either side
+    are dropped.
+    """
+    dictionary: Dict[Tuple[str, str], Dict] = {}
+    for entry in dict_list:
+        src_norm = normalize_word(entry["source"])
+        tgt_norm = normalize_word(entry["target"])
+        if not src_norm or not tgt_norm:
+            continue
+        key = (src_norm, tgt_norm)
+        entry_count = entry["count"]
+        entry_prob = entry.get("probability")
+        if key in dictionary:
+            existing = dictionary[key]
+            old_count = existing["count"]
+            combined_count = old_count + entry_count
+            if entry_prob is not None and "probability" in existing:
+                existing["probability"] = (
+                    existing["probability"] * old_count + entry_prob * entry_count
+                ) / combined_count
+            existing["count"] = combined_count
+        else:
+            dictionary[key] = {"count": entry_count}
+            if entry_prob is not None:
+                dictionary[key]["probability"] = entry_prob
+    return dictionary
+
+
+def build_src_to_translations(
+    dictionary: Dict[Tuple[str, str], Dict],
+    min_count: int = 3,
+) -> Dict[str, List[Tuple[str, int]]]:
+    """Index the dictionary by source word: src_norm -> [(tgt_norm, count), ...]
+    sorted by count descending.
+
+    Entries with count < min_count are dropped to suppress noise; this mirrors
+    build_reverse_dictionary() in the aqua-assessments port (same cutoff).
+    Used by the greedy dictionary-lookup alignment inside score_verse_pair.
+    """
+    result: Dict[str, List[Tuple[str, int]]] = defaultdict(list)
+    for (src_norm, tgt_norm), info in dictionary.items():
+        if info["count"] >= min_count:
+            result[src_norm].append((tgt_norm, info["count"]))
+    for src in result:
+        result[src].sort(key=lambda pair: pair[1], reverse=True)
+    return dict(result)
+
+
+def compute_link_score(
+    src_word: str,
+    tgt_word: str,
+    dictionary: Dict[Tuple[str, str], Dict],
+    cooccurrence: Dict[Tuple[str, str], Dict],
+) -> float:
+    """Confidence in [0, 1] for a single alignment link.
+
+    When co_occur_count >= 2 (enough signal for the ratio to be meaningful),
+    combine the stored model probability with the aligned/co_occur ratio via
+    a weighted geometric mean (probability weight 2, co-occurrence weight 1).
+    Otherwise fall back to the stored probability alone.
+    """
+    src_norm = normalize_word(src_word)
+    tgt_norm = normalize_word(tgt_word)
+    key = (src_norm, tgt_norm)
+
+    s_prob = dictionary.get(key, {}).get("probability", 0.0)
+
+    cooc = cooccurrence.get(key, {"co_occur": 0, "aligned": 0})
+    co_occur_count = cooc["co_occur"]
+    aligned_count = cooc["aligned"]
+
+    if co_occur_count >= 2:
+        s_cooc = aligned_count / co_occur_count
+        log_score = (
+            2.0 * math.log(max(s_prob, 1e-10)) + math.log(max(s_cooc, 1e-10))
+        ) / 3.0
+        return math.exp(log_score)
+    return s_prob
+
+
+def score_verse_pair(
+    src_text: str,
+    tgt_text: str,
+    dictionary: Dict[Tuple[str, str], Dict],
+    src_to_translations: Dict[str, List[Tuple[str, int]]],
+    cooccurrence: Dict[Tuple[str, str], Dict],
+) -> Dict[str, float]:
+    """Score one verse pair from artifacts only (no eflomal call).
+
+    Algorithm (port of _realtime_dictionary in aqua-assessments app.py):
+      1. Split src_text / tgt_text on whitespace.
+      2. Build tgt_norm -> [tgt_idx, ...] for greedy matching.
+      3. For each source word in order, normalize, and walk
+         src_to_translations[src_norm] (sorted by count desc). For the first
+         candidate tgt_norm, take the first unmatched tgt index whose
+         normalized form matches and commit the link.
+      4. Score each link via compute_link_score.
+      5. verse_score = mean(link_scores) * min(src_coverage, tgt_coverage).
+
+    Returns {"verse_score", "avg_link_score", "coverage", "num_links"}.
+    All zero if either side is empty or no links are found. Values are
+    rounded to 4 decimals to match the aqua-assessments convention and keep
+    stored scores consistent across back-end runs.
+    """
+    src_words = src_text.strip().split() if src_text else []
+    tgt_words = tgt_text.strip().split() if tgt_text else []
+
+    if not src_words or not tgt_words:
+        return {
+            "verse_score": 0.0,
+            "avg_link_score": 0.0,
+            "coverage": 0.0,
+            "num_links": 0,
+        }
+
+    tgt_norm_to_idx: Dict[str, List[int]] = defaultdict(list)
+    for j, tgt in enumerate(tgt_words):
+        tgt_norm = normalize_word(tgt)
+        if tgt_norm:
+            tgt_norm_to_idx[tgt_norm].append(j)
+
+    links: List[Tuple[int, int, str, str]] = []
+    used_tgt: set = set()
+
+    for i, src in enumerate(src_words):
+        src_norm = normalize_word(src)
+        if not src_norm:
+            continue
+        for tgt_norm, _count in src_to_translations.get(src_norm, []):
+            matched = False
+            for j in tgt_norm_to_idx.get(tgt_norm, []):
+                if j not in used_tgt:
+                    links.append((i, j, src, tgt_words[j]))
+                    used_tgt.add(j)
+                    matched = True
+                    break
+            if matched:
+                break
+
+    if not links:
+        return {
+            "verse_score": 0.0,
+            "avg_link_score": 0.0,
+            "coverage": 0.0,
+            "num_links": 0,
+        }
+
+    link_scores = [
+        compute_link_score(sw, tw, dictionary, cooccurrence)
+        for _, _, sw, tw in links
+    ]
+    avg_link_score = sum(link_scores) / len(link_scores)
+
+    aligned_src = len({i for i, _, _, _ in links})
+    aligned_tgt = len({j for _, j, _, _ in links})
+    src_coverage = aligned_src / len(src_words)
+    tgt_coverage = aligned_tgt / len(tgt_words)
+    coverage = min(src_coverage, tgt_coverage)
+
+    verse_score = avg_link_score * coverage
+
+    return {
+        "verse_score": round(verse_score, 4),
+        "avg_link_score": round(avg_link_score, 4),
+        "coverage": round(coverage, 4),
+        "num_links": len(links),
+    }

--- a/utils/eflomal_scoring.py
+++ b/utils/eflomal_scoring.py
@@ -61,14 +61,15 @@ def normalize_dictionary_list(
 
 def build_src_to_translations(
     dictionary: Dict[Tuple[str, str], Dict],
-    min_count: int = 3,
+    min_count: int = 1,
 ) -> Dict[str, List[Tuple[str, int]]]:
     """Index the dictionary by source word: src_norm -> [(tgt_norm, count), ...]
     sorted by count descending.
 
-    Entries with count < min_count are dropped to suppress noise; this mirrors
-    build_reverse_dictionary() in the aqua-assessments port (same cutoff).
-    Used by the greedy dictionary-lookup alignment inside score_verse_pair.
+    Default `min_count=1` keeps every pair; matches the inline index the
+    aqua-assessments reference builds in `_realtime_dictionary`, which
+    applies no cutoff. Callers that want denoising (e.g. missing-words
+    detection) can pass a higher threshold explicitly.
     """
     result: Dict[str, List[Tuple[str, int]]] = defaultdict(list)
     for (src_norm, tgt_norm), info in dictionary.items():
@@ -117,7 +118,7 @@ def score_verse_pair(
     dictionary: Dict[Tuple[str, str], Dict],
     src_to_translations: Dict[str, List[Tuple[str, int]]],
     cooccurrence: Dict[Tuple[str, str], Dict],
-) -> Dict[str, float]:
+) -> Dict[str, float | int]:
     """Score one verse pair from artifacts only (no eflomal call).
 
     Algorithm (port of _realtime_dictionary in aqua-assessments app.py):
@@ -134,6 +135,11 @@ def score_verse_pair(
     All zero if either side is empty or no links are found. Values are
     rounded to 4 decimals to match the aqua-assessments convention and keep
     stored scores consistent across back-end runs.
+
+    Coverage denominators use the count of non-empty-normalized tokens
+    (i.e. tokens that were actually candidates for alignment), not the raw
+    whitespace-split length, so punctuation-only tokens don't silently
+    deflate the score.
     """
     src_words = src_text.strip().split() if src_text else []
     tgt_words = tgt_text.strip().split() if tgt_text else []
@@ -147,18 +153,22 @@ def score_verse_pair(
         }
 
     tgt_norm_to_idx: Dict[str, List[int]] = defaultdict(list)
+    tgt_alignable = 0
     for j, tgt in enumerate(tgt_words):
         tgt_norm = normalize_word(tgt)
         if tgt_norm:
             tgt_norm_to_idx[tgt_norm].append(j)
+            tgt_alignable += 1
 
     links: List[Tuple[int, int, str, str]] = []
     used_tgt: set = set()
+    src_alignable = 0
 
     for i, src in enumerate(src_words):
         src_norm = normalize_word(src)
         if not src_norm:
             continue
+        src_alignable += 1
         for tgt_norm, _count in src_to_translations.get(src_norm, []):
             matched = False
             for j in tgt_norm_to_idx.get(tgt_norm, []):
@@ -185,8 +195,8 @@ def score_verse_pair(
 
     aligned_src = len({i for i, _, _, _ in links})
     aligned_tgt = len({j for _, j, _, _ in links})
-    src_coverage = aligned_src / len(src_words)
-    tgt_coverage = aligned_tgt / len(tgt_words)
+    src_coverage = aligned_src / src_alignable
+    tgt_coverage = aligned_tgt / tgt_alignable
     coverage = min(src_coverage, tgt_coverage)
 
     verse_score = avg_link_score * coverage

--- a/utils/eflomal_scoring.py
+++ b/utils/eflomal_scoring.py
@@ -179,8 +179,7 @@ def score_verse_pair(
         }
 
     link_scores = [
-        compute_link_score(sw, tw, dictionary, cooccurrence)
-        for _, _, sw, tw in links
+        compute_link_score(sw, tw, dictionary, cooccurrence) for _, _, sw, tw in links
     ]
     avg_link_score = sum(link_scores) / len(link_scores)
 


### PR DESCRIPTION
## feat: server-side eflomal verse scoring and missing-word detection

### Summary

Adds two new endpoints that compute verse-level quality metrics entirely from corpus-level artifacts already stored in the database — no re-running eflomal required.

**The key insight:** eflomal trains on the full parallel corpus and produces corpus-level statistics (translation probabilities, co-occurrence counts). These are stored in the DB. Per-verse insights can be re-derived on-the-fly by running a greedy alignment simulation against those statistics for any individual verse pair.

---

### Background: what the artifacts represent

After an eflomal training run completes, the runner pushes three artifact tables:

| Table | What it stores |
|---|---|
| `EflomalDictionary` | `(source_word, target_word, count, probability)` — translation pairs learned across the entire corpus |
| `EflomalCooccurrence` | `(source_word, target_word, co_occur_count, aligned_count)` — how often a pair appeared in the same verse vs. how often eflomal actually linked them |
| `EflomalTargetWordCount` | `(word, count)` — how many times each normalized target word appeared across the training corpus |

No verse-level alignments are stored. These three tables are sufficient to reconstruct both verse scoring and missing-word detection on-demand.

---

### Endpoint 1: `POST /v3/assessment/{id}/eflomal/score-verses`

Returns `InsertResponse { ids: [...] }`. Writes one `AssessmentResult` row per verse and transitions the assessment to `"finished"`.

#### Step-by-step: how a verse score is computed

**1. Normalize words**

Every token is normalized by lowercasing and stripping non-alphanumeric characters: `"God's"` → `"gods"`, `"«Licht!»"` → `"licht"`. Punctuation-only tokens collapse to `""` and are excluded entirely — they do not count toward coverage denominators.

**2. Build in-memory dictionary** (`normalize_dictionary_list`)

`EflomalDictionary` rows are loaded and folded into `Dict[(src_norm, tgt_norm) → {count, probability}]`. Rows that normalize to the same pair are merged: counts sum, probabilities are count-weighted averaged.

**3. Build source-to-translations index** (`build_src_to_translations`)

The dictionary is inverted into `src_norm → [(tgt_norm, count), ...]` sorted by count descending. This is the lookup used during greedy alignment — "what are the most common translations of this source word?"

**4. Load co-occurrence data**

`EflomalCooccurrence` rows are loaded into `Dict[(src_norm, tgt_norm) → {co_occur, aligned}]`.

**5. Load verse pairs** (`_load_verse_pairs`)

A single SQL self-join on `VerseText` returns every `(vref, src_text, tgt_text)` triple where both the reference (source) and revision (target) have non-empty text.

**6. Greedy alignment per verse**

For each verse pair:
1. Split both texts on whitespace. Build `tgt_norm → [positions]` for fast lookup.
2. Iterate source words left-to-right. For each non-empty `src_norm`, walk `src_to_translations[src_norm]` in count-descending order. For the first candidate `tgt_norm`, take the first unmatched target position and commit the link. Each target position is used at most once.

**7. Score each link** (`compute_link_score`)

For each committed `(src_word, tgt_word)` pair:
- If `co_occur_count ≥ 2`: weighted geometric mean of stored `probability` (weight 2) and `aligned/co_occur` ratio (weight 1):
  `score = exp((2·ln(p) + ln(r)) / 3)`
- Otherwise: use stored `probability` directly (not enough signal for the ratio).

**8. Aggregate to verse score**

`avg_link_score = mean(link_scores)`
`src_coverage = aligned_src_count / alignable_src_tokens`
`tgt_coverage = aligned_tgt_count / alignable_tgt_tokens`
`verse_score = avg_link_score × min(src_coverage, tgt_coverage)`

All values rounded to 4 decimal places. A verse with no dictionary matches scores 0.

**9. Bulk insert + finalize**

Rows are batched at `min(5000, floor(32767 / columns))` to respect asyncpg's 32,767-parameter limit. Prior `AssessmentResult` rows for the assessment are deleted before insert (idempotent). The assessment status transitions to `"finished"` in the same transaction.

---

### Endpoint 2: `GET /v3/assessment/{id}/eflomal/missing-words`

Returns `EflomalMissingWordsResponse { assessment_id, results: [...], total_count }`.

No data is written to the DB — results are computed on-the-fly per request.

#### Step-by-step: how missing words are detected

A target word is "missing" if the corpus evidence says it normally translates a specific source word, but that source word is absent from the current verse — meaning the target word is present without an apparent counterpart.

**1. Build reverse dictionary** (`build_reverse_dictionary`)

The dictionary is inverted to `tgt_norm → [(src_norm, count), ...]` with a `min_count=3` cutoff to filter noise. This answers: "what source words does this target word usually translate?"

**2. Load target word counts**

`EflomalTargetWordCount` rows are loaded into `{word_norm: count}`. This is the corpus-wide frequency of each target word — needed to compute alignment frequency.

**3. For each verse pair, scan unaligned target words**

For every target word at position `j`:
1. Skip if already aligned (i.e. `j` committed a link in the greedy alignment step — currently the endpoint runs detection without a prior alignment pass, so all target words are candidates).
2. Normalize; skip if normalized form is `< min_word_len` characters (default 3).
3. Look up `known_sources = reverse_dict[tgt_norm]`. Skip if empty — we have no corpus evidence about what this word translates.
4. If any `known_source` appears in the source verse's normalized word set → skip. The word has a plausible source-side counterpart; it's just unaligned by the greedy algorithm, not genuinely absent.
5. Compute `alignment_frequency = total_alignment_count / corpus_appearances`. Skip if `< min_alignment_count` (default 10) or `< min_frequency` (default 0.5). These filters prevent rare or inconsistently-aligned words from generating noise.
6. Flag the word: `score = min(alignment_frequency, 1.0)`.

**Query parameters** (all optional):
- `min_alignment_count` (default 10) — corpus-wide alignment count floor
- `min_frequency` (default 0.5) — minimum fraction of corpus appearances that are aligned
- `min_word_len` (default 3) — minimum normalized word length

---

### Files changed

| File | Change |
|---|---|
| `utils/eflomal_scoring.py` | New — pure-Python scoring + missing-word primitives (stdlib only) |
| `assessment_routes/v3/eflomal_scoring_service.py` | New — async DB orchestration for both endpoints |
| `assessment_routes/v3/eflomal_routes.py` | Two new endpoints: `POST .../score-verses`, `GET .../missing-words` |
| `models.py` | New Pydantic models: `EflomalMissingWordItem`, `EflomalMissingWordsResponse` |
| `test/test_assessment_routes/test_eflomal_scoring.py` | New — unit + integration tests for all new primitives and endpoints |

---

### API reference

```
POST /v3/assessment/{assessment_id}/eflomal/score-verses
→ 200 InsertResponse { "ids": [...] }
→ 403  not authorized
→ 404  assessment not found / no eflomal artifacts
→ 409  assessment not in "running" or "finished" status
→ 422  dictionary is empty
→ 500  db / unexpected error

GET /v3/assessment/{assessment_id}/eflomal/missing-words
    ?min_alignment_count=10&min_frequency=0.5&min_word_len=3
→ 200 EflomalMissingWordsResponse {
        "assessment_id": int,
        "results": [{ "vref", "target_word", "known_sources", "score" }, ...],
        "total_count": int
      }
→ 403  not authorized
→ 404  assessment not found / no eflomal artifacts
→ 422  dictionary is empty
→ 500  db / unexpected error
```

**Prerequisites** (must be pushed before calling either endpoint):
1. `POST /v3/assessment/{id}/eflomal/metadata`
2. `POST /v3/assessment/{id}/eflomal/dictionary`
3. `POST /v3/assessment/{id}/eflomal/cooccurrences`
4. `POST /v3/assessment/{id}/eflomal/target-word-counts` _(required for missing-words; not needed for score-verses)_

`score-verses` is idempotent — re-calling overwrites prior `AssessmentResult` rows cleanly.

---

### Test coverage

**Unit tests** (`utils/eflomal_scoring.py`):
- `normalize_word` — casing, punctuation stripping, empty collapse
- `normalize_dictionary_list` — case-insensitive merge, count-weighted probability, empty-normalized drops
- `build_src_to_translations` — default/explicit `min_count`, sort order
- `compute_link_score` — probability-only fallback, weighted geometric mean
- `score_verse_pair` — empty texts, no dictionary match, basic alignment, punctuation tokens ignored in coverage, partial coverage bottleneck on `min(src, tgt)`
- `build_reverse_dictionary` — `min_count` cutoff, sort order
- `detect_missing_words_for_verse` — flags unexpected target word, skips already-aligned indices, skips when known source present, respects `min_frequency`

**Integration tests** (real Postgres):
- `score-verses`: happy path end-to-end, idempotent retry, missing artifacts → 404, empty dictionary → 422, unauthorized → 403
- `missing-words`: happy path end-to-end (verifies flagged word + known sources), no artifacts → 404, unauthorized → 403