### PR TITLE
feat(tfidf): sweep stale staging rows on /init

### DIFF
--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -6,6 +6,7 @@ import io
 import socket
 import time
 import uuid
+from datetime import datetime, timedelta
 from typing import Dict, List, Union
 
 import fastapi
@@ -68,6 +69,10 @@ _MAX_COMPONENTS_BYTES = 200 * 1024 * 1024
 # Per-chunk cap for the chunked upload path. Keeps any individual POST well
 # under platform/proxy limits even when the aggregate matrix is multi-GB.
 _MAX_CHUNK_BYTES = 100 * 1024 * 1024
+
+# Age at which an unfinished staging row is considered abandoned and gets
+# swept opportunistically on the next /init. Cascaded chunk rows go with it.
+_STAGING_TTL_HOURS = 24
 
 # TfidfPcaVector.vector is declared Vector(300); queries against the corpus
 # must always be 300-dim regardless of what artifact metadata claims.
@@ -352,6 +357,39 @@ async def _load_tfidf_assessment_for_upload(
     return assessment
 
 
+async def _sweep_stale_staging(
+    db: AsyncSession, *, ttl_hours: int = _STAGING_TTL_HOURS
+) -> int:
+    """Drop tfidf_svd_staging rows older than ttl_hours; chunks cascade.
+
+    Uses SKIP LOCKED so a concurrent /chunk write (which holds FOR KEY SHARE)
+    on a stale-but-still-touched row defers to the next sweep instead of
+    blocking this /init.
+    """
+    cutoff = datetime.utcnow() - timedelta(hours=ttl_hours)
+    stale = (
+        select(TfidfSvdStaging.upload_id)
+        .where(TfidfSvdStaging.created_at < cutoff)
+        .with_for_update(skip_locked=True)
+    )
+    # synchronize_session=False because the in_(subquery) clause can't be
+    # evaluated in Python by the ORM; nothing in this session has loaded the
+    # stale rows anyway, so there's no identity-map state to invalidate.
+    result = await db.execute(
+        delete(TfidfSvdStaging)
+        .where(TfidfSvdStaging.upload_id.in_(stale))
+        .execution_options(synchronize_session=False)
+    )
+    deleted = result.rowcount or 0
+    if deleted:
+        logger.info(
+            "Swept %d stale tfidf staging row(s) older than %dh",
+            deleted,
+            ttl_hours,
+        )
+    return deleted
+
+
 def _validate_vectorizer_shapes(body: TfidfArtifactsInitRequest) -> None:
     n_word_features = len(body.word_vectorizer.vocabulary)
     n_char_features = len(body.char_vectorizer.vocabulary)
@@ -400,6 +438,14 @@ async def init_tfidf_artifacts_upload(
     """
     await _load_tfidf_assessment_for_upload(assessment_id, current_user, db)
     _validate_vectorizer_shapes(body)
+
+    try:
+        await _sweep_stale_staging(db)
+    except SQLAlchemyError:
+        # Sweep is opportunistic — never fail the user's /init because
+        # cleanup of someone else's abandoned upload couldn't proceed.
+        logger.exception("Stale tfidf staging sweep failed; continuing with /init")
+        await db.rollback()
 
     staging = TfidfSvdStaging(
         assessment_id=assessment_id,

--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -6,7 +6,6 @@ import io
 import socket
 import time
 import uuid
-from datetime import datetime, timedelta
 from typing import Dict, List, Union
 
 import fastapi
@@ -366,10 +365,13 @@ async def _sweep_stale_staging(
     on a stale-but-still-touched row defers to the next sweep instead of
     blocking this /init.
     """
-    cutoff = datetime.utcnow() - timedelta(hours=ttl_hours)
+    # Compute the cutoff in SQL (now() - interval) so it uses the same clock
+    # as the column's server_default=func.now() — no Python-vs-DB clock skew,
+    # no UTC-vs-local-time hazard from the column being plain TIMESTAMP.
+    cutoff_expr = func.now() - text(f"interval '{ttl_hours} hours'")
     stale = (
         select(TfidfSvdStaging.upload_id)
-        .where(TfidfSvdStaging.created_at < cutoff)
+        .where(TfidfSvdStaging.created_at < cutoff_expr)
         .with_for_update(skip_locked=True)
     )
     # synchronize_session=False because the in_(subquery) clause can't be
@@ -380,7 +382,7 @@ async def _sweep_stale_staging(
         .where(TfidfSvdStaging.upload_id.in_(stale))
         .execution_options(synchronize_session=False)
     )
-    deleted = result.rowcount or 0
+    deleted = result.rowcount
     if deleted:
         logger.info(
             "Swept %d stale tfidf staging row(s) older than %dh",
@@ -439,11 +441,17 @@ async def init_tfidf_artifacts_upload(
     await _load_tfidf_assessment_for_upload(assessment_id, current_user, db)
     _validate_vectorizer_shapes(body)
 
+    # The sweep runs before the staging insert and any rollback here drops
+    # the whole transaction. _load_tfidf_assessment_for_upload above is a
+    # plain read with no locks, so that's fine; if it ever takes a lock
+    # this ordering needs revisiting.
     try:
         await _sweep_stale_staging(db)
-    except SQLAlchemyError:
+    except Exception:
         # Sweep is opportunistic — never fail the user's /init because
         # cleanup of someone else's abandoned upload couldn't proceed.
+        # Catch broadly (not just SQLAlchemyError) so driver-level failures
+        # like asyncpg connection errors honour the same contract.
         logger.exception("Stale tfidf staging sweep failed; continuing with /init")
         await db.rollback()
 

--- a/test/test_assessment_routes/test_tfidf_chunked_upload.py
+++ b/test/test_assessment_routes/test_tfidf_chunked_upload.py
@@ -6,10 +6,10 @@ Covers /v3/assessment/{id}/tfidf-artifacts/init, /chunk, /commit, /abort.
 import base64
 import io
 import uuid
-from datetime import datetime, timedelta
 
 import numpy as np
 import pytest
+from sqlalchemy import func, text
 
 from database.models import Assessment, TfidfSvdChunk, TfidfSvdStaging
 
@@ -834,6 +834,8 @@ def _insert_stale_staging(
 ) -> uuid.UUID:
     """Drop a hand-crafted staging row (and optional chunk) into the db with a
     backdated created_at, so the sweep treats it as abandoned."""
+    # Backdate via SQL `now() - interval ...` so the comparison stays on the
+    # DB clock — same expression the production sweep uses for its cutoff.
     staging = TfidfSvdStaging(
         upload_id=uuid.uuid4(),
         assessment_id=assessment_id,
@@ -851,7 +853,7 @@ def _insert_stale_staging(
         svd_n_features=2,
         svd_dtype="float32",
         total_chunks=1,
-        created_at=datetime.utcnow() - timedelta(hours=age_hours),
+        created_at=func.now() - text(f"interval '{age_hours} hours'"),
     )
     session.add(staging)
     session.flush()
@@ -961,15 +963,17 @@ def test_init_continues_when_sweep_fails(
     client, regular_token1, chunk_tfidf_assessment_id, test_db_session, monkeypatch
 ):
     """If _sweep_stale_staging raises, /init must still succeed — the cleanup
-    is opportunistic and must never break a user's upload."""
-    from sqlalchemy.exc import SQLAlchemyError
+    is opportunistic and must never break a user's upload.
 
+    Raises a plain RuntimeError (not SQLAlchemyError) to verify the broader
+    `except Exception` actually catches driver-level/non-ORM failures too.
+    """
     from assessment_routes.v3 import tfidf_artifact_routes as routes
 
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     async def boom(db, *, ttl_hours=routes._STAGING_TTL_HOURS):
-        raise SQLAlchemyError("simulated sweep failure")
+        raise RuntimeError("simulated sweep failure")
 
     monkeypatch.setattr(routes, "_sweep_stale_staging", boom)
 

--- a/test/test_assessment_routes/test_tfidf_chunked_upload.py
+++ b/test/test_assessment_routes/test_tfidf_chunked_upload.py
@@ -5,11 +5,13 @@ Covers /v3/assessment/{id}/tfidf-artifacts/init, /chunk, /commit, /abort.
 
 import base64
 import io
+import uuid
+from datetime import datetime, timedelta
 
 import numpy as np
 import pytest
 
-from database.models import Assessment
+from database.models import Assessment, TfidfSvdChunk, TfidfSvdStaging
 
 prefix = "v3"
 
@@ -818,5 +820,99 @@ def test_chunk_oversize_rejected_with_413(
     client.post(
         f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
         json={"upload_id": upload_id},
+        headers=headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stale-staging sweep — /init opportunistically drops abandoned uploads
+# ---------------------------------------------------------------------------
+
+
+def _insert_stale_staging(
+    session, assessment_id: int, *, age_hours: float, with_chunk: bool = True
+) -> uuid.UUID:
+    """Drop a hand-crafted staging row (and optional chunk) into the db with a
+    backdated created_at, so the sweep treats it as abandoned."""
+    staging = TfidfSvdStaging(
+        upload_id=uuid.uuid4(),
+        assessment_id=assessment_id,
+        source_language="swh",
+        n_components=4,
+        n_corpus_vrefs=1,
+        sklearn_version="1.6.1",
+        word_vocabulary={"w0": 0},
+        word_idf=[1.0],
+        word_params={},
+        char_vocabulary={"c0": 0},
+        char_idf=[1.0],
+        char_params={},
+        svd_n_components=4,
+        svd_n_features=2,
+        svd_dtype="float32",
+        total_chunks=1,
+        created_at=datetime.utcnow() - timedelta(hours=age_hours),
+    )
+    session.add(staging)
+    session.flush()
+    if with_chunk:
+        session.add(
+            TfidfSvdChunk(
+                upload_id=staging.upload_id,
+                chunk_index=0,
+                components_bytes=b"placeholder",
+            )
+        )
+    session.commit()
+    return staging.upload_id
+
+
+def test_init_sweeps_stale_staging_rows(
+    client, regular_token1, chunk_tfidf_assessment_id, test_db_session
+):
+    """/init drops staging rows older than the TTL (with their chunks via cascade),
+    leaves fresh rows alone, and still creates the new upload."""
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    stale_id = _insert_stale_staging(
+        test_db_session, chunk_tfidf_assessment_id, age_hours=48
+    )
+    fresh_id = _insert_stale_staging(
+        test_db_session, chunk_tfidf_assessment_id, age_hours=1, with_chunk=False
+    )
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(total_chunks=1),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    new_upload_id = resp.json()["upload_id"]
+
+    test_db_session.expire_all()
+    assert (
+        test_db_session.query(TfidfSvdStaging)
+        .filter_by(upload_id=stale_id)
+        .one_or_none()
+        is None
+    )
+    assert (
+        test_db_session.query(TfidfSvdChunk).filter_by(upload_id=stale_id).count() == 0
+    )
+    assert (
+        test_db_session.query(TfidfSvdStaging)
+        .filter_by(upload_id=fresh_id)
+        .one_or_none()
+        is not None
+    )
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": new_upload_id},
+        headers=headers,
+    )
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": str(fresh_id)},
         headers=headers,
     )

--- a/test/test_assessment_routes/test_tfidf_chunked_upload.py
+++ b/test/test_assessment_routes/test_tfidf_chunked_upload.py
@@ -868,17 +868,44 @@ def _insert_stale_staging(
 
 
 def test_init_sweeps_stale_staging_rows(
-    client, regular_token1, chunk_tfidf_assessment_id, test_db_session
+    client,
+    regular_token1,
+    chunk_tfidf_assessment_id,
+    chunk_non_tfidf_assessment_id,
+    test_db_session,
+    monkeypatch,
 ):
     """/init drops staging rows older than the TTL (with their chunks via cascade),
-    leaves fresh rows alone, and still creates the new upload."""
+    sweeps purely by age (not assessment), leaves fresh rows alone, and logs the count.
+    """
+    from assessment_routes.v3 import tfidf_artifact_routes as routes
+
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     stale_id = _insert_stale_staging(
         test_db_session, chunk_tfidf_assessment_id, age_hours=48
     )
+    # A stale row attached to a different assessment must also be swept —
+    # the cleanup is purely time-based, not assessment-scoped.
+    cross_stale_id = _insert_stale_staging(
+        test_db_session,
+        chunk_non_tfidf_assessment_id,
+        age_hours=72,
+        with_chunk=False,
+    )
     fresh_id = _insert_stale_staging(
         test_db_session, chunk_tfidf_assessment_id, age_hours=1, with_chunk=False
+    )
+
+    info_calls = []
+    real_info = routes.logger.info
+    monkeypatch.setattr(
+        routes.logger,
+        "info",
+        lambda msg, *args, **kwargs: (
+            info_calls.append((msg, args)),
+            real_info(msg, *args, **kwargs),
+        )[1],
     )
 
     resp = client.post(
@@ -901,10 +928,22 @@ def test_init_sweeps_stale_staging_rows(
     )
     assert (
         test_db_session.query(TfidfSvdStaging)
+        .filter_by(upload_id=cross_stale_id)
+        .one_or_none()
+        is None
+    )
+    assert (
+        test_db_session.query(TfidfSvdStaging)
         .filter_by(upload_id=fresh_id)
         .one_or_none()
         is not None
     )
+
+    sweep_logs = [
+        (msg, args) for msg, args in info_calls if "Swept" in msg and "stale" in msg
+    ]
+    assert len(sweep_logs) == 1
+    assert sweep_logs[0][1][0] == 2  # two stale rows reported
 
     client.post(
         f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
@@ -914,5 +953,44 @@ def test_init_sweeps_stale_staging_rows(
     client.post(
         f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
         json={"upload_id": str(fresh_id)},
+        headers=headers,
+    )
+
+
+def test_init_continues_when_sweep_fails(
+    client, regular_token1, chunk_tfidf_assessment_id, test_db_session, monkeypatch
+):
+    """If _sweep_stale_staging raises, /init must still succeed — the cleanup
+    is opportunistic and must never break a user's upload."""
+    from sqlalchemy.exc import SQLAlchemyError
+
+    from assessment_routes.v3 import tfidf_artifact_routes as routes
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    async def boom(db, *, ttl_hours=routes._STAGING_TTL_HOURS):
+        raise SQLAlchemyError("simulated sweep failure")
+
+    monkeypatch.setattr(routes, "_sweep_stale_staging", boom)
+
+    resp = client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/init",
+        json=_init_body(total_chunks=1),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    new_upload_id = resp.json()["upload_id"]
+
+    test_db_session.expire_all()
+    assert (
+        test_db_session.query(TfidfSvdStaging)
+        .filter_by(upload_id=uuid.UUID(new_upload_id))
+        .one_or_none()
+        is not None
+    )
+
+    client.post(
+        f"{prefix}/assessment/{chunk_tfidf_assessment_id}/tfidf-artifacts/abort",
+        json={"upload_id": new_upload_id},
         headers=headers,
     )


### PR DESCRIPTION
## Summary

- Closes #589 — abandoned chunked uploads no longer accumulate `tfidf_svd_staging` rows (and their cascaded chunks) forever.
- New `_sweep_stale_staging` helper deletes any staging row older than `_STAGING_TTL_HOURS = 24`, called opportunistically at the top of `init_tfidf_artifacts_upload`.
- Uses `FOR UPDATE SKIP LOCKED` on the candidate set so an in-flight `/chunk` write (which holds `FOR KEY SHARE`) is never blocked — those rows just defer to the next sweep.
- Sweep failure is logged and swallowed: someone else's abandoned upload should never break the user's `/init`.
- Logs `Swept N stale tfidf staging row(s) older than 24h` on every non-zero sweep so ops can see how much state is being reclaimed.

Picked option 2 from the issue (lazy sweep) — no new infra, self-maintaining, and the existing `ix_tfidf_svd_staging_created_at` index makes the cutoff scan cheap.

## Test plan

- [x] New `test_init_sweeps_stale_staging_rows` — backdates a staging row + chunk by 48h and a second one by 1h, calls `/init`, verifies the stale row and its chunks are gone via cascade, the fresh row is untouched, and the new upload succeeds.
- [x] All 22 existing chunked-upload tests still pass.
- [x] All 37 existing single-POST TF-IDF tests still pass.
- [x] `black` / `isort` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)