### PR TITLE
Forward include_critique through /v3/predict to agent (fixes #606)

### DIFF
--- a/models.py
+++ b/models.py
@@ -414,6 +414,7 @@ class PredictInput(BaseModel):
                 "source_language": "eng",
                 "target_language": "swh",
                 "apps": ["ngrams", "tfidf"],
+                "include_critique": False,
             }
         }
     }

--- a/models.py
+++ b/models.py
@@ -397,6 +397,7 @@ class PredictInput(BaseModel):
     target_language: Optional[str] = Field(default=None, max_length=10)
     limit: Optional[int] = Field(default=None, ge=1, le=10000)
     apps: Optional[List[str]] = None
+    include_critique: bool = False
 
     model_config = {
         "json_schema_extra": {

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -274,58 +274,39 @@ def test_predict_forwards_payload_to_modal(client, regular_token1):
     assert payload["target_language"] == "swh"
 
 
-def test_predict_forwards_include_critique_to_modal(client, regular_token1):
-    """`include_critique` is forwarded to Modal so the agent runs the critique pass."""
+@pytest.mark.parametrize(
+    "extra,expected",
+    [
+        ({"include_critique": True}, True),
+        ({"include_critique": False}, False),
+        ({}, False),
+    ],
+    ids=["explicit_true", "explicit_false", "omitted_defaults_false"],
+)
+def test_predict_forwards_include_critique_to_modal(
+    client, regular_token1, extra, expected
+):
+    """`include_critique` survives `model_dump(exclude={"apps"})` and reaches Modal —
+    regression guard for the bug where the missing field was silently stripped."""
     captured = {}
 
-    def from_name(app_name, fn_name, environment_name=None):
-        mock_fn = AsyncMock()
+    async def capture(payload):
+        captured["payload"] = payload
+        return {"ok": True}
 
-        async def capture(payload):
-            captured["payload"] = payload
-            return {"ok": True}
-
-        mock_fn.remote.aio = AsyncMock(side_effect=capture)
-        return mock_fn
-
-    mock_cls = AsyncMock()
-    mock_cls.from_name = from_name
-    with patch("predict_routes.v3.predict_routes.modal.Function", mock_cls):
+    with patch(
+        "predict_routes.v3.predict_routes.modal.Function",
+        _make_modal_mock({"ngrams": capture}),
+    ):
         response = client.post(
             f"/{prefix}/predict",
-            json=_body(apps=["ngrams"], include_critique=True),
+            json=_body(apps=["ngrams"], **extra),
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
 
     assert response.status_code == 200, response.text
-    assert captured["payload"]["include_critique"] is True
-
-
-def test_predict_include_critique_defaults_false(client, regular_token1):
-    """When omitted, `include_critique` is forwarded as False."""
-    captured = {}
-
-    def from_name(app_name, fn_name, environment_name=None):
-        mock_fn = AsyncMock()
-
-        async def capture(payload):
-            captured["payload"] = payload
-            return {"ok": True}
-
-        mock_fn.remote.aio = AsyncMock(side_effect=capture)
-        return mock_fn
-
-    mock_cls = AsyncMock()
-    mock_cls.from_name = from_name
-    with patch("predict_routes.v3.predict_routes.modal.Function", mock_cls):
-        response = client.post(
-            f"/{prefix}/predict",
-            json=_body(apps=["ngrams"]),
-            headers={"Authorization": f"Bearer {regular_token1}"},
-        )
-
-    assert response.status_code == 200, response.text
-    assert captured["payload"]["include_critique"] is False
+    assert "include_critique" in captured["payload"]
+    assert captured["payload"]["include_critique"] is expected
 
 
 def test_predict_duplicate_apps_deduplicated(client, regular_token1):

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -274,6 +274,60 @@ def test_predict_forwards_payload_to_modal(client, regular_token1):
     assert payload["target_language"] == "swh"
 
 
+def test_predict_forwards_include_critique_to_modal(client, regular_token1):
+    """`include_critique` is forwarded to Modal so the agent runs the critique pass."""
+    captured = {}
+
+    def from_name(app_name, fn_name, environment_name=None):
+        mock_fn = AsyncMock()
+
+        async def capture(payload):
+            captured["payload"] = payload
+            return {"ok": True}
+
+        mock_fn.remote.aio = AsyncMock(side_effect=capture)
+        return mock_fn
+
+    mock_cls = AsyncMock()
+    mock_cls.from_name = from_name
+    with patch("predict_routes.v3.predict_routes.modal.Function", mock_cls):
+        response = client.post(
+            f"/{prefix}/predict",
+            json=_body(apps=["ngrams"], include_critique=True),
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert captured["payload"]["include_critique"] is True
+
+
+def test_predict_include_critique_defaults_false(client, regular_token1):
+    """When omitted, `include_critique` is forwarded as False."""
+    captured = {}
+
+    def from_name(app_name, fn_name, environment_name=None):
+        mock_fn = AsyncMock()
+
+        async def capture(payload):
+            captured["payload"] = payload
+            return {"ok": True}
+
+        mock_fn.remote.aio = AsyncMock(side_effect=capture)
+        return mock_fn
+
+    mock_cls = AsyncMock()
+    mock_cls.from_name = from_name
+    with patch("predict_routes.v3.predict_routes.modal.Function", mock_cls):
+        response = client.post(
+            f"/{prefix}/predict",
+            json=_body(apps=["ngrams"]),
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200, response.text
+    assert captured["payload"]["include_critique"] is False
+
+
 def test_predict_duplicate_apps_deduplicated(client, regular_token1):
     """Duplicate entries in `apps` are deduplicated; Modal is called once per app."""
     call_count = {"ngrams": 0}


### PR DESCRIPTION
## Summary
- Add `include_critique: bool = False` to `PredictInput` so the field survives `body.model_dump(exclude={\"apps\"})` and reaches the agent on Modal.
- Without this, Pydantic v2's `extra=\"ignore\"` silently stripped the field, and the agent always logged `📭 include_critique=False — skipping per-verse critique pass.` even when callers sent `include_critique: true`.

Closes #606.

## Test plan
- [x] `test_predict_forwards_include_critique_to_modal` — asserts the flag arrives in the Modal payload when set to `true`.
- [x] `test_predict_include_critique_defaults_false` — asserts it defaults to `false` when omitted.
- [x] Full `test/test_predict_routes/test_predict_routes.py` suite passes (21/21).
- [ ] Manual: re-run the issue's repro and confirm `results.agent.data.pairs[0].critique` is non-null with `omissions/additions/replacements`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)