### PR TITLE
feat(train): single status channel + per-session results endpoint

### DIFF
--- a/alembic/migrations/versions/b7a3e9d6f1c2_drop_training_job_status_fields.py
+++ b/alembic/migrations/versions/b7a3e9d6f1c2_drop_training_job_status_fields.py
@@ -26,14 +26,32 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.drop_index("ix_training_job_status", table_name="training_job")
-    op.drop_index("ix_training_job_type_status", table_name="training_job")
-    op.drop_index("ix_training_job_revisions_type_status", table_name="training_job")
-    op.create_index(
-        "ix_training_job_revisions_type",
-        "training_job",
-        ["source_revision_id", "target_revision_id", "type"],
-    )
+    # Index changes use CONCURRENTLY so they don't take ACCESS EXCLUSIVE on
+    # training_job during a rolling deploy. CONCURRENTLY can't run inside a
+    # transaction, so wrap the index ops in an autocommit block; the column
+    # drops below stay in the regular transactional block.
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_training_job_status",
+            table_name="training_job",
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "ix_training_job_type_status",
+            table_name="training_job",
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "ix_training_job_revisions_type_status",
+            table_name="training_job",
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_training_job_revisions_type",
+            "training_job",
+            ["source_revision_id", "target_revision_id", "type"],
+            postgresql_concurrently=True,
+        )
     op.drop_column("training_job", "status")
     op.drop_column("training_job", "status_detail")
     op.drop_column("training_job", "percent_complete")
@@ -90,11 +108,27 @@ def downgrade() -> None:
             server_default="queued",
         ),
     )
-    op.drop_index("ix_training_job_revisions_type", table_name="training_job")
-    op.create_index(
-        "ix_training_job_revisions_type_status",
-        "training_job",
-        ["source_revision_id", "target_revision_id", "type", "status"],
-    )
-    op.create_index("ix_training_job_type_status", "training_job", ["type", "status"])
-    op.create_index("ix_training_job_status", "training_job", ["status"])
+    with op.get_context().autocommit_block():
+        op.drop_index(
+            "ix_training_job_revisions_type",
+            table_name="training_job",
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_training_job_revisions_type_status",
+            "training_job",
+            ["source_revision_id", "target_revision_id", "type", "status"],
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_training_job_type_status",
+            "training_job",
+            ["type", "status"],
+            postgresql_concurrently=True,
+        )
+        op.create_index(
+            "ix_training_job_status",
+            "training_job",
+            ["status"],
+            postgresql_concurrently=True,
+        )

--- a/alembic/migrations/versions/b7a3e9d6f1c2_drop_training_job_status_fields.py
+++ b/alembic/migrations/versions/b7a3e9d6f1c2_drop_training_job_status_fields.py
@@ -1,0 +1,100 @@
+"""drop training_job status fields (single-channel status on assessment)
+
+Revision ID: b7a3e9d6f1c2
+Revises: c9e7b1f2d3a4
+Create Date: 2026-04-29 00:00:00.000000
+
+Completes the rollout in aqua-api#584. After aqua-assessments#202 the
+runner only PATCHes /v3/assessment/{id}/status, so TrainingJob.status*
+columns are no longer written. Drop them, along with the now-unused
+status-bearing indexes, and replace ix_training_job_revisions_type_status
+with a narrower index on (source_revision_id, target_revision_id, type)
+that supports the duplicate-job lookup (which now joins to Assessment to
+check liveness).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b7a3e9d6f1c2"
+down_revision: Union[str, None] = "c9e7b1f2d3a4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index("ix_training_job_status", table_name="training_job")
+    op.drop_index("ix_training_job_type_status", table_name="training_job")
+    op.drop_index("ix_training_job_revisions_type_status", table_name="training_job")
+    op.create_index(
+        "ix_training_job_revisions_type",
+        "training_job",
+        ["source_revision_id", "target_revision_id", "type"],
+    )
+    op.drop_column("training_job", "status")
+    op.drop_column("training_job", "status_detail")
+    op.drop_column("training_job", "percent_complete")
+    op.drop_column("training_job", "external_ids")
+    op.drop_column("training_job", "result_url")
+    op.drop_column("training_job", "result_metadata")
+    op.drop_column("training_job", "start_time")
+    op.drop_column("training_job", "end_time")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "training_job",
+        sa.Column("end_time", sa.TIMESTAMP(), nullable=True),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column("start_time", sa.TIMESTAMP(), nullable=True),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column(
+            "result_metadata",
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column("result_url", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column(
+            "external_ids",
+            sa.dialects.postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column("percent_complete", sa.Float(), nullable=True),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column("status_detail", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column(
+            "status",
+            sa.Text(),
+            nullable=False,
+            server_default="queued",
+        ),
+    )
+    op.drop_index("ix_training_job_revisions_type", table_name="training_job")
+    op.create_index(
+        "ix_training_job_revisions_type_status",
+        "training_job",
+        ["source_revision_id", "target_revision_id", "type", "status"],
+    )
+    op.create_index("ix_training_job_type_status", "training_job", ["type", "status"])
+    op.create_index("ix_training_job_status", "training_job", ["status"])

--- a/alembic/migrations/versions/b7a3e9d6f1c2_drop_training_job_status_fields.py
+++ b/alembic/migrations/versions/b7a3e9d6f1c2_drop_training_job_status_fields.py
@@ -25,32 +25,43 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _drop_invalid_index(bind, name: str) -> None:
+    """If a previous CONCURRENTLY build was interrupted Postgres leaves the
+    index in an INVALID state — IF NOT EXISTS will then skip the rebuild
+    and the planner could still try to use the broken one. Detect and drop
+    so this migration is safely retryable. Mirrors the pattern in
+    7f2e9a4b8c31_add_pg_trgm_index_on_verse_text.py."""
+    is_invalid = bind.exec_driver_sql(
+        f"SELECT 1 FROM pg_class c "
+        f"JOIN pg_index i ON i.indexrelid = c.oid "
+        f"WHERE c.relname = '{name}' AND NOT i.indisvalid"
+    ).scalar()
+    if is_invalid:
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+
+
 def upgrade() -> None:
     # Index changes use CONCURRENTLY so they don't take ACCESS EXCLUSIVE on
     # training_job during a rolling deploy. CONCURRENTLY can't run inside a
     # transaction, so wrap the index ops in an autocommit block; the column
     # drops below stay in the regular transactional block.
+    #
+    # IF EXISTS / IF NOT EXISTS make the autocommit block safely retryable
+    # if a deploy is interrupted between index ops (each CONCURRENTLY op
+    # commits independently). Mirrors the pattern in
+    # 7f2e9a4b8c31_add_pg_trgm_index_on_verse_text.py.
+    bind = op.get_bind()
     with op.get_context().autocommit_block():
-        op.drop_index(
-            "ix_training_job_status",
-            table_name="training_job",
-            postgresql_concurrently=True,
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_training_job_status")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_training_job_type_status")
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS " "ix_training_job_revisions_type_status"
         )
-        op.drop_index(
-            "ix_training_job_type_status",
-            table_name="training_job",
-            postgresql_concurrently=True,
-        )
-        op.drop_index(
-            "ix_training_job_revisions_type_status",
-            table_name="training_job",
-            postgresql_concurrently=True,
-        )
-        op.create_index(
-            "ix_training_job_revisions_type",
-            "training_job",
-            ["source_revision_id", "target_revision_id", "type"],
-            postgresql_concurrently=True,
+        _drop_invalid_index(bind, "ix_training_job_revisions_type")
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_training_job_revisions_type "
+            "ON training_job (source_revision_id, target_revision_id, type)"
         )
     op.drop_column("training_job", "status")
     op.drop_column("training_job", "status_detail")
@@ -108,27 +119,19 @@ def downgrade() -> None:
             server_default="queued",
         ),
     )
+    bind = op.get_bind()
     with op.get_context().autocommit_block():
-        op.drop_index(
-            "ix_training_job_revisions_type",
-            table_name="training_job",
-            postgresql_concurrently=True,
-        )
-        op.create_index(
-            "ix_training_job_revisions_type_status",
-            "training_job",
-            ["source_revision_id", "target_revision_id", "type", "status"],
-            postgresql_concurrently=True,
-        )
-        op.create_index(
-            "ix_training_job_type_status",
-            "training_job",
-            ["type", "status"],
-            postgresql_concurrently=True,
-        )
-        op.create_index(
-            "ix_training_job_status",
-            "training_job",
-            ["status"],
-            postgresql_concurrently=True,
-        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_training_job_revisions_type")
+        for name, cols in (
+            (
+                "ix_training_job_revisions_type_status",
+                "source_revision_id, target_revision_id, type, status",
+            ),
+            ("ix_training_job_type_status", "type, status"),
+            ("ix_training_job_status", "status"),
+        ):
+            _drop_invalid_index(bind, name)
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} "
+                f"ON training_job ({cols})"
+            )

--- a/database/models.py
+++ b/database/models.py
@@ -181,22 +181,16 @@ class TrainingJob(Base):
         String(3), ForeignKey("iso_language.iso639"), nullable=False
     )
 
-    status = Column(Text, nullable=False, default="queued")
-    status_detail = Column(Text, nullable=True)
-    percent_complete = Column(Float, nullable=True)
-
-    external_ids = Column(JSONB, nullable=True)
-    result_url = Column(Text, nullable=True)
-    result_metadata = Column(JSONB, nullable=True)
     options = Column(JSONB, nullable=True)
 
     requested_time = Column(TIMESTAMP, default=func.now())
-    start_time = Column(TIMESTAMP, nullable=True)
-    end_time = Column(TIMESTAMP, nullable=True)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     session_id = Column(Text, nullable=True)
 
+    # Status / timing / progress live on the linked Assessment row.
+    # See aqua-api#584/#593: aqua-assessments runner writes only to
+    # /v3/assessment/{id}/status; TrainingJob is metadata only.
     assessment_id = Column(
         Integer,
         ForeignKey("assessment.id", ondelete="SET NULL"),
@@ -212,15 +206,12 @@ class TrainingJob(Base):
     assessment = relationship("Assessment", foreign_keys=[assessment_id])
 
     __table_args__ = (
-        Index("ix_training_job_status", "status"),
-        Index("ix_training_job_type_status", "type", "status"),
         Index("ix_training_job_lang_pair", "source_language", "target_language"),
         Index(
-            "ix_training_job_revisions_type_status",
+            "ix_training_job_revisions_type",
             "source_revision_id",
             "target_revision_id",
             "type",
-            "status",
         ),
         Index("ix_training_job_session_id", "session_id"),
         Index("ix_training_job_assessment_id", "assessment_id"),

--- a/models.py
+++ b/models.py
@@ -1107,17 +1107,6 @@ class TrainingType(str, Enum):
     agent_critique = "agent-critique"
 
 
-class TrainingStatus(str, Enum):
-    queued = "queued"
-    preparing = "preparing"
-    training = "training"
-    downloading = "downloading"
-    uploading = "uploading"
-    completed = "completed"
-    completed_with_errors = "completed_with_errors"
-    failed = "failed"
-
-
 class TrainingJobIn(BaseModel):
     source_revision_id: int
     target_revision_id: int
@@ -1131,27 +1120,29 @@ class TrainingJobIn(BaseModel):
 
 
 class TrainingJobOut(BaseModel):
+    """TrainingJob is metadata only after aqua-api#584 — status, timing, and
+    progress are sourced from the linked Assessment row when serializing."""
+
     id: int
     type: str
     source_revision_id: int
     target_revision_id: int
     source_language: str
     target_language: str
-    status: str
-    status_detail: Optional[str] = None
-    percent_complete: Optional[float] = None
-    external_ids: Optional[Dict[str, Any]] = None
-    result_url: Optional[str] = None
-    result_metadata: Optional[Dict[str, Any]] = None
     options: Optional[Dict[str, Any]] = None
     requested_time: Optional[datetime.datetime] = None
-    start_time: Optional[datetime.datetime] = None
-    end_time: Optional[datetime.datetime] = None
     owner_id: Optional[int] = None
     session_id: Optional[str] = None
     assessment_id: Optional[int] = None
 
-    model_config = {"from_attributes": True, "use_enum_values": True}
+    # Mirrored from the linked Assessment row.
+    status: Optional[str] = None
+    status_detail: Optional[str] = None
+    percent_complete: Optional[float] = None
+    start_time: Optional[datetime.datetime] = None
+    end_time: Optional[datetime.datetime] = None
+
+    model_config = {"use_enum_values": True}
 
 
 class InferenceReadiness(BaseModel):
@@ -1165,15 +1156,25 @@ class TrainingResponse(BaseModel):
     inference_readiness: Dict[str, InferenceReadiness]
 
 
-class TrainingJobStatusUpdate(BaseModel):
-    status: TrainingStatus
-    status_detail: Optional[str] = None
-    percent_complete: Optional[float] = Field(None, ge=0.0, le=100.0)
-    external_ids: Optional[Dict[str, Any]] = None
-    result_url: Optional[str] = None
-    result_metadata: Optional[Dict[str, Any]] = None
+class TrainingSessionVrefResults(BaseModel):
+    vref: str
+    semantic_similarity: Optional[Result_v2] = None
+    word_alignment: List[WordAlignment] = Field(default_factory=list)
 
-    model_config = {"use_enum_values": True}
+
+class TrainingSessionResultsPage(BaseModel):
+    items: List[TrainingSessionVrefResults]
+    total_count: int
+    page: Optional[int] = None
+    page_size: Optional[int] = None
+
+
+class TrainingSessionResultsResponse(BaseModel):
+    session_id: str
+    training_jobs: List[TrainingJobOut]
+    inference_readiness: Dict[str, InferenceReadiness]
+    results: TrainingSessionResultsPage
+    ngrams: List[NgramResult] = Field(default_factory=list)
 
 
 class EflomalDictionaryItem(BaseModel):

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1,7 +1,15 @@
 # test_train_routes.py
 from unittest.mock import AsyncMock, patch
 
-from database.models import Assessment, TrainingJob, VerseText
+from database.models import (
+    AlignmentTopSourceScores,
+    Assessment,
+    AssessmentResult,
+    NgramsTable,
+    NgramVrefTable,
+    TrainingJob,
+    VerseText,
+)
 from models import TrainingType
 
 prefix = "v3"
@@ -274,14 +282,13 @@ def test_training_job_full_lifecycle_via_runner(
     test_revision_id_2,
     db_session,
 ):
-    """End-to-end lifecycle via the runner (acceptance item for #582).
+    """End-to-end lifecycle via the runner.
 
-    (1) POST /train dispatches to ("runner", "run_assessment_runner") with
-        an AssessmentIn-shaped config carrying is_training=True.
-    (2) PATCH /train/{id}/status accepts the full phase sequence the
-        runner emits: preparing → training → downloading → uploading →
-        completed.
-    (3) The paired Assessment row mirrors to finished at the end.
+    Status, percent_complete, and timing live on the linked Assessment row
+    (aqua-api#584). The aqua-assessments runner pushes the phased sequence
+    queued → preparing → training → downloading → uploading → finished
+    against PATCH /v3/assessment/{id}/status; aqua-api just exposes the
+    result via /v3/train reads.
     """
     payloads = []
     calls = []
@@ -313,23 +320,24 @@ def test_training_job_full_lifecycle_via_runner(
     assert config.get("is_training") is True
     assert "train_job_id" not in kwargs
 
-    # (2) Simulate the runner's phase callbacks on the status endpoint.
+    # (2) Simulate the runner's phase callbacks against the assessment-status
+    # endpoint — the only channel that exists post #584 / aqua-assessments#202.
     last_percent = {
         "preparing": 5.0,
         "training": 40.0,
         "downloading": 75.0,
         "uploading": 90.0,
-        "completed": 100.0,
+        "finished": 100.0,
     }
     for next_status in [
         "preparing",
         "training",
         "downloading",
         "uploading",
-        "completed",
+        "finished",
     ]:
         resp = client.patch(
-            f"{prefix}/train/{job['id']}/status",
+            f"{prefix}/assessment/{job['assessment_id']}/status",
             json={
                 "status": next_status,
                 "percent_complete": last_percent[next_status],
@@ -339,12 +347,17 @@ def test_training_job_full_lifecycle_via_runner(
         assert (
             resp.status_code == 200
         ), f"phase {next_status} rejected: {resp.status_code} {resp.text}"
-        assert resp.json()["status"] == next_status
 
-    # (3) Assessment mirrored to finished.
-    assessment = _get_assessment(db_session, job["assessment_id"])
-    assert assessment.status == "finished"
-    assert assessment.end_time is not None
+    # (3) /v3/train reads now reflect the assessment-driven status.
+    job_resp = client.get(
+        f"{prefix}/train/{job['id']}",
+        headers=_auth_headers(regular_token1),
+    )
+    assert job_resp.status_code == 200
+    job_view = job_resp.json()
+    assert job_view["status"] == "finished"
+    assert job_view["percent_complete"] == 100.0
+    assert job_view["end_time"] is not None
 
 
 def test_duplicate_detection_scoped_to_apps_filter(
@@ -387,10 +400,14 @@ def test_duplicate_detection_scoped_to_apps_filter(
     types = {job["type"] for job in r3.json()["training_jobs"]}
     assert types == {"ngrams"}
 
-    # Clean up so these jobs don't pollute later tests.
-    jobs = db_session.query(TrainingJob).filter_by(status="queued").all()
-    for j in jobs:
-        j.status = "failed"
+    # Clean up so these jobs don't pollute later tests — TrainingJob no
+    # longer carries status, so terminate the linked Assessments instead.
+    db_session.expire_all()
+    queued_assessments = (
+        db_session.query(Assessment).filter_by(status="queued", is_training=True).all()
+    )
+    for a in queued_assessments:
+        a.status = "failed"
     db_session.commit()
 
 
@@ -451,11 +468,16 @@ def test_create_training_job_duplicate_detection(
     )
     assert response3.status_code == 200
 
-    # Clean up: mark all as failed so they don't interfere with other tests
-    jobs = db_session.query(TrainingJob).all()
-    for job in jobs:
-        if job.status == "queued":
-            job.status = "failed"
+    # Clean up: mark all queued training assessments as failed so they don't
+    # interfere with other tests (TrainingJob has no status column post-#584).
+    db_session.expire_all()
+    queued = (
+        db_session.query(Assessment)
+        .filter(Assessment.is_training.is_(True), Assessment.status == "queued")
+        .all()
+    )
+    for a in queued:
+        a.status = "failed"
     db_session.commit()
 
 
@@ -531,213 +553,6 @@ def test_get_training_job_not_found(client, regular_token1):
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 404
-
-
-def test_patch_status_valid_transitions(
-    client, regular_token1, test_revision_id, test_revision_id_2, db_session
-):
-    """PATCH /train/{job_id}/status updates fields and enforces state machine."""
-    create_resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "status_test"},
-        apps=["tfidf"],
-    )
-    job_id = _get_first_job_id(create_resp)
-
-    # queued -> preparing
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={
-            "status": "preparing",
-            "external_ids": {"engine_id": "eng123"},
-        },
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["status"] == "preparing"
-    assert data["start_time"] is not None
-    assert data["external_ids"] == {"engine_id": "eng123"}
-
-    # preparing -> training
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "training", "percent_complete": 10.0},
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 200
-    assert resp.json()["percent_complete"] == 10.0
-
-    # training -> downloading
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "downloading"},
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 200
-
-    # downloading -> uploading
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "uploading"},
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 200
-
-    # uploading -> completed
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={
-            "status": "completed",
-            "result_url": "https://huggingface.co/sil-ai/test-model",
-            "result_metadata": {"bleu": 32.5},
-        },
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["status"] == "completed"
-    assert data["end_time"] is not None
-    assert data["result_url"] == "https://huggingface.co/sil-ai/test-model"
-
-
-def test_patch_status_invalid_transition(
-    client, regular_token1, test_revision_id, test_revision_id_2
-):
-    """PATCH /train/{job_id}/status rejects invalid state transitions."""
-    create_resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "invalid_transition_test"},
-    )
-    job_id = _get_first_job_id(create_resp)
-
-    # queued -> training (skipping preparing) should fail
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "training"},
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 422
-
-    # queued -> completed should fail
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "completed"},
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 422
-
-
-def test_patch_status_terminal_rejected(
-    client, regular_token1, test_revision_id, test_revision_id_2
-):
-    """PATCH /train/{job_id}/status rejects updates to terminal jobs."""
-    create_resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "terminal_test"},
-    )
-    job_id = _get_first_job_id(create_resp)
-
-    # Move to failed
-    client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "failed", "status_detail": "test failure"},
-        headers=_auth_headers(regular_token1),
-    )
-
-    # Try to update again
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "preparing"},
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 409
-
-
-def test_patch_status_failed_from_any(
-    client, regular_token1, test_revision_id, test_revision_id_2
-):
-    """Any non-terminal status can transition to failed."""
-    create_resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "failed_any_test"},
-    )
-    job_id = _get_first_job_id(create_resp)
-
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "failed", "status_detail": "queued_to_failed"},
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 200
-    assert resp.json()["status"] == "failed"
-
-
-def test_patch_status_completed_with_errors(
-    client, regular_token1, test_revision_id, test_revision_id_2
-):
-    """uploading -> completed_with_errors is valid."""
-    create_resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "completed_errors_test"},
-        apps=["tfidf"],
-    )
-    job_id = _get_first_job_id(create_resp)
-
-    # Walk to uploading
-    for next_status in ["preparing", "training", "downloading", "uploading"]:
-        client.patch(
-            f"{prefix}/train/{job_id}/status",
-            json={"status": next_status},
-            headers=_auth_headers(regular_token1),
-        )
-
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={
-            "status": "completed_with_errors",
-            "status_detail": "completed_with_errors: huggingface upload failed",
-        },
-        headers=_auth_headers(regular_token1),
-    )
-    assert resp.status_code == 200
-    assert resp.json()["status"] == "completed_with_errors"
-
-
-def test_patch_status_unauthenticated(
-    client, regular_token1, test_revision_id, test_revision_id_2
-):
-    """PATCH /train/{job_id}/status rejects unauthenticated requests."""
-    create_resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "bad_token_test"},
-        apps=["tfidf"],
-    )
-    job_id = _get_first_job_id(create_resp)
-
-    resp = client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "preparing"},
-    )
-    assert resp.status_code == 401
 
 
 def test_get_training_data_filter(
@@ -880,7 +695,7 @@ def test_get_training_data_empty(
 
 
 def test_delete_training_job_terminal(
-    client, regular_token1, test_revision_id, test_revision_id_2
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
 ):
     """DELETE /train/{job_id} soft deletes terminal jobs."""
     create_resp = _create_training_jobs_via_api(
@@ -890,25 +705,18 @@ def test_delete_training_job_terminal(
         test_revision_id_2,
         options={"tag": "delete_test"},
     )
-    job_id = _get_first_job_id(create_resp)
+    job = create_resp.json()["training_jobs"][0]
 
-    # Move to failed (terminal)
-    client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "failed"},
-        headers=_auth_headers(regular_token1),
-    )
+    _set_assessment_status(db_session, job["assessment_id"], "failed")
 
-    # Now delete
     resp = client.delete(
-        f"{prefix}/train/{job_id}",
+        f"{prefix}/train/{job['id']}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert resp.status_code == 200
 
-    # Should be 404 now
     resp = client.get(
-        f"{prefix}/train/{job_id}",
+        f"{prefix}/train/{job['id']}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert resp.status_code == 404
@@ -936,7 +744,12 @@ def test_delete_training_job_active_rejected(
 
 
 def test_delete_training_job_unauthorized(
-    client, regular_token1, regular_token2, test_revision_id, test_revision_id_2
+    client,
+    regular_token1,
+    regular_token2,
+    test_revision_id,
+    test_revision_id_2,
+    db_session,
 ):
     """DELETE /train/{job_id} rejects non-owner non-admin."""
     create_resp = _create_training_jobs_via_api(
@@ -946,18 +759,12 @@ def test_delete_training_job_unauthorized(
         test_revision_id_2,
         options={"tag": "delete_unauth_test"},
     )
-    job_id = _get_first_job_id(create_resp)
-
-    # Move to failed
-    client.patch(
-        f"{prefix}/train/{job_id}/status",
-        json={"status": "failed"},
-        headers=_auth_headers(regular_token1),
-    )
+    job = create_resp.json()["training_jobs"][0]
+    _set_assessment_status(db_session, job["assessment_id"], "failed")
 
     # testuser2 is not owner
     resp = client.delete(
-        f"{prefix}/train/{job_id}",
+        f"{prefix}/train/{job['id']}",
         headers={"Authorization": f"Bearer {regular_token2}"},
     )
     assert resp.status_code == 403
@@ -1131,115 +938,6 @@ def test_trainable_types_route_through_runner_with_is_training(
         assert "train_job_id" not in kwargs
 
 
-def test_completed_mirrors_to_assessment_finished(
-    client, regular_token1, test_revision_id, test_revision_id_2, db_session
-):
-    """TrainingJob completed -> Assessment finished; stale status_detail cleared."""
-    resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "mirror_completed_test"},
-        apps=["tfidf"],
-    )
-    assert resp.status_code == 200
-    job = resp.json()["training_jobs"][0]
-    assessment_id = job["assessment_id"]
-    assert assessment_id is not None
-
-    # Drop a progress detail during uploading. On completed, this stale detail
-    # must not leak onto the Assessment.
-    for next_status, detail in [
-        ("preparing", None),
-        ("training", None),
-        ("downloading", None),
-        ("uploading", "uploading artifact 3/4"),
-    ]:
-        body = {"status": next_status}
-        if detail is not None:
-            body["status_detail"] = detail
-        client.patch(
-            f"{prefix}/train/{job['id']}/status",
-            json=body,
-            headers=_auth_headers(regular_token1),
-        )
-    # Assessment should still be queued through non-terminal transitions
-    assert _get_assessment(db_session, assessment_id).status == "queued"
-
-    client.patch(
-        f"{prefix}/train/{job['id']}/status",
-        json={"status": "completed"},
-        headers=_auth_headers(regular_token1),
-    )
-    assessment = _get_assessment(db_session, assessment_id)
-    assert assessment.status == "finished"
-    assert assessment.status_detail is None
-    assert assessment.end_time is not None
-
-
-def test_failed_mirrors_to_assessment_failed(
-    client, regular_token1, test_revision_id, test_revision_id_2, db_session
-):
-    """TrainingJob failed -> Assessment failed with status_detail copied."""
-    resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "mirror_failed_test"},
-        apps=["ngrams"],
-    )
-    assert resp.status_code == 200
-    job = resp.json()["training_jobs"][0]
-    assessment_id = job["assessment_id"]
-
-    client.patch(
-        f"{prefix}/train/{job['id']}/status",
-        json={"status": "failed", "status_detail": "oom on worker"},
-        headers=_auth_headers(regular_token1),
-    )
-    assessment = _get_assessment(db_session, assessment_id)
-    assert assessment.status == "failed"
-    assert assessment.status_detail == "oom on worker"
-    assert assessment.end_time is not None
-
-
-def test_completed_with_errors_mirrors_to_assessment_failed(
-    client, regular_token1, test_revision_id, test_revision_id_2, db_session
-):
-    """TrainingJob completed_with_errors -> Assessment failed (no cwe in AssessmentStatus)."""
-    resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "mirror_cwe_test"},
-        apps=["word-alignment"],
-    )
-    assert resp.status_code == 200
-    job = resp.json()["training_jobs"][0]
-    assessment_id = job["assessment_id"]
-
-    for next_status in ["preparing", "training", "downloading", "uploading"]:
-        client.patch(
-            f"{prefix}/train/{job['id']}/status",
-            json={"status": next_status},
-            headers=_auth_headers(regular_token1),
-        )
-    client.patch(
-        f"{prefix}/train/{job['id']}/status",
-        json={
-            "status": "completed_with_errors",
-            "status_detail": "hf upload failed",
-        },
-        headers=_auth_headers(regular_token1),
-    )
-    assessment = _get_assessment(db_session, assessment_id)
-    assert assessment.status == "failed"
-    assert assessment.status_detail == "hf upload failed"
-
-
 def test_assessment_id_reaches_sem_sim_runner_config(
     client, regular_token1, test_revision_id, test_revision_id_2
 ):
@@ -1280,34 +978,6 @@ def test_assessment_id_reaches_sem_sim_runner_config(
     _, args, _kwargs = runner_calls[0]
     config = args[0]
     assert config["id"] == job["assessment_id"]
-
-
-def test_non_terminal_transition_does_not_mirror_to_assessment(
-    client, regular_token1, test_revision_id, test_revision_id_2, db_session
-):
-    """PATCH to training/preparing/etc. must leave the Assessment in queued."""
-    resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "non_terminal_mirror_test"},
-        apps=["tfidf"],
-    )
-    job = resp.json()["training_jobs"][0]
-    assessment_id = job["assessment_id"]
-
-    for next_status in ["preparing", "training"]:
-        client.patch(
-            f"{prefix}/train/{job['id']}/status",
-            json={"status": next_status},
-            headers=_auth_headers(regular_token1),
-        )
-        assessment = _get_assessment(db_session, assessment_id)
-        assert (
-            assessment.status == "queued"
-        ), f"Assessment mirrored on non-terminal '{next_status}'"
-        assert assessment.end_time is None
 
 
 def test_apps_filter_creates_assessments_only_for_selected_types(
@@ -1368,87 +1038,18 @@ def test_duplicate_post_does_not_create_duplicate_assessment(
     )
     assert len(assessments) == 1
 
-    # Clean up so queued jobs don't pollute later tests.
-    jobs = (
-        db_session.query(TrainingJob)
-        .filter_by(status="queued")
-        .filter(TrainingJob.options.op("@>")(opts))
+    # Clean up so queued jobs don't pollute later tests — TrainingJob has
+    # no status column post-#584; mark each job's linked Assessment failed.
+    db_session.expire_all()
+    queued = (
+        db_session.query(Assessment)
+        .join(TrainingJob, TrainingJob.assessment_id == Assessment.id)
+        .filter(TrainingJob.options.op("@>")(opts), Assessment.status == "queued")
         .all()
     )
-    for j in jobs:
-        j.status = "failed"
+    for a in queued:
+        a.status = "failed"
     db_session.commit()
-
-
-def test_mirror_respects_soft_deleted_assessment(
-    client, regular_token1, test_revision_id, test_revision_id_2, db_session
-):
-    """A soft-deleted Assessment must not be touched by the mirror helper."""
-    resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "mirror_deleted_test"},
-        apps=["ngrams"],
-    )
-    job = resp.json()["training_jobs"][0]
-    assessment_id = job["assessment_id"]
-
-    assessment = db_session.query(Assessment).filter_by(id=assessment_id).one()
-    assessment.deleted = True
-    db_session.commit()
-
-    client.patch(
-        f"{prefix}/train/{job['id']}/status",
-        json={"status": "failed", "status_detail": "after-delete"},
-        headers=_auth_headers(regular_token1),
-    )
-    db_session.expire_all()
-    assessment = db_session.query(Assessment).filter_by(id=assessment_id).one()
-    assert assessment.status == "queued"
-    assert assessment.status_detail is None
-    assert assessment.end_time is None
-
-
-def test_mirror_does_not_clobber_already_terminal_assessment(
-    client, regular_token1, test_revision_id, test_revision_id_2, db_session
-):
-    """If aqua-assessments already PATCHed Assessment to finished, mirror must not overwrite."""
-    resp = _create_training_jobs_via_api(
-        client,
-        regular_token1,
-        test_revision_id,
-        test_revision_id_2,
-        options={"tag": "mirror_no_clobber_test"},
-        apps=["agent-critique"],
-    )
-    job = resp.json()["training_jobs"][0]
-    assessment_id = job["assessment_id"]
-
-    assessment = db_session.query(Assessment).filter_by(id=assessment_id).one()
-    assessment.status = "finished"
-    assessment.status_detail = "posted-by-aqua-assessments"
-    db_session.commit()
-
-    for next_status in ["preparing", "training", "downloading", "uploading"]:
-        client.patch(
-            f"{prefix}/train/{job['id']}/status",
-            json={"status": next_status},
-            headers=_auth_headers(regular_token1),
-        )
-    client.patch(
-        f"{prefix}/train/{job['id']}/status",
-        json={
-            "status": "completed_with_errors",
-            "status_detail": "post-terminal mirror should be ignored",
-        },
-        headers=_auth_headers(regular_token1),
-    )
-    db_session.expire_all()
-    assessment = db_session.query(Assessment).filter_by(id=assessment_id).one()
-    assert assessment.status == "finished"
-    assert assessment.status_detail == "posted-by-aqua-assessments"
 
 
 def test_training_job_options_validator_rejects_non_scalar(
@@ -1469,22 +1070,25 @@ def test_training_job_options_validator_rejects_non_scalar(
     assert resp.status_code == 422
 
 
-def test_dispatch_failure_mirrors_to_assessment_failed(
+def test_dispatch_failure_marks_assessment_failed(
     client, regular_token1, test_revision_id, test_revision_id_2, db_session
 ):
-    """A Modal spawn failure marks both the TrainingJob and the Assessment failed."""
+    """A Modal spawn failure writes failed + dispatch_failed detail directly
+    onto the linked Assessment (the runner never got a chance to advance
+    Assessment.status past `queued`)."""
     resp = _create_training_jobs_via_api(
         client,
         regular_token1,
         test_revision_id,
         test_revision_id_2,
-        options={"tag": "mirror_dispatch_fail_test"},
+        options={"tag": "dispatch_fail_assessment_test"},
         apps=["tfidf"],
         spawn_by_type={"tfidf": RuntimeError("boom")},
     )
     assert resp.status_code == 200
     job = resp.json()["training_jobs"][0]
     assert job["status"] == "failed"
+    assert "dispatch_failed" in (job["status_detail"] or "")
     assessment = _get_assessment(db_session, job["assessment_id"])
     assert assessment.status == "failed"
     assert "dispatch_failed" in (assessment.status_detail or "")
@@ -1515,22 +1119,14 @@ def test_get_training_status_readiness_updates(
         is False
     )
 
-    # Mark the semantic-similarity job as completed
+    # Mark the semantic-similarity assessment as finished — readiness is
+    # computed from Assessment.status, the single source of truth.
     sem_sim_job = [
         j for j in data["training_jobs"] if j["type"] == "semantic-similarity"
     ][0]
-    for next_status in [
-        "preparing",
-        "training",
-        "downloading",
-        "uploading",
-        "completed",
-    ]:
-        client.patch(
-            f"{prefix}/train/{sem_sim_job['id']}/status",
-            json={"status": next_status},
-            headers=_auth_headers(regular_token1),
-        )
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
 
     # Now check readiness again
     status_resp = client.get(
@@ -1542,3 +1138,374 @@ def test_get_training_status_readiness_updates(
         status_resp.json()["inference_readiness"]["semantic-similarity"]["ready"]
         is True
     )
+
+
+# -- Session results endpoint tests --
+
+
+def _advance_assessment_to_finished(client, token, assessment_id):
+    """Walk an Assessment through the phased training sequence to finished
+    via PATCH /v3/assessment/{id}/status — the single status channel."""
+    for next_status in (
+        "preparing",
+        "training",
+        "downloading",
+        "uploading",
+        "finished",
+    ):
+        client.patch(
+            f"{prefix}/assessment/{assessment_id}/status",
+            json={"status": next_status},
+            headers=_auth_headers(token),
+        )
+
+
+def _set_assessment_status(db_session, assessment_id, status):
+    """Direct-write helper for tests that just need an Assessment in a
+    specific terminal state (bypasses the validated transition path)."""
+    db_session.expire_all()
+    assessment = (
+        db_session.query(Assessment).filter(Assessment.id == assessment_id).one()
+    )
+    assessment.status = status
+    db_session.commit()
+
+
+def _seed_sem_sim_results(db_session, assessment_id, vrefs_with_scores):
+    for vref, score in vrefs_with_scores:
+        book, rest = vref.split(" ")
+        chap, vs = rest.split(":")
+        db_session.add(
+            AssessmentResult(
+                assessment_id=assessment_id,
+                vref=vref,
+                book=book,
+                chapter=int(chap),
+                verse=int(vs),
+                score=score,
+            )
+        )
+    db_session.commit()
+
+
+def _seed_word_alignment(db_session, assessment_id, rows):
+    """rows: list of (vref, source, target, score)."""
+    for vref, source, target, score in rows:
+        book, rest = vref.split(" ")
+        chap, vs = rest.split(":")
+        db_session.add(
+            AlignmentTopSourceScores(
+                assessment_id=assessment_id,
+                vref=vref,
+                book=book,
+                chapter=int(chap),
+                verse=int(vs),
+                source=source,
+                target=target,
+                score=score,
+            )
+        )
+    db_session.commit()
+
+
+def _seed_ngrams(db_session, assessment_id, ngrams_with_vrefs):
+    """ngrams_with_vrefs: list of (ngram, ngram_size, [vrefs])."""
+    for ngram, size, vrefs in ngrams_with_vrefs:
+        ng = NgramsTable(assessment_id=assessment_id, ngram=ngram, ngram_size=size)
+        db_session.add(ng)
+        db_session.flush()
+        for v in vrefs:
+            db_session.add(NgramVrefTable(ngram_id=ng.id, vref=v))
+    db_session.commit()
+
+
+def test_session_results_no_auth(client):
+    response = client.get(f"{prefix}/train/status/some-uuid/results")
+    assert response.status_code == 401
+
+
+def test_session_results_unknown_session(client, regular_token1):
+    response = client.get(
+        f"{prefix}/train/status/nonexistent-uuid/results",
+        headers=_auth_headers(regular_token1),
+    )
+    assert response.status_code == 404
+
+
+def test_session_results_in_flight_returns_status_only(
+    client, regular_token1, test_revision_id, test_revision_id_2
+):
+    """No completed jobs yet → results=[], total_count=0, but training_jobs
+    surfaces status for every queued job."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_in_flight"},
+        apps=["semantic-similarity", "word-alignment"],
+    )
+    session_id = create_resp.json()["session_id"]
+
+    response = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == session_id
+    assert data["results"]["items"] == []
+    assert data["results"]["total_count"] == 0
+    assert data["ngrams"] == []
+    types_returned = {j["type"] for j in data["training_jobs"]}
+    assert types_returned == {"semantic-similarity", "word-alignment"}
+
+
+def test_session_results_interleaves_completed_apps(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """sem-sim score and word-alignment per-word rows for the same vref
+    appear under one bucket; an in-flight type just doesn't contribute."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_interleave"},
+        apps=["semantic-similarity", "word-alignment", "ngrams"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    jobs_by_type = {j["type"]: j for j in payload["training_jobs"]}
+
+    sem_sim_job = jobs_by_type["semantic-similarity"]
+    wa_job = jobs_by_type["word-alignment"]
+    # ngrams left in-flight on purpose: must not appear in `results`.
+
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
+    _advance_assessment_to_finished(client, regular_token1, wa_job["assessment_id"])
+
+    _seed_sem_sim_results(
+        db_session,
+        sem_sim_job["assessment_id"],
+        [("GEN 1:1", 0.83), ("GEN 1:2", 0.42)],
+    )
+    _seed_word_alignment(
+        db_session,
+        wa_job["assessment_id"],
+        [
+            ("GEN 1:1", "beginning", "principio", 0.91),
+            ("GEN 1:1", "god", "dios", 0.88),
+            ("GEN 1:2", "earth", "tierra", 0.77),
+        ],
+    )
+
+    response = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"]["total_count"] == 2
+    assert data["ngrams"] == []  # ngrams job still in-flight
+
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    assert set(by_vref) == {"GEN 1:1", "GEN 1:2"}
+    assert by_vref["GEN 1:1"]["semantic_similarity"]["score"] == 0.83
+    assert len(by_vref["GEN 1:1"]["word_alignment"]) == 2
+    assert {wa["source"] for wa in by_vref["GEN 1:1"]["word_alignment"]} == {
+        "beginning",
+        "god",
+    }
+    assert by_vref["GEN 1:2"]["semantic_similarity"]["score"] == 0.42
+    assert len(by_vref["GEN 1:2"]["word_alignment"]) == 1
+
+
+def test_session_results_filter_by_book_chapter(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_filter"},
+        apps=["semantic-similarity"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    sem_sim_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
+    _seed_sem_sim_results(
+        db_session,
+        sem_sim_job["assessment_id"],
+        [
+            ("GEN 1:1", 0.10),
+            ("GEN 1:2", 0.20),
+            ("GEN 2:1", 0.30),
+            ("EXO 1:1", 0.40),
+        ],
+    )
+
+    # book scope
+    resp_book = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"book": "GEN"},
+        headers=_auth_headers(regular_token1),
+    )
+    assert resp_book.status_code == 200
+    assert resp_book.json()["results"]["total_count"] == 3
+
+    # chapter scope (within book)
+    resp_chap = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"book": "GEN", "chapter": 1},
+        headers=_auth_headers(regular_token1),
+    )
+    assert resp_chap.status_code == 200
+    chap_results = resp_chap.json()["results"]
+    assert chap_results["total_count"] == 2
+    assert {b["vref"] for b in chap_results["items"]} == {"GEN 1:1", "GEN 1:2"}
+
+    # verse scope
+    verse_results = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"book": "GEN", "chapter": 1, "verse": 2},
+        headers=_auth_headers(regular_token1),
+    ).json()["results"]
+    assert verse_results["total_count"] == 1
+    assert verse_results["items"][0]["vref"] == "GEN 1:2"
+
+
+def test_session_results_pagination_canonical_order(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """Pagination is by vref in canonical bible order (BookReference.number,
+    chapter, verse) — not lexicographic on the vref string."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_paging"},
+        apps=["semantic-similarity"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    sem_sim_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
+    # Verses chosen so that lexicographic sort would be wrong:
+    #   "GEN 1:10" < "GEN 1:2" alphabetically, but 2 comes first canonically.
+    _seed_sem_sim_results(
+        db_session,
+        sem_sim_job["assessment_id"],
+        [
+            ("GEN 1:1", 0.1),
+            ("GEN 1:2", 0.2),
+            ("GEN 1:10", 0.3),
+            ("GEN 2:1", 0.4),
+        ],
+    )
+
+    page1 = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"page": 1, "page_size": 2},
+        headers=_auth_headers(regular_token1),
+    ).json()["results"]
+    page2 = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"page": 2, "page_size": 2},
+        headers=_auth_headers(regular_token1),
+    ).json()["results"]
+    assert page1["total_count"] == 4
+    assert page1["page"] == 1
+    assert page1["page_size"] == 2
+    assert [b["vref"] for b in page1["items"]] == ["GEN 1:1", "GEN 1:2"]
+    assert [b["vref"] for b in page2["items"]] == ["GEN 1:10", "GEN 2:1"]
+
+
+def test_session_results_filter_validation(
+    client, regular_token1, test_revision_id, test_revision_id_2
+):
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_validation"},
+        apps=["semantic-similarity"],
+    )
+    session_id = create_resp.json()["session_id"]
+    base = f"{prefix}/train/status/{session_id}/results"
+    headers = _auth_headers(regular_token1)
+
+    assert client.get(base, params={"chapter": 1}, headers=headers).status_code == 400
+    assert (
+        client.get(
+            base, params={"verse": 1, "book": "GEN"}, headers=headers
+        ).status_code
+        == 400
+    )
+    assert client.get(base, params={"page": 1}, headers=headers).status_code == 400
+    assert (
+        client.get(base, params={"page_size": 10}, headers=headers).status_code == 400
+    )
+
+
+def test_session_results_ngrams_top_level(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """Ngrams come back at the top level (not nested per vref) and are
+    filtered to ones whose vrefs intersect the requested window."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_ngrams"},
+        apps=["ngrams"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    ng_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(client, regular_token1, ng_job["assessment_id"])
+    _seed_ngrams(
+        db_session,
+        ng_job["assessment_id"],
+        [
+            ("in the", 2, ["GEN 1:1", "GEN 1:2"]),
+            ("god created", 2, ["GEN 1:1"]),
+            ("the people", 2, ["EXO 1:1"]),
+        ],
+    )
+
+    # No filter: all ngrams come back.
+    full = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    assert full["results"]["items"] == []  # ngrams don't contribute to per-vref bucket
+    assert full["results"]["total_count"] == 0
+    assert {n["ngram"] for n in full["ngrams"]} == {
+        "in the",
+        "god created",
+        "the people",
+    }
+
+    # GEN scope: only ngrams with at least one GEN vref.
+    gen_only = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"book": "GEN"},
+        headers=_auth_headers(regular_token1),
+    ).json()
+    assert {n["ngram"] for n in gen_only["ngrams"]} == {"in the", "god created"}
+    # Even when filtered, each ngram carries its full vrefs list (matches
+    # the existing /v3/ngrams_result shape).
+    in_the = next(n for n in gen_only["ngrams"] if n["ngram"] == "in the")
+    assert sorted(in_the["vrefs"]) == ["GEN 1:1", "GEN 1:2"]

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1509,3 +1509,178 @@ def test_session_results_ngrams_top_level(
     # the existing /v3/ngrams_result shape).
     in_the = next(n for n in gen_only["ngrams"] if n["ngram"] == "in the")
     assert sorted(in_the["vrefs"]) == ["GEN 1:1", "GEN 1:2"]
+
+
+def test_session_results_unknown_book_returns_400(
+    client, regular_token1, test_revision_id, test_revision_id_2
+):
+    """Unknown book abbreviations are rejected up front. Also closes a
+    LIKE-injection vector — `_` and `%` are SQL wildcards that would
+    otherwise broaden the ngram filter."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_unknown_book"},
+        apps=["semantic-similarity"],
+    )
+    session_id = create_resp.json()["session_id"]
+
+    for bad in ("ZZZ", "GE_", "%", "GE%"):
+        resp = client.get(
+            f"{prefix}/train/status/{session_id}/results",
+            params={"book": bad},
+            headers=_auth_headers(regular_token1),
+        )
+        assert resp.status_code == 400, f"book={bad!r} should be rejected"
+
+
+def test_session_results_failed_assessment_does_not_leak(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """A `failed` Assessment is terminal but not finished — any rows that
+    happen to be in the result tables for that assessment must NOT appear
+    in the per-vref bucket."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_failed_no_leak"},
+        apps=["semantic-similarity"],
+    )
+    sem_sim_job = create_resp.json()["training_jobs"][0]
+    session_id = create_resp.json()["session_id"]
+
+    _set_assessment_status(db_session, sem_sim_job["assessment_id"], "failed")
+    # Seed a stray row under the failed assessment_id — could happen if the
+    # runner pushed partial results before failing.
+    _seed_sem_sim_results(db_session, sem_sim_job["assessment_id"], [("GEN 1:1", 0.5)])
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    assert data["results"]["items"] == []
+    assert data["results"]["total_count"] == 0
+
+
+def test_session_results_word_alignment_only_completed(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """Word-alignment alone finished, sem-sim still in-flight: results
+    bucket carries word_alignment rows for each vref and
+    semantic_similarity is null (sem-sim doesn't gate the response)."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_wa_only"},
+        apps=["semantic-similarity", "word-alignment"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    jobs_by_type = {j["type"]: j for j in payload["training_jobs"]}
+    wa_job = jobs_by_type["word-alignment"]
+
+    _advance_assessment_to_finished(client, regular_token1, wa_job["assessment_id"])
+    _seed_word_alignment(
+        db_session,
+        wa_job["assessment_id"],
+        [("GEN 1:1", "beginning", "principio", 0.91)],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    assert data["results"]["total_count"] == 1
+    only = data["results"]["items"][0]
+    assert only["vref"] == "GEN 1:1"
+    assert only["semantic_similarity"] is None
+    assert len(only["word_alignment"]) == 1
+
+
+def test_session_results_admin_can_read_other_owner_session(
+    client,
+    regular_token1,
+    admin_token,
+    test_revision_id,
+    test_revision_id_2,
+    db_session,
+):
+    """Admin auth path bypasses the version-access scoping in
+    _load_session_jobs — verify that path actually returns the session
+    (not 404 / 403) when admin queries someone else's session."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_admin_access"},
+        apps=["semantic-similarity"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    sem_sim_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
+    _seed_sem_sim_results(db_session, sem_sim_job["assessment_id"], [("GEN 1:1", 0.7)])
+
+    resp = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(admin_token),
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["session_id"] == session_id
+    assert data["results"]["total_count"] == 1
+
+
+def test_repost_after_assessment_terminates_succeeds(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """The whole point of #593: an orphan/terminal Assessment must not
+    block a re-POST for the same revision pair + type + options."""
+    opts = {"tag": "repost_after_terminate"}
+    first = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options=opts,
+        apps=["tfidf"],
+    )
+    assert first.status_code == 200
+    job = first.json()["training_jobs"][0]
+
+    # While the linked Assessment is still queued, re-POST is rejected.
+    blocked = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options=opts,
+        apps=["tfidf"],
+    )
+    assert blocked.status_code == 409
+
+    # Terminate the Assessment — duplicate-detection should now see no
+    # active job and let the re-POST through with a new TrainingJob.
+    _set_assessment_status(db_session, job["assessment_id"], "failed")
+
+    second = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options=opts,
+        apps=["tfidf"],
+    )
+    assert second.status_code == 200, second.json()
+    new_job = second.json()["training_jobs"][0]
+    assert new_job["id"] != job["id"]
+    assert new_job["assessment_id"] != job["assessment_id"]

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -15,6 +15,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 
+from assessment_routes.v3.results_query_routes import validate_parameters
 from database.dependencies import get_db
 from database.models import (
     AlignmentTopSourceScores,
@@ -65,7 +66,6 @@ router = fastapi.APIRouter()
 # downloading → uploading → finished sequence; failures land as `failed`.
 ASSESSMENT_TERMINAL_VALUES = {s.value for s in ASSESSMENT_TERMINAL_STATUSES}
 ASSESSMENT_FINISHED_VALUE = AssessmentStatus.finished.value
-ASSESSMENT_FAILED_VALUE = AssessmentStatus.failed.value
 
 # Training types that have a corresponding aqua-assessments Assessment row.
 # Every type listed here must also appear in AssessmentType in models.py so
@@ -164,6 +164,17 @@ def _job_out(job: TrainingJob, assessment: Optional[Assessment]) -> TrainingJobO
         start_time=assessment.start_time if assessment is not None else None,
         end_time=assessment.end_time if assessment is not None else None,
     )
+
+
+async def _load_assessments_for(
+    jobs: List[TrainingJob], db: AsyncSession
+) -> dict[int, Assessment]:
+    """Bulk-fetch the Assessment rows linked from a set of TrainingJobs."""
+    assessment_ids = [j.assessment_id for j in jobs if j.assessment_id is not None]
+    if not assessment_ids:
+        return {}
+    rows = await db.execute(select(Assessment).where(Assessment.id.in_(assessment_ids)))
+    return {a.id: a for a in rows.scalars().all()}
 
 
 async def _compute_inference_readiness(
@@ -284,7 +295,7 @@ async def create_training_job(
         if training_type.value not in selected_types:
             continue
         # Duplicate check per type — "active" means linked Assessment is
-        # not in a terminal state.
+        # live (not soft-deleted) and not in a terminal state.
         dup_stmt = (
             select(TrainingJob)
             .join(Assessment, Assessment.id == TrainingJob.assessment_id)
@@ -293,6 +304,7 @@ async def create_training_job(
                 TrainingJob.target_revision_id == job_in.target_revision_id,
                 TrainingJob.type == training_type.value,
                 TrainingJob.deleted.is_not(True),
+                Assessment.deleted.is_not(True),
                 Assessment.status.notin_(list(ASSESSMENT_TERMINAL_VALUES)),
             )
         )
@@ -392,13 +404,16 @@ async def create_training_job(
     }
     if failure_assessment_ids:
         # Direct write — Assessment.status is the source of truth and the
-        # runner never got a chance to advance it past `queued`.
+        # runner never got a chance to advance it past `queued`. Skip
+        # soft-deleted rows defensively even though they can't appear in
+        # this code path today (assessments are freshly created above).
         now = datetime.utcnow()
         failed_assessments = (
             (
                 await db.execute(
                     select(Assessment).where(
-                        Assessment.id.in_(list(failure_assessment_ids.keys()))
+                        Assessment.id.in_(list(failure_assessment_ids.keys())),
+                        Assessment.deleted.is_not(True),
                     )
                 )
             )
@@ -406,7 +421,7 @@ async def create_training_job(
             .all()
         )
         for a in failed_assessments:
-            a.status = ASSESSMENT_FAILED_VALUE
+            a.status = AssessmentStatus.failed.value
             a.status_detail = failure_assessment_ids[a.id]
             a.start_time = a.start_time or now
             a.end_time = now
@@ -425,17 +440,6 @@ async def create_training_job(
         ],
         inference_readiness=readiness,
     )
-
-
-async def _load_assessments_for(
-    jobs: List[TrainingJob], db: AsyncSession
-) -> dict[int, Assessment]:
-    """Bulk-fetch the Assessment rows linked from a set of TrainingJobs."""
-    assessment_ids = [j.assessment_id for j in jobs if j.assessment_id is not None]
-    if not assessment_ids:
-        return {}
-    rows = await db.execute(select(Assessment).where(Assessment.id.in_(assessment_ids)))
-    return {a.id: a for a in rows.scalars().all()}
 
 
 @router.get("/train", response_model=List[TrainingJobOut])
@@ -574,22 +578,20 @@ async def get_training_session_results(
     across every verse it appears in. Tfidf and agent_critique training
     runs produce nothing the client wants here (vector-only / no vrefs).
     """
-    # Filter validation mirrors validate_parameters() from results_query_routes.
-    if chapter is not None and book is None:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="chapter requires book",
+    await validate_parameters(book, chapter, verse, None, page, page_size)
+    if book is not None:
+        # Pin `book` to a known abbreviation up front. Both safety (the
+        # ngram path interpolates `book` into a LIKE pattern, where `_`
+        # and `%` would otherwise broaden the match) and ergonomics (a
+        # 400 with a clear message beats an empty result for a typo).
+        known = await db.scalar(
+            select(BookReference.abbreviation).where(BookReference.abbreviation == book)
         )
-    if verse is not None and (book is None or chapter is None):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="verse requires book and chapter",
-        )
-    if (page is None) != (page_size is None):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="page and page_size must be set together",
-        )
+        if known is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Unknown book abbreviation: {book}",
+            )
 
     jobs = await _load_session_jobs(session_id, current_user, db)
     if not jobs:
@@ -606,12 +608,12 @@ async def get_training_session_results(
     # surface via the training_jobs status block; their type just won't
     # appear in any vref bucket yet. "Finished" is read off the linked
     # Assessment.status — TrainingJob is metadata only after #584.
+    # (j.assessment present already implies j.assessment_id present —
+    # the FK is SET NULL on delete.)
     completed_assessment_id_by_type: dict[str, int] = {
         j.type: j.assessment_id
         for j in jobs
-        if j.assessment is not None
-        and j.assessment.status == ASSESSMENT_FINISHED_VALUE
-        and j.assessment_id is not None
+        if j.assessment is not None and j.assessment.status == ASSESSMENT_FINISHED_VALUE
     }
     sem_sim_id = completed_assessment_id_by_type.get(
         TrainingType.semantic_similarity.value
@@ -665,18 +667,26 @@ async def get_training_session_results(
     total_count = 0
     if per_vref_subqueries:
         union_subq = per_vref_subqueries[0].union(*per_vref_subqueries[1:]).subquery()
-        # UNION already deduplicates, so a plain select counts distinct vrefs.
-        count_result = await db.execute(select(func.count()).select_from(union_subq))
-        total_count = count_result.scalar() or 0
-
-        ordered_q = (
-            select(union_subq.c.vref)
-            .join(BookReference, BookReference.abbreviation == union_subq.c.book)
-            .order_by(
-                BookReference.number,
+        # Apply the BookReference join up front so total_count and the page
+        # both see the same row set — without it, vrefs whose `book` doesn't
+        # match a BookReference row would be counted but never paginated.
+        joined_subq = (
+            select(
+                union_subq.c.vref,
+                BookReference.number.label("book_number"),
                 union_subq.c.chapter,
                 union_subq.c.verse,
             )
+            .join(BookReference, BookReference.abbreviation == union_subq.c.book)
+            .subquery()
+        )
+        count_result = await db.execute(select(func.count()).select_from(joined_subq))
+        total_count = count_result.scalar() or 0
+
+        ordered_q = select(joined_subq.c.vref).order_by(
+            joined_subq.c.book_number,
+            joined_subq.c.chapter,
+            joined_subq.c.verse,
         )
         if page is not None and page_size is not None:
             ordered_q = ordered_q.offset((page - 1) * page_size).limit(page_size)
@@ -693,16 +703,23 @@ async def get_training_session_results(
             )
         )
         for r in rows.scalars().all():
+            # First-write-wins: the (assessment_id, vref) pair has no DB
+            # uniqueness constraint, so duplicates are theoretically
+            # possible. Mirror the word-alignment helper's pattern of
+            # collecting deterministically rather than silently
+            # last-write-overwriting.
+            if r.vref in sem_sim_by_vref:
+                continue
             sem_sim_by_vref[r.vref] = Result_v2(
                 id=r.id,
                 assessment_id=r.assessment_id,
                 vref=r.vref,
                 score=float(r.score) if r.score is not None else 0.0,
-                flag=bool(r.flag),
+                flag=r.flag or False,
                 note=r.note,
                 source=r.source,
                 target=r.target,
-                hide=bool(r.hide),
+                hide=r.hide or False,
             )
 
     word_align_by_vref: dict[str, List[WordAlignment]] = {}
@@ -722,9 +739,9 @@ async def get_training_session_results(
                     source=r.source,
                     target=r.target,
                     score=float(r.score) if r.score is not None else 0.0,
-                    flag=bool(r.flag),
+                    flag=r.flag or False,
                     note=r.note,
-                    hide=bool(r.hide),
+                    hide=r.hide or False,
                 )
             )
 
@@ -741,6 +758,8 @@ async def get_training_session_results(
     # in the requested book/chapter/verse window (or all ngrams when no
     # filter). Returns each ngram's full vrefs list, not just the matching
     # ones, so the client sees the same shape as /v3/ngrams_result.
+    # `book` was validated against BookReference above, so the LIKE
+    # patterns can't smuggle SQL wildcards.
     ngrams_list: List[NgramResult] = []
     if ngrams_id is not None:
         matching_q = (
@@ -969,13 +988,21 @@ async def delete_training_job(
             detail="Not authorized to delete this training job",
         )
 
-    assessment_status = job.assessment.status if job.assessment is not None else None
-    if assessment_status not in ASSESSMENT_TERMINAL_VALUES:
+    if job.assessment is None:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
-                f"Cannot delete job whose assessment is in '{assessment_status}' "
-                "status. Only terminal jobs can be deleted."
+                "Cannot delete training job: linked assessment is missing, "
+                "so terminal status cannot be verified."
+            ),
+        )
+    if job.assessment.status not in ASSESSMENT_TERMINAL_VALUES:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Cannot delete job whose assessment is in "
+                f"'{job.assessment.status}' status. "
+                "Only terminal jobs can be deleted."
             ),
         )
 

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -11,16 +11,21 @@ import fastapi
 import modal
 from dotenv import load_dotenv
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import aliased
+from sqlalchemy.orm import aliased, selectinload
 
 from database.dependencies import get_db
 from database.models import (
+    AlignmentTopSourceScores,
     Assessment,
+    AssessmentResult,
     BibleRevision,
     BibleVersion,
     BibleVersionAccess,
+    BookReference,
+    NgramsTable,
+    NgramVrefTable,
     TrainingJob,
 )
 from database.models import UserDB as UserModel
@@ -30,12 +35,18 @@ from database.models import (
 )
 from models import (
     ASSESSMENT_TERMINAL_STATUSES,
+    AssessmentStatus,
     InferenceReadiness,
+    NgramResult,
+    Result_v2,
     TrainingJobIn,
     TrainingJobOut,
-    TrainingJobStatusUpdate,
     TrainingResponse,
+    TrainingSessionResultsPage,
+    TrainingSessionResultsResponse,
+    TrainingSessionVrefResults,
     TrainingType,
+    WordAlignment,
 )
 from security_routes.auth_routes import get_current_user
 from utils.logging_config import setup_logger
@@ -48,17 +59,13 @@ logger = setup_logger(__name__, container_id=container_id)
 
 router = fastapi.APIRouter()
 
-# Valid state transitions: current_status -> set of allowed next statuses
-VALID_TRANSITIONS = {
-    "queued": {"preparing", "failed"},
-    "preparing": {"training", "failed"},
-    "training": {"training", "downloading", "failed"},
-    "downloading": {"uploading", "failed"},
-    "uploading": {"completed", "completed_with_errors", "failed"},
-}
-
-TERMINAL_STATUSES = {"completed", "completed_with_errors", "failed"}
-COMPLETED_STATUSES = {"completed", "completed_with_errors"}
+# Status, transitions, and progress live on the linked Assessment row
+# (aqua-api#584). The aqua-assessments runner PATCHes
+# /v3/assessment/{id}/status with the phased queued → preparing → training →
+# downloading → uploading → finished sequence; failures land as `failed`.
+ASSESSMENT_TERMINAL_VALUES = {s.value for s in ASSESSMENT_TERMINAL_STATUSES}
+ASSESSMENT_FINISHED_VALUE = AssessmentStatus.finished.value
+ASSESSMENT_FAILED_VALUE = AssessmentStatus.failed.value
 
 # Training types that have a corresponding aqua-assessments Assessment row.
 # Every type listed here must also appear in AssessmentType in models.py so
@@ -134,59 +141,46 @@ def _build_runner_train_config(
     return config
 
 
-async def _mirror_terminal_status_to_assessment(
-    job: TrainingJob, db: AsyncSession
-) -> None:
-    """Fallback reconciliation: reflect a TrainingJob terminal status onto its
-    linked Assessment when aqua-assessments' own PATCH /v3/assessment/status
-    flow didn't land (dispatch failure, worker died before posting, legacy
-    sem-sim path).
-
-    Mapping: completed → finished; failed / completed_with_errors → failed.
-    completed_with_errors flattens to failed because AssessmentStatus has no
-    cwe value; the TrainingJob detail is copied onto Assessment.status_detail
-    only for the failure paths (carrying an uploading-phase progress detail
-    onto a successful Assessment would be misleading).
-
-    Because this is reconciliation, it deliberately bypasses
-    ASSESSMENT_VALID_TRANSITIONS (queued → terminal is not a valid transition
-    there). To avoid clobbering aqua-assessments' own terminal post, this
-    helper is a no-op if the Assessment is already in a terminal state.
-    Also a no-op if the Assessment row has been soft-deleted.
-    """
-    if job.assessment_id is None:
-        return
-    assessment = await db.get(Assessment, job.assessment_id)
-    if assessment is None or assessment.deleted:
-        return
-    if assessment.status in ASSESSMENT_TERMINAL_STATUSES:
-        return
-
-    if job.status == "completed":
-        assessment.status = "finished"
-        assessment.status_detail = None
-    elif job.status in ("failed", "completed_with_errors"):
-        assessment.status = "failed"
-        if job.status_detail is not None:
-            assessment.status_detail = job.status_detail
-    else:
-        return
-
-    now = datetime.utcnow()
-    assessment.start_time = job.start_time or assessment.start_time or now
-    assessment.end_time = job.end_time or now
+def _job_out(job: TrainingJob, assessment: Optional[Assessment]) -> TrainingJobOut:
+    """Build a TrainingJobOut, sourcing status fields from the linked
+    Assessment row (the single channel of truth after #584)."""
+    return TrainingJobOut(
+        id=job.id,
+        type=job.type,
+        source_revision_id=job.source_revision_id,
+        target_revision_id=job.target_revision_id,
+        source_language=job.source_language,
+        target_language=job.target_language,
+        options=job.options,
+        requested_time=job.requested_time,
+        owner_id=job.owner_id,
+        session_id=job.session_id,
+        assessment_id=job.assessment_id,
+        status=assessment.status if assessment is not None else None,
+        status_detail=assessment.status_detail if assessment is not None else None,
+        percent_complete=(
+            assessment.percent_complete if assessment is not None else None
+        ),
+        start_time=assessment.start_time if assessment is not None else None,
+        end_time=assessment.end_time if assessment is not None else None,
+    )
 
 
 async def _compute_inference_readiness(
     source_revision_id: int, target_revision_id: int, db: AsyncSession
 ) -> dict:
-    """Check which inference types are ready based on completed training jobs."""
-    # Find all completed training jobs for this revision pair
-    stmt = select(TrainingJob.type).where(
-        TrainingJob.source_revision_id == source_revision_id,
-        TrainingJob.target_revision_id == target_revision_id,
-        TrainingJob.deleted.is_not(True),
-        TrainingJob.status.in_(list(COMPLETED_STATUSES)),
+    """Check which inference types are ready by looking at the Assessment row
+    linked from each TrainingJob — `finished` means results are pushed and
+    inference can proceed."""
+    stmt = (
+        select(TrainingJob.type)
+        .join(Assessment, Assessment.id == TrainingJob.assessment_id)
+        .where(
+            TrainingJob.source_revision_id == source_revision_id,
+            TrainingJob.target_revision_id == target_revision_id,
+            TrainingJob.deleted.is_not(True),
+            Assessment.status == ASSESSMENT_FINISHED_VALUE,
+        )
     )
     result = await db.execute(stmt)
     completed_types = {row[0] for row in result.all()}
@@ -289,13 +283,18 @@ async def create_training_job(
     for training_type in TrainingType:
         if training_type.value not in selected_types:
             continue
-        # Duplicate check per type
-        dup_stmt = select(TrainingJob).where(
-            TrainingJob.source_revision_id == job_in.source_revision_id,
-            TrainingJob.target_revision_id == job_in.target_revision_id,
-            TrainingJob.type == training_type.value,
-            TrainingJob.deleted.is_not(True),
-            TrainingJob.status.notin_(list(TERMINAL_STATUSES)),
+        # Duplicate check per type — "active" means linked Assessment is
+        # not in a terminal state.
+        dup_stmt = (
+            select(TrainingJob)
+            .join(Assessment, Assessment.id == TrainingJob.assessment_id)
+            .where(
+                TrainingJob.source_revision_id == job_in.source_revision_id,
+                TrainingJob.target_revision_id == job_in.target_revision_id,
+                TrainingJob.type == training_type.value,
+                TrainingJob.deleted.is_not(True),
+                Assessment.status.notin_(list(ASSESSMENT_TERMINAL_VALUES)),
+            )
         )
         dup_result = await db.execute(dup_stmt)
         duplicate = False
@@ -310,7 +309,8 @@ async def create_training_job(
 
         # Create a paired Assessment row so aqua-assessments can write
         # artifacts under the same assessment_id pattern used by the assess()
-        # path.
+        # path. Assessment.status is the single channel of training-run
+        # status — runner PATCHes it through the phased sequence.
         assessment = Assessment(
             revision_id=job_in.source_revision_id,
             reference_id=job_in.target_revision_id,
@@ -325,14 +325,12 @@ async def create_training_job(
         await db.flush()
         assessment_id = assessment.id
 
-        # Create training job record
         training_job = TrainingJob(
             type=training_type.value,
             source_revision_id=job_in.source_revision_id,
             target_revision_id=job_in.target_revision_id,
             source_language=source_language,
             target_language=target_language,
-            status="queued",
             options=job_in.options,
             requested_time=datetime.utcnow(),
             owner_id=current_user.id,
@@ -387,25 +385,57 @@ async def create_training_job(
             return job, e
 
     results = await asyncio.gather(*(dispatch_job(j) for j in training_jobs))
-    for job, exc in results:
-        if exc:
-            job.status = "failed"
-            job.status_detail = f"dispatch_failed: {type(exc).__name__}: {exc}"
-            job.end_time = datetime.utcnow()
-            await _mirror_terminal_status_to_assessment(job, db)
-    await db.commit()
-    for job in training_jobs:
-        await db.refresh(job)
+    failure_assessment_ids = {
+        job.assessment_id: f"dispatch_failed: {type(exc).__name__}: {exc}"
+        for job, exc in results
+        if exc and job.assessment_id is not None
+    }
+    if failure_assessment_ids:
+        # Direct write — Assessment.status is the source of truth and the
+        # runner never got a chance to advance it past `queued`.
+        now = datetime.utcnow()
+        failed_assessments = (
+            (
+                await db.execute(
+                    select(Assessment).where(
+                        Assessment.id.in_(list(failure_assessment_ids.keys()))
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for a in failed_assessments:
+            a.status = ASSESSMENT_FAILED_VALUE
+            a.status_detail = failure_assessment_ids[a.id]
+            a.start_time = a.start_time or now
+            a.end_time = now
+        await db.commit()
 
+    assessments_by_id = await _load_assessments_for(training_jobs, db)
     readiness = await _compute_inference_readiness(
         job_in.source_revision_id, job_in.target_revision_id, db
     )
 
     return TrainingResponse(
         session_id=session_id,
-        training_jobs=[TrainingJobOut.model_validate(job) for job in training_jobs],
+        training_jobs=[
+            _job_out(job, assessments_by_id.get(job.assessment_id))
+            for job in training_jobs
+        ],
         inference_readiness=readiness,
     )
+
+
+async def _load_assessments_for(
+    jobs: List[TrainingJob], db: AsyncSession
+) -> dict[int, Assessment]:
+    """Bulk-fetch the Assessment rows linked from a set of TrainingJobs."""
+    assessment_ids = [j.assessment_id for j in jobs if j.assessment_id is not None]
+    if not assessment_ids:
+        return {}
+    rows = await db.execute(select(Assessment).where(Assessment.id.in_(assessment_ids)))
+    return {a.id: a for a in rows.scalars().all()}
 
 
 @router.get("/train", response_model=List[TrainingJobOut])
@@ -417,11 +447,18 @@ async def list_training_jobs(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
-    """List training jobs accessible to the current user."""
-    stmt = select(TrainingJob).where(TrainingJob.deleted.is_not(True))
+    """List training jobs accessible to the current user. The ?status filter
+    matches the linked Assessment.status."""
+    stmt = (
+        select(TrainingJob)
+        .options(selectinload(TrainingJob.assessment))
+        .where(TrainingJob.deleted.is_not(True))
+    )
 
     if status_filter:
-        stmt = stmt.where(TrainingJob.status == status_filter)
+        stmt = stmt.join(Assessment, Assessment.id == TrainingJob.assessment_id).where(
+            Assessment.status == status_filter
+        )
     if type_filter:
         stmt = stmt.where(TrainingJob.type == type_filter)
     if source_language:
@@ -449,22 +486,24 @@ async def list_training_jobs(
         )
 
     result = await db.execute(stmt)
-    jobs = result.scalars().all()
-    return [TrainingJobOut.model_validate(j) for j in jobs]
+    jobs = result.scalars().unique().all()
+    return [_job_out(j, j.assessment) for j in jobs]
 
 
-@router.get("/train/status", response_model=TrainingResponse)
-async def get_training_status(
-    session_id: str = Query(...),
-    db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
-):
-    """Get the status of a training session by session_id."""
-    stmt = select(TrainingJob).where(
-        TrainingJob.session_id == session_id,
-        TrainingJob.deleted.is_not(True),
+async def _load_session_jobs(
+    session_id: str, current_user: UserModel, db: AsyncSession
+) -> List[TrainingJob]:
+    """Shared loader: returns jobs for session_id with the same auth scoping
+    used by /train/status. Eager-loads each job's linked Assessment so
+    callers can read status fields without N+1 lookups."""
+    stmt = (
+        select(TrainingJob)
+        .options(selectinload(TrainingJob.assessment))
+        .where(
+            TrainingJob.session_id == session_id,
+            TrainingJob.deleted.is_not(True),
+        )
     )
-
     if not current_user.is_admin:
         version_ids = await _get_accessible_version_ids(current_user, db)
         SourceRevision = aliased(BibleRevision)
@@ -483,10 +522,18 @@ async def get_training_status(
                 TargetRevision.bible_version_id.in_(version_ids),
             )
         )
-
     result = await db.execute(stmt)
-    jobs = result.scalars().all()
+    return list(result.scalars().unique().all())
 
+
+@router.get("/train/status", response_model=TrainingResponse)
+async def get_training_status(
+    session_id: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Get the status of a training session by session_id."""
+    jobs = await _load_session_jobs(session_id, current_user, db)
     if not jobs:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -499,8 +546,261 @@ async def get_training_status(
 
     return TrainingResponse(
         session_id=session_id,
-        training_jobs=[TrainingJobOut.model_validate(j) for j in jobs],
+        training_jobs=[_job_out(j, j.assessment) for j in jobs],
         inference_readiness=readiness,
+    )
+
+
+@router.get(
+    "/train/status/{session_id}/results",
+    response_model=TrainingSessionResultsResponse,
+)
+async def get_training_session_results(
+    session_id: str,
+    book: Optional[str] = None,
+    chapter: Optional[int] = None,
+    verse: Optional[int] = None,
+    page: Optional[int] = None,
+    page_size: Optional[int] = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Single read endpoint that returns training-job status + interleaved
+    per-vref results for every completed job in the session.
+
+    Per vref: semantic_similarity score (one row), word_alignment per-word
+    rows (multiple). Ngrams are returned at the top level — each ngram has
+    many vrefs, so nesting them per verse would duplicate the same ngram
+    across every verse it appears in. Tfidf and agent_critique training
+    runs produce nothing the client wants here (vector-only / no vrefs).
+    """
+    # Filter validation mirrors validate_parameters() from results_query_routes.
+    if chapter is not None and book is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="chapter requires book",
+        )
+    if verse is not None and (book is None or chapter is None):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="verse requires book and chapter",
+        )
+    if (page is None) != (page_size is None):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="page and page_size must be set together",
+        )
+
+    jobs = await _load_session_jobs(session_id, current_user, db)
+    if not jobs:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No training jobs found for session_id={session_id}",
+        )
+
+    readiness = await _compute_inference_readiness(
+        jobs[0].source_revision_id, jobs[0].target_revision_id, db
+    )
+
+    # Only finished jobs contribute results. In-flight (or failed) jobs
+    # surface via the training_jobs status block; their type just won't
+    # appear in any vref bucket yet. "Finished" is read off the linked
+    # Assessment.status — TrainingJob is metadata only after #584.
+    completed_assessment_id_by_type: dict[str, int] = {
+        j.type: j.assessment_id
+        for j in jobs
+        if j.assessment is not None
+        and j.assessment.status == ASSESSMENT_FINISHED_VALUE
+        and j.assessment_id is not None
+    }
+    sem_sim_id = completed_assessment_id_by_type.get(
+        TrainingType.semantic_similarity.value
+    )
+    word_align_id = completed_assessment_id_by_type.get(
+        TrainingType.word_alignment.value
+    )
+    ngrams_id = completed_assessment_id_by_type.get(TrainingType.ngrams.value)
+
+    # vref universe = distinct vrefs across the per-vref result tables for
+    # all completed types in the session, with optional book/chapter/verse
+    # scoping. Carries (book, chapter, verse) so we can canonical-sort via
+    # BookReference.number after the union.
+    per_vref_subqueries = []
+
+    def _scope(q, model):
+        if book is not None:
+            q = q.where(model.book == book)
+        if chapter is not None:
+            q = q.where(model.chapter == chapter)
+        if verse is not None:
+            q = q.where(model.verse == verse)
+        return q
+
+    if sem_sim_id is not None:
+        per_vref_subqueries.append(
+            _scope(
+                select(
+                    AssessmentResult.vref,
+                    AssessmentResult.book,
+                    AssessmentResult.chapter,
+                    AssessmentResult.verse,
+                ).where(AssessmentResult.assessment_id == sem_sim_id),
+                AssessmentResult,
+            )
+        )
+    if word_align_id is not None:
+        per_vref_subqueries.append(
+            _scope(
+                select(
+                    AlignmentTopSourceScores.vref,
+                    AlignmentTopSourceScores.book,
+                    AlignmentTopSourceScores.chapter,
+                    AlignmentTopSourceScores.verse,
+                ).where(AlignmentTopSourceScores.assessment_id == word_align_id),
+                AlignmentTopSourceScores,
+            )
+        )
+
+    page_vrefs: List[str] = []
+    total_count = 0
+    if per_vref_subqueries:
+        union_subq = per_vref_subqueries[0].union(*per_vref_subqueries[1:]).subquery()
+        # UNION already deduplicates, so a plain select counts distinct vrefs.
+        count_result = await db.execute(select(func.count()).select_from(union_subq))
+        total_count = count_result.scalar() or 0
+
+        ordered_q = (
+            select(union_subq.c.vref)
+            .join(BookReference, BookReference.abbreviation == union_subq.c.book)
+            .order_by(
+                BookReference.number,
+                union_subq.c.chapter,
+                union_subq.c.verse,
+            )
+        )
+        if page is not None and page_size is not None:
+            ordered_q = ordered_q.offset((page - 1) * page_size).limit(page_size)
+
+        page_vrefs = [row[0] for row in (await db.execute(ordered_q)).all()]
+
+    # Per-vref data fetches (only the page's vrefs).
+    sem_sim_by_vref: dict[str, Result_v2] = {}
+    if sem_sim_id is not None and page_vrefs:
+        rows = await db.execute(
+            select(AssessmentResult).where(
+                AssessmentResult.assessment_id == sem_sim_id,
+                AssessmentResult.vref.in_(page_vrefs),
+            )
+        )
+        for r in rows.scalars().all():
+            sem_sim_by_vref[r.vref] = Result_v2(
+                id=r.id,
+                assessment_id=r.assessment_id,
+                vref=r.vref,
+                score=float(r.score) if r.score is not None else 0.0,
+                flag=bool(r.flag),
+                note=r.note,
+                source=r.source,
+                target=r.target,
+                hide=bool(r.hide),
+            )
+
+    word_align_by_vref: dict[str, List[WordAlignment]] = {}
+    if word_align_id is not None and page_vrefs:
+        rows = await db.execute(
+            select(AlignmentTopSourceScores).where(
+                AlignmentTopSourceScores.assessment_id == word_align_id,
+                AlignmentTopSourceScores.vref.in_(page_vrefs),
+            )
+        )
+        for r in rows.scalars().all():
+            word_align_by_vref.setdefault(r.vref, []).append(
+                WordAlignment(
+                    id=r.id,
+                    assessment_id=r.assessment_id,
+                    vref=r.vref,
+                    source=r.source,
+                    target=r.target,
+                    score=float(r.score) if r.score is not None else 0.0,
+                    flag=bool(r.flag),
+                    note=r.note,
+                    hide=bool(r.hide),
+                )
+            )
+
+    results_list = [
+        TrainingSessionVrefResults(
+            vref=v,
+            semantic_similarity=sem_sim_by_vref.get(v),
+            word_alignment=word_align_by_vref.get(v, []),
+        )
+        for v in page_vrefs
+    ]
+
+    # Ngrams: top-level, filtered to ngrams that appear in at least one vref
+    # in the requested book/chapter/verse window (or all ngrams when no
+    # filter). Returns each ngram's full vrefs list, not just the matching
+    # ones, so the client sees the same shape as /v3/ngrams_result.
+    ngrams_list: List[NgramResult] = []
+    if ngrams_id is not None:
+        matching_q = (
+            select(NgramsTable.id)
+            .join(NgramVrefTable, NgramVrefTable.ngram_id == NgramsTable.id)
+            .where(NgramsTable.assessment_id == ngrams_id)
+            .distinct()
+        )
+        if verse is not None:
+            matching_q = matching_q.where(
+                NgramVrefTable.vref == f"{book} {chapter}:{verse}"
+            )
+        elif chapter is not None:
+            matching_q = matching_q.where(
+                NgramVrefTable.vref.like(f"{book} {chapter}:%")
+            )
+        elif book is not None:
+            matching_q = matching_q.where(NgramVrefTable.vref.like(f"{book} %"))
+
+        matching_ids = [row[0] for row in (await db.execute(matching_q)).all()]
+        if matching_ids:
+            full_q = (
+                select(
+                    NgramsTable.id,
+                    NgramsTable.ngram,
+                    NgramsTable.ngram_size,
+                    NgramVrefTable.vref,
+                )
+                .join(NgramVrefTable, NgramVrefTable.ngram_id == NgramsTable.id)
+                .where(NgramsTable.id.in_(matching_ids))
+            )
+            buckets: dict[int, dict] = {}
+            for nid, ngram, size, ngram_vref in (await db.execute(full_q)).all():
+                b = buckets.setdefault(
+                    nid,
+                    {"ngram": ngram, "ngram_size": size, "vrefs": []},
+                )
+                b["vrefs"].append(ngram_vref)
+            ngrams_list = [
+                NgramResult(
+                    id=nid,
+                    assessment_id=ngrams_id,
+                    ngram=b["ngram"],
+                    ngram_size=b["ngram_size"],
+                    vrefs=b["vrefs"],
+                )
+                for nid, b in buckets.items()
+            ]
+
+    return TrainingSessionResultsResponse(
+        session_id=session_id,
+        training_jobs=[_job_out(j, j.assessment) for j in jobs],
+        inference_readiness=readiness,
+        results=TrainingSessionResultsPage(
+            items=results_list,
+            total_count=total_count,
+            page=page,
+            page_size=page_size,
+        ),
+        ngrams=ngrams_list,
     )
 
 
@@ -511,7 +811,12 @@ async def get_training_job(
     current_user: UserModel = Depends(get_current_user),
 ):
     """Get a single training job by ID."""
-    job = await db.get(TrainingJob, job_id)
+    stmt = (
+        select(TrainingJob)
+        .options(selectinload(TrainingJob.assessment))
+        .where(TrainingJob.id == job_id)
+    )
+    job = (await db.execute(stmt)).scalars().first()
     if not job or job.deleted:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -532,77 +837,7 @@ async def get_training_job(
                 detail="Not authorized to access this training job",
             )
 
-    return TrainingJobOut.model_validate(job)
-
-
-@router.patch("/train/{job_id}/status", response_model=TrainingJobOut)
-async def update_training_job_status(
-    job_id: int,
-    update: TrainingJobStatusUpdate,
-    db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
-):
-    """Runner callback to update training job status."""
-    job = await db.get(TrainingJob, job_id)
-    if not job or job.deleted:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Training job not found",
-        )
-
-    # Auth: admin, owner, or group access to both revisions
-    if not current_user.is_admin and job.owner_id != current_user.id:
-        version_ids = await _get_accessible_version_ids(current_user, db)
-        source_rev = await db.get(BibleRevision, job.source_revision_id)
-        target_rev = await db.get(BibleRevision, job.target_revision_id)
-        if (
-            source_rev.bible_version_id not in version_ids
-            or target_rev.bible_version_id not in version_ids
-        ):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Not authorized to update this training job",
-            )
-
-    if job.status in TERMINAL_STATUSES:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"Job is already in terminal status '{job.status}'",
-        )
-
-    # Validate state transition
-    allowed_next = VALID_TRANSITIONS.get(job.status, set())
-    if update.status not in allowed_next:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Invalid transition from '{job.status}' to '{update.status}'",
-        )
-
-    # Update fields
-    job.status = update.status
-    if update.status_detail is not None:
-        job.status_detail = update.status_detail
-    if update.percent_complete is not None:
-        job.percent_complete = update.percent_complete
-    if update.external_ids is not None:
-        job.external_ids = update.external_ids
-    if update.result_url is not None:
-        job.result_url = update.result_url
-    if update.result_metadata is not None:
-        job.result_metadata = update.result_metadata
-
-    # Set start_time on first non-queued status
-    if job.start_time is None and update.status != "queued":
-        job.start_time = datetime.utcnow()
-
-    # Set end_time on terminal status
-    if update.status in TERMINAL_STATUSES:
-        job.end_time = datetime.utcnow()
-        await _mirror_terminal_status_to_assessment(job, db)
-
-    await db.commit()
-    await db.refresh(job)
-    return TrainingJobOut.model_validate(job)
+    return _job_out(job, job.assessment)
 
 
 @router.get("/train/{job_id}/data")
@@ -715,7 +950,12 @@ async def delete_training_job(
     current_user: UserModel = Depends(get_current_user),
 ):
     """Soft delete a training job (terminal jobs only)."""
-    job = await db.get(TrainingJob, job_id)
+    stmt = (
+        select(TrainingJob)
+        .options(selectinload(TrainingJob.assessment))
+        .where(TrainingJob.id == job_id)
+    )
+    job = (await db.execute(stmt)).scalars().first()
     if not job or job.deleted:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -729,11 +969,14 @@ async def delete_training_job(
             detail="Not authorized to delete this training job",
         )
 
-    # Only allow deletion of terminal jobs
-    if job.status not in TERMINAL_STATUSES:
+    assessment_status = job.assessment.status if job.assessment is not None else None
+    if assessment_status not in ASSESSMENT_TERMINAL_VALUES:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
-            detail=f"Cannot delete job in '{job.status}' status. Only terminal jobs can be deleted.",
+            detail=(
+                f"Cannot delete job whose assessment is in '{assessment_status}' "
+                "status. Only terminal jobs can be deleted."
+            ),
         )
 
     job.deleted = True

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -564,8 +564,8 @@ async def get_training_session_results(
     book: Optional[str] = None,
     chapter: Optional[int] = None,
     verse: Optional[int] = None,
-    page: Optional[int] = None,
-    page_size: Optional[int] = None,
+    page: Optional[int] = Query(None, ge=1),
+    page_size: Optional[int] = Query(None, ge=1, le=1000),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -781,35 +781,38 @@ async def get_training_session_results(
         elif book is not None:
             matching_q = matching_q.where(NgramVrefTable.vref.like(f"{book} %"))
 
-        matching_ids = [row[0] for row in (await db.execute(matching_q)).all()]
-        if matching_ids:
-            full_q = (
-                select(
-                    NgramsTable.id,
-                    NgramsTable.ngram,
-                    NgramsTable.ngram_size,
-                    NgramVrefTable.vref,
-                )
-                .join(NgramVrefTable, NgramVrefTable.ngram_id == NgramsTable.id)
-                .where(NgramsTable.id.in_(matching_ids))
+        # Keep matching_q as a subquery and join in SQL rather than
+        # materializing IDs into a Python list and re-binding via IN(...).
+        # For large filter windows the IN list could blow past Postgres'
+        # parameter limit and doubles the round-trip count.
+        matching_subq = matching_q.subquery()
+        full_q = (
+            select(
+                NgramsTable.id,
+                NgramsTable.ngram,
+                NgramsTable.ngram_size,
+                NgramVrefTable.vref,
             )
-            buckets: dict[int, dict] = {}
-            for nid, ngram, size, ngram_vref in (await db.execute(full_q)).all():
-                b = buckets.setdefault(
-                    nid,
-                    {"ngram": ngram, "ngram_size": size, "vrefs": []},
-                )
-                b["vrefs"].append(ngram_vref)
-            ngrams_list = [
-                NgramResult(
-                    id=nid,
-                    assessment_id=ngrams_id,
-                    ngram=b["ngram"],
-                    ngram_size=b["ngram_size"],
-                    vrefs=b["vrefs"],
-                )
-                for nid, b in buckets.items()
-            ]
+            .join(NgramVrefTable, NgramVrefTable.ngram_id == NgramsTable.id)
+            .join(matching_subq, matching_subq.c.id == NgramsTable.id)
+        )
+        buckets: dict[int, dict] = {}
+        for nid, ngram, size, ngram_vref in (await db.execute(full_q)).all():
+            b = buckets.setdefault(
+                nid,
+                {"ngram": ngram, "ngram_size": size, "vrefs": []},
+            )
+            b["vrefs"].append(ngram_vref)
+        ngrams_list = [
+            NgramResult(
+                id=nid,
+                assessment_id=ngrams_id,
+                ngram=b["ngram"],
+                ngram_size=b["ngram_size"],
+                vrefs=b["vrefs"],
+            )
+            for nid, b in buckets.items()
+        ]
 
     return TrainingSessionResultsResponse(
         session_id=session_id,

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -578,7 +578,9 @@ async def get_training_session_results(
     across every verse it appears in. Tfidf and agent_critique training
     runs produce nothing the client wants here (vector-only / no vrefs).
     """
-    await validate_parameters(book, chapter, verse, None, page, page_size)
+    await validate_parameters(
+        book, chapter, verse, aggregate=None, page=page, page_size=page_size
+    )
     if book is not None:
         # Pin `book` to a known abbreviation up front. Both safety (the
         # ngram path interpolates `book` into a LIKE pattern, where `_`


### PR DESCRIPTION
## Summary

Two related scopes bundled because the new endpoint surfaced the stale-status bug that #593 was tracking:

- **New `GET /v3/train/status/{session_id}/results`** — single endpoint that returns interleaved per-vref results across all completed jobs in a session, with `book` / `chapter` / `verse` filters and pagination by vref in canonical bible order. Sem-sim scores and word-alignment per-word rows nest under each vref; ngrams are top-level (one ngram → many vrefs would duplicate the same ngram across every verse it appears in). Tfidf and agent-critique training runs contribute nothing here (vector-only / no vrefs from training).
- **Drop the `TrainingJob.status*` columns** (`status`, `status_detail`, `percent_complete`, `start_time`, `end_time`, `external_ids`, `result_url`, `result_metadata`) and the three status-bearing indexes. Status is now projected onto `TrainingJobOut` from the linked `Assessment` at serialization time.

After aqua-assessments#202 the runner only PATCHes `/v3/assessment/{id}/status`, so `TrainingJob.status` was never being updated and read endpoints were serving stale data (jobs frozen in `queued`). Closes #593.

### Endpoint changes
- `PATCH /v3/train/{id}/status` — **removed** (no consumer).
- `POST /v3/train` duplicate check joins to Assessment; dispatch failures write `failed` directly onto the linked Assessment.
- `GET /v3/train`, `/v3/train/status`, `/v3/train/{id}`, `/v3/train/status/{session_id}/results` — eager-load the linked Assessment via `selectinload` and serialize through a shared `_job_out(job, assessment)` builder.
- `GET /v3/train?status=...` — filter now matches Assessment.status.
- `DELETE /v3/train/{id}` — terminality check uses Assessment.status.
- `_compute_inference_readiness` joins to Assessment and looks for `status == "finished"`.

### Migration

`b7a3e9d6f1c2_drop_training_job_status_fields.py` — drops the 8 columns and 3 indexes; replaces `ix_training_job_revisions_type_status` with a status-free `ix_training_job_revisions_type` for the duplicate-job lookup. Single-PR migration as #593 prescribed.

### Follow-up

Making `TrainingJob.assessment_id` NOT NULL was in #593's acceptance list but conflicts with the existing `ondelete=SET NULL` FK action. Best done in a small separate PR that flips both the FK action and the nullability together.

## Test plan

- [x] `pytest test/test_train_routes/test_train_routes.py` — 42 passed
- [x] `pytest test/test_assessment_routes/test_assessment_routes.py test/test_predict_routes/` — 78 passed
- [x] Full suite — 711 passed
- [x] `black --check` and `isort --check-only` clean on changed files
- [x] Migration applies on dev DB
- [ ] End-to-end smoke against staging — verify a real training run lands status on Assessment and `/v3/train/status/{id}/results` reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)