### PR TITLE
feat(eflomal): persist priors + BPE models for predict() (#573)

### DIFF
--- a/alembic/migrations/versions/d62d257fb2b2_add_eflomal_priors_and_bpe_model_tables.py
+++ b/alembic/migrations/versions/d62d257fb2b2_add_eflomal_priors_and_bpe_model_tables.py
@@ -1,0 +1,80 @@
+"""add eflomal priors and bpe model tables
+
+Revision ID: d62d257fb2b2
+Revises: c9a2f4b7e3d8
+Create Date: 2026-04-23 20:30:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "d62d257fb2b2"
+down_revision: Union[str, None] = "c9a2f4b7e3d8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "eflomal_prior",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("assessment_id", sa.Integer(), nullable=False),
+        sa.Column("source_bpe", sa.Text(), nullable=False),
+        sa.Column("target_bpe", sa.Text(), nullable=False),
+        sa.Column("alpha", sa.Float(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["assessment_id"], ["eflomal_assessment.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_eflomal_prior_assessment",
+        "eflomal_prior",
+        ["assessment_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ux_eflomal_prior_assessment_source_target",
+        "eflomal_prior",
+        ["assessment_id", "source_bpe", "target_bpe"],
+        unique=True,
+    )
+
+    op.create_table(
+        "eflomal_bpe_model",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("assessment_id", sa.Integer(), nullable=False),
+        sa.Column("direction", sa.Text(), nullable=False),
+        sa.Column("model_bytes", sa.LargeBinary(), nullable=False),
+        sa.CheckConstraint(
+            "direction IN ('source', 'target')",
+            name="ck_eflomal_bpe_model_direction",
+        ),
+        sa.ForeignKeyConstraint(
+            ["assessment_id"], ["eflomal_assessment.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ux_eflomal_bpe_model_assessment_direction",
+        "eflomal_bpe_model",
+        ["assessment_id", "direction"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ux_eflomal_bpe_model_assessment_direction", table_name="eflomal_bpe_model"
+    )
+    op.drop_table("eflomal_bpe_model")
+    op.drop_index(
+        "ux_eflomal_prior_assessment_source_target", table_name="eflomal_prior"
+    )
+    op.drop_index("ix_eflomal_prior_assessment", table_name="eflomal_prior")
+    op.drop_table("eflomal_prior")

--- a/alembic/migrations/versions/d62d257fb2b2_add_eflomal_priors_and_bpe_model_tables.py
+++ b/alembic/migrations/versions/d62d257fb2b2_add_eflomal_priors_and_bpe_model_tables.py
@@ -27,6 +27,9 @@ def upgrade() -> None:
         sa.Column("source_bpe", sa.Text(), nullable=False),
         sa.Column("target_bpe", sa.Text(), nullable=False),
         sa.Column("alpha", sa.Float(), nullable=False),
+        sa.CheckConstraint(
+            "alpha >= 0.5 AND alpha <= 0.95", name="ck_eflomal_prior_alpha_range"
+        ),
         sa.ForeignKeyConstraint(
             ["assessment_id"], ["eflomal_assessment.id"], ondelete="CASCADE"
         ),

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -50,6 +50,10 @@ router = fastapi.APIRouter()
 _BATCH_SIZE = 5_000
 _MAX_BODY_ITEMS = 5_000
 
+# BPE model protobufs are typically 100–300 KB each; allow generous headroom
+# but still cap to protect memory / DB.
+_MAX_BPE_MODEL_BYTES = 10 * 1024 * 1024  # 10 MB per direction
+
 
 def _check_body_size(body):
     if len(body) > _MAX_BODY_ITEMS:
@@ -622,6 +626,16 @@ async def push_eflomal_bpe_models(
             status_code=422,
             detail="source_model_b64 and target_model_b64 must be valid base64",
         )
+
+    for direction, blob in (("source", source_bytes), ("target", target_bytes)):
+        if len(blob) > _MAX_BPE_MODEL_BYTES:
+            raise HTTPException(
+                status_code=413,
+                detail=(
+                    f"{direction}_model_b64 decodes to {len(blob)} bytes "
+                    f"(max {_MAX_BPE_MODEL_BYTES})"
+                ),
+            )
 
     try:
         await db.execute(

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -27,7 +27,6 @@ from database.models import UserDB as UserModel
 from models import (
     EflomalAssessmentOut,
     EflomalBpeModels,
-    EflomalBpeModelsPushResponse,
     EflomalCooccurrenceItem,
     EflomalDictionaryItem,
     EflomalPriorItem,
@@ -147,8 +146,8 @@ async def _fetch_eflomal_response(
         )
     )
     parent_row = parent.first()
-    revision_revision_id = parent_row.revision_id if parent_row else None
-    reference_revision_id = parent_row.reference_id if parent_row else None
+    revision_id = parent_row.revision_id if parent_row else None
+    reference_id = parent_row.reference_id if parent_row else None
 
     return EflomalResultsPullResponse(
         assessment_id=eflomal.assessment_id,
@@ -159,8 +158,8 @@ async def _fetch_eflomal_response(
         num_dictionary_entries=eflomal.num_dictionary_entries,
         num_missing_words=eflomal.num_missing_words,
         created_at=eflomal.created_at,
-        reference_revision_id=reference_revision_id,
-        revision_revision_id=revision_revision_id,
+        reference_id=reference_id,
+        revision_id=revision_id,
         dictionary=[
             EflomalDictionaryItem(
                 source_word=r.source_word,
@@ -531,6 +530,11 @@ async def push_eflomal_priors(
     Maximum of 5,000 items per request. For larger datasets, split into
     multiple requests of 5,000 items or fewer.
 
+    Not idempotent: enforced by a unique index on (assessment_id, source_bpe,
+    target_bpe). Re-pushing a batch that overlaps previously-inserted rows
+    fails with 400. Callers should push each prior exactly once per
+    assessment.
+
     Returns the list of inserted row IDs in the same order as the input.
     """
     eflomal = await _get_eflomal_assessment(assessment_id, db)
@@ -539,9 +543,9 @@ async def push_eflomal_priors(
             status_code=403, detail="Not authorized for this assessment"
         )
 
+    _check_body_size(body)
     if not body:
         return InsertResponse(ids=[])
-    _check_body_size(body)
 
     rows = [
         {
@@ -590,7 +594,7 @@ async def push_eflomal_priors(
 
 @router.post(
     "/assessment/{assessment_id}/eflomal-bpe-models",
-    response_model=EflomalBpeModelsPushResponse,
+    response_model=InsertResponse,
 )
 async def push_eflomal_bpe_models(
     assessment_id: int,
@@ -644,7 +648,7 @@ async def push_eflomal_bpe_models(
         result = await db.execute(stmt)
         ids = [r[0] for r in result.fetchall()]
         await db.commit()
-        return EflomalBpeModelsPushResponse(ids=ids)
+        return InsertResponse(ids=ids)
     except IntegrityError:
         await db.rollback()
         raise HTTPException(

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -1,11 +1,13 @@
 __version__ = "v3"
 
+import base64
+import binascii
 import socket
 from typing import List
 
 import fastapi
 from fastapi import Depends, HTTPException
-from sqlalchemy import desc, insert, select
+from sqlalchemy import delete, desc, insert, select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -15,15 +17,20 @@ from database.models import (
 )
 from database.models import EflomalAssessment as EflomalAssessmentModel
 from database.models import (
+    EflomalBpeModel,
     EflomalCooccurrence,
     EflomalDictionary,
+    EflomalPrior,
     EflomalTargetWordCount,
 )
 from database.models import UserDB as UserModel
 from models import (
     EflomalAssessmentOut,
+    EflomalBpeModels,
+    EflomalBpeModelsPushResponse,
     EflomalCooccurrenceItem,
     EflomalDictionaryItem,
+    EflomalPriorItem,
     EflomalResultsPullResponse,
     EflomalResultsPushRequest,
     EflomalTargetWordCountItem,
@@ -110,6 +117,39 @@ async def _fetch_eflomal_response(
     )
     twc_rows = twc_result.scalars().all()
 
+    prior_result = await db.execute(
+        select(EflomalPrior).where(EflomalPrior.assessment_id == ea_id)
+    )
+    prior_rows = prior_result.scalars().all()
+
+    bpe_result = await db.execute(
+        select(EflomalBpeModel).where(EflomalBpeModel.assessment_id == ea_id)
+    )
+    bpe_rows = bpe_result.scalars().all()
+
+    bpe_by_direction = {r.direction: r for r in bpe_rows}
+    bpe_models = None
+    if "source" in bpe_by_direction and "target" in bpe_by_direction:
+        bpe_models = EflomalBpeModels(
+            source_model_b64=base64.b64encode(
+                bpe_by_direction["source"].model_bytes
+            ).decode("ascii"),
+            target_model_b64=base64.b64encode(
+                bpe_by_direction["target"].model_bytes
+            ).decode("ascii"),
+        )
+
+    # Fetch parent Assessment to expose revision/reference IDs for predict-time
+    # anchor sampling.
+    parent = await db.execute(
+        select(Assessment.revision_id, Assessment.reference_id).where(
+            Assessment.id == eflomal.assessment_id
+        )
+    )
+    parent_row = parent.first()
+    revision_revision_id = parent_row.revision_id if parent_row else None
+    reference_revision_id = parent_row.reference_id if parent_row else None
+
     return EflomalResultsPullResponse(
         assessment_id=eflomal.assessment_id,
         source_language=eflomal.source_language,
@@ -119,6 +159,8 @@ async def _fetch_eflomal_response(
         num_dictionary_entries=eflomal.num_dictionary_entries,
         num_missing_words=eflomal.num_missing_words,
         created_at=eflomal.created_at,
+        reference_revision_id=reference_revision_id,
+        revision_revision_id=revision_revision_id,
         dictionary=[
             EflomalDictionaryItem(
                 source_word=r.source_word,
@@ -144,6 +186,15 @@ async def _fetch_eflomal_response(
             )
             for r in twc_rows
         ],
+        priors=[
+            EflomalPriorItem(
+                source_bpe=r.source_bpe,
+                target_bpe=r.target_bpe,
+                alpha=r.alpha,
+            )
+            for r in prior_rows
+        ],
+        bpe_models=bpe_models,
     )
 
 
@@ -462,6 +513,164 @@ async def push_eflomal_target_word_counts(
         raise HTTPException(
             status_code=500,
             detail=f"Unexpected error inserting {len(rows)} target word counts for assessment {assessment_id}",
+        )
+
+
+@router.post(
+    "/assessment/{assessment_id}/eflomal-priors",
+    response_model=InsertResponse,
+)
+async def push_eflomal_priors(
+    assessment_id: int,
+    body: List[EflomalPriorItem],
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Bulk insert LEX-format priors for an eflomal assessment.
+
+    Maximum of 5,000 items per request. For larger datasets, split into
+    multiple requests of 5,000 items or fewer.
+
+    Returns the list of inserted row IDs in the same order as the input.
+    """
+    eflomal = await _get_eflomal_assessment(assessment_id, db)
+    if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
+        raise HTTPException(
+            status_code=403, detail="Not authorized for this assessment"
+        )
+
+    if not body:
+        return InsertResponse(ids=[])
+    _check_body_size(body)
+
+    rows = [
+        {
+            "assessment_id": eflomal.id,
+            "source_bpe": item.source_bpe,
+            "target_bpe": item.target_bpe,
+            "alpha": item.alpha,
+        }
+        for item in body
+    ]
+    try:
+        ids = await _batch_insert(db, EflomalPrior, rows)
+        await db.commit()
+        return InsertResponse(ids=ids)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail=f"Duplicate or constraint violation inserting {len(rows)} priors for assessment {assessment_id}",
+        )
+    except SQLAlchemyError:
+        logger.exception(
+            "Bulk insert failed for eflomal_prior, assessment_id=%s, item_count=%d",
+            assessment_id,
+            len(rows),
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Database error inserting {len(rows)} priors for assessment {assessment_id}",
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception(
+            "Unexpected error pushing eflomal priors, assessment_id=%s, item_count=%d",
+            assessment_id,
+            len(rows),
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error inserting {len(rows)} priors for assessment {assessment_id}",
+        )
+
+
+@router.post(
+    "/assessment/{assessment_id}/eflomal-bpe-models",
+    response_model=EflomalBpeModelsPushResponse,
+)
+async def push_eflomal_bpe_models(
+    assessment_id: int,
+    body: EflomalBpeModels,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Store the SentencePiece BPE models for an eflomal assessment.
+
+    Idempotent on (assessment_id, direction): existing rows for this assessment
+    are deleted and replaced with the new pair. The request body carries
+    base64-encoded serialized protobuf bytes for the source and target models.
+    """
+    eflomal = await _get_eflomal_assessment(assessment_id, db)
+    if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
+        raise HTTPException(
+            status_code=403, detail="Not authorized for this assessment"
+        )
+
+    try:
+        source_bytes = base64.b64decode(body.source_model_b64, validate=True)
+        target_bytes = base64.b64decode(body.target_model_b64, validate=True)
+    except (binascii.Error, ValueError):
+        raise HTTPException(
+            status_code=422,
+            detail="source_model_b64 and target_model_b64 must be valid base64",
+        )
+
+    try:
+        await db.execute(
+            delete(EflomalBpeModel).where(EflomalBpeModel.assessment_id == eflomal.id)
+        )
+        stmt = (
+            insert(EflomalBpeModel)
+            .values(
+                [
+                    {
+                        "assessment_id": eflomal.id,
+                        "direction": "source",
+                        "model_bytes": source_bytes,
+                    },
+                    {
+                        "assessment_id": eflomal.id,
+                        "direction": "target",
+                        "model_bytes": target_bytes,
+                    },
+                ]
+            )
+            .returning(EflomalBpeModel.id)
+        )
+        result = await db.execute(stmt)
+        ids = [r[0] for r in result.fetchall()]
+        await db.commit()
+        return EflomalBpeModelsPushResponse(ids=ids)
+    except IntegrityError:
+        await db.rollback()
+        raise HTTPException(
+            status_code=400,
+            detail=f"Constraint violation inserting BPE models for assessment {assessment_id}",
+        )
+    except SQLAlchemyError:
+        logger.exception(
+            "Insert failed for eflomal_bpe_model, assessment_id=%s", assessment_id
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Database error inserting BPE models for assessment {assessment_id}",
+        )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.exception(
+            "Unexpected error pushing eflomal BPE models, assessment_id=%s",
+            assessment_id,
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Unexpected error inserting BPE models for assessment {assessment_id}",
         )
 
 

--- a/database/models.py
+++ b/database/models.py
@@ -860,6 +860,69 @@ class EflomalTargetWordCount(Base):
     )
 
 
+class EflomalPrior(Base):
+    """LEX-format priors from the final alignment loop, one row per BPE token pair.
+
+    Consumed at predict-time by eflomal together with the BPE models to
+    score unseen verse pairs against a small anchor sample from training.
+
+    - source_bpe / target_bpe: SentencePiece pieces (e.g. "▁house").
+    - alpha: Dirichlet-prior strength, typically in [0.5, 0.95].
+    """
+
+    __tablename__ = "eflomal_prior"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    assessment_id = Column(
+        Integer, ForeignKey("eflomal_assessment.id", ondelete="CASCADE"), nullable=False
+    )
+    source_bpe = Column(Text, nullable=False)
+    target_bpe = Column(Text, nullable=False)
+    alpha = Column(Float, nullable=False)
+
+    __table_args__ = (
+        Index("ix_eflomal_prior_assessment", "assessment_id"),
+        Index(
+            "ux_eflomal_prior_assessment_source_target",
+            "assessment_id",
+            "source_bpe",
+            "target_bpe",
+            unique=True,
+        ),
+    )
+
+
+class EflomalBpeModel(Base):
+    """Serialized SentencePiece BPE model protobuf, one per direction.
+
+    Two rows per assessment — direction 'source' and 'target'. The
+    model_bytes column stores the output of
+    SentencePieceProcessor.serialized_model_proto() directly.
+    """
+
+    __tablename__ = "eflomal_bpe_model"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    assessment_id = Column(
+        Integer, ForeignKey("eflomal_assessment.id", ondelete="CASCADE"), nullable=False
+    )
+    direction = Column(Text, nullable=False)
+    model_bytes = Column(LargeBinary, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "direction IN ('source', 'target')",
+            name="ck_eflomal_bpe_model_direction",
+        ),
+        Index(
+            "ux_eflomal_bpe_model_assessment_direction",
+            "assessment_id",
+            "direction",
+            unique=True,
+        ),
+    )
+
+
 class LanguageProfile(Base):
     __tablename__ = "language_profiles"
 

--- a/database/models.py
+++ b/database/models.py
@@ -881,6 +881,9 @@ class EflomalPrior(Base):
     alpha = Column(Float, nullable=False)
 
     __table_args__ = (
+        CheckConstraint(
+            "alpha >= 0.5 AND alpha <= 0.95", name="ck_eflomal_prior_alpha_range"
+        ),
         Index("ix_eflomal_prior_assessment", "assessment_id"),
         Index(
             "ux_eflomal_prior_assessment_source_target",

--- a/models.py
+++ b/models.py
@@ -1209,12 +1209,6 @@ class EflomalBpeModels(BaseModel):
     target_model_b64: str
 
 
-class EflomalBpeModelsPushResponse(BaseModel):
-    """Push response for /eflomal-bpe-models — row IDs for source and target."""
-
-    ids: List[int]
-
-
 class EflomalResultsPullResponse(BaseModel):
     """Full eflomal training artifacts for inference consumption.
 
@@ -1230,8 +1224,8 @@ class EflomalResultsPullResponse(BaseModel):
     num_dictionary_entries: int
     num_missing_words: int
     created_at: Optional[datetime.datetime] = None
-    reference_revision_id: Optional[int] = None
-    revision_revision_id: Optional[int] = None
+    reference_id: Optional[int] = None
+    revision_id: Optional[int] = None
     dictionary: list[EflomalDictionaryItem]
     cooccurrences: list[EflomalCooccurrenceItem]
     target_word_counts: list[EflomalTargetWordCountItem]

--- a/models.py
+++ b/models.py
@@ -1194,6 +1194,27 @@ class EflomalAssessmentOut(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class EflomalPriorItem(BaseModel):
+    """LEX prior row: one BPE token pair with a Dirichlet-prior alpha."""
+
+    source_bpe: str
+    target_bpe: str
+    alpha: float
+
+
+class EflomalBpeModels(BaseModel):
+    """SentencePiece BPE models (serialized protobuf), one per direction."""
+
+    source_model_b64: str
+    target_model_b64: str
+
+
+class EflomalBpeModelsPushResponse(BaseModel):
+    """Push response for /eflomal-bpe-models — row IDs for source and target."""
+
+    ids: List[int]
+
+
 class EflomalResultsPullResponse(BaseModel):
     """Full eflomal training artifacts for inference consumption.
 
@@ -1209,9 +1230,13 @@ class EflomalResultsPullResponse(BaseModel):
     num_dictionary_entries: int
     num_missing_words: int
     created_at: Optional[datetime.datetime] = None
+    reference_revision_id: Optional[int] = None
+    revision_revision_id: Optional[int] = None
     dictionary: list[EflomalDictionaryItem]
     cooccurrences: list[EflomalCooccurrenceItem]
     target_word_counts: list[EflomalTargetWordCountItem]
+    priors: list[EflomalPriorItem] = Field(default_factory=list)
+    bpe_models: Optional[EflomalBpeModels] = None
 
 
 # --- TF-IDF artifact (encoder state) models ---

--- a/models.py
+++ b/models.py
@@ -1199,7 +1199,7 @@ class EflomalPriorItem(BaseModel):
 
     source_bpe: str
     target_bpe: str
-    alpha: float
+    alpha: float = Field(ge=0.5, le=0.95, allow_inf_nan=False)
 
 
 class EflomalBpeModels(BaseModel):

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -645,6 +645,19 @@ def test_push_eflomal_priors_unauthorized(
     assert response.status_code == 403
 
 
+def test_push_eflomal_priors_alpha_out_of_range(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Alpha outside [0.5, 0.95] should be rejected with 422."""
+    payload = [{"source_bpe": "▁x", "target_bpe": "▁y", "alpha": 1.5}]
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-priors",
+        json=payload,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 422
+
+
 # ---------------------------------------------------------------------------
 # BPE models endpoint
 # ---------------------------------------------------------------------------
@@ -731,6 +744,24 @@ def test_push_eflomal_bpe_models_unauthorized(
         headers={"Authorization": f"Bearer {regular_token2}"},
     )
     assert response.status_code == 403
+
+
+def test_push_eflomal_bpe_models_too_large(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Oversized BPE model payload should return 413."""
+    oversized = b"\x00" * (10 * 1024 * 1024 + 1)
+    payload = {
+        "source_model_b64": base64.b64encode(oversized).decode("ascii"),
+        "target_model_b64": base64.b64encode(b"tiny").decode("ascii"),
+    }
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-bpe-models",
+        json=payload,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 413
+    assert "source" in response.json()["detail"]
 
 
 def test_push_eflomal_priors_duplicate_rejected(

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -409,12 +409,15 @@ def test_pull_eflomal_results_success(client, regular_token1, _ensure_eflomal_pu
     assert "word" in first_twc
     assert "count" in first_twc
 
-    # Priors (n=5 in _push_all)
-    assert len(data["priors"]) == 5
-    first_prior = data["priors"][0]
-    assert "source_bpe" in first_prior
-    assert "target_bpe" in first_prior
-    assert "alpha" in first_prior
+    # Priors (n=5 in _push_all) — round-trip content check, not just keys
+    expected_priors = {
+        (p["source_bpe"], p["target_bpe"]): p["alpha"] for p in _prior_items(5)
+    }
+    assert len(data["priors"]) == len(expected_priors)
+    for p in data["priors"]:
+        key = (p["source_bpe"], p["target_bpe"])
+        assert key in expected_priors
+        assert p["alpha"] == pytest.approx(expected_priors[key])
 
     # BPE models (round-trip base64)
     assert data["bpe_models"] is not None
@@ -426,8 +429,8 @@ def test_pull_eflomal_results_success(client, regular_token1, _ensure_eflomal_pu
     )
 
     # Revision / reference IDs from the parent Assessment
-    assert data["revision_revision_id"] is not None
-    assert data["reference_revision_id"] is not None
+    assert data["revision_id"] is not None
+    assert data["reference_id"] is not None
 
 
 def test_pull_eflomal_results_not_found(client, regular_token1):
@@ -502,8 +505,8 @@ def test_pull_eflomal_results_by_language_success(
     assert len(data["target_word_counts"]) == 5
     assert len(data["priors"]) == 5
     assert data["bpe_models"] is not None
-    assert data["revision_revision_id"] is not None
-    assert data["reference_revision_id"] is not None
+    assert data["revision_id"] is not None
+    assert data["reference_id"] is not None
 
 
 def test_pull_eflomal_results_by_language_not_found(client, regular_token1):
@@ -730,29 +733,79 @@ def test_push_eflomal_bpe_models_unauthorized(
     assert response.status_code == 403
 
 
+def test_push_eflomal_priors_duplicate_rejected(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Re-pushing a prior that already exists should fail the unique constraint."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    # Use a fixed, unique payload that won't collide with other tests' priors
+    payload = [{"source_bpe": "▁dupe_probe", "target_bpe": "▁dupe_probe", "alpha": 0.7}]
+    first = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-priors",
+        json=payload,
+        headers=headers,
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-priors",
+        json=payload,
+        headers=headers,
+    )
+    assert second.status_code == 400
+    assert "Duplicate" in second.json()["detail"]
+
+
 # ---------------------------------------------------------------------------
 # Back-compat: pulls on assessments without priors / BPE models should succeed
 # ---------------------------------------------------------------------------
 
 
-def test_pull_eflomal_results_without_priors_or_bpe(
-    client, regular_token1, test_eflomal_assessment_id
+@pytest.fixture(scope="module")
+def test_eflomal_assessment_metadata_only_id(
+    test_db_session, test_revision_id, test_revision_id_2
 ):
-    """Older-style assessments (metadata + core data only) still return 200.
+    """Word-alignment assessment with eflomal metadata pushed but NO priors/BPE.
 
-    The test_eflomal_assessment_id fixture receives metadata/dictionary/etc via
-    earlier tests but the dedicated priors/BPE-models tests may or may not have
-    run in the same ordering. Exercise a pull and assert the new fields are
-    present with safe defaults when empty.
+    Isolated from test_eflomal_assessment_id so other tests in this module
+    cannot pollute it with priors / BPE models.
     """
-    # Pull: should always succeed regardless of whether priors/BPE exist
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="word-alignment",
+        status="running",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+    return assessment.id
+
+
+def test_pull_eflomal_results_without_priors_or_bpe(
+    client, regular_token1, test_eflomal_assessment_metadata_only_id
+):
+    """Older-style assessments (no priors, no BPE) still return 200."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    # Push metadata only — no priors / BPE pushes
+    meta_resp = client.post(
+        f"{prefix}/assessment/eflomal/results",
+        json=_metadata_payload(test_eflomal_assessment_metadata_only_id),
+        headers=headers,
+    )
+    assert meta_resp.status_code == 200
+
     response = client.get(
         f"{prefix}/assessment/eflomal/results",
-        params={"assessment_id": test_eflomal_assessment_id},
-        headers={"Authorization": f"Bearer {regular_token1}"},
+        params={"assessment_id": test_eflomal_assessment_metadata_only_id},
+        headers=headers,
     )
     assert response.status_code == 200
     data = response.json()
-    assert "priors" in data
-    assert isinstance(data["priors"], list)
-    assert "bpe_models" in data  # value may be null if BPE not yet pushed
+    # With no priors pushed, the field must be an empty list (not null/missing)
+    assert data["priors"] == []
+    # With no BPE models pushed, the field must be null
+    assert data["bpe_models"] is None
+    # Parent revision/reference IDs come from the Assessment row
+    assert data["revision_id"] is not None
+    assert data["reference_id"] is not None

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -20,7 +20,9 @@ def _prior_items(n=5):
     ]
 
 
-def _bpe_payload(source_bytes=b"source-proto-bytes", target_bytes=b"target-proto-bytes"):
+def _bpe_payload(
+    source_bytes=b"source-proto-bytes", target_bytes=b"target-proto-bytes"
+):
     return {
         "source_model_b64": base64.b64encode(source_bytes).decode("ascii"),
         "target_model_b64": base64.b64encode(target_bytes).decode("ascii"),

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -1,10 +1,30 @@
 # test_eflomal_routes.py
 
+import base64
+
 import pytest
 
 from database.models import Assessment
 
 prefix = "v3"
+
+
+def _prior_items(n=5):
+    return [
+        {
+            "source_bpe": f"▁src_{i}",
+            "target_bpe": f"▁tgt_{i}",
+            "alpha": 0.5 + (i % 5) * 0.05,
+        }
+        for i in range(n)
+    ]
+
+
+def _bpe_payload(source_bytes=b"source-proto-bytes", target_bytes=b"target-proto-bytes"):
+    return {
+        "source_model_b64": base64.b64encode(source_bytes).decode("ascii"),
+        "target_model_b64": base64.b64encode(target_bytes).decode("ascii"),
+    }
 
 
 def _metadata_payload(
@@ -88,6 +108,20 @@ def _push_all(client, token, assessment_id, source_language=None, target_languag
     resp = client.post(
         f"{prefix}/assessment/{assessment_id}/eflomal-target-word-counts",
         json=_target_word_count_items(),
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal-priors",
+        json=_prior_items(),
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/eflomal-bpe-models",
+        json=_bpe_payload(),
         headers=headers,
     )
     assert resp.status_code == 200
@@ -373,6 +407,26 @@ def test_pull_eflomal_results_success(client, regular_token1, _ensure_eflomal_pu
     assert "word" in first_twc
     assert "count" in first_twc
 
+    # Priors (n=5 in _push_all)
+    assert len(data["priors"]) == 5
+    first_prior = data["priors"][0]
+    assert "source_bpe" in first_prior
+    assert "target_bpe" in first_prior
+    assert "alpha" in first_prior
+
+    # BPE models (round-trip base64)
+    assert data["bpe_models"] is not None
+    assert base64.b64decode(data["bpe_models"]["source_model_b64"]) == (
+        b"source-proto-bytes"
+    )
+    assert base64.b64decode(data["bpe_models"]["target_model_b64"]) == (
+        b"target-proto-bytes"
+    )
+
+    # Revision / reference IDs from the parent Assessment
+    assert data["revision_revision_id"] is not None
+    assert data["reference_revision_id"] is not None
+
 
 def test_pull_eflomal_results_not_found(client, regular_token1):
     """Non-existent assessment_id should return 404."""
@@ -444,6 +498,10 @@ def test_pull_eflomal_results_by_language_success(
     assert len(data["dictionary"]) == 10
     assert len(data["cooccurrences"]) == 20
     assert len(data["target_word_counts"]) == 5
+    assert len(data["priors"]) == 5
+    assert data["bpe_models"] is not None
+    assert data["revision_revision_id"] is not None
+    assert data["reference_revision_id"] is not None
 
 
 def test_pull_eflomal_results_by_language_not_found(client, regular_token1):
@@ -507,3 +565,192 @@ def test_pull_eflomal_results_partial_language(client, regular_token1):
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# Priors endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_push_eflomal_priors(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Push priors entries for an existing eflomal assessment."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-priors",
+        json=_prior_items(4),
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert len(response.json()["ids"]) == 4
+
+
+def test_push_eflomal_priors_empty_body(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Empty priors list should return 200 with no ids."""
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-priors",
+        json=[],
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["ids"] == []
+
+
+def test_push_eflomal_priors_body_too_large(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Exceeding body size limit should return 400 with a helpful message."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    body = _prior_items(5001)
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-priors",
+        json=body,
+        headers=headers,
+    )
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert "5001" in detail
+    assert "5000" in detail
+
+
+def test_push_eflomal_priors_no_metadata(
+    client, regular_token1, test_eflomal_assessment_unpushed_id
+):
+    """Pushing priors before metadata should return 404."""
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_unpushed_id}/eflomal-priors",
+        json=_prior_items(2),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 404
+
+
+def test_push_eflomal_priors_unauthorized(
+    client, regular_token2, test_eflomal_assessment_id
+):
+    """User without access should receive 403."""
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-priors",
+        json=_prior_items(2),
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# BPE models endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_push_eflomal_bpe_models(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Push BPE models (source + target) for an eflomal assessment."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-bpe-models",
+        json=_bpe_payload(),
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert len(response.json()["ids"]) == 2
+
+
+def test_push_eflomal_bpe_models_idempotent(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Second push replaces the prior pair (delete-then-insert)."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    first = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-bpe-models",
+        json=_bpe_payload(b"old-src", b"old-tgt"),
+        headers=headers,
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-bpe-models",
+        json=_bpe_payload(b"new-src", b"new-tgt"),
+        headers=headers,
+    )
+    assert second.status_code == 200
+    assert len(second.json()["ids"]) == 2
+
+    # Pull and verify latest bytes won
+    pull = client.get(
+        f"{prefix}/assessment/eflomal/results",
+        params={"assessment_id": test_eflomal_assessment_id},
+        headers=headers,
+    )
+    assert pull.status_code == 200
+    data = pull.json()
+    assert data["bpe_models"] is not None
+    assert base64.b64decode(data["bpe_models"]["source_model_b64"]) == b"new-src"
+    assert base64.b64decode(data["bpe_models"]["target_model_b64"]) == b"new-tgt"
+
+
+def test_push_eflomal_bpe_models_invalid_base64(
+    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+):
+    """Invalid base64 in either field should return 422."""
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-bpe-models",
+        json={"source_model_b64": "not!!valid!!base64", "target_model_b64": "aGk="},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 422
+
+
+def test_push_eflomal_bpe_models_no_metadata(
+    client, regular_token1, test_eflomal_assessment_unpushed_id
+):
+    """Pushing BPE models before metadata should return 404."""
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_unpushed_id}/eflomal-bpe-models",
+        json=_bpe_payload(),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 404
+
+
+def test_push_eflomal_bpe_models_unauthorized(
+    client, regular_token2, test_eflomal_assessment_id
+):
+    """User without access should receive 403."""
+    response = client.post(
+        f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-bpe-models",
+        json=_bpe_payload(),
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Back-compat: pulls on assessments without priors / BPE models should succeed
+# ---------------------------------------------------------------------------
+
+
+def test_pull_eflomal_results_without_priors_or_bpe(
+    client, regular_token1, test_eflomal_assessment_id
+):
+    """Older-style assessments (metadata + core data only) still return 200.
+
+    The test_eflomal_assessment_id fixture receives metadata/dictionary/etc via
+    earlier tests but the dedicated priors/BPE-models tests may or may not have
+    run in the same ordering. Exercise a pull and assert the new fields are
+    present with safe defaults when empty.
+    """
+    # Pull: should always succeed regardless of whether priors/BPE exist
+    response = client.get(
+        f"{prefix}/assessment/eflomal/results",
+        params={"assessment_id": test_eflomal_assessment_id},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert "priors" in data
+    assert isinstance(data["priors"], list)
+    assert "bpe_models" in data  # value may be null if BPE not yet pushed


### PR DESCRIPTION
## Summary
- Add two new artifact tables — `eflomal_prior` and `eflomal_bpe_model` — alongside the existing eflomal artifacts.
- Add `POST /v3/assessment/{id}/eflomal-priors` (chunked, 5k cap) and `POST /v3/assessment/{id}/eflomal-bpe-models` (single call, idempotent on `(assessment_id, direction)`).
- Extend `GET /v3/assessment/eflomal/results` with `priors`, `bpe_models`, and the parent assessment's `revision_id` / `reference_id` so predict() can sample training anchors.

### Notes on diverging from the issue spec
- Field names: issue proposed `revision_revision_id` / `reference_revision_id` — switched to `revision_id` / `reference_id` on review (the stutter was confusing; the issue explicitly invited naming adjustments).
- `alpha` is validated to `[0.5, 0.95]` at both the API (`Field(ge=0.5, le=0.95, allow_inf_nan=False)`) and DB layer (CHECK constraint).
- BPE model base64 payloads are capped at 10 MB decoded per direction (typical size is 100–300 KB).

Back-compat: older assessments with no priors / BPE models continue to return 200 — `priors` is an empty list and `bpe_models` is `null`.

Fixes #573

## Test plan
- [x] `pytest test/test_assessment_routes/test_eflomal_routes.py` — 37/37 pass
- [x] `pytest test/test_assessment_routes/` — all pass
- [x] `black`, `isort`, `flake8` clean on touched files
- [x] `alembic upgrade head` applies cleanly on top of `c9a2f4b7e3d8`
- [ ] Consumer (aqua-assessments runner) wired up after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)