### PR TITLE
Remove serval-nmt training type

### DIFF
--- a/models.py
+++ b/models.py
@@ -1091,7 +1091,6 @@ class AgentTranslationOut(BaseModel):
 
 
 class TrainingType(str, Enum):
-    serval_nmt = "serval-nmt"
     semantic_similarity = "semantic-similarity"
     tfidf = "tfidf"
     word_alignment = "word-alignment"

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -29,9 +29,9 @@ def _make_modal_mock(
 
     spawn_by_app: optional dict mapping Modal app name -> Exception (or None for success).
     spawn_by_type: optional dict mapping training-type value -> Exception (or None).
-        Non-serval-nmt training types all share one Modal function
-        ("runner", "run_assessment_runner"), so failures can't be isolated
-        by app_name; keying on args[0]["type"] recovers per-type isolation.
+        All training types share one Modal function ("runner",
+        "run_assessment_runner"), so failures can't be isolated by app_name;
+        keying on args[0]["type"] recovers per-type isolation.
     default_exc: Exception raised by any call not matched by the two dicts above.
     calls: optional list; (app, fn_name) is appended per from_name invocation.
     payloads: optional list; (app, args, kwargs) is appended per spawn invocation.
@@ -225,9 +225,8 @@ def test_create_training_job_per_app_dispatch_isolation(
 ):
     """A spawn failure for one assessment type must not affect the others.
 
-    All non-serval-nmt training types share a single Modal function, so
-    isolation is recovered by keying the mock on args[0]["type"] rather
-    than app_name.
+    All training types share a single Modal function, so isolation is
+    recovered by keying the mock on args[0]["type"] rather than app_name.
     """
     response = _create_training_jobs_via_api(
         client,
@@ -266,28 +265,6 @@ def test_semantic_similarity_routes_through_runner(
     assert len(jobs) == 1 and jobs[0]["type"] == "semantic-similarity"
     assert jobs[0]["status"] == "failed"
     assert ("runner", "run_assessment_runner") in calls
-
-
-def test_serval_nmt_routes_through_train_runner(
-    client, regular_token1, test_revision_id, test_revision_id_2
-):
-    """serval-nmt must dispatch to ("train-runner", "run_training_job")."""
-    calls = []
-    response = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "serval_routing_test"},
-        apps=["serval-nmt"],
-        spawn_by_app={"train-runner": RuntimeError("runner down")},
-        calls=calls,
-    )
-    assert response.status_code == 200
-    jobs = response.json()["training_jobs"]
-    assert len(jobs) == 1 and jobs[0]["type"] == "serval-nmt"
-    assert jobs[0]["status"] == "failed"
-    assert ("train-runner", "run_training_job") in calls
 
 
 def test_training_job_full_lifecycle_via_runner(
@@ -425,9 +402,8 @@ def test_training_type_enum_covered_by_dispatch():
     """
     from train_routes.v3.train_routes import TRAINABLE_ASSESSMENT_TYPES
 
-    reachable = TRAINABLE_ASSESSMENT_TYPES | {TrainingType.serval_nmt.value}
     enum_values = {t.value for t in TrainingType}
-    missing = enum_values - reachable
+    missing = enum_values - TRAINABLE_ASSESSMENT_TYPES
     assert not missing, f"TrainingType values with no dispatch branch: {missing}"
 
 
@@ -1055,11 +1031,7 @@ def _get_assessment(db_session, assessment_id):
 def test_training_job_creates_assessment_for_trainable_types(
     client, regular_token1, test_revision_id, test_revision_id_2, db_session
 ):
-    """Every non-serval-nmt TrainingJob has a matching Assessment row.
-
-    serval-nmt must have assessment_id=None because aqua-assessments has no
-    assessment type for NMT engines.
-    """
+    """Every TrainingJob has a matching Assessment row."""
     resp = _create_training_jobs_via_api(
         client,
         regular_token1,
@@ -1070,9 +1042,7 @@ def test_training_job_creates_assessment_for_trainable_types(
     assert resp.status_code == 200
     jobs = {job["type"]: job for job in resp.json()["training_jobs"]}
 
-    assert jobs["serval-nmt"]["assessment_id"] is None
-
-    for training_type in ALL_TRAINING_TYPES - {"serval-nmt"}:
+    for training_type in ALL_TRAINING_TYPES:
         job = jobs[training_type]
         assert (
             job["assessment_id"] is not None
@@ -1091,10 +1061,10 @@ def test_training_job_creates_assessment_for_trainable_types(
 def test_trainable_types_route_through_runner_with_is_training(
     client, regular_token1, test_revision_id, test_revision_id_2
 ):
-    """Every non-serval-nmt training type must dispatch through
-    ("runner", "run_assessment_runner") with an AssessmentIn-shaped
-    config carrying is_training=True. Asserts both the dispatch target
-    and the assessment_id identity on the payload.
+    """Every training type must dispatch through ("runner",
+    "run_assessment_runner") with an AssessmentIn-shaped config carrying
+    is_training=True. Asserts both the dispatch target and the
+    assessment_id identity on the payload.
     """
     calls = []
     payloads = []

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -61,7 +61,6 @@ TERMINAL_STATUSES = {"completed", "completed_with_errors", "failed"}
 COMPLETED_STATUSES = {"completed", "completed_with_errors"}
 
 # Training types that have a corresponding aqua-assessments Assessment row.
-# serval-nmt is excluded — it produces a translation engine, not an assessment.
 # Every type listed here must also appear in AssessmentType in models.py so the
 # Assessment row is readable by the existing /v3/assessment endpoints.
 TRAINABLE_ASSESSMENT_TYPES = {
@@ -146,8 +145,7 @@ async def _mirror_terminal_status_to_assessment(
     Because this is reconciliation, it deliberately bypasses
     ASSESSMENT_VALID_TRANSITIONS (queued → terminal is not a valid transition
     there). To avoid clobbering aqua-assessments' own terminal post, this
-    helper is a no-op if the Assessment is already in a terminal state.
-    Also a no-op for jobs with no linked Assessment (e.g. serval-nmt) or
+    helper is a no-op if the Assessment is already in a terminal state, or
     whose Assessment row has been soft-deleted.
     """
     if job.assessment_id is None:
@@ -306,7 +304,7 @@ async def create_training_job(
 
         # For trainable assessment types, create a paired Assessment row so
         # aqua-assessments can write artifacts under the same assessment_id
-        # pattern used by the assess() path. serval-nmt is skipped.
+        # pattern used by the assess() path.
         assessment_id = None
         if training_type.value in TRAINABLE_ASSESSMENT_TYPES:
             assessment = Assessment(
@@ -358,13 +356,7 @@ async def create_training_job(
     async def dispatch_job(job: TrainingJob):
         """Returns (job, exception) tuple. Does NOT mutate the DB session."""
         try:
-            if job.type == TrainingType.serval_nmt.value:
-                f = modal.Function.from_name(
-                    "train-runner", "run_training_job", environment_name=modal_env
-                )
-                job_out = TrainingJobOut.model_validate(job)
-                await f.spawn.aio(job_out.model_dump(mode="json"))
-            elif job.type in TRAINABLE_ASSESSMENT_TYPES:
+            if job.type in TRAINABLE_ASSESSMENT_TYPES:
                 # Runner dispatches to the right app's assess() based on
                 # config.type and, because config["is_training"] is True,
                 # emits the phased status sequence (preparing → training →


### PR DESCRIPTION
## Summary
serval-nmt was the only \`TrainingType\` without a corresponding aqua-assessments \`Assessment\` row, and the only one dispatched to a separate Modal app (\`train-runner.run_training_job\`) instead of the shared assessment runner. We're not using it for now, and removing it lets every \`TrainingType\` have a 1:1 \`Assessment\` — which sets up a follow-up simplification of the \`TrainingJob\` model (eliminate duplicated status fields by deriving from the linked Assessment).

## Changes
- \`TrainingType.serval_nmt\` dropped from the enum (\`models.py\`).
- Dispatch branch in \`POST /v3/train\` collapses to a single \`TRAINABLE_ASSESSMENT_TYPES\` path; the \`train-runner\` Modal function is no longer referenced anywhere in this repo.
- Comments / docstrings that called out "serval-nmt is excluded / no Assessment / dispatches separately" updated.
- \`test_serval_nmt_routes_through_train_runner\` deleted.
- \`test_training_type_enum_covered_by_dispatch\` simplified (no special case).
- \`test_training_job_creates_assessment_for_trainable_types\` simplified (every type now has an assessment_id).

## Test plan
- [x] Lint clean (\`black\`, \`flake8\`).
- [ ] CI test suite (full \`test_train_routes\` against the localdb).
- [x] \`grep -rn serval\` returns nothing in active code.

## Notes
- Existing \`training_job\` rows of type \`serval-nmt\` in the shared dev/prod DB will not validate against the new enum on read. If any rows exist, they'll need a one-line cleanup (\`UPDATE training_job SET deleted = true WHERE type = 'serval-nmt';\` or DELETE) before this lands. Worth a quick pre-merge check.
- No migration in this PR — column shape unchanged. Just the enum value going away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)