### PR TITLE
fix(migration): cap lock_timeout/statement_timeout on threshold SET DEFAULT

### DIFF
--- a/alembic/migrations/versions/c9e7b1f2d3a4_threshold_scores_hide_flag_default.py
+++ b/alembic/migrations/versions/c9e7b1f2d3a4_threshold_scores_hide_flag_default.py
@@ -15,6 +15,13 @@ just ``ALTER COLUMN ... SET DEFAULT false``. Backfilling existing NULL
 rows is handled out of band by
 ``scripts/backfill_alignment_threshold_hide_flag.sql``.
 
+The ``SET DEFAULT`` step takes ``ACCESS EXCLUSIVE`` briefly. To avoid
+holding back the lock queue on the very large prod table if something
+slow is in flight, ``upgrade()`` sets ``lock_timeout = 5s`` and
+``statement_timeout = 60s`` for the duration of the catalog updates
+(then resets ``statement_timeout`` for the CONCURRENTLY index build,
+which legitimately runs long).
+
 Also creates ``ix_alignment_threshold_scores_assessment_id``: the read
 endpoint (``GET /alignmentscores?score_type=threshold``) filters by
 ``assessment_id``, and unlike the top-source sibling this column had no
@@ -46,10 +53,25 @@ _INDEX = f"ix_{_TABLE}_assessment_id"
 
 
 def upgrade() -> None:
+    # ``ALTER TABLE ... SET DEFAULT`` takes ACCESS EXCLUSIVE on the table.
+    # The catalog update itself is sub-second, but if a long-running query
+    # holds even a shared lock we'll queue for ACCESS EXCLUSIVE -- and once
+    # we're queued, every new query queues behind us, freezing the table
+    # for the duration of the wait. ``alignment_threshold_scores`` is a
+    # very large, hot table on prod, so cap the lock wait and the total
+    # statement time: if we can't get the lock fast we fail the migration
+    # cleanly rather than stalling the queue, and the operator can retry
+    # in a quieter window. CREATE INDEX CONCURRENTLY (below) doesn't take
+    # ACCESS EXCLUSIVE so these limits don't constrain it meaningfully.
+    op.execute(sa.text("SET lock_timeout = '5s'"))
+    op.execute(sa.text("SET statement_timeout = '60s'"))
     for column in _COLUMNS:
         op.execute(
             sa.text(f"ALTER TABLE {_TABLE} ALTER COLUMN {column} SET DEFAULT false")
         )
+    # Reset statement_timeout before the CONCURRENTLY index build, which can
+    # legitimately run for tens of minutes to hours on a large table.
+    op.execute(sa.text("SET statement_timeout = 0"))
     bind = op.get_bind()
     with op.get_context().autocommit_block():
         is_invalid = bind.exec_driver_sql(


### PR DESCRIPTION
## Summary
Follow-up to PR #598. Adds `SET lock_timeout = '5s'` and `SET statement_timeout = '60s'` around the `SET DEFAULT false` steps in `c9e7b1f2d3a4_threshold_scores_hide_flag_default.py` so that the migration fails fast on a busy `alignment_threshold_scores` instead of camping on the lock queue and freezing the table for the duration of the wait. `statement_timeout` is reset to `0` before the `CREATE INDEX CONCURRENTLY` step, which legitimately runs long.

The `CREATE INDEX CONCURRENTLY` step itself is unchanged — it doesn't take `ACCESS EXCLUSIVE`, so it doesn't need a timeout.

This will be applied to prod from this branch checkout before merge so that the catalog update has the safety net on its first run; merging back into main keeps the file in sync.

## Test plan
- [x] `alembic downgrade -1 && alembic upgrade head` round-trip locally — clean
- [x] black/isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)