### PR TITLE
feat(train): orchestrator signals training mode via config.is_training

### DIFF
--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -300,7 +300,7 @@ def test_training_job_full_lifecycle_via_runner(
     """End-to-end lifecycle via the runner (acceptance item for #582).
 
     (1) POST /train dispatches to ("runner", "run_assessment_runner") with
-        an AssessmentIn-shaped config and train_job_id kwarg.
+        an AssessmentIn-shaped config carrying is_training=True.
     (2) PATCH /train/{id}/status accepts the full phase sequence the
         runner emits: preparing → training → downloading → uploading →
         completed.
@@ -332,8 +332,9 @@ def test_training_job_full_lifecycle_via_runner(
     config = args[0]
     assert config["type"] == "tfidf"
     assert config["id"] == job["assessment_id"]
-    assert "train" not in config  # training mode is signaled by train_job_id kwarg
-    assert kwargs.get("train_job_id") == job["id"]
+    assert "train" not in config  # training mode is signaled by is_training on config
+    assert config.get("is_training") is True
+    assert "train_job_id" not in kwargs
 
     # (2) Simulate the runner's phase callbacks on the status endpoint.
     last_percent = {
@@ -1087,13 +1088,13 @@ def test_training_job_creates_assessment_for_trainable_types(
         assert assessment.is_training is True
 
 
-def test_trainable_types_route_through_runner_with_train_job_id(
+def test_trainable_types_route_through_runner_with_is_training(
     client, regular_token1, test_revision_id, test_revision_id_2
 ):
     """Every non-serval-nmt training type must dispatch through
     ("runner", "run_assessment_runner") with an AssessmentIn-shaped
-    config and train_job_id passed as a kwarg. Asserts both the dispatch
-    target and the train_job_id/assessment_id identity on the payload.
+    config carrying is_training=True. Asserts both the dispatch target
+    and the assessment_id identity on the payload.
     """
     calls = []
     payloads = []
@@ -1137,12 +1138,13 @@ def test_trainable_types_route_through_runner_with_train_job_id(
         assert config["id"] == jobs[t]["assessment_id"]
         assert config["revision_id"] == test_revision_id
         assert config["reference_id"] == test_revision_id_2
-        # Training mode is signaled by the train_job_id kwarg, not by a
-        # config["train"] flag — that used to be required by sem-sim's
-        # assess() but has been superseded by a `finetune` kwarg that
-        # callers opt into via /v3/train options.
+        # Training mode is signaled by is_training=True on the config
+        # dict, not by a config["train"] flag — that used to be required
+        # by sem-sim's assess() but has been superseded by a `finetune`
+        # kwarg that callers opt into via /v3/train options.
         assert "train" not in config
-        assert kwargs.get("train_job_id") == jobs[t]["id"]
+        assert config.get("is_training") is True
+        assert "train_job_id" not in kwargs
 
 
 def test_completed_mirrors_to_assessment_finished(

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -108,12 +108,12 @@ def _build_runner_train_config(
     artifact-push URLs like `/v3/assessment/{id}/results`, which are keyed
     on Assessment.id.
 
-    `train_job_id` is NOT in this dict — it's passed as a kwarg on spawn
-    and is what makes the runner switch to training mode and emit phase
-    callbacks (preparing → training → downloading → uploading →
-    completed/failed) to PATCH /v3/train/{id}/status. Per-app behavior
-    toggles (e.g. sem-sim's `finetune`) flow through the caller's
-    `options` → `config["kwargs"]` — aqua-api doesn't hard-code them.
+    `is_training=True` is the single signal the runner keys on to emit the
+    phased status sequence (preparing → training → downloading → uploading
+    → finished) against PATCH /v3/assessment/{id}/status. Per-app
+    behaviour toggles (e.g. sem-sim's `finetune`) flow through the
+    caller's `options` → `config["kwargs"]` — aqua-api doesn't hard-code
+    them.
     """
     config = {
         "id": job.assessment_id,
@@ -122,6 +122,7 @@ def _build_runner_train_config(
         "type": job.type,
         "source_language": source_language,
         "target_language": target_language,
+        "is_training": True,
     }
     if options:
         config["kwargs"] = options
@@ -364,10 +365,11 @@ async def create_training_job(
                 job_out = TrainingJobOut.model_validate(job)
                 await f.spawn.aio(job_out.model_dump(mode="json"))
             elif job.type in TRAINABLE_ASSESSMENT_TYPES:
-                # Runner's train_job_id path: dispatches to the right app's
-                # assess() based on config.type and emits the phase callbacks
-                # (preparing → training → downloading → uploading →
-                # completed/failed) against PATCH /v3/train/{id}/status.
+                # Runner dispatches to the right app's assess() based on
+                # config.type and, because config["is_training"] is True,
+                # emits the phased status sequence (preparing → training →
+                # downloading → uploading → finished/failed) against
+                # PATCH /v3/assessment/{id}/status.
                 f = modal.Function.from_name(
                     "runner", "run_assessment_runner", environment_name=modal_env
                 )
@@ -379,7 +381,7 @@ async def create_training_job(
                     target_language,
                     job_in.options,
                 )
-                await f.spawn.aio(config, os.getenv("AQUA_DB", ""), train_job_id=job.id)
+                await f.spawn.aio(config, os.getenv("AQUA_DB", ""))
             else:
                 raise RuntimeError(
                     f"No dispatch configured for training type '{job.type}'"


### PR DESCRIPTION
## Summary

Follow-up to aqua-assessments#202 / this repo's #584: the runner no longer accepts the \`train_job_id\` kwarg. The orchestrator was still passing it, which would fail every \`POST /v3/train\` spawn inside the Modal worker with \`TypeError: run_assessment_runner() got an unexpected keyword argument 'train_job_id'\`.

- \`_build_runner_train_config\` sets \`is_training=True\` on the config dict — the runner's new single signal for phased status emission.
- Drop the \`train_job_id\` kwarg from \`f.spawn.aio\`.
- Update the two tests that asserted on the kwarg to assert on the config flag instead. \`test_trainable_types_route_through_runner_with_train_job_id\` → \`..._with_is_training\`.

## Test plan

- [x] \`ruff check --ignore E501 .\` clean
- [x] \`pytest test/test_train_routes/\` — 47 pass locally
- [ ] Dev end-to-end training run once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)