### PR TITLE
Retire phased AssessmentStatus states (preparing/training/downloading/uploading)

### DIFF
--- a/alembic/migrations/versions/c1f3a8d2e9b6_collapse_phased_assessment_statuses.py
+++ b/alembic/migrations/versions/c1f3a8d2e9b6_collapse_phased_assessment_statuses.py
@@ -1,0 +1,42 @@
+"""collapse phased assessment statuses to running
+
+Revision ID: c1f3a8d2e9b6
+Revises: b7a3e9d6f1c2
+Create Date: 2026-04-30 00:00:00.000000
+
+Retires the phased AssessmentStatus values (preparing, training,
+downloading, uploading) introduced for training-job runs (aqua-api#584).
+After aqua-assessments unified its progress reporting onto a single
+running channel with percent_complete (and aqua-api#608 collapsed
+TrainingJob status onto the linked Assessment), the phased states no
+longer reflect distinct work — every running app reports progress as
+running → running self-loops. See aqua-api#609 for the full rationale.
+
+The assessment.status column is plain Text (no Postgres enum type), so
+this migration is a pure data update: any non-terminal row sitting in a
+phased state is moved to 'running'. Terminal rows (finished, failed) and
+queued rows are unaffected.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c1f3a8d2e9b6"
+down_revision: Union[str, None] = "b7a3e9d6f1c2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE assessment SET status = 'running' "
+        "WHERE status IN ('preparing', 'training', 'downloading', 'uploading')"
+    )
+
+
+def downgrade() -> None:
+    # Irreversible: the original phase a row was in is not recoverable
+    # from the collapsed state. No-op so the migration can be unwound
+    # without erroring; rows stay on 'running'.
+    pass

--- a/models.py
+++ b/models.py
@@ -205,39 +205,17 @@ class VerseText(BaseModel):
 
 class AssessmentStatus(str, Enum):
     queued = "queued"
-    preparing = "preparing"
     running = "running"
-    training = "training"
-    downloading = "downloading"
-    uploading = "uploading"
     finished = "finished"
     failed = "failed"
 
 
-# Training-job runs use the phased path queued → preparing → training →
-# downloading → uploading → finished. Plain assessments use queued →
-# running → finished. failed is reachable from any non-terminal state.
+# All assessment runs (training and non-training) follow queued → running →
+# finished. Progress within `running` is reported via percent_complete on
+# self-loop PATCHes. `failed` is reachable from any non-terminal state.
 ASSESSMENT_VALID_TRANSITIONS = {
     AssessmentStatus.queued: {
-        AssessmentStatus.preparing,
         AssessmentStatus.running,
-        AssessmentStatus.failed,
-    },
-    AssessmentStatus.preparing: {
-        AssessmentStatus.training,
-        AssessmentStatus.failed,
-    },
-    AssessmentStatus.training: {
-        AssessmentStatus.training,
-        AssessmentStatus.downloading,
-        AssessmentStatus.failed,
-    },
-    AssessmentStatus.downloading: {
-        AssessmentStatus.uploading,
-        AssessmentStatus.failed,
-    },
-    AssessmentStatus.uploading: {
-        AssessmentStatus.finished,
         AssessmentStatus.failed,
     },
     # running → running is intentional: allows runners to send progress updates

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -2,6 +2,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from database.models import Assessment, BibleVersionAccess
 from database.models import UserDB
 from database.models import UserDB as UserModel
@@ -1134,19 +1136,34 @@ def test_patch_assessment_status_invalid_transition(
     assert resp.status_code == 422
 
 
+@pytest.mark.parametrize(
+    "retired_status", ["preparing", "training", "downloading", "uploading"]
+)
+def test_patch_assessment_status_retired_phased_value_rejected(
+    client, regular_token1, db_session, test_db_session, retired_status
+):
+    """Retired phased status values are rejected at the schema layer (422)."""
+    aid = _create_assessment(client, regular_token1, db_session)
+
+    resp = _patch_status(client, regular_token1, aid, {"status": retired_status})
+    assert resp.status_code == 422
+
+
 def test_patch_assessment_status_terminal_rejected(
     client, regular_token1, db_session, test_db_session
 ):
-    """PATCH /assessment/{id}/status rejects updates to terminal assessments."""
-    aid = _create_assessment(client, regular_token1, db_session)
+    """PATCH /assessment/{id}/status rejects updates to terminal assessments
+    from both `failed` and `finished`, against any next status."""
+    for terminal in ("failed", "finished"):
+        aid = _create_assessment(client, regular_token1, db_session)
+        resp = _patch_status(client, regular_token1, aid, {"status": "running"})
+        assert resp.status_code == 200
+        resp = _patch_status(client, regular_token1, aid, {"status": terminal})
+        assert resp.status_code == 200
 
-    # Move to failed
-    resp = _patch_status(client, regular_token1, aid, {"status": "failed"})
-    assert resp.status_code == 200
-
-    # Try to update again
-    resp = _patch_status(client, regular_token1, aid, {"status": "running"})
-    assert resp.status_code == 409
+        for next_status in ("running", "failed", "finished"):
+            resp = _patch_status(client, regular_token1, aid, {"status": next_status})
+            assert resp.status_code == 409, f"{terminal} → {next_status}: {resp.text}"
 
 
 def test_patch_assessment_status_not_found(
@@ -1214,8 +1231,8 @@ def test_patch_assessment_status_running_progress_then_finished(
         data = resp.json()
         assert data["status"] == next_status
         assert data["percent_complete"] == pct
-
-    assert data["end_time"] is not None
+        if next_status == "finished":
+            assert data["end_time"] is not None
 
 
 def test_patch_assessment_status_percent_complete_on_running(
@@ -1263,7 +1280,8 @@ def test_assessment_via_assess_route_is_not_training(
 def test_patch_assessment_status_failed_from_each_non_terminal_state(
     client, regular_token1, db_session, test_db_session
 ):
-    """failed must be reachable from each non-terminal status."""
+    """failed must be reachable from each non-terminal status, and stamps
+    both start_time (if not yet set) and end_time."""
     for stop_at in ("queued", "running"):
         aid = _create_assessment(client, regular_token1, db_session)
         if stop_at == "running":
@@ -1272,7 +1290,12 @@ def test_patch_assessment_status_failed_from_each_non_terminal_state(
 
         resp = _patch_status(client, regular_token1, aid, {"status": "failed"})
         assert resp.status_code == 200, f"failed from {stop_at}: {resp.text}"
-        assert resp.json()["status"] == "failed"
+        data = resp.json()
+        assert data["status"] == "failed"
+        assert data["end_time"] is not None
+        # The route stamps start_time on any non-queued transition, so
+        # failed-from-queued sets start_time too.
+        assert data["start_time"] is not None
 
 
 def test_patch_assessment_status_percent_complete_persists_when_omitted(

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1190,19 +1190,17 @@ def test_patch_assessment_status_admin_can_update(
     assert resp.json()["status"] == "running"
 
 
-def test_patch_assessment_status_phased_sequence(
+def test_patch_assessment_status_running_progress_then_finished(
     client, regular_token1, db_session, test_db_session
 ):
-    """PATCH /assessment/{id}/status walks the training-phase sequence and
-    persists percent_complete on each step."""
+    """PATCH /assessment/{id}/status reports progress via running self-loops
+    and persists percent_complete on each step before finishing."""
     aid = _create_assessment(client, regular_token1, db_session)
 
     steps = [
-        ("preparing", 5.0),
-        ("training", 30.0),
-        ("training", 75.0),
-        ("downloading", 90.0),
-        ("uploading", 95.0),
+        ("running", 5.0),
+        ("running", 40.0),
+        ("running", 90.0),
         ("finished", 100.0),
     ]
     for next_status, pct in steps:
@@ -1251,19 +1249,6 @@ def test_patch_assessment_status_percent_complete_out_of_range(
     assert resp.status_code == 422
 
 
-def test_patch_assessment_status_phased_invalid_skip(
-    client, regular_token1, db_session, test_db_session
-):
-    """Skipping phases (preparing → uploading) is rejected."""
-    aid = _create_assessment(client, regular_token1, db_session)
-
-    resp = _patch_status(client, regular_token1, aid, {"status": "preparing"})
-    assert resp.status_code == 200
-
-    resp = _patch_status(client, regular_token1, aid, {"status": "uploading"})
-    assert resp.status_code == 422
-
-
 def test_assessment_via_assess_route_is_not_training(
     client, regular_token1, db_session, test_db_session
 ):
@@ -1275,35 +1260,19 @@ def test_assessment_via_assess_route_is_not_training(
     assert resp.json()["is_training"] is False
 
 
-def test_patch_assessment_status_failed_from_each_phase(
+def test_patch_assessment_status_failed_from_each_non_terminal_state(
     client, regular_token1, db_session, test_db_session
 ):
-    """failed must be reachable from each non-terminal phased status."""
-    walk = ["preparing", "training", "downloading", "uploading"]
-    for stop_at in walk:
+    """failed must be reachable from each non-terminal status."""
+    for stop_at in ("queued", "running"):
         aid = _create_assessment(client, regular_token1, db_session)
-        for next_status in walk:
-            resp = _patch_status(client, regular_token1, aid, {"status": next_status})
-            assert resp.status_code == 200, f"{next_status}: {resp.text}"
-            if next_status == stop_at:
-                break
+        if stop_at == "running":
+            resp = _patch_status(client, regular_token1, aid, {"status": "running"})
+            assert resp.status_code == 200, resp.text
 
         resp = _patch_status(client, regular_token1, aid, {"status": "failed"})
         assert resp.status_code == 200, f"failed from {stop_at}: {resp.text}"
         assert resp.json()["status"] == "failed"
-
-
-def test_patch_assessment_status_cross_path_preparing_to_running_rejected(
-    client, regular_token1, db_session, test_db_session
-):
-    """Once on the phased path, the plain `running` status is not reachable."""
-    aid = _create_assessment(client, regular_token1, db_session)
-
-    resp = _patch_status(client, regular_token1, aid, {"status": "preparing"})
-    assert resp.status_code == 200
-
-    resp = _patch_status(client, regular_token1, aid, {"status": "running"})
-    assert resp.status_code == 422
 
 
 def test_patch_assessment_status_percent_complete_persists_when_omitted(
@@ -1331,23 +1300,22 @@ def test_patch_assessment_status_percent_complete_persists_when_omitted(
     assert resp.json()["percent_complete"] == 75.0
 
 
-def test_patch_assessment_status_start_time_set_on_preparing(
+def test_patch_assessment_status_start_time_set_on_running(
     client, regular_token1, db_session, test_db_session
 ):
-    """The first non-queued transition (preparing) stamps start_time."""
+    """The first non-queued transition (running) stamps start_time."""
     aid = _create_assessment(client, regular_token1, db_session)
 
-    resp = _patch_status(client, regular_token1, aid, {"status": "preparing"})
+    resp = _patch_status(client, regular_token1, aid, {"status": "running"})
     assert resp.status_code == 200
     assert resp.json()["start_time"] is not None
 
 
-def test_create_assessment_blocked_while_in_phased_status(
+def test_create_assessment_blocked_while_running(
     client, regular_token1, db_session, test_db_session
 ):
-    """A plain POST /assessment must 409 while a duplicate row is in any
-    in-progress phased status (preparing/training/downloading/uploading),
-    not just queued/running."""
+    """A plain POST /assessment must 409 while a duplicate row is still
+    running (i.e. has not reached a terminal status)."""
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
     reference_id = upload_revision(client, regular_token1, version_id)
@@ -1368,10 +1336,9 @@ def test_create_assessment_blocked_while_in_phased_status(
         assert first.status_code == 200
         aid = first.json()[0]["id"]
 
-    # Drive the existing row deep into the phased path.
-    for next_status in ["preparing", "training"]:
-        resp = _patch_status(client, regular_token1, aid, {"status": next_status})
-        assert resp.status_code == 200
+    # Drive the existing row to running.
+    resp = _patch_status(client, regular_token1, aid, {"status": "running"})
+    assert resp.status_code == 200
 
     # Second POST for the same revision/type must be blocked.
     with patch(

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1141,11 +1141,14 @@ def _advance_assessment_to_finished(client, token, assessment_id):
     """Walk an Assessment through queued → running → finished via PATCH
     /v3/assessment/{id}/status — the single status channel."""
     for next_status in ("running", "finished"):
-        client.patch(
+        resp = client.patch(
             f"{prefix}/assessment/{assessment_id}/status",
             json={"status": next_status},
             headers=_auth_headers(token),
         )
+        assert (
+            resp.status_code == 200
+        ), f"advance to {next_status} failed: {resp.status_code} {resp.text}"
 
 
 def _set_assessment_status(db_session, assessment_id, status):

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -285,10 +285,10 @@ def test_training_job_full_lifecycle_via_runner(
     """End-to-end lifecycle via the runner.
 
     Status, percent_complete, and timing live on the linked Assessment row
-    (aqua-api#584). The aqua-assessments runner pushes the phased sequence
-    queued → preparing → training → downloading → uploading → finished
-    against PATCH /v3/assessment/{id}/status; aqua-api just exposes the
-    result via /v3/train reads.
+    (aqua-api#584). The aqua-assessments runner reports progress as
+    queued → running (with percent_complete self-loops) → finished against
+    PATCH /v3/assessment/{id}/status; aqua-api just exposes the result via
+    /v3/train reads.
     """
     payloads = []
     calls = []
@@ -320,33 +320,27 @@ def test_training_job_full_lifecycle_via_runner(
     assert config.get("is_training") is True
     assert "train_job_id" not in kwargs
 
-    # (2) Simulate the runner's phase callbacks against the assessment-status
-    # endpoint — the only channel that exists post #584 / aqua-assessments#202.
-    last_percent = {
-        "preparing": 5.0,
-        "training": 40.0,
-        "downloading": 75.0,
-        "uploading": 90.0,
-        "finished": 100.0,
-    }
-    for next_status in [
-        "preparing",
-        "training",
-        "downloading",
-        "uploading",
-        "finished",
-    ]:
+    # (2) Simulate the runner's progress callbacks against the
+    # assessment-status endpoint — the only channel that exists post
+    # #584 / aqua-assessments#202.
+    progress_steps = [
+        ("running", 5.0),
+        ("running", 40.0),
+        ("running", 90.0),
+        ("finished", 100.0),
+    ]
+    for next_status, pct in progress_steps:
         resp = client.patch(
             f"{prefix}/assessment/{job['assessment_id']}/status",
             json={
                 "status": next_status,
-                "percent_complete": last_percent[next_status],
+                "percent_complete": pct,
             },
             headers=_auth_headers(regular_token1),
         )
         assert (
             resp.status_code == 200
-        ), f"phase {next_status} rejected: {resp.status_code} {resp.text}"
+        ), f"step {next_status}@{pct} rejected: {resp.status_code} {resp.text}"
 
     # (3) /v3/train reads now reflect the assessment-driven status.
     job_resp = client.get(
@@ -1144,15 +1138,9 @@ def test_get_training_status_readiness_updates(
 
 
 def _advance_assessment_to_finished(client, token, assessment_id):
-    """Walk an Assessment through the phased training sequence to finished
-    via PATCH /v3/assessment/{id}/status — the single status channel."""
-    for next_status in (
-        "preparing",
-        "training",
-        "downloading",
-        "uploading",
-        "finished",
-    ):
+    """Walk an Assessment through queued → running → finished via PATCH
+    /v3/assessment/{id}/status — the single status channel."""
+    for next_status in ("running", "finished"):
         client.patch(
             f"{prefix}/assessment/{assessment_id}/status",
             json={"status": next_status},

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -62,8 +62,9 @@ router = fastapi.APIRouter()
 
 # Status, transitions, and progress live on the linked Assessment row
 # (aqua-api#584). The aqua-assessments runner PATCHes
-# /v3/assessment/{id}/status with the phased queued → preparing → training →
-# downloading → uploading → finished sequence; failures land as `failed`.
+# /v3/assessment/{id}/status with the queued → running → finished sequence,
+# reporting progress via percent_complete on running self-loops; failures
+# land as `failed`.
 ASSESSMENT_TERMINAL_VALUES = {s.value for s in ASSESSMENT_TERMINAL_STATUSES}
 ASSESSMENT_FINISHED_VALUE = AssessmentStatus.finished.value
 
@@ -120,10 +121,10 @@ def _build_runner_train_config(
     artifact-push URLs like `/v3/assessment/{id}/results`, which are keyed
     on Assessment.id.
 
-    `is_training=True` is the single signal the runner keys on to emit the
-    phased status sequence (preparing → training → downloading → uploading
-    → finished) against PATCH /v3/assessment/{id}/status. Per-app
-    behaviour toggles (e.g. sem-sim's `finetune`) flow through the
+    `is_training=True` tells the runner to dispatch to the app's training
+    path (rather than its inference path); status reporting itself is the
+    same queued → running → finished sequence used by every assessment.
+    Per-app behaviour toggles (e.g. sem-sim's `finetune`) flow through the
     caller's `options` → `config["kwargs"]` — aqua-api doesn't hard-code
     them.
     """
@@ -375,10 +376,9 @@ async def create_training_job(
                     f"No dispatch configured for training type '{job.type}'"
                 )
             # Runner dispatches to the right app's assess() based on
-            # config.type and, because config["is_training"] is True,
-            # emits the phased status sequence (preparing → training →
-            # downloading → uploading → finished/failed) against
-            # PATCH /v3/assessment/{id}/status.
+            # config.type and config["is_training"], and reports progress
+            # via PATCH /v3/assessment/{id}/status (queued → running →
+            # finished/failed).
             f = modal.Function.from_name(
                 "runner", "run_assessment_runner", environment_name=modal_env
             )

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -323,7 +323,8 @@ async def create_training_job(
         # Create a paired Assessment row so aqua-assessments can write
         # artifacts under the same assessment_id pattern used by the assess()
         # path. Assessment.status is the single channel of training-run
-        # status — runner PATCHes it through the phased sequence.
+        # status — runner PATCHes it queued → running (with percent_complete
+        # self-loops) → finished.
         assessment = Assessment(
             revision_id=job_in.source_revision_id,
             reference_id=job_in.target_revision_id,

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -122,8 +122,9 @@ def _build_runner_train_config(
     on Assessment.id.
 
     `is_training=True` tells the runner to dispatch to the app's training
-    path (rather than its inference path); status reporting itself is the
-    same queued → running → finished sequence used by every assessment.
+    path (rather than its inference path); status reporting itself uses
+    the same queued → running → finished|failed lifecycle as every
+    assessment.
     Per-app behaviour toggles (e.g. sem-sim's `finetune`) flow through the
     caller's `options` → `config["kwargs"]` — aqua-api doesn't hard-code
     them.


### PR DESCRIPTION
## Summary

- Collapse `AssessmentStatus` to `queued`, `running`, `finished`, `failed`. The phased states (`preparing`, `training`, `downloading`, `uploading`) no longer reflect distinct work after the runner unified on a single `running` channel with `percent_complete` (per #608).
- Trim `ASSESSMENT_VALID_TRANSITIONS` to `queued → running → finished | failed`, with `running → running` retained for progress self-loops.
- Add Alembic migration `c1f3a8d2e9b6` that maps any non-terminal row in a phased state to `running`. `assessment.status` is plain `Text`, so it's a pure data UPDATE — no enum type to alter. Downgrade is intentionally a no-op (the original phase isn't recoverable; `running` is valid in both the old and new state machines).
- Update `train_routes` comments and test lifecycles to drive `queued → running (with percent updates) → finished`. Remove tests that exercised phased-only behaviour (skip rejection, cross-path rejection).

No runner change required at retirement time — the runner already PATCHes `running → running` and `running → finished`, both of which were already legal transitions.

### Bonus cleanup checked

The issue mentioned a possible bonus cleanup of hardcoded `status_detail` strings tied to phased states (e.g. "Finalizing", "Training complete"). Searched routes and runners — no such strings exist in this repo.

### Downstream consumer impact

External consumers (notably the aqua-app UI and any webhook subscriber) that polled `GET /v3/train?status=preparing` (or `training`/`downloading`/`uploading`) will silently get `[]` after this lands — the filter is a plain string equality on `Assessment.status`. Functionally equivalent to filtering on `running`; cosmetic only. Anyone displaying `status` literally should map the four retired values to `running` (they shouldn't see them anyway after the migration).

Fixes #609

## Test plan

- [x] pytest test/ — 714 passed locally before review fixes; 88 passed in the affected suites after review fixes
- [x] alembic upgrade head against local DB advances b7a3e9d6f1c2 → c1f3a8d2e9b6
- [x] pre-commit (black, isort, EOL, trailing-whitespace) clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)