### PR TITLE
feat(eflomal): replace dictionary with pre-built reverse_dict in results

### DIFF
--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -3,6 +3,8 @@ __version__ = "v3"
 import base64
 import binascii
 import socket
+import unicodedata
+from collections import defaultdict
 from typing import List
 
 import fastapi
@@ -32,6 +34,7 @@ from models import (
     EflomalPriorItem,
     EflomalResultsPullResponse,
     EflomalResultsPushRequest,
+    EflomalReverseDictSource,
     EflomalTargetWordCountItem,
     InsertResponse,
 )
@@ -53,6 +56,20 @@ _MAX_BODY_ITEMS = 5_000
 # BPE model protobufs are typically 100–300 KB each; allow generous headroom
 # but still cap to protect memory / DB.
 _MAX_BPE_MODEL_BYTES = 10 * 1024 * 1024  # 10 MB per direction
+
+# Minimum dictionary count for an entry to appear in reverse_dict. Matches the
+# client-side threshold previously applied in build_reverse_dictionary.
+_REVERSE_DICT_MIN_COUNT = 3
+
+
+def _normalize_word(word: str) -> str:
+    """NFC + casefold + keep Unicode letters / numbers / combining marks.
+
+    Must match the client-side normalize_word in aqua-assessments exactly so
+    that missing-word lookups hit the same keys.
+    """
+    nfc = unicodedata.normalize("NFC", word).casefold()
+    return "".join(ch for ch in nfc if unicodedata.category(ch)[0] in ("L", "N", "M"))
 
 
 def _check_body_size(body):
@@ -96,6 +113,35 @@ async def _batch_insert(db, model_cls, rows):
         result = await db.execute(stmt)
         inserted_ids.extend(r[0] for r in result.fetchall())
     return inserted_ids
+
+
+def _build_reverse_dict(
+    dictionary_rows,
+) -> dict[str, list[EflomalReverseDictSource]]:
+    """Group dictionary rows by normalized target word.
+
+    Rows with count < _REVERSE_DICT_MIN_COUNT are dropped. Source counts
+    sharing a normalized target+source key are summed. Sources are sorted by
+    count descending.
+    """
+    grouped: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for r in dictionary_rows:
+        if r.count < _REVERSE_DICT_MIN_COUNT:
+            continue
+        tgt = _normalize_word(r.target_word)
+        src = _normalize_word(r.source_word)
+        if not tgt or not src:
+            continue
+        grouped[tgt][src] += r.count
+
+    result: dict[str, list[EflomalReverseDictSource]] = {}
+    for tgt, sources in grouped.items():
+        items = [
+            EflomalReverseDictSource(source=src, count=c) for src, c in sources.items()
+        ]
+        items.sort(key=lambda s: s.count, reverse=True)
+        result[tgt] = items
+    return result
 
 
 async def _fetch_eflomal_response(
@@ -159,15 +205,7 @@ async def _fetch_eflomal_response(
         created_at=eflomal.created_at,
         reference_id=reference_id,
         revision_id=revision_id,
-        dictionary=[
-            EflomalDictionaryItem(
-                source_word=r.source_word,
-                target_word=r.target_word,
-                count=r.count,
-                probability=r.probability,
-            )
-            for r in dictionary_rows
-        ],
+        reverse_dict=_build_reverse_dict(dictionary_rows),
         target_word_counts=[
             EflomalTargetWordCountItem(
                 word=r.word,

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -57,19 +57,16 @@ _MAX_BODY_ITEMS = 5_000
 # but still cap to protect memory / DB.
 _MAX_BPE_MODEL_BYTES = 10 * 1024 * 1024  # 10 MB per direction
 
-# Minimum dictionary count for an entry to appear in reverse_dict. Matches the
-# client-side threshold previously applied in build_reverse_dictionary.
 _REVERSE_DICT_MIN_COUNT = 3
 
 
 def _normalize_word(word: str) -> str:
-    """NFC + casefold + keep Unicode letters / numbers / combining marks.
-
-    Must match the client-side normalize_word in aqua-assessments exactly so
-    that missing-word lookups hit the same keys.
-    """
-    nfc = unicodedata.normalize("NFC", word).casefold()
-    return "".join(ch for ch in nfc if unicodedata.category(ch)[0] in ("L", "N", "M"))
+    # casefold can produce non-NFC output (e.g. some CJK/Turkic mappings), so
+    # NFC again after casefold to keep keys byte-identical across clients.
+    folded = unicodedata.normalize("NFC", unicodedata.normalize("NFC", word).casefold())
+    return "".join(
+        ch for ch in folded if unicodedata.category(ch)[0] in ("L", "N", "M")
+    )
 
 
 def _check_body_size(body):
@@ -118,16 +115,8 @@ async def _batch_insert(db, model_cls, rows):
 def _build_reverse_dict(
     dictionary_rows,
 ) -> dict[str, list[EflomalReverseDictSource]]:
-    """Group dictionary rows by normalized target word.
-
-    Rows with count < _REVERSE_DICT_MIN_COUNT are dropped. Source counts
-    sharing a normalized target+source key are summed. Sources are sorted by
-    count descending.
-    """
     grouped: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
     for r in dictionary_rows:
-        if r.count < _REVERSE_DICT_MIN_COUNT:
-            continue
         tgt = _normalize_word(r.target_word)
         src = _normalize_word(r.source_word)
         if not tgt or not src:
@@ -137,8 +126,12 @@ def _build_reverse_dict(
     result: dict[str, list[EflomalReverseDictSource]] = {}
     for tgt, sources in grouped.items():
         items = [
-            EflomalReverseDictSource(source=src, count=c) for src, c in sources.items()
+            EflomalReverseDictSource(source=src, count=c)
+            for src, c in sources.items()
+            if c >= _REVERSE_DICT_MIN_COUNT
         ]
+        if not items:
+            continue
         items.sort(key=lambda s: s.count, reverse=True)
         result[tgt] = items
     return result

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -132,7 +132,7 @@ def _build_reverse_dict(
         ]
         if not items:
             continue
-        items.sort(key=lambda s: s.count, reverse=True)
+        items.sort(key=lambda s: (-s.count, s.source))
         result[tgt] = items
     return result
 

--- a/models.py
+++ b/models.py
@@ -1202,6 +1202,13 @@ class EflomalPriorItem(BaseModel):
     alpha: float = Field(ge=0.5, le=0.95, allow_inf_nan=False)
 
 
+class EflomalReverseDictSource(BaseModel):
+    """One source-word candidate in a reverse_dict entry."""
+
+    source: str
+    count: int
+
+
 class EflomalBpeModels(BaseModel):
     """SentencePiece BPE models (serialized protobuf), one per direction."""
 
@@ -1226,7 +1233,9 @@ class EflomalResultsPullResponse(BaseModel):
     created_at: Optional[datetime.datetime] = None
     reference_id: Optional[int] = None
     revision_id: Optional[int] = None
-    dictionary: list[EflomalDictionaryItem]
+    reverse_dict: dict[str, list["EflomalReverseDictSource"]] = Field(
+        default_factory=dict
+    )
     target_word_counts: list[EflomalTargetWordCountItem]
     priors: list[EflomalPriorItem] = Field(default_factory=list)
     bpe_models: Optional[EflomalBpeModels] = None

--- a/models.py
+++ b/models.py
@@ -1233,7 +1233,7 @@ class EflomalResultsPullResponse(BaseModel):
     created_at: Optional[datetime.datetime] = None
     reference_id: Optional[int] = None
     revision_id: Optional[int] = None
-    reverse_dict: dict[str, list["EflomalReverseDictSource"]] = Field(
+    reverse_dict: dict[str, list[EflomalReverseDictSource]] = Field(
         default_factory=dict
     )
     target_word_counts: list[EflomalTargetWordCountItem]

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -387,13 +387,16 @@ def test_pull_eflomal_results_success(client, regular_token1, _ensure_eflomal_pu
     assert data["num_missing_words"] == 3
     assert data["created_at"] is not None
 
-    # Dictionary entries (n_dict=10 in _push_all)
-    assert len(data["dictionary"]) == 10
-    first_dict = data["dictionary"][0]
-    assert "source_word" in first_dict
-    assert "target_word" in first_dict
-    assert "count" in first_dict
-    assert "probability" in first_dict
+    # reverse_dict is built server-side from dictionary rows with count >= 3,
+    # keyed by normalized target word. _dictionary_items uses counts 1..10, so
+    # 8 entries survive the filter (counts 3..10), each with a single source.
+    assert "dictionary" not in data
+    reverse_dict = data["reverse_dict"]
+    assert len(reverse_dict) == 8
+    # "tgt_2" normalizes to "tgt2" (underscore dropped by NFC+casefold+L|N|M).
+    assert "tgt2" in reverse_dict
+    sources = reverse_dict["tgt2"]
+    assert sources == [{"source": "src2", "count": 3}]
 
     # Target word counts (n_twc=5 in _push_all)
     assert len(data["target_word_counts"]) == 5
@@ -492,7 +495,8 @@ def test_pull_eflomal_results_by_language_success(
     assert data["num_dictionary_entries"] == 10
     assert data["num_missing_words"] == 3
     assert data["created_at"] is not None
-    assert len(data["dictionary"]) == 10
+    assert "dictionary" not in data
+    assert len(data["reverse_dict"]) == 8
     assert len(data["target_word_counts"]) == 5
     assert len(data["priors"]) == 5
     assert data["bpe_models"] is not None

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -9,6 +9,27 @@ from database.models import Assessment
 prefix = "v3"
 
 
+def test_build_reverse_dict_aggregates_and_filters_collisions():
+    """Colliding raw rows aggregate under normalization, then min_count filter."""
+    from types import SimpleNamespace
+
+    from assessment_routes.v3.eflomal_routes import _build_reverse_dict
+
+    rows = [
+        # God+god collide under normalization, summed count 4 >= 3 survives.
+        SimpleNamespace(source_word="God", target_word="Mungu", count=2),
+        SimpleNamespace(source_word="god", target_word="mungu", count=2),
+        # Lord+lord collide too, but summed count 2 < 3 gets filtered out.
+        SimpleNamespace(source_word="Lord", target_word="Mungu", count=1),
+        SimpleNamespace(source_word="lord", target_word="mungu", count=1),
+        # Lone row below threshold is excluded.
+        SimpleNamespace(source_word="spirit", target_word="roho", count=2),
+    ]
+    result = _build_reverse_dict(rows)
+    assert set(result.keys()) == {"mungu"}
+    assert [(s.source, s.count) for s in result["mungu"]] == [("god", 4)]
+
+
 def _prior_items(n=5):
     return [
         {


### PR DESCRIPTION
## Summary
- Build `reverse_dict` server-side from dictionary rows (normalized target → `[{source, count}, ...]`, filtered to `count >= 3`, sorted desc) and drop the raw `dictionary` field from `GET /v3/assessment/eflomal/results`.
- Target payload shrinks ~80% (dictionary was ~10 MB / 83% of the post-#575 response).
- Normalization is NFC + casefold + keep Unicode L/N/M — must stay byte-identical to the aqua-assessments `normalize_word` spec (aqua-assessments#196) so missing-word lookups hit the same keys.

Fixes #577

## Test plan
- [x] `pytest test/test_assessment_routes/test_eflomal_routes.py` (37 passed)
- [ ] aqua-assessments team verifies against localhost:8000 using the new `reverse_dict` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)