### PR TITLE
fix(eflomal): drop cooccurrences from GET /assessment/eflomal/results

### DIFF
--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -108,11 +108,6 @@ async def _fetch_eflomal_response(
     )
     dictionary_rows = dict_result.scalars().all()
 
-    cooc_result = await db.execute(
-        select(EflomalCooccurrence).where(EflomalCooccurrence.assessment_id == ea_id)
-    )
-    cooccurrence_rows = cooc_result.scalars().all()
-
     twc_result = await db.execute(
         select(EflomalTargetWordCount).where(
             EflomalTargetWordCount.assessment_id == ea_id
@@ -172,15 +167,6 @@ async def _fetch_eflomal_response(
                 probability=r.probability,
             )
             for r in dictionary_rows
-        ],
-        cooccurrences=[
-            EflomalCooccurrenceItem(
-                source_word=r.source_word,
-                target_word=r.target_word,
-                co_occur_count=r.co_occur_count,
-                aligned_count=r.aligned_count,
-            )
-            for r in cooccurrence_rows
         ],
         target_word_counts=[
             EflomalTargetWordCountItem(

--- a/models.py
+++ b/models.py
@@ -1227,7 +1227,6 @@ class EflomalResultsPullResponse(BaseModel):
     reference_id: Optional[int] = None
     revision_id: Optional[int] = None
     dictionary: list[EflomalDictionaryItem]
-    cooccurrences: list[EflomalCooccurrenceItem]
     target_word_counts: list[EflomalTargetWordCountItem]
     priors: list[EflomalPriorItem] = Field(default_factory=list)
     bpe_models: Optional[EflomalBpeModels] = None

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -395,14 +395,6 @@ def test_pull_eflomal_results_success(client, regular_token1, _ensure_eflomal_pu
     assert "count" in first_dict
     assert "probability" in first_dict
 
-    # Cooccurrence entries (n_cooc=20 in _push_all)
-    assert len(data["cooccurrences"]) == 20
-    first_cooc = data["cooccurrences"][0]
-    assert "source_word" in first_cooc
-    assert "target_word" in first_cooc
-    assert "co_occur_count" in first_cooc
-    assert "aligned_count" in first_cooc
-
     # Target word counts (n_twc=5 in _push_all)
     assert len(data["target_word_counts"]) == 5
     first_twc = data["target_word_counts"][0]
@@ -501,7 +493,6 @@ def test_pull_eflomal_results_by_language_success(
     assert data["num_missing_words"] == 3
     assert data["created_at"] is not None
     assert len(data["dictionary"]) == 10
-    assert len(data["cooccurrences"]) == 20
     assert len(data["target_word_counts"]) == 5
     assert len(data["priors"]) == 5
     assert data["bpe_models"] is not None


### PR DESCRIPTION
## Summary

- Removes `cooccurrences` field from the `EflomalResultsPullResponse` model and stops querying/serializing cooccurrence rows in `_fetch_eflomal_response`
- The cooccurrence data is ~95% of the pull response payload but `predict()` never reads it — that code path was dropped in aqua-assessments#191 and no current client consumes it from the API
- The `POST /assessment/{id}/eflomal-cooccurrences` push endpoint and DB table are untouched — data is still stored, just not returned on GET

Closes #575