### PR TITLE
Add eflomal-backed missing words detection

### DIFF
--- a/assessment_routes/v3/results_query_routes.py
+++ b/assessment_routes/v3/results_query_routes.py
@@ -21,6 +21,9 @@ from database.models import (
     Assessment,
     AssessmentResult,
     BibleRevision,
+    EflomalAssessment,
+    EflomalDictionary,
+    EflomalTargetWordCount,
     NgramsTable,
     NgramVrefTable,
     TextLengthsTable,
@@ -35,6 +38,13 @@ from models import Result_v2 as Result
 from models import TextLengthsResult, TfidfResult, WordAlignment
 from security_routes.auth_routes import get_current_user
 from security_routes.utilities import is_user_authorized_for_assessment
+from utils.eflomal_missing_words import (
+    DEFAULT_MIN_FREQUENCY,
+    build_directional_dicts,
+    compute_word_counts,
+    detect_orphans,
+    greedy_align,
+)
 from utils.logging_config import setup_logger
 from utils.verse_range_utils import merge_verse_ranges
 
@@ -2014,6 +2024,162 @@ async def get_alignment_scores(
     return {"results": result_data, "total_count": total_count}
 
 
+async def _get_missing_words_eflomal(
+    revision_id: int,
+    reference_id: int,
+    direction: str,
+    threshold: Optional[float],
+    book: Optional[str],
+    chapter: Optional[int],
+    verse: Optional[int],
+    db: AsyncSession,
+) -> Tuple[List[Result], int, Optional[int]]:
+    """Compute eflomal-style orphan/missing words on the API side.
+
+    Finds the most recent finished Assessment with a matching EflomalAssessment
+    for (revision_id, reference_id), pulls the dictionary + target word counts,
+    optionally tallies source word counts on the fly, then runs the per-verse
+    greedy alignment + orphan detector for each verse pair in the requested
+    book/chapter/verse scope.
+    """
+    main = (
+        await db.execute(
+            select(EflomalAssessment, Assessment.id.label("parent_id"))
+            .join(Assessment, Assessment.id == EflomalAssessment.assessment_id)
+            .where(
+                Assessment.revision_id == revision_id,
+                Assessment.reference_id == reference_id,
+                Assessment.status == "finished",
+            )
+            .order_by(Assessment.end_time.desc())
+        )
+    ).first()
+    if not main:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "No completed eflomal assessment found for the given "
+                "revision_id and reference_id"
+            ),
+        )
+    eflomal_assessment, parent_assessment_id = main
+
+    dict_rows = (
+        await db.execute(
+            select(
+                EflomalDictionary.source_word,
+                EflomalDictionary.target_word,
+                EflomalDictionary.count,
+            ).where(EflomalDictionary.assessment_id == eflomal_assessment.id)
+        )
+    ).all()
+    forward_dict, reverse_dict = build_directional_dicts(dict_rows)
+
+    tgt_count_rows = (
+        await db.execute(
+            select(EflomalTargetWordCount.word, EflomalTargetWordCount.count).where(
+                EflomalTargetWordCount.assessment_id == eflomal_assessment.id
+            )
+        )
+    ).all()
+    tgt_word_counts: Dict[str, int] = {r.word: r.count for r in tgt_count_rows}
+
+    src_word_counts: Dict[str, int] = {}
+    if direction in ("source", "both"):
+        # Source-direction scan needs corpus-wide source word frequencies.
+        # We don't store an eflomal_source_word_count table, so tally on the
+        # fly from the reference revision text.
+        ref_text_blobs = (
+            (
+                await db.execute(
+                    select(VerseText.text).where(VerseText.revision_id == reference_id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        src_word_counts = compute_word_counts(ref_text_blobs)
+
+    ref_query = select(VerseText.verse_reference, VerseText.text).where(
+        VerseText.revision_id == reference_id
+    )
+    if book is not None:
+        ref_query = ref_query.where(VerseText.book == book)
+    if chapter is not None:
+        ref_query = ref_query.where(VerseText.chapter == chapter)
+    if verse is not None:
+        ref_query = ref_query.where(VerseText.verse == verse)
+    reference_texts: Dict[str, str] = {
+        r.verse_reference: r.text for r in (await db.execute(ref_query)).all()
+    }
+    if not reference_texts:
+        return [], 0, parent_assessment_id
+
+    revision_text_rows = (
+        await db.execute(
+            select(VerseText.verse_reference, VerseText.text).where(
+                VerseText.revision_id == revision_id,
+                VerseText.verse_reference.in_(list(reference_texts)),
+            )
+        )
+    ).all()
+    revision_texts: Dict[str, str] = {
+        r.verse_reference: r.text for r in revision_text_rows
+    }
+
+    min_frequency = float(threshold) if threshold is not None else DEFAULT_MIN_FREQUENCY
+
+    results: List[Result] = []
+    for vref, ref_text in reference_texts.items():
+        rev_text = revision_texts.get(vref)
+        if not ref_text or not rev_text:
+            continue
+        src_words = ref_text.split()
+        tgt_words = rev_text.split()
+        if not src_words or not tgt_words:
+            continue
+        aligned_src, aligned_tgt = greedy_align(src_words, tgt_words, forward_dict)
+        orphans = detect_orphans(
+            src_words=src_words,
+            tgt_words=tgt_words,
+            aligned_src=aligned_src,
+            aligned_tgt=aligned_tgt,
+            direction=direction,
+            forward_dict=forward_dict,
+            reverse_dict=reverse_dict,
+            src_word_counts=src_word_counts,
+            tgt_word_counts=tgt_word_counts,
+            min_frequency=min_frequency,
+        )
+        for o in orphans:
+            if o["missing_side"] == "target":
+                results.append(
+                    Result(
+                        assessment_id=parent_assessment_id,
+                        vref=vref,
+                        source=o["known_counterparts"],
+                        target=[{"word": o["missing_word"]}],
+                        score=o["score"],
+                        flag=False,
+                        note="orphan_target",
+                    )
+                )
+            else:
+                results.append(
+                    Result(
+                        assessment_id=parent_assessment_id,
+                        vref=vref,
+                        source=o["missing_word"],
+                        target=[{"word": o["known_counterparts"]}],
+                        score=o["score"],
+                        flag=False,
+                        note="orphan_source",
+                    )
+                )
+
+    return results, len(results), parent_assessment_id
+
+
 @router.get("/missingwords", response_model=Dict[str, Union[List[Result], int]])
 async def get_missing_words(
     revision_id: int,
@@ -2023,6 +2189,23 @@ async def get_missing_words(
     book: Optional[str] = None,
     chapter: Optional[int] = None,
     verse: Optional[int] = None,
+    use_eflomal: bool = Query(
+        False,
+        description=(
+            "Use eflomal-derived orphan/missing-word detection over the corpus "
+            "dictionary instead of the legacy alignment-score path."
+        ),
+    ),
+    direction: str = Query(
+        "target",
+        pattern="^(source|target|both)$",
+        description=(
+            "Side(s) to detect orphans on. Only used when use_eflomal=True. "
+            "'target' finds unaligned revision words with no source counterpart; "
+            "'source' is the symmetric reference-side variant; 'both' returns "
+            "both kinds, distinguished by the response's note field."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -2054,6 +2237,39 @@ async def get_missing_words(
     request_start = time.perf_counter()
 
     await validate_parameters(book, chapter, verse)
+
+    if use_eflomal:
+        result_list, total_count, assessment_id = await _get_missing_words_eflomal(
+            revision_id=revision_id,
+            reference_id=reference_id,
+            direction=direction,
+            threshold=threshold,
+            book=book,
+            chapter=chapter,
+            verse=verse,
+            db=db,
+        )
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"get_missing_words (eflomal) completed in {duration}s",
+            extra={
+                "method": "GET",
+                "path": "/missingwords",
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "use_eflomal": True,
+                "direction": direction,
+                "threshold": threshold,
+                "book": book,
+                "chapter": chapter,
+                "verse": verse,
+                "assessment_id": assessment_id,
+                "total_count": total_count,
+                "results_returned": len(result_list),
+                "duration_s": duration,
+            },
+        )
+        return {"results": result_list, "total_count": total_count}
 
     if baseline_ids is None:
         baseline_ids = []

--- a/test/test_assessment_routes/test_eflomal_missingwords.py
+++ b/test/test_assessment_routes/test_eflomal_missingwords.py
@@ -1,0 +1,275 @@
+"""Tests for the use_eflomal=True branch of GET /v3/missingwords."""
+
+import pytest
+
+from database.models import (
+    Assessment,
+    BibleRevision,
+    BibleVersion,
+    BibleVersionAccess,
+    EflomalAssessment,
+    EflomalDictionary,
+    EflomalTargetWordCount,
+    Group,
+    UserDB,
+    VerseText,
+)
+
+EFLOMAL_REV_ID = 8801  # revision (target / swh)
+EFLOMAL_REF_ID = 8800  # reference (source / eng)
+EFLOMAL_VERSION_ID = 8800
+EFLOMAL_ASSESSMENT_ID = 8800
+
+
+def _seed_eflomal_fixture(db_session):
+    """Create a single-verse eflomal assessment with engineered orphans.
+
+    Engineered scenario for vref 'GEN 1:1':
+      reference (eng)  = "god created"
+      revision  (swh)  = "mungu kosmos borderline"
+      dictionary       = god→mungu(100), created→aliumba(100),
+                         world→kosmos(100), alpha→borderline(10)
+      target counts    = mungu:100, kosmos:200, borderline:50
+                         (alignment freq for kosmos = 100/200 = 0.5,
+                          alignment freq for borderline = 10/50 = 0.2)
+      reference corpus is just one verse, so src_word_counts derived on the
+      fly are {"god": 1, "created": 1}.
+
+    Greedy alignment matches god↔mungu only. With default min_frequency=0.5:
+      - target side: 'kosmos' is an orphan (known src 'world' not in source);
+        'borderline' is dropped at min_frequency=0.5 but emitted at 0.1.
+      - source side: 'created' is an orphan (known tgt 'aliumba' not in
+        target); 'god' was aligned, so skipped.
+    """
+    if (
+        db_session.query(Assessment)
+        .filter(Assessment.id == EFLOMAL_ASSESSMENT_ID)
+        .first()
+    ):
+        return EFLOMAL_ASSESSMENT_ID
+
+    user = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    user_id = user.id if user else None
+
+    version = BibleVersion(
+        id=EFLOMAL_VERSION_ID,
+        abbreviation="EFLM",
+        name="Eflomal Missingwords Test",
+        owner_id=user_id,
+    )
+    db_session.add(version)
+
+    db_session.add(
+        BibleRevision(id=EFLOMAL_REF_ID, bible_version_id=EFLOMAL_VERSION_ID)
+    )
+    db_session.add(
+        BibleRevision(id=EFLOMAL_REV_ID, bible_version_id=EFLOMAL_VERSION_ID)
+    )
+
+    db_session.add(
+        VerseText(
+            text="god created",
+            revision_id=EFLOMAL_REF_ID,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
+    db_session.add(
+        VerseText(
+            text="mungu kosmos borderline",
+            revision_id=EFLOMAL_REV_ID,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
+
+    assessment = Assessment(
+        id=EFLOMAL_ASSESSMENT_ID,
+        revision_id=EFLOMAL_REV_ID,
+        reference_id=EFLOMAL_REF_ID,
+        type="word-alignment",
+        status="finished",
+        assessment_version="1",
+    )
+    db_session.add(assessment)
+
+    group = db_session.query(Group.id).first()
+    if group:
+        db_session.add(
+            BibleVersionAccess(bible_version_id=EFLOMAL_VERSION_ID, group_id=group[0])
+        )
+
+    db_session.commit()
+
+    eflomal = EflomalAssessment(
+        assessment_id=EFLOMAL_ASSESSMENT_ID,
+        source_language="eng",
+        target_language="swh",
+    )
+    db_session.add(eflomal)
+    db_session.commit()
+    db_session.refresh(eflomal)
+
+    db_session.add_all(
+        [
+            EflomalDictionary(
+                assessment_id=eflomal.id,
+                source_word="god",
+                target_word="mungu",
+                count=100,
+                probability=0.95,
+            ),
+            EflomalDictionary(
+                assessment_id=eflomal.id,
+                source_word="created",
+                target_word="aliumba",
+                count=100,
+                probability=0.9,
+            ),
+            EflomalDictionary(
+                assessment_id=eflomal.id,
+                source_word="world",
+                target_word="kosmos",
+                count=100,
+                probability=0.9,
+            ),
+            EflomalDictionary(
+                assessment_id=eflomal.id,
+                source_word="alpha",
+                target_word="borderline",
+                count=10,
+                probability=0.6,
+            ),
+        ]
+    )
+    db_session.add_all(
+        [
+            EflomalTargetWordCount(assessment_id=eflomal.id, word="mungu", count=100),
+            EflomalTargetWordCount(assessment_id=eflomal.id, word="kosmos", count=200),
+            EflomalTargetWordCount(
+                assessment_id=eflomal.id, word="borderline", count=50
+            ),
+        ]
+    )
+    db_session.commit()
+
+    return EFLOMAL_ASSESSMENT_ID
+
+
+@pytest.fixture(scope="module")
+def eflomal_fixture(test_db_session):
+    return _seed_eflomal_fixture(test_db_session)
+
+
+def _get(client, token, **params):
+    return client.get(
+        "/v3/missingwords",
+        params=params,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def test_eflomal_direction_target(client, regular_token1, eflomal_fixture):
+    response = _get(
+        client,
+        regular_token1,
+        revision_id=EFLOMAL_REV_ID,
+        reference_id=EFLOMAL_REF_ID,
+        use_eflomal=True,
+        direction="target",
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    notes = sorted((r["note"], r["target"][0]["word"]) for r in body["results"])
+    assert notes == [("orphan_target", "kosmos")]
+    assert body["total_count"] == 1
+    only = body["results"][0]
+    assert only["vref"] == "GEN 1:1"
+    assert "world(100)" in only["source"]
+    assert pytest.approx(only["score"], abs=1e-4) == 0.5
+
+
+def test_eflomal_direction_source(client, regular_token1, eflomal_fixture):
+    response = _get(
+        client,
+        regular_token1,
+        revision_id=EFLOMAL_REV_ID,
+        reference_id=EFLOMAL_REF_ID,
+        use_eflomal=True,
+        direction="source",
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total_count"] == 1
+    only = body["results"][0]
+    assert only["note"] == "orphan_source"
+    assert only["source"] == "created"
+    assert "aliumba(100)" in only["target"][0]["word"]
+    assert only["vref"] == "GEN 1:1"
+
+
+def test_eflomal_direction_both(client, regular_token1, eflomal_fixture):
+    response = _get(
+        client,
+        regular_token1,
+        revision_id=EFLOMAL_REV_ID,
+        reference_id=EFLOMAL_REF_ID,
+        use_eflomal=True,
+        direction="both",
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    notes = sorted(r["note"] for r in body["results"])
+    assert notes == ["orphan_source", "orphan_target"]
+    assert body["total_count"] == 2
+
+
+def test_eflomal_threshold_override_admits_borderline(
+    client, regular_token1, eflomal_fixture
+):
+    # min_frequency lowered to 0.1 so the alignment_frequency=0.2 borderline
+    # word now passes; we should see kosmos AND borderline.
+    response = _get(
+        client,
+        regular_token1,
+        revision_id=EFLOMAL_REV_ID,
+        reference_id=EFLOMAL_REF_ID,
+        use_eflomal=True,
+        direction="target",
+        threshold=0.1,
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    found = sorted(r["target"][0]["word"] for r in body["results"])
+    assert found == ["borderline", "kosmos"]
+
+
+def test_eflomal_invalid_direction_returns_422(client, regular_token1, eflomal_fixture):
+    response = _get(
+        client,
+        regular_token1,
+        revision_id=EFLOMAL_REV_ID,
+        reference_id=EFLOMAL_REF_ID,
+        use_eflomal=True,
+        direction="garbage",
+    )
+    assert response.status_code == 422
+
+
+def test_eflomal_missing_assessment_returns_404(
+    client, regular_token1, test_db_session
+):
+    # Use revision IDs that have no eflomal assessment attached.
+    response = _get(
+        client,
+        regular_token1,
+        revision_id=999999,
+        reference_id=999998,
+        use_eflomal=True,
+        direction="both",
+    )
+    assert response.status_code == 404

--- a/utils/eflomal_missing_words.py
+++ b/utils/eflomal_missing_words.py
@@ -1,0 +1,219 @@
+"""Helpers for computing eflomal-style missing words on the API side.
+
+Ported from aqua-assessments/assessments/word_alignment/eflomal_steps/scoring.py
+and generalised to detect orphans in either direction (target or source).
+"""
+
+from collections import defaultdict
+from typing import Dict, Iterable, List, Set, Tuple
+
+from assessment_routes.v3.eflomal_routes import _normalize_word as normalize_word
+
+DEFAULT_MIN_ALIGNMENT_COUNT = 10
+DEFAULT_MIN_FREQUENCY = 0.5
+DEFAULT_MIN_WORD_LEN = 3
+DEFAULT_REVERSE_DICT_MIN_COUNT = 3
+KNOWN_COUNTERPARTS_SHOWN = 5
+
+
+def build_directional_dicts(
+    dict_rows: Iterable,
+    min_count: int = DEFAULT_REVERSE_DICT_MIN_COUNT,
+) -> Tuple[Dict[str, List[Tuple[str, int]]], Dict[str, List[Tuple[str, int]]]]:
+    """Build (forward, reverse) dicts from EflomalDictionary rows.
+
+    forward: src_norm -> [(tgt_norm, count), ...] sorted desc
+    reverse: tgt_norm -> [(src_norm, count), ...] sorted desc
+
+    Each row must expose ``.source_word``, ``.target_word``, ``.count``.
+    Raw rows that collide under normalization (e.g. "God" and "god") are
+    aggregated *before* applying ``min_count``, matching the behavior of
+    ``assessment_routes.v3.eflomal_routes._build_reverse_dict``.
+    """
+    forward_grouped: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    reverse_grouped: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    for row in dict_rows:
+        src = normalize_word(row.source_word)
+        tgt = normalize_word(row.target_word)
+        if not src or not tgt:
+            continue
+        forward_grouped[src][tgt] += row.count
+        reverse_grouped[tgt][src] += row.count
+
+    forward = _finalize_grouped(forward_grouped, min_count)
+    reverse = _finalize_grouped(reverse_grouped, min_count)
+    return forward, reverse
+
+
+def _finalize_grouped(
+    grouped: Dict[str, Dict[str, int]], min_count: int
+) -> Dict[str, List[Tuple[str, int]]]:
+    out: Dict[str, List[Tuple[str, int]]] = {}
+    for key, counterparts in grouped.items():
+        items = [(cp, c) for cp, c in counterparts.items() if c >= min_count]
+        if not items:
+            continue
+        # Deterministic order: highest count first, alphabetical tiebreaker.
+        items.sort(key=lambda x: (-x[1], x[0]))
+        out[key] = items
+    return out
+
+
+def compute_word_counts(texts: Iterable[str]) -> Dict[str, int]:
+    """Tally normalized-word frequencies across a set of verse texts.
+
+    Used to build ``src_word_counts`` on the fly for the source-direction scan
+    (we don't store an eflomal_source_word_count table).
+    """
+    counts: Dict[str, int] = defaultdict(int)
+    for blob in texts:
+        if not blob:
+            continue
+        for word in blob.split():
+            norm = normalize_word(word)
+            if norm:
+                counts[norm] += 1
+    return dict(counts)
+
+
+def greedy_align(
+    src_words: List[str],
+    tgt_words: List[str],
+    forward_dict: Dict[str, List[Tuple[str, int]]],
+) -> Tuple[Set[int], Set[int]]:
+    """Greedy per-verse dictionary match. Returns (aligned_src_idx, aligned_tgt_idx).
+
+    Reproduces app.py:_realtime_dictionary lines 567-585 in the reference impl:
+    for each source word, walk its candidate translations in count-desc order
+    and consume the first still-unmatched target index that carries the same
+    normalized form.
+    """
+    tgt_norm_to_idx: Dict[str, List[int]] = defaultdict(list)
+    for j, tgt in enumerate(tgt_words):
+        tgt_norm = normalize_word(tgt)
+        if tgt_norm:
+            tgt_norm_to_idx[tgt_norm].append(j)
+
+    aligned_src: Set[int] = set()
+    aligned_tgt: Set[int] = set()
+
+    for i, src in enumerate(src_words):
+        src_norm = normalize_word(src)
+        if not src_norm:
+            continue
+        for tgt_norm, _count in forward_dict.get(src_norm, []):
+            matched = False
+            for j in tgt_norm_to_idx.get(tgt_norm, []):
+                if j not in aligned_tgt:
+                    aligned_src.add(i)
+                    aligned_tgt.add(j)
+                    matched = True
+                    break
+            if matched:
+                break
+    return aligned_src, aligned_tgt
+
+
+def _detect_orphans_one_side(
+    *,
+    candidate_words: List[str],
+    aligned_indices: Set[int],
+    counterpart_words_norm: Set[str],
+    counterpart_dict: Dict[str, List[Tuple[str, int]]],
+    candidate_word_counts: Dict[str, int],
+    min_alignment_count: int,
+    min_frequency: float,
+    min_word_len: int,
+) -> List[dict]:
+    orphans: List[dict] = []
+    for j, word in enumerate(candidate_words):
+        if j in aligned_indices:
+            continue
+        word_norm = normalize_word(word)
+        if not word_norm or len(word_norm) < min_word_len:
+            continue
+        known = counterpart_dict.get(word_norm, [])
+        if not known:
+            continue
+        if any(cp in counterpart_words_norm for cp, _ in known):
+            continue
+        total_alignment_count = sum(c for _, c in known)
+        if total_alignment_count < min_alignment_count:
+            continue
+        appearances = candidate_word_counts.get(word_norm, 0)
+        if not appearances:
+            continue
+        alignment_frequency = total_alignment_count / appearances
+        if alignment_frequency < min_frequency:
+            continue
+        known_str = "; ".join(
+            f"{cp}({c})" for cp, c in known[:KNOWN_COUNTERPARTS_SHOWN]
+        )
+        orphans.append(
+            {
+                "missing_word": word,
+                "known_counterparts": known_str,
+                "score": round(min(alignment_frequency, 1.0), 4),
+            }
+        )
+    return orphans
+
+
+def detect_orphans(
+    *,
+    src_words: List[str],
+    tgt_words: List[str],
+    aligned_src: Set[int],
+    aligned_tgt: Set[int],
+    direction: str,
+    forward_dict: Dict[str, List[Tuple[str, int]]],
+    reverse_dict: Dict[str, List[Tuple[str, int]]],
+    src_word_counts: Dict[str, int],
+    tgt_word_counts: Dict[str, int],
+    min_alignment_count: int = DEFAULT_MIN_ALIGNMENT_COUNT,
+    min_frequency: float = DEFAULT_MIN_FREQUENCY,
+    min_word_len: int = DEFAULT_MIN_WORD_LEN,
+) -> List[dict]:
+    """Detect orphans on either side (or both) of one verse pair.
+
+    direction:
+      - "target": find unaligned target words whose known source translations
+        do not appear on the source side of this verse.
+      - "source": symmetric — unaligned source words whose known target
+        translations do not appear on the target side of this verse.
+      - "both": both kinds, distinguished in the output by ``missing_side``.
+
+    Each output dict has: ``missing_word``, ``missing_side``,
+    ``known_counterparts``, ``score``.
+    """
+    src_norms = {n for n in (normalize_word(w) for w in src_words) if n}
+    tgt_norms = {n for n in (normalize_word(w) for w in tgt_words) if n}
+
+    out: List[dict] = []
+    if direction in ("target", "both"):
+        for o in _detect_orphans_one_side(
+            candidate_words=tgt_words,
+            aligned_indices=aligned_tgt,
+            counterpart_words_norm=src_norms,
+            counterpart_dict=reverse_dict,
+            candidate_word_counts=tgt_word_counts,
+            min_alignment_count=min_alignment_count,
+            min_frequency=min_frequency,
+            min_word_len=min_word_len,
+        ):
+            o["missing_side"] = "target"
+            out.append(o)
+    if direction in ("source", "both"):
+        for o in _detect_orphans_one_side(
+            candidate_words=src_words,
+            aligned_indices=aligned_src,
+            counterpart_words_norm=tgt_norms,
+            counterpart_dict=forward_dict,
+            candidate_word_counts=src_word_counts,
+            min_alignment_count=min_alignment_count,
+            min_frequency=min_frequency,
+            min_word_len=min_word_len,
+        ):
+            o["missing_side"] = "source"
+            out.append(o)
+    return out


### PR DESCRIPTION
## Summary
- add an eflomal-backed execution path to `GET /v3/missingwords` behind the new `use_eflomal=true` query parameter
- support directional orphan detection with `direction=target|source|both`, using the existing result shape with `orphan_target` and `orphan_source` notes
- add shared helper logic for building normalized directional dictionaries, greedy word matching, on-the-fly source word counts, and orphan detection
- add focused API tests covering target-only, source-only, both directions, threshold overrides, invalid direction handling, and missing-assessment behavior

## Why
The existing missing-words route depends on the legacy alignment-score path. This change allows the API to compute missing/orphan words directly from a finished eflomal assessment, using the corpus dictionary and word-frequency thresholds to identify words that are left unmatched in either direction.

## Implementation
- query the most recent finished assessment for the supplied `revision_id` and `reference_id` that has an associated `EflomalAssessment`
- load eflomal dictionary rows and target word counts, and derive source word counts from the reference revision when source-side detection is requested
- run a per-verse greedy alignment pass, then detect orphan words on the target side, source side, or both depending on the request
- keep the existing response model, mapping target-side findings to `source=<known counterparts>` and `target=[{"word": <missing word>}]`, and source-side findings to the symmetric structure

## API Notes
- `use_eflomal` defaults to `false`, so the existing route behavior is unchanged unless the new path is explicitly requested
- `direction` defaults to `target` and is only meaningful when `use_eflomal=true`
- `threshold` is reused as the minimum alignment-frequency threshold for orphan detection on the eflomal path
- the eflomal path returns `404` when no completed eflomal assessment exists for the requested revision/reference pair

## Testing
- `AQUA_DB="postgresql+asyncpg://dbuser:dbpassword@localhost:5432/dbname" venv/bin/python -m pytest test/test_assessment_routes/test_eflomal_missingwords.py -v`
