### PR TITLE
feat(texts): add limit/random/seed params for anchor sampling

### DIFF
--- a/bible_routes/v3/verse_routes.py
+++ b/bible_routes/v3/verse_routes.py
@@ -1,9 +1,10 @@
 __version__ = "v3"
 
 import pathlib
+import random as random_module
 import unicodedata
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, status
@@ -42,6 +43,15 @@ def _is_range_marker(x):
 
 def _combine_text(field, values):
     return " ".join(v for v in values if v and v != "<range>")
+
+
+def _sample_items(items, limit, random, seed):
+    if limit is None or limit >= len(items):
+        return items
+    if not random:
+        return items[:limit]
+    indices = sorted(random_module.Random(seed).sample(range(len(items)), limit))
+    return [items[i] for i in indices]
 
 
 def extract_unique_words(text: str) -> List[str]:
@@ -760,6 +770,22 @@ async def get_texts(
             "'intersection': only verses where every revision has text."
         ),
     ),
+    limit: Optional[int] = Query(
+        None,
+        ge=1,
+        description="Maximum number of verses to return per revision_id.",
+    ),
+    random: bool = Query(
+        False,
+        description=(
+            "If true, sample uniformly at random (after include_verses filtering) "
+            "instead of returning the first `limit` verses in canonical order."
+        ),
+    ),
+    seed: Optional[int] = Query(
+        None,
+        description="RNG seed for deterministic sampling. Ignored if random=false.",
+    ),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -866,7 +892,8 @@ async def get_texts(
     if include_verses == IncludeVerses.all:
         # Return exactly 41,899 rows per revision — no merging,
         # <range> markers replaced with empty strings
-        for vref in _VREF_LIST:
+        vrefs_to_emit = _sample_items(_VREF_LIST, limit, random, seed)
+        for vref in vrefs_to_emit:
             rev_verses = vref_to_revisions.get(vref, {})
             book, cv = vref.split(" ", 1)
             chapter_str, verse_str = cv.split(":")
@@ -931,6 +958,8 @@ async def get_texts(
         merged_records = [
             r for r in merged_records if any(r[f].strip() for f in text_fields)
         ]
+
+    merged_records = _sample_items(merged_records, limit, random, seed)
 
     for record in merged_records:
         vrefs = record["vrefs"]

--- a/bible_routes/v3/verse_routes.py
+++ b/bible_routes/v3/verse_routes.py
@@ -45,7 +45,9 @@ def _combine_text(field, values):
     return " ".join(v for v in values if v and v != "<range>")
 
 
-def _sample_items(items, limit, random, seed):
+def _sample_items(
+    items: List[Any], limit: Optional[int], random: bool, seed: Optional[int]
+) -> List[Any]:
     if limit is None or limit >= len(items):
         return items
     if not random:
@@ -773,18 +775,27 @@ async def get_texts(
     limit: Optional[int] = Query(
         None,
         ge=1,
-        description="Maximum number of verses to return per revision_id.",
+        description=(
+            "Maximum number of verses to return per revision_id. "
+            "With include_verses='all', limit applies to the 41,899 canonical "
+            "verse slots (so some returned rows may have empty text)."
+        ),
     ),
     random: bool = Query(
         False,
         description=(
             "If true, sample uniformly at random (after include_verses filtering) "
-            "instead of returning the first `limit` verses in canonical order."
+            "instead of returning the first `limit` verses in canonical order. "
+            "Response is still ordered canonically."
         ),
     ),
     seed: Optional[int] = Query(
         None,
-        description="RNG seed for deterministic sampling. Ignored if random=false.",
+        description=(
+            "RNG seed for deterministic sampling. Only meaningful when "
+            "random=true; ignored otherwise. If omitted with random=true, "
+            "sampling is non-deterministic."
+        ),
     ),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
@@ -800,6 +811,15 @@ async def get_texts(
     Description: List of revision IDs to fetch (minimum 2).
     - include_verses: IncludeVerses (all|union|intersection, default "union")
     Description: Which verses to include in the response.
+    - limit: Optional[int]
+    Description: Maximum number of verses per revision_id. Sampling happens
+    after include_verses filtering and <range> merging.
+    - random: bool (default false)
+    Description: If true, sample uniformly at random; otherwise return the
+    first `limit` verses in canonical order.
+    - seed: Optional[int]
+    Description: RNG seed. Combined with random=true, two calls with the
+    same seed return the same sample. Ignored if random=false.
 
     Returns:
     Dict[str, List[VerseText]]: Dictionary keyed by revision_id (as string),

--- a/test/test_bible_routes/test_verse_routes.py
+++ b/test/test_bible_routes/test_verse_routes.py
@@ -1731,7 +1731,7 @@ def test_texts_endpoint_limit_without_random(client, regular_token1, db_session)
     assert len(data[str(revision_id1)]) == 5
     assert len(data[str(revision_id2)]) == 5
     # First verse should be the canonical first
-    assert data[str(revision_id1)][0]["verse_references"][0] == "GEN 1:1"
+    assert data[str(revision_id1)][0]["verse_reference"] == "GEN 1:1"
 
 
 def test_texts_endpoint_random_sample_deterministic(client, regular_token1, db_session):
@@ -1761,6 +1761,7 @@ def test_texts_endpoint_random_sample_deterministic(client, regular_token1, db_s
     # Different seed should give different sample
     params_alt = {**params, "seed": 99999}
     r3 = client.get(f"/{prefix}/texts", params=params_alt, headers=headers)
+    assert r3.status_code == 200
     refs3 = [v["verse_reference"] for v in r3.json()[str(revision_id1)]]
     assert refs1 != refs3
 

--- a/test/test_bible_routes/test_verse_routes.py
+++ b/test/test_bible_routes/test_verse_routes.py
@@ -1708,3 +1708,83 @@ def test_texts_include_verses_whitespace_treated_as_empty(
 
     # GEN 1:3 should be excluded (whitespace-only = empty)
     assert "GEN 1:3" not in rev1_vrefs
+
+
+def test_texts_endpoint_limit_without_random(client, regular_token1, db_session):
+    """Test /texts with ?limit returns the first N verses in canonical order."""
+    version_id1 = create_bible_version(client, regular_token1, db_session)
+    version_id2 = create_bible_version(client, regular_token1, db_session)
+    revision_id1 = upload_revision(client, regular_token1, version_id1)
+    revision_id2 = upload_revision(client, regular_token1, version_id2)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    response = client.get(
+        f"/{prefix}/texts",
+        params={
+            "revision_ids": [revision_id1, revision_id2],
+            "limit": 5,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data[str(revision_id1)]) == 5
+    assert len(data[str(revision_id2)]) == 5
+    # First verse should be the canonical first
+    assert data[str(revision_id1)][0]["verse_references"][0] == "GEN 1:1"
+
+
+def test_texts_endpoint_random_sample_deterministic(client, regular_token1, db_session):
+    """Test /texts with ?random&seed returns the same sample on repeat calls."""
+    version_id1 = create_bible_version(client, regular_token1, db_session)
+    version_id2 = create_bible_version(client, regular_token1, db_session)
+    revision_id1 = upload_revision(client, regular_token1, version_id1)
+    revision_id2 = upload_revision(client, regular_token1, version_id2)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    params = {
+        "revision_ids": [revision_id1, revision_id2],
+        "limit": 10,
+        "random": "true",
+        "seed": 17087,
+    }
+    r1 = client.get(f"/{prefix}/texts", params=params, headers=headers)
+    r2 = client.get(f"/{prefix}/texts", params=params, headers=headers)
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    d1, d2 = r1.json(), r2.json()
+    assert len(d1[str(revision_id1)]) == 10
+    refs1 = [v["verse_reference"] for v in d1[str(revision_id1)]]
+    refs2 = [v["verse_reference"] for v in d2[str(revision_id1)]]
+    assert refs1 == refs2
+
+    # Different seed should give different sample
+    params_alt = {**params, "seed": 99999}
+    r3 = client.get(f"/{prefix}/texts", params=params_alt, headers=headers)
+    refs3 = [v["verse_reference"] for v in r3.json()[str(revision_id1)]]
+    assert refs1 != refs3
+
+
+def test_texts_endpoint_limit_with_include_verses_all(
+    client, regular_token1, db_session
+):
+    """Test /texts with ?limit respects include_verses=all."""
+    version_id1 = create_bible_version(client, regular_token1, db_session)
+    version_id2 = create_bible_version(client, regular_token1, db_session)
+    revision_id1 = upload_revision(client, regular_token1, version_id1)
+    revision_id2 = upload_revision(client, regular_token1, version_id2)
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    response = client.get(
+        f"/{prefix}/texts",
+        params={
+            "revision_ids": [revision_id1, revision_id2],
+            "include_verses": "all",
+            "limit": 3,
+        },
+        headers=headers,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data[str(revision_id1)]) == 3
+    assert len(data[str(revision_id2)]) == 3


### PR DESCRIPTION
## Summary
- Add optional `limit`, `random`, `seed` query params to `GET /v3/texts`.
- Sampling runs after `include_verses` filtering and `<range>` merging; canonical ordering is preserved in the response. `random=true` with a shared `seed` is deterministic across calls.
- Enables aqua-assessments to fetch ~200 anchors instead of ~9,571 verse pairs on cold predict.

Fixes #579

## Test plan
- [x] New: first-N (no random) returns canonical-order prefix
- [x] New: `random=true` + `seed` is deterministic; different seed yields different sample
- [x] New: `include_verses=all` + `limit` returns `limit` rows per revision
- [x] All 14 existing `/texts` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)