### PR TITLE
feat(tfidf): chunked upload for SVD artifacts

### DIFF
--- a/alembic/migrations/versions/f8a2c3d4e5b6_add_tfidf_svd_staging_tables.py
+++ b/alembic/migrations/versions/f8a2c3d4e5b6_add_tfidf_svd_staging_tables.py
@@ -9,7 +9,6 @@ Create Date: 2026-04-24 19:00:00.000000
 from typing import Sequence, Union
 
 import sqlalchemy as sa
-from sqlalchemy.dialects import postgresql
 
 from alembic import op
 
@@ -21,11 +20,14 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    # gen_random_uuid() is a core function in PostgreSQL 13+ (no pgcrypto
+    # extension required). Earlier Postgres versions will fail CREATE TABLE
+    # with "function gen_random_uuid() does not exist".
     op.create_table(
         "tfidf_svd_staging",
         sa.Column(
             "upload_id",
-            postgresql.UUID(as_uuid=True),
+            sa.dialects.postgresql.UUID(as_uuid=True),
             server_default=sa.text("gen_random_uuid()"),
             nullable=False,
         ),
@@ -36,21 +38,33 @@ def upgrade() -> None:
         sa.Column("sklearn_version", sa.Text(), nullable=False),
         sa.Column(
             "word_vocabulary",
-            postgresql.JSONB(astext_type=sa.Text()),
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
             nullable=False,
         ),
-        sa.Column("word_idf", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column(
-            "word_params", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+            "word_idf",
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "word_params",
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
         ),
         sa.Column(
             "char_vocabulary",
-            postgresql.JSONB(astext_type=sa.Text()),
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
             nullable=False,
         ),
-        sa.Column("char_idf", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
         sa.Column(
-            "char_params", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+            "char_idf",
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column(
+            "char_params",
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
         ),
         sa.Column("svd_n_components", sa.Integer(), nullable=False),
         sa.Column("svd_n_features", sa.Integer(), nullable=False),
@@ -82,7 +96,9 @@ def upgrade() -> None:
 
     op.create_table(
         "tfidf_svd_chunk",
-        sa.Column("upload_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "upload_id", sa.dialects.postgresql.UUID(as_uuid=True), nullable=False
+        ),
         sa.Column("chunk_index", sa.Integer(), nullable=False),
         sa.Column("components_bytes", sa.LargeBinary(), nullable=False),
         sa.Column(

--- a/alembic/migrations/versions/f8a2c3d4e5b6_add_tfidf_svd_staging_tables.py
+++ b/alembic/migrations/versions/f8a2c3d4e5b6_add_tfidf_svd_staging_tables.py
@@ -1,0 +1,107 @@
+"""add tfidf svd staging tables for chunked upload
+
+Revision ID: f8a2c3d4e5b6
+Revises: e5b8c9d2f7a3
+Create Date: 2026-04-24 19:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "f8a2c3d4e5b6"
+down_revision: Union[str, None] = "e5b8c9d2f7a3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tfidf_svd_staging",
+        sa.Column(
+            "upload_id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("assessment_id", sa.Integer(), nullable=False),
+        sa.Column("source_language", sa.String(length=3), nullable=True),
+        sa.Column("n_components", sa.Integer(), nullable=False),
+        sa.Column("n_corpus_vrefs", sa.Integer(), nullable=False),
+        sa.Column("sklearn_version", sa.Text(), nullable=False),
+        sa.Column(
+            "word_vocabulary",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("word_idf", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "word_params", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
+        sa.Column(
+            "char_vocabulary",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+        ),
+        sa.Column("char_idf", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column(
+            "char_params", postgresql.JSONB(astext_type=sa.Text()), nullable=False
+        ),
+        sa.Column("svd_n_components", sa.Integer(), nullable=False),
+        sa.Column("svd_n_features", sa.Integer(), nullable=False),
+        sa.Column("svd_dtype", sa.Text(), nullable=False),
+        sa.Column("total_chunks", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["assessment_id"], ["assessment.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("upload_id"),
+    )
+    op.create_index(
+        "ix_tfidf_svd_staging_assessment",
+        "tfidf_svd_staging",
+        ["assessment_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_tfidf_svd_staging_created_at",
+        "tfidf_svd_staging",
+        ["created_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "tfidf_svd_chunk",
+        sa.Column("upload_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("chunk_index", sa.Integer(), nullable=False),
+        sa.Column("components_bytes", sa.LargeBinary(), nullable=False),
+        sa.Column(
+            "received_at",
+            sa.TIMESTAMP(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(
+            ["upload_id"],
+            ["tfidf_svd_staging.upload_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("upload_id", "chunk_index"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("tfidf_svd_chunk")
+    op.drop_index("ix_tfidf_svd_staging_created_at", table_name="tfidf_svd_staging")
+    op.drop_index("ix_tfidf_svd_staging_assessment", table_name="tfidf_svd_staging")
+    op.drop_table("tfidf_svd_staging")

--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -2,13 +2,17 @@ __version__ = "v3"
 
 import base64
 import binascii
+import io
 import socket
 import time
+import uuid
 from typing import Dict, List, Union
 
 import fastapi
+import numpy as np
 from fastapi import Depends, HTTPException, status
-from sqlalchemy import Float, cast, delete, desc, select, text
+from sqlalchemy import Float, cast, delete, desc, func, select, text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -19,6 +23,8 @@ from database.models import (
     TfidfArtifactRun,
     TfidfPcaVector,
     TfidfSvd,
+    TfidfSvdChunk,
+    TfidfSvdStaging,
     TfidfVectorizerArtifact,
 )
 from database.models import UserDB as UserModel
@@ -27,6 +33,13 @@ from database.models import (
 )
 from models import (
     TFIDF_MAX_BATCH_RESULTS,
+    TfidfArtifactsAbortRequest,
+    TfidfArtifactsAbortResponse,
+    TfidfArtifactsChunkRequest,
+    TfidfArtifactsChunkResponse,
+    TfidfArtifactsCommitRequest,
+    TfidfArtifactsInitRequest,
+    TfidfArtifactsInitResponse,
     TfidfArtifactsPullResponse,
     TfidfArtifactsPushRequest,
     TfidfArtifactsPushResponse,
@@ -51,9 +64,20 @@ router = fastapi.APIRouter()
 # overhead without letting a single request dominate API memory.
 _MAX_COMPONENTS_BYTES = 200 * 1024 * 1024
 
+# Per-chunk cap for the chunked upload path. Keeps any individual POST well
+# under platform/proxy limits even when the aggregate matrix is multi-GB.
+_MAX_CHUNK_BYTES = 100 * 1024 * 1024
+
 # TfidfPcaVector.vector is declared Vector(300); queries against the corpus
 # must always be 300-dim regardless of what artifact metadata claims.
 _CORPUS_VECTOR_DIM = 300
+
+
+def _parse_upload_id(raw: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(raw)
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(status_code=422, detail=f"Invalid upload_id: {raw!r}")
 
 
 async def _rank_against_corpus(
@@ -297,6 +321,435 @@ async def push_tfidf_artifacts(
         n_word_features=n_word_features,
         n_char_features=n_char_features,
         components_bytes=len(components_bytes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chunked upload — for SVD matrices that exceed the single-POST cap.
+# Flow: init → chunks (N POSTs) → commit. Abort drops an in-flight upload.
+# ---------------------------------------------------------------------------
+
+
+async def _load_tfidf_assessment_for_upload(
+    assessment_id: int, current_user: UserModel, db: AsyncSession
+) -> Assessment:
+    """Common guard for init/commit: assessment exists, is tfidf, user authorized."""
+    assessment = await db.scalar(
+        select(Assessment).where(Assessment.id == assessment_id).limit(1)
+    )
+    if assessment is None:
+        raise HTTPException(status_code=404, detail="Assessment not found")
+    if assessment.type != "tfidf":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Assessment type must be 'tfidf', got '{assessment.type}'",
+        )
+    if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
+        raise HTTPException(
+            status_code=403, detail="Not authorized for this assessment"
+        )
+    return assessment
+
+
+def _validate_vectorizer_shapes(body: TfidfArtifactsInitRequest) -> tuple[int, int]:
+    n_word_features = len(body.word_vectorizer.vocabulary)
+    n_char_features = len(body.char_vectorizer.vocabulary)
+    if n_word_features != len(body.word_vectorizer.idf):
+        raise HTTPException(
+            status_code=422,
+            detail="word_vectorizer.vocabulary and idf must have the same length",
+        )
+    if n_char_features != len(body.char_vectorizer.idf):
+        raise HTTPException(
+            status_code=422,
+            detail="char_vectorizer.vocabulary and idf must have the same length",
+        )
+    if body.n_components != body.svd.n_components:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"body.n_components ({body.n_components}) must equal "
+                f"svd.n_components ({body.svd.n_components})"
+            ),
+        )
+    if body.svd.n_features != n_word_features + n_char_features:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"svd.n_features ({body.svd.n_features}) must equal "
+                f"n_word_features + n_char_features ({n_word_features + n_char_features})"
+            ),
+        )
+    return n_word_features, n_char_features
+
+
+@router.post(
+    "/assessment/{assessment_id}/tfidf-artifacts/init",
+    response_model=TfidfArtifactsInitResponse,
+)
+async def init_tfidf_artifacts_upload(
+    assessment_id: int,
+    body: TfidfArtifactsInitRequest,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Start a chunked TF-IDF artifact upload.
+
+    Creates a staging row with the vectorizer and SVD metadata. Returns an
+    upload_id that the caller uses to POST chunks and finally commit.
+    """
+    await _load_tfidf_assessment_for_upload(assessment_id, current_user, db)
+    _validate_vectorizer_shapes(body)
+
+    staging = TfidfSvdStaging(
+        assessment_id=assessment_id,
+        source_language=body.source_language,
+        n_components=body.n_components,
+        n_corpus_vrefs=body.n_corpus_vrefs,
+        sklearn_version=body.sklearn_version,
+        word_vocabulary=body.word_vectorizer.vocabulary,
+        word_idf=body.word_vectorizer.idf,
+        word_params=body.word_vectorizer.params,
+        char_vocabulary=body.char_vectorizer.vocabulary,
+        char_idf=body.char_vectorizer.idf,
+        char_params=body.char_vectorizer.params,
+        svd_n_components=body.svd.n_components,
+        svd_n_features=body.svd.n_features,
+        svd_dtype=body.svd.dtype,
+        total_chunks=body.total_chunks,
+    )
+    try:
+        db.add(staging)
+        await db.commit()
+        await db.refresh(staging)
+    except SQLAlchemyError:
+        logger.exception(
+            "Failed to open tfidf staging upload, assessment_id=%s", assessment_id
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to open staging upload for assessment {assessment_id}",
+        )
+
+    return TfidfArtifactsInitResponse(
+        upload_id=str(staging.upload_id),
+        assessment_id=assessment_id,
+        total_chunks=body.total_chunks,
+    )
+
+
+@router.post(
+    "/assessment/{assessment_id}/tfidf-artifacts/chunks",
+    response_model=TfidfArtifactsChunkResponse,
+)
+async def upload_tfidf_artifact_chunk(
+    assessment_id: int,
+    body: TfidfArtifactsChunkRequest,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Push one chunk of SVD components. Idempotent per (upload_id, chunk_index)."""
+    upload_id = _parse_upload_id(body.upload_id)
+
+    staging = await db.scalar(
+        select(TfidfSvdStaging).where(TfidfSvdStaging.upload_id == upload_id)
+    )
+    if staging is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
+    if staging.assessment_id != assessment_id:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"upload_id belongs to assessment {staging.assessment_id}, "
+                f"not {assessment_id}"
+            ),
+        )
+    if not await is_user_authorized_for_assessment(
+        current_user.id, staging.assessment_id, db
+    ):
+        raise HTTPException(
+            status_code=403, detail="Not authorized for this assessment"
+        )
+    if body.chunk_index >= staging.total_chunks:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"chunk_index {body.chunk_index} out of range for "
+                f"total_chunks={staging.total_chunks}"
+            ),
+        )
+
+    try:
+        chunk_bytes = base64.b64decode(body.components_b64, validate=True)
+    except (binascii.Error, ValueError) as e:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid base64 in components_b64: {e}",
+        )
+    if len(chunk_bytes) > _MAX_CHUNK_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"chunk decoded to {len(chunk_bytes)} bytes, "
+                f"over the {_MAX_CHUNK_BYTES}-byte per-chunk limit"
+            ),
+        )
+
+    stmt = (
+        pg_insert(TfidfSvdChunk)
+        .values(
+            upload_id=upload_id,
+            chunk_index=body.chunk_index,
+            components_bytes=chunk_bytes,
+        )
+        .on_conflict_do_update(
+            index_elements=["upload_id", "chunk_index"],
+            set_={
+                "components_bytes": chunk_bytes,
+                "received_at": func.now(),
+            },
+        )
+    )
+    try:
+        await db.execute(stmt)
+        chunks_received = await db.scalar(
+            select(func.count())
+            .select_from(TfidfSvdChunk)
+            .where(TfidfSvdChunk.upload_id == upload_id)
+        )
+        await db.commit()
+    except SQLAlchemyError:
+        logger.exception("Failed to persist tfidf chunk, upload_id=%s", upload_id)
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to persist chunk {body.chunk_index}",
+        )
+
+    return TfidfArtifactsChunkResponse(
+        upload_id=str(upload_id),
+        chunk_index=body.chunk_index,
+        bytes_received=len(chunk_bytes),
+        chunks_received=int(chunks_received or 0),
+        total_chunks=staging.total_chunks,
+    )
+
+
+@router.post(
+    "/assessment/{assessment_id}/tfidf-artifacts/commit",
+    response_model=TfidfArtifactsPushResponse,
+)
+async def commit_tfidf_artifacts_upload(
+    assessment_id: int,
+    body: TfidfArtifactsCommitRequest,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Reassemble staged chunks and materialise final artifact rows.
+
+    Validates all total_chunks chunks are present, vstacks them into a single
+    components_ matrix, and writes the TfidfArtifactRun + vectorizer + SVD rows
+    in one transaction. Existing artifacts for the assessment are replaced.
+    """
+    upload_id = _parse_upload_id(body.upload_id)
+
+    staging = await db.scalar(
+        select(TfidfSvdStaging).where(TfidfSvdStaging.upload_id == upload_id)
+    )
+    if staging is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
+    if staging.assessment_id != assessment_id:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"upload_id belongs to assessment {staging.assessment_id}, "
+                f"not {assessment_id}"
+            ),
+        )
+    await _load_tfidf_assessment_for_upload(assessment_id, current_user, db)
+
+    chunk_rows = (
+        await db.execute(
+            select(TfidfSvdChunk.chunk_index, TfidfSvdChunk.components_bytes)
+            .where(TfidfSvdChunk.upload_id == upload_id)
+            .order_by(TfidfSvdChunk.chunk_index)
+        )
+    ).all()
+    if len(chunk_rows) != staging.total_chunks:
+        present = {row.chunk_index for row in chunk_rows}
+        missing = sorted(set(range(staging.total_chunks)) - present)
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"expected {staging.total_chunks} chunks, got {len(chunk_rows)} "
+                f"(missing: {missing})"
+            ),
+        )
+
+    try:
+        slabs = [
+            np.load(io.BytesIO(row.components_bytes), allow_pickle=False)
+            for row in chunk_rows
+        ]
+    except (ValueError, OSError) as e:
+        raise HTTPException(
+            status_code=422, detail=f"Chunk is not a valid .npy payload: {e}"
+        )
+
+    expected_dtype = np.dtype(staging.svd_dtype)
+    for idx, slab in enumerate(slabs):
+        if slab.ndim != 2 or slab.shape[1] != staging.svd_n_features:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"chunk {idx} has shape {slab.shape}; expected "
+                    f"(*, {staging.svd_n_features})"
+                ),
+            )
+        if slab.dtype != expected_dtype:
+            raise HTTPException(
+                status_code=422,
+                detail=(
+                    f"chunk {idx} has dtype {slab.dtype}; expected " f"{expected_dtype}"
+                ),
+            )
+
+    combined = np.vstack(slabs) if slabs else np.empty((0, staging.svd_n_features))
+    if combined.shape != (staging.svd_n_components, staging.svd_n_features):
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"reassembled shape {combined.shape} does not match declared "
+                f"({staging.svd_n_components}, {staging.svd_n_features})"
+            ),
+        )
+
+    buf = io.BytesIO()
+    np.save(buf, combined, allow_pickle=False)
+    components_npy = buf.getvalue()
+
+    n_word_features = len(staging.word_vocabulary)
+    n_char_features = len(staging.char_vocabulary)
+
+    try:
+        await db.execute(
+            delete(TfidfArtifactRun).where(
+                TfidfArtifactRun.assessment_id == assessment_id
+            )
+        )
+        db.add(
+            TfidfArtifactRun(
+                assessment_id=assessment_id,
+                source_language=staging.source_language,
+                n_components=staging.n_components,
+                n_word_features=n_word_features,
+                n_char_features=n_char_features,
+                n_corpus_vrefs=staging.n_corpus_vrefs,
+                sklearn_version=staging.sklearn_version,
+            )
+        )
+        await db.flush()
+        db.add(
+            TfidfVectorizerArtifact(
+                assessment_id=assessment_id,
+                kind="word",
+                vocabulary=staging.word_vocabulary,
+                idf=staging.word_idf,
+                params=staging.word_params,
+            )
+        )
+        db.add(
+            TfidfVectorizerArtifact(
+                assessment_id=assessment_id,
+                kind="char",
+                vocabulary=staging.char_vocabulary,
+                idf=staging.char_idf,
+                params=staging.char_params,
+            )
+        )
+        db.add(
+            TfidfSvd(
+                assessment_id=assessment_id,
+                n_components=staging.svd_n_components,
+                n_features=staging.svd_n_features,
+                components_npy=components_npy,
+                dtype=staging.svd_dtype,
+            )
+        )
+        await db.execute(
+            delete(TfidfSvdStaging).where(TfidfSvdStaging.upload_id == upload_id)
+        )
+        await db.commit()
+    except SQLAlchemyError:
+        logger.exception(
+            "Failed to commit tfidf chunked upload, upload_id=%s", upload_id
+        )
+        await db.rollback()
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to commit tfidf upload for assessment {assessment_id}",
+        )
+
+    return TfidfArtifactsPushResponse(
+        assessment_id=assessment_id,
+        n_word_features=n_word_features,
+        n_char_features=n_char_features,
+        components_bytes=len(components_npy),
+    )
+
+
+@router.post(
+    "/assessment/{assessment_id}/tfidf-artifacts/abort",
+    response_model=TfidfArtifactsAbortResponse,
+)
+async def abort_tfidf_artifacts_upload(
+    assessment_id: int,
+    body: TfidfArtifactsAbortRequest,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Cancel an in-flight chunked upload and drop its staged chunks."""
+    upload_id = _parse_upload_id(body.upload_id)
+
+    staging = await db.scalar(
+        select(TfidfSvdStaging).where(TfidfSvdStaging.upload_id == upload_id)
+    )
+    if staging is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
+    if staging.assessment_id != assessment_id:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"upload_id belongs to assessment {staging.assessment_id}, "
+                f"not {assessment_id}"
+            ),
+        )
+    if not await is_user_authorized_for_assessment(
+        current_user.id, staging.assessment_id, db
+    ):
+        raise HTTPException(
+            status_code=403, detail="Not authorized for this assessment"
+        )
+
+    chunks_removed = await db.scalar(
+        select(func.count())
+        .select_from(TfidfSvdChunk)
+        .where(TfidfSvdChunk.upload_id == upload_id)
+    )
+    try:
+        await db.execute(
+            delete(TfidfSvdStaging).where(TfidfSvdStaging.upload_id == upload_id)
+        )
+        await db.commit()
+    except SQLAlchemyError:
+        logger.exception("Failed to abort tfidf upload, upload_id=%s", upload_id)
+        await db.rollback()
+        raise HTTPException(status_code=500, detail="Failed to abort upload")
+
+    return TfidfArtifactsAbortResponse(
+        upload_id=str(upload_id),
+        chunks_removed=int(chunks_removed or 0),
     )
 
 

--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -461,11 +461,17 @@ async def upload_tfidf_artifact_chunk(
             status_code=403, detail="Not authorized for this assessment"
         )
 
+    # FOR KEY SHARE conflicts with the commit endpoint's FOR UPDATE lock, so
+    # a commit in progress forces this chunk write to wait (or, if commit
+    # already finished and deleted staging, returns 404 cleanly) instead of
+    # racing into an FK-violation 500 on the cascaded tfidf_svd_chunk delete.
     staging = await db.scalar(
-        select(TfidfSvdStaging).where(
+        select(TfidfSvdStaging)
+        .where(
             TfidfSvdStaging.upload_id == upload_id,
             TfidfSvdStaging.assessment_id == assessment_id,
         )
+        .with_for_update(key_share=True)
     )
     if staging is None:
         raise HTTPException(status_code=404, detail="Upload not found")
@@ -607,7 +613,8 @@ async def commit_tfidf_artifacts_upload(
 
     # np.save preserves byte order in the header, so dtype equality rejects
     # big-endian clients even though the numeric type matches. Compare by
-    # kind+itemsize instead.
+    # kind+itemsize, then normalise to expected_dtype so the persisted .npy
+    # bytes match the declared svd_dtype metadata exactly.
     expected_dtype = np.dtype(staging.svd_dtype)
     for idx, slab in enumerate(slabs):
         if slab.ndim != 2 or slab.shape[1] != staging.svd_n_features:
@@ -628,6 +635,8 @@ async def commit_tfidf_artifacts_upload(
                     f"chunk {idx} has dtype {slab.dtype}; expected " f"{expected_dtype}"
                 ),
             )
+        if slab.dtype != expected_dtype:
+            slabs[idx] = slab.astype(expected_dtype, copy=False)
 
     combined = np.vstack(slabs) if slabs else np.empty((0, staging.svd_n_features))
     if combined.shape != (staging.svd_n_components, staging.svd_n_features):

--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -32,6 +32,7 @@ from database.models import (
     VerseText,
 )
 from models import (
+    TFIDF_CORPUS_VECTOR_DIM,
     TFIDF_MAX_BATCH_RESULTS,
     TfidfArtifactsAbortRequest,
     TfidfArtifactsAbortResponse,
@@ -70,7 +71,7 @@ _MAX_CHUNK_BYTES = 100 * 1024 * 1024
 
 # TfidfPcaVector.vector is declared Vector(300); queries against the corpus
 # must always be 300-dim regardless of what artifact metadata claims.
-_CORPUS_VECTOR_DIM = 300
+# Imported as TFIDF_CORPUS_VECTOR_DIM from models.py.
 
 
 def _parse_upload_id(raw: str) -> uuid.UUID:
@@ -351,7 +352,7 @@ async def _load_tfidf_assessment_for_upload(
     return assessment
 
 
-def _validate_vectorizer_shapes(body: TfidfArtifactsInitRequest) -> tuple[int, int]:
+def _validate_vectorizer_shapes(body: TfidfArtifactsInitRequest) -> None:
     n_word_features = len(body.word_vectorizer.vocabulary)
     n_char_features = len(body.char_vectorizer.vocabulary)
     if n_word_features != len(body.word_vectorizer.idf):
@@ -380,7 +381,6 @@ def _validate_vectorizer_shapes(body: TfidfArtifactsInitRequest) -> tuple[int, i
                 f"n_word_features + n_char_features ({n_word_features + n_char_features})"
             ),
         )
-    return n_word_features, n_char_features
 
 
 @router.post(
@@ -440,7 +440,7 @@ async def init_tfidf_artifacts_upload(
 
 
 @router.post(
-    "/assessment/{assessment_id}/tfidf-artifacts/chunks",
+    "/assessment/{assessment_id}/tfidf-artifacts/chunk",
     response_model=TfidfArtifactsChunkResponse,
 )
 async def upload_tfidf_artifact_chunk(
@@ -452,25 +452,23 @@ async def upload_tfidf_artifact_chunk(
     """Push one chunk of SVD components. Idempotent per (upload_id, chunk_index)."""
     upload_id = _parse_upload_id(body.upload_id)
 
-    staging = await db.scalar(
-        select(TfidfSvdStaging).where(TfidfSvdStaging.upload_id == upload_id)
-    )
-    if staging is None:
-        raise HTTPException(status_code=404, detail="Upload not found")
-    if staging.assessment_id != assessment_id:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"upload_id belongs to assessment {staging.assessment_id}, "
-                f"not {assessment_id}"
-            ),
-        )
-    if not await is_user_authorized_for_assessment(
-        current_user.id, staging.assessment_id, db
-    ):
+    # Authorize against the URL assessment *before* any staging lookup, so
+    # callers cannot probe upload_ids to discover which assessments they exist
+    # on. Uploads whose staging row belongs to a different assessment return
+    # the same 404 as uploads that do not exist.
+    if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
         raise HTTPException(
             status_code=403, detail="Not authorized for this assessment"
         )
+
+    staging = await db.scalar(
+        select(TfidfSvdStaging).where(
+            TfidfSvdStaging.upload_id == upload_id,
+            TfidfSvdStaging.assessment_id == assessment_id,
+        )
+    )
+    if staging is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
     if body.chunk_index >= staging.total_chunks:
         raise HTTPException(
             status_code=422,
@@ -513,6 +511,10 @@ async def upload_tfidf_artifact_chunk(
     )
     try:
         await db.execute(stmt)
+        # Advisory: count inside this transaction is correct for the current
+        # upsert, but can skew against a concurrent writer for the same
+        # upload_id. Callers relying on this to decide when to commit should
+        # treat it as a hint, not a strict ready signal.
         chunks_received = await db.scalar(
             select(func.count())
             .select_from(TfidfSvdChunk)
@@ -554,20 +556,26 @@ async def commit_tfidf_artifacts_upload(
     """
     upload_id = _parse_upload_id(body.upload_id)
 
+    # Authorize against the URL assessment before touching staging, so we
+    # never 422 with a cross-assessment upload_id (which would leak the owning
+    # assessment id to unauthorized callers). Mismatched or missing uploads
+    # both surface as 404.
+    await _load_tfidf_assessment_for_upload(assessment_id, current_user, db)
+
+    # Lock the staging row for the duration of this transaction so two
+    # concurrent commits for the same upload_id serialise — without this,
+    # both passes the chunk-count check and both try to write the final
+    # artifact rows, producing a unique-constraint collision.
     staging = await db.scalar(
-        select(TfidfSvdStaging).where(TfidfSvdStaging.upload_id == upload_id)
+        select(TfidfSvdStaging)
+        .where(
+            TfidfSvdStaging.upload_id == upload_id,
+            TfidfSvdStaging.assessment_id == assessment_id,
+        )
+        .with_for_update()
     )
     if staging is None:
         raise HTTPException(status_code=404, detail="Upload not found")
-    if staging.assessment_id != assessment_id:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"upload_id belongs to assessment {staging.assessment_id}, "
-                f"not {assessment_id}"
-            ),
-        )
-    await _load_tfidf_assessment_for_upload(assessment_id, current_user, db)
 
     chunk_rows = (
         await db.execute(
@@ -597,6 +605,9 @@ async def commit_tfidf_artifacts_upload(
             status_code=422, detail=f"Chunk is not a valid .npy payload: {e}"
         )
 
+    # np.save preserves byte order in the header, so dtype equality rejects
+    # big-endian clients even though the numeric type matches. Compare by
+    # kind+itemsize instead.
     expected_dtype = np.dtype(staging.svd_dtype)
     for idx, slab in enumerate(slabs):
         if slab.ndim != 2 or slab.shape[1] != staging.svd_n_features:
@@ -607,7 +618,10 @@ async def commit_tfidf_artifacts_upload(
                     f"(*, {staging.svd_n_features})"
                 ),
             )
-        if slab.dtype != expected_dtype:
+        if (slab.dtype.kind, slab.dtype.itemsize) != (
+            expected_dtype.kind,
+            expected_dtype.itemsize,
+        ):
             raise HTTPException(
                 status_code=422,
                 detail=(
@@ -709,28 +723,27 @@ async def abort_tfidf_artifacts_upload(
     current_user: UserModel = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Cancel an in-flight chunked upload and drop its staged chunks."""
+    """Cancel an in-flight chunked upload and drop its staged chunks.
+
+    Authorization is at the assessment level — any caller authorized for the
+    assessment can abort any in-flight upload for it (uploads have no
+    per-initiator ownership by design).
+    """
     upload_id = _parse_upload_id(body.upload_id)
 
-    staging = await db.scalar(
-        select(TfidfSvdStaging).where(TfidfSvdStaging.upload_id == upload_id)
-    )
-    if staging is None:
-        raise HTTPException(status_code=404, detail="Upload not found")
-    if staging.assessment_id != assessment_id:
-        raise HTTPException(
-            status_code=422,
-            detail=(
-                f"upload_id belongs to assessment {staging.assessment_id}, "
-                f"not {assessment_id}"
-            ),
-        )
-    if not await is_user_authorized_for_assessment(
-        current_user.id, staging.assessment_id, db
-    ):
+    if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
         raise HTTPException(
             status_code=403, detail="Not authorized for this assessment"
         )
+
+    staging = await db.scalar(
+        select(TfidfSvdStaging).where(
+            TfidfSvdStaging.upload_id == upload_id,
+            TfidfSvdStaging.assessment_id == assessment_id,
+        )
+    )
+    if staging is None:
+        raise HTTPException(status_code=404, detail="Upload not found")
 
     chunks_removed = await db.scalar(
         select(func.count())
@@ -872,13 +885,13 @@ async def _resolve_assessment_for_by_vector(
     # The corpus vectors are stored as Vector(300), so queries must always be
     # 300-dim. If an artifact run claims otherwise, fail fast with 422 rather
     # than letting pgvector raise a dimension-mismatch error at query time.
-    if run is not None and run.n_components != _CORPUS_VECTOR_DIM:
+    if run is not None and run.n_components != TFIDF_CORPUS_VECTOR_DIM:
         raise HTTPException(
             status_code=422,
             detail=(
                 f"Assessment {assessment_id} has artifact run "
                 f"n_components={run.n_components}, but stored TF-IDF vectors "
-                f"require dimension {_CORPUS_VECTOR_DIM}"
+                f"require dimension {TFIDF_CORPUS_VECTOR_DIM}"
             ),
         )
 
@@ -906,12 +919,12 @@ async def get_tfidf_result_by_vector(
         body.assessment_id, current_user, db
     )
 
-    if len(body.vector) != _CORPUS_VECTOR_DIM:
+    if len(body.vector) != TFIDF_CORPUS_VECTOR_DIM:
         raise HTTPException(
             status_code=422,
             detail=(
                 f"Vector length {len(body.vector)} does not match required "
-                f"dimension {_CORPUS_VECTOR_DIM} for assessment {body.assessment_id}"
+                f"dimension {TFIDF_CORPUS_VECTOR_DIM} for assessment {body.assessment_id}"
             ),
         )
 

--- a/database/models.py
+++ b/database/models.py
@@ -16,7 +16,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy.sql import func
@@ -1167,3 +1167,55 @@ class TfidfSvd(Base):
     n_features = Column(Integer, nullable=False)
     components_npy = Column(LargeBinary, nullable=False)
     dtype = Column(Text, nullable=False, server_default="float32")
+
+
+class TfidfSvdStaging(Base):
+    """In-flight chunked upload of TF-IDF artifacts. Dropped after commit/abort."""
+
+    __tablename__ = "tfidf_svd_staging"
+
+    upload_id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+    assessment_id = Column(
+        Integer,
+        ForeignKey("assessment.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source_language = Column(String(3), nullable=True)
+    n_components = Column(Integer, nullable=False)
+    n_corpus_vrefs = Column(Integer, nullable=False)
+    sklearn_version = Column(Text, nullable=False)
+    word_vocabulary = Column(JSONB, nullable=False)
+    word_idf = Column(JSONB, nullable=False)
+    word_params = Column(JSONB, nullable=False)
+    char_vocabulary = Column(JSONB, nullable=False)
+    char_idf = Column(JSONB, nullable=False)
+    char_params = Column(JSONB, nullable=False)
+    svd_n_components = Column(Integer, nullable=False)
+    svd_n_features = Column(Integer, nullable=False)
+    svd_dtype = Column(Text, nullable=False)
+    total_chunks = Column(Integer, nullable=False)
+    created_at = Column(TIMESTAMP, nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        Index("ix_tfidf_svd_staging_assessment", "assessment_id"),
+        Index("ix_tfidf_svd_staging_created_at", "created_at"),
+    )
+
+
+class TfidfSvdChunk(Base):
+    """One staged slice of an SVD components matrix. vstacked on commit."""
+
+    __tablename__ = "tfidf_svd_chunk"
+
+    upload_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("tfidf_svd_staging.upload_id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    chunk_index = Column(Integer, primary_key=True)
+    components_bytes = Column(LargeBinary, nullable=False)
+    received_at = Column(TIMESTAMP, nullable=False, server_default=func.now())

--- a/models.py
+++ b/models.py
@@ -1319,6 +1319,59 @@ class TfidfArtifactsPullResponse(BaseModel):
     svd: TfidfSvdPayload
 
 
+# --- Chunked TF-IDF artifact upload (for components_ arrays over the single-POST cap) ---
+
+
+class TfidfSvdMeta(BaseModel):
+    n_components: int
+    n_features: int
+    dtype: Literal["float32", "float64"] = "float32"
+
+
+class TfidfArtifactsInitRequest(BaseModel):
+    source_language: Optional[str] = Field(default=None, max_length=3)
+    n_components: int
+    n_corpus_vrefs: int
+    sklearn_version: str
+    word_vectorizer: TfidfVectorizerPayload
+    char_vectorizer: TfidfVectorizerPayload
+    svd: TfidfSvdMeta
+    total_chunks: int = Field(..., ge=1, le=1024)
+
+
+class TfidfArtifactsInitResponse(BaseModel):
+    upload_id: str
+    assessment_id: int
+    total_chunks: int
+
+
+class TfidfArtifactsChunkRequest(BaseModel):
+    upload_id: str
+    chunk_index: int = Field(..., ge=0)
+    components_b64: str
+
+
+class TfidfArtifactsChunkResponse(BaseModel):
+    upload_id: str
+    chunk_index: int
+    bytes_received: int
+    chunks_received: int
+    total_chunks: int
+
+
+class TfidfArtifactsCommitRequest(BaseModel):
+    upload_id: str
+
+
+class TfidfArtifactsAbortRequest(BaseModel):
+    upload_id: str
+
+
+class TfidfArtifactsAbortResponse(BaseModel):
+    upload_id: str
+    chunks_removed: int
+
+
 TFIDF_CORPUS_VECTOR_DIM = 300
 
 

--- a/models.py
+++ b/models.py
@@ -1281,10 +1281,15 @@ class TfidfVectorizerPayload(BaseModel):
     params: Dict[str, Any]
 
 
-class TfidfSvdPayload(BaseModel):
-    n_components: int
-    n_features: int
+# TfidfSvdMeta (shape + dtype only) is shared by chunked uploads that don't
+# carry the bytes inline. TfidfSvdPayload adds the base64-encoded .npy blob.
+class TfidfSvdMeta(BaseModel):
+    n_components: int = Field(..., ge=1, le=4096)
+    n_features: int = Field(..., ge=1, le=10_000_000)
     dtype: Literal["float32", "float64"] = "float32"
+
+
+class TfidfSvdPayload(TfidfSvdMeta):
     components_b64: str
 
 
@@ -1320,12 +1325,6 @@ class TfidfArtifactsPullResponse(BaseModel):
 
 
 # --- Chunked TF-IDF artifact upload (for components_ arrays over the single-POST cap) ---
-
-
-class TfidfSvdMeta(BaseModel):
-    n_components: int
-    n_features: int
-    dtype: Literal["float32", "float64"] = "float32"
 
 
 class TfidfArtifactsInitRequest(BaseModel):

--- a/test/test_assessment_routes/test_tfidf_chunked_upload.py
+++ b/test/test_assessment_routes/test_tfidf_chunked_upload.py
@@ -1,0 +1,591 @@
+"""Tests for the chunked TF-IDF artifact upload endpoints.
+
+Covers /v3/assessment/{id}/tfidf-artifacts/init, /chunks, /commit, /abort.
+"""
+
+import base64
+import io
+
+import numpy as np
+import pytest
+
+from database.models import Assessment
+
+prefix = "v3"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _chunk_b64(slab: np.ndarray) -> str:
+    buf = io.BytesIO()
+    np.save(buf, slab, allow_pickle=False)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _build_components(
+    n_components: int, n_features: int, dtype: str = "float32", seed: int = 7
+) -> np.ndarray:
+    rng = np.random.default_rng(seed=seed)
+    return rng.standard_normal((n_components, n_features)).astype(dtype)
+
+
+def _split_components(arr: np.ndarray, total_chunks: int):
+    """Split along axis 0 into exactly `total_chunks` slabs (last one may be larger)."""
+    return np.array_split(arr, total_chunks, axis=0)
+
+
+def _init_body(
+    n_components: int = 8,
+    n_word_features: int = 3,
+    n_char_features: int = 4,
+    total_chunks: int = 4,
+    source_language: str = "swh",
+    dtype: str = "float32",
+) -> dict:
+    n_features = n_word_features + n_char_features
+    return {
+        "source_language": source_language,
+        "n_components": n_components,
+        "n_corpus_vrefs": 42,
+        "sklearn_version": "1.6.1",
+        "word_vectorizer": {
+            "vocabulary": {f"w{i}": i for i in range(n_word_features)},
+            "idf": [1.0 + 0.1 * i for i in range(n_word_features)],
+            "params": {
+                "analyzer": "word",
+                "ngram_range": [1, 2],
+                "lowercase": True,
+                "max_df": 0.12,
+                "min_df": 2,
+            },
+        },
+        "char_vectorizer": {
+            "vocabulary": {f"c{i}": i for i in range(n_char_features)},
+            "idf": [2.0 + 0.1 * i for i in range(n_char_features)],
+            "params": {
+                "analyzer": "char_wb",
+                "ngram_range": [3, 6],
+                "lowercase": True,
+                "max_df": 0.3,
+                "min_df": 2,
+            },
+        },
+        "svd": {
+            "n_components": n_components,
+            "n_features": n_features,
+            "dtype": dtype,
+        },
+        "total_chunks": total_chunks,
+    }
+
+
+def _decode_components(payload: dict) -> np.ndarray:
+    return np.load(io.BytesIO(base64.b64decode(payload["components_b64"])))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def chunk_tfidf_assessment_id(test_db_session, test_revision_id, test_revision_id_2):
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="tfidf",
+        status="running",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+    return assessment.id
+
+
+@pytest.fixture(scope="module")
+def chunk_non_tfidf_assessment_id(
+    test_db_session, test_revision_id, test_revision_id_2
+):
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="word-alignment",
+        status="running",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+    return assessment.id
+
+
+# ---------------------------------------------------------------------------
+# Round-trip tests
+# ---------------------------------------------------------------------------
+
+
+def test_chunked_upload_round_trip(client, regular_token1, chunk_tfidf_assessment_id):
+    """Init → 4 chunks → commit, then GET returns the original matrix byte-for-byte."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    n_components, n_features = 8, 7
+    arr = _build_components(n_components, n_features)
+    slabs = _split_components(arr, total_chunks=4)
+    assert sum(s.shape[0] for s in slabs) == n_components
+
+    init_body = _init_body(
+        n_components=n_components,
+        n_word_features=3,
+        n_char_features=4,
+        total_chunks=len(slabs),
+    )
+
+    init_resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=init_body,
+        headers=headers,
+    )
+    assert init_resp.status_code == 200, init_resp.text
+    init_data = init_resp.json()
+    upload_id = init_data["upload_id"]
+    assert init_data["assessment_id"] == chunk_tfidf_assessment_id
+    assert init_data["total_chunks"] == len(slabs)
+
+    # Upload chunks in mixed order to confirm commit sorts by index.
+    for i in [2, 0, 3, 1]:
+        resp = client.post(
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            json={
+                "upload_id": upload_id,
+                "chunk_index": i,
+                "components_b64": _chunk_b64(slabs[i]),
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["chunk_index"] == i
+        assert data["bytes_received"] > 0
+
+    commit_resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/commit",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert commit_resp.status_code == 200, commit_resp.text
+    commit_data = commit_resp.json()
+    assert commit_data["assessment_id"] == chunk_tfidf_assessment_id
+    assert commit_data["n_word_features"] == 3
+    assert commit_data["n_char_features"] == 4
+    assert commit_data["components_bytes"] > 0
+
+    # Verify the assembled matrix equals the original, byte-for-byte.
+    pull_resp = client.get(
+        f"{prefix}/assessment/tfidf/artifacts",
+        params={"assessment_id": chunk_tfidf_assessment_id},
+        headers=headers,
+    )
+    assert pull_resp.status_code == 200, pull_resp.text
+    pulled = pull_resp.json()
+    assert pulled["svd"]["n_components"] == n_components
+    assert pulled["svd"]["n_features"] == n_features
+    round_tripped = _decode_components(pulled["svd"])
+    assert round_tripped.shape == arr.shape
+    assert np.array_equal(arr, round_tripped)
+
+
+def test_chunked_upload_chunk_idempotency(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    """Re-posting the same chunk_index replaces the bytes; commit still sees one chunk per index."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    arr = _build_components(6, 7, seed=11)
+    slabs = _split_components(arr, total_chunks=2)
+
+    init_body = _init_body(
+        n_components=6, n_word_features=3, n_char_features=4, total_chunks=2
+    )
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=init_body,
+        headers=headers,
+    ).json()["upload_id"]
+
+    # Upload a wrong chunk 0 first, then overwrite with the correct one.
+    wrong = np.zeros_like(slabs[0])
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 0,
+            "components_b64": _chunk_b64(wrong),
+        },
+        headers=headers,
+    )
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 0,
+            "components_b64": _chunk_b64(slabs[0]),
+        },
+        headers=headers,
+    )
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 1,
+            "components_b64": _chunk_b64(slabs[1]),
+        },
+        headers=headers,
+    )
+
+    commit = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/commit",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert commit.status_code == 200, commit.text
+
+    pulled = client.get(
+        f"{prefix}/assessment/tfidf/artifacts",
+        params={"assessment_id": chunk_tfidf_assessment_id},
+        headers=headers,
+    ).json()
+    round_tripped = _decode_components(pulled["svd"])
+    assert np.array_equal(arr, round_tripped)
+
+
+# ---------------------------------------------------------------------------
+# Error paths
+# ---------------------------------------------------------------------------
+
+
+def test_init_wrong_assessment_type(
+    client, regular_token1, chunk_non_tfidf_assessment_id
+):
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_non_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 400
+
+
+def test_init_unauthorized(client, regular_token2, chunk_tfidf_assessment_id):
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(),
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_init_not_found(client, regular_token1):
+    resp = client.post(
+        f"{prefix}/assessment/99999999/tfidf-artifacts/init",
+        json=_init_body(),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_init_n_components_mismatch(client, regular_token1, chunk_tfidf_assessment_id):
+    body = _init_body()
+    body["n_components"] = 42  # svd.n_components still 8
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=body,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
+
+
+def test_commit_missing_chunks_rejected(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    """Commit with fewer chunks than total_chunks returns 422 listing the gaps."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    arr = _build_components(6, 7, seed=13)
+    slabs = _split_components(arr, total_chunks=3)
+
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(n_components=6, total_chunks=3),
+        headers=headers,
+    ).json()["upload_id"]
+
+    # Only upload chunk 0 and 2 — chunk 1 missing.
+    for i in [0, 2]:
+        client.post(
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            json={
+                "upload_id": upload_id,
+                "chunk_index": i,
+                "components_b64": _chunk_b64(slabs[i]),
+            },
+            headers=headers,
+        )
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/commit",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "missing" in resp.json()["detail"]
+    assert "1" in resp.json()["detail"]
+
+    # Clean up so we don't leave staging rows lying around.
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+
+
+def test_chunk_index_out_of_range(client, regular_token1, chunk_tfidf_assessment_id):
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(total_chunks=2),
+        headers=headers,
+    ).json()["upload_id"]
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 5,  # total_chunks=2, so 5 is out of range
+            "components_b64": _chunk_b64(_build_components(1, 7)),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+
+
+def test_chunk_upload_id_assessment_mismatch(
+    client, regular_token1, chunk_tfidf_assessment_id, chunk_non_tfidf_assessment_id
+):
+    """Posting a chunk to the wrong assessment_id in the URL is rejected."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(total_chunks=1),
+        headers=headers,
+    ).json()["upload_id"]
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_non_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 0,
+            "components_b64": _chunk_b64(_build_components(8, 7)),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert str(chunk_tfidf_assessment_id) in resp.json()["detail"]
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+
+
+def test_chunk_unknown_upload_id(client, regular_token1, chunk_tfidf_assessment_id):
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        json={
+            "upload_id": "00000000-0000-0000-0000-000000000000",
+            "chunk_index": 0,
+            "components_b64": _chunk_b64(_build_components(1, 7)),
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_chunk_invalid_upload_id(client, regular_token1, chunk_tfidf_assessment_id):
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        json={
+            "upload_id": "not-a-uuid",
+            "chunk_index": 0,
+            "components_b64": _chunk_b64(_build_components(1, 7)),
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
+
+
+def test_chunk_shape_mismatch_rejected_on_commit(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    """A chunk whose feature dimension doesn't match the declared metadata is
+    caught at commit time."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(
+            n_components=6, n_word_features=3, n_char_features=4, total_chunks=2
+        ),
+        headers=headers,
+    ).json()["upload_id"]
+
+    # First chunk has correct feature width (7), second has wrong (9).
+    ok = _build_components(3, 7, seed=1)
+    bad = _build_components(3, 9, seed=2)
+    for i, slab in enumerate([ok, bad]):
+        client.post(
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            json={
+                "upload_id": upload_id,
+                "chunk_index": i,
+                "components_b64": _chunk_b64(slab),
+            },
+            headers=headers,
+        )
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/commit",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "shape" in resp.json()["detail"]
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+
+
+def test_abort_drops_staging_and_chunks(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(total_chunks=3),
+        headers=headers,
+    ).json()["upload_id"]
+
+    slabs = _split_components(_build_components(8, 7, seed=3), total_chunks=3)
+    # Only upload 2 of 3 chunks, then abort.
+    for i in [0, 1]:
+        client.post(
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            json={
+                "upload_id": upload_id,
+                "chunk_index": i,
+                "components_b64": _chunk_b64(slabs[i]),
+            },
+            headers=headers,
+        )
+
+    abort_resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert abort_resp.status_code == 200, abort_resp.text
+    assert abort_resp.json()["chunks_removed"] == 2
+
+    # After abort, further chunk posts with this upload_id must 404.
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 2,
+            "components_b64": _chunk_b64(slabs[2]),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_commit_replaces_existing_artifacts(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    """Running init→commit a second time overwrites the artifacts from the first run."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    arr = _build_components(4, 7, seed=99)
+    slabs = _split_components(arr, total_chunks=2)
+
+    init_body = _init_body(
+        n_components=4, n_word_features=3, n_char_features=4, total_chunks=2
+    )
+    init_body["source_language"] = "eng"
+    init_body["n_corpus_vrefs"] = 999
+
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=init_body,
+        headers=headers,
+    ).json()["upload_id"]
+    for i, slab in enumerate(slabs):
+        client.post(
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            json={
+                "upload_id": upload_id,
+                "chunk_index": i,
+                "components_b64": _chunk_b64(slab),
+            },
+            headers=headers,
+        )
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/commit",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+
+    pulled = client.get(
+        f"{prefix}/assessment/tfidf/artifacts",
+        params={"assessment_id": chunk_tfidf_assessment_id},
+        headers=headers,
+    ).json()
+    assert pulled["source_language"] == "eng"
+    assert pulled["n_corpus_vrefs"] == 999
+    assert pulled["n_components"] == 4
+    round_tripped = _decode_components(pulled["svd"])
+    assert np.array_equal(arr, round_tripped)
+
+
+def test_abort_unauthorized(
+    client, regular_token1, regular_token2, chunk_tfidf_assessment_id
+):
+    """Another user cannot abort someone else's staging upload."""
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(total_chunks=1),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    ).json()["upload_id"]
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert resp.status_code == 403
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )

--- a/test/test_assessment_routes/test_tfidf_chunked_upload.py
+++ b/test/test_assessment_routes/test_tfidf_chunked_upload.py
@@ -1,6 +1,6 @@
 """Tests for the chunked TF-IDF artifact upload endpoints.
 
-Covers /v3/assessment/{id}/tfidf-artifacts/init, /chunks, /commit, /abort.
+Covers /v3/assessment/{id}/tfidf-artifacts/init, /chunk, /commit, /abort.
 """
 
 import base64
@@ -83,7 +83,9 @@ def _init_body(
 
 
 def _decode_components(payload: dict) -> np.ndarray:
-    return np.load(io.BytesIO(base64.b64decode(payload["components_b64"])))
+    return np.load(
+        io.BytesIO(base64.b64decode(payload["components_b64"])), allow_pickle=False
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +158,7 @@ def test_chunked_upload_round_trip(client, regular_token1, chunk_tfidf_assessmen
     # Upload chunks in mixed order to confirm commit sorts by index.
     for i in [2, 0, 3, 1]:
         resp = client.post(
-            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
             json={
                 "upload_id": upload_id,
                 "chunk_index": i,
@@ -217,7 +219,7 @@ def test_chunked_upload_chunk_idempotency(
     # Upload a wrong chunk 0 first, then overwrite with the correct one.
     wrong = np.zeros_like(slabs[0])
     client.post(
-        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
         json={
             "upload_id": upload_id,
             "chunk_index": 0,
@@ -226,7 +228,7 @@ def test_chunked_upload_chunk_idempotency(
         headers=headers,
     )
     client.post(
-        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
         json={
             "upload_id": upload_id,
             "chunk_index": 0,
@@ -235,7 +237,7 @@ def test_chunked_upload_chunk_idempotency(
         headers=headers,
     )
     client.post(
-        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
         json={
             "upload_id": upload_id,
             "chunk_index": 1,
@@ -322,7 +324,7 @@ def test_commit_missing_chunks_rejected(
     # Only upload chunk 0 and 2 — chunk 1 missing.
     for i in [0, 2]:
         client.post(
-            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
             json={
                 "upload_id": upload_id,
                 "chunk_index": i,
@@ -357,7 +359,7 @@ def test_chunk_index_out_of_range(client, regular_token1, chunk_tfidf_assessment
     ).json()["upload_id"]
 
     resp = client.post(
-        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
         json={
             "upload_id": upload_id,
             "chunk_index": 5,  # total_chunks=2, so 5 is out of range
@@ -377,7 +379,9 @@ def test_chunk_index_out_of_range(client, regular_token1, chunk_tfidf_assessment
 def test_chunk_upload_id_assessment_mismatch(
     client, regular_token1, chunk_tfidf_assessment_id, chunk_non_tfidf_assessment_id
 ):
-    """Posting a chunk to the wrong assessment_id in the URL is rejected."""
+    """Posting a chunk whose upload_id belongs to a different assessment
+    returns 404 (same as an unknown upload_id) — we must not reveal which
+    assessment an upload_id belongs to."""
     headers = {"Authorization": f"Bearer {regular_token1}"}
     upload_id = client.post(
         f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
@@ -386,7 +390,7 @@ def test_chunk_upload_id_assessment_mismatch(
     ).json()["upload_id"]
 
     resp = client.post(
-        f"{prefix}/assessment/{chunk_non_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        f"{prefix}/assessment/{chunk_non_tfidf_assessment_id}/tfidf-artifacts/chunk",
         json={
             "upload_id": upload_id,
             "chunk_index": 0,
@@ -394,8 +398,8 @@ def test_chunk_upload_id_assessment_mismatch(
         },
         headers=headers,
     )
-    assert resp.status_code == 422
-    assert str(chunk_tfidf_assessment_id) in resp.json()["detail"]
+    assert resp.status_code == 404
+    assert str(chunk_tfidf_assessment_id) not in resp.json()["detail"]
 
     client.post(
         f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
@@ -406,7 +410,7 @@ def test_chunk_upload_id_assessment_mismatch(
 
 def test_chunk_unknown_upload_id(client, regular_token1, chunk_tfidf_assessment_id):
     resp = client.post(
-        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
         json={
             "upload_id": "00000000-0000-0000-0000-000000000000",
             "chunk_index": 0,
@@ -419,7 +423,7 @@ def test_chunk_unknown_upload_id(client, regular_token1, chunk_tfidf_assessment_
 
 def test_chunk_invalid_upload_id(client, regular_token1, chunk_tfidf_assessment_id):
     resp = client.post(
-        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
         json={
             "upload_id": "not-a-uuid",
             "chunk_index": 0,
@@ -450,7 +454,7 @@ def test_chunk_shape_mismatch_rejected_on_commit(
     bad = _build_components(3, 9, seed=2)
     for i, slab in enumerate([ok, bad]):
         client.post(
-            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
             json={
                 "upload_id": upload_id,
                 "chunk_index": i,
@@ -489,7 +493,7 @@ def test_abort_drops_staging_and_chunks(
     # Only upload 2 of 3 chunks, then abort.
     for i in [0, 1]:
         client.post(
-            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
             json={
                 "upload_id": upload_id,
                 "chunk_index": i,
@@ -508,7 +512,7 @@ def test_abort_drops_staging_and_chunks(
 
     # After abort, further chunk posts with this upload_id must 404.
     resp = client.post(
-        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
         json={
             "upload_id": upload_id,
             "chunk_index": 2,
@@ -541,7 +545,7 @@ def test_commit_replaces_existing_artifacts(
     ).json()["upload_id"]
     for i, slab in enumerate(slabs):
         client.post(
-            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunks",
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
             json={
                 "upload_id": upload_id,
                 "chunk_index": i,
@@ -570,7 +574,12 @@ def test_commit_replaces_existing_artifacts(
 def test_abort_unauthorized(
     client, regular_token1, regular_token2, chunk_tfidf_assessment_id
 ):
-    """Another user cannot abort someone else's staging upload."""
+    """A user without access to the assessment cannot abort its uploads.
+
+    Abort authz is at the assessment level, not the upload-initiator level:
+    any caller authorized for the assessment may abort any in-flight upload
+    for it.
+    """
     upload_id = client.post(
         f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
         json=_init_body(total_chunks=1),
@@ -588,4 +597,226 @@ def test_abort_unauthorized(
         f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
         json={"upload_id": upload_id},
         headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Additional coverage: post-commit/abort behaviour, oversize, dtype, total=1
+# ---------------------------------------------------------------------------
+
+
+def _run_single_chunk_upload(
+    client, headers, assessment_id, *, arr, source_language="swh"
+) -> str:
+    """Helper: init + 1 chunk + commit a tiny matrix. Returns the upload_id used."""
+    body = _init_body(
+        n_components=arr.shape[0],
+        n_word_features=3,
+        n_char_features=4,
+        total_chunks=1,
+        source_language=source_language,
+    )
+    upload_id = client.post(
+        f"{prefix}/assessment/{assessment_id}/tfidf-artifacts/init",
+        json=body,
+        headers=headers,
+    ).json()["upload_id"]
+    client.post(
+        f"{prefix}/assessment/{assessment_id}/tfidf-artifacts/chunk",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 0,
+            "components_b64": _chunk_b64(arr),
+        },
+        headers=headers,
+    )
+    commit = client.post(
+        f"{prefix}/assessment/{assessment_id}/tfidf-artifacts/commit",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert commit.status_code == 200, commit.text
+    return upload_id
+
+
+def test_total_chunks_one_happy_path(client, regular_token1, chunk_tfidf_assessment_id):
+    """total_chunks=1 is the corner case most likely to hit off-by-one bugs."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    arr = _build_components(4, 7, seed=101)
+    _run_single_chunk_upload(client, headers, chunk_tfidf_assessment_id, arr=arr)
+
+    pulled = client.get(
+        f"{prefix}/assessment/tfidf/artifacts",
+        params={"assessment_id": chunk_tfidf_assessment_id},
+        headers=headers,
+    ).json()
+    assert np.array_equal(arr, _decode_components(pulled["svd"]))
+
+
+def test_second_commit_same_upload_id_404s(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    """Commit deletes the staging row, so a replay of the same upload_id 404s."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    arr = _build_components(4, 7, seed=201)
+    upload_id = _run_single_chunk_upload(
+        client, headers, chunk_tfidf_assessment_id, arr=arr
+    )
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/commit",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_chunk_post_after_commit_404s(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    """Late chunk posts to an already-committed upload_id must 404."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    arr = _build_components(4, 7, seed=202)
+    upload_id = _run_single_chunk_upload(
+        client, headers, chunk_tfidf_assessment_id, arr=arr
+    )
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 0,
+            "components_b64": _chunk_b64(arr),
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_abort_after_commit_404s(client, regular_token1, chunk_tfidf_assessment_id):
+    """Abort on an already-committed upload_id must 404."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    arr = _build_components(4, 7, seed=203)
+    upload_id = _run_single_chunk_upload(
+        client, headers, chunk_tfidf_assessment_id, arr=arr
+    )
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+
+
+def test_chunk_invalid_base64(client, regular_token1, chunk_tfidf_assessment_id):
+    """Garbled components_b64 on the chunk endpoint returns 422."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(total_chunks=1),
+        headers=headers,
+    ).json()["upload_id"]
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 0,
+            "components_b64": "not-valid-base64!!!",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "base64" in resp.json()["detail"]
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+
+
+def test_chunk_dtype_mismatch_rejected_at_commit(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    """Init declared float32 but a chunk was saved as float64 — commit rejects."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    # Init says float32
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(
+            n_components=4,
+            n_word_features=3,
+            n_char_features=4,
+            total_chunks=1,
+            dtype="float32",
+        ),
+        headers=headers,
+    ).json()["upload_id"]
+    # But the chunk is float64
+    wrong_dtype = _build_components(4, 7, dtype="float64", seed=7)
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
+        json={
+            "upload_id": upload_id,
+            "chunk_index": 0,
+            "components_b64": _chunk_b64(wrong_dtype),
+        },
+        headers=headers,
+    )
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/commit",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    assert "dtype" in resp.json()["detail"]
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
+    )
+
+
+def test_chunk_oversize_rejected_with_413(
+    client, regular_token1, chunk_tfidf_assessment_id
+):
+    """A chunk decoded past _MAX_CHUNK_BYTES is rejected with 413.
+
+    Rather than actually allocating 100 MiB of bytes, monkey-patch the cap
+    down to a small value for the duration of this test.
+    """
+    from assessment_routes.v3 import tfidf_artifact_routes as routes
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    upload_id = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(total_chunks=1),
+        headers=headers,
+    ).json()["upload_id"]
+
+    original_cap = routes._MAX_CHUNK_BYTES
+    routes._MAX_CHUNK_BYTES = 32  # bytes — any real chunk blows past this
+    try:
+        resp = client.post(
+            f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/chunk",
+            json={
+                "upload_id": upload_id,
+                "chunk_index": 0,
+                "components_b64": _chunk_b64(_build_components(8, 7)),
+            },
+            headers=headers,
+        )
+        assert resp.status_code == 413
+        assert "per-chunk" in resp.json()["detail"]
+    finally:
+        routes._MAX_CHUNK_BYTES = original_cap
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": upload_id},
+        headers=headers,
     )


### PR DESCRIPTION
## Summary

- Four new endpoints under `/v3/assessment/{id}/tfidf-artifacts/` — `init`, `chunk`, `commit`, `abort` — for streaming SVD components matrices that exceed the 200 MiB single-POST cap.
- Caller splits `components_` along axis 0 into `N` slabs (each an `np.save`-serialized sub-array), POSTs them one by one to `/chunk` with idempotent upsert on `(upload_id, chunk_index)`, then hits `/commit` which `np.vstack`s the slabs and writes the existing `TfidfSvd`/vectorizer/run rows in one transaction.
- Single-POST `/tfidf-artifacts` endpoint untouched — small-vocab languages don't need the three-trip dance.
- New tables `tfidf_svd_staging` + `tfidf_svd_chunk` hold in-flight uploads (cascading FK on staging delete). Migration `f8a2c3d4e5b6` adds them.
- Commit takes `SELECT ... FOR UPDATE` on staging; chunk writes take `FOR KEY SHARE` so they serialise cleanly against an in-flight commit (preventing FK-violation races on cascaded delete).

Fixes #587
Follow-up: #589 (stale-staging sweep)

## Test plan

- [x] 22 integration tests in `test_tfidf_chunked_upload.py` — byte-for-byte round-trip through 4 out-of-order chunks; chunk idempotency; missing-chunk commit lists the gaps; out-of-range index; upload_id/assessment mismatch returns 404 (no leak); unknown/invalid UUID; feature-dim & dtype mismatch caught at commit; abort cleanup; commit replaces prior artifacts; unauthorized abort; `total_chunks=1`; second commit/post-commit chunk/abort-after-commit all 404; invalid base64 on chunk; oversize chunk (413).
- [x] Existing 37 TF-IDF tests still pass.
- [x] `black`/`isort` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)