### PR TITLE
[codex] Speed up bulk result inserts

### DIFF
--- a/assessment_routes/v3/results_push_routes.py
+++ b/assessment_routes/v3/results_push_routes.py
@@ -379,18 +379,18 @@ async def push_text_lengths(
     if not body:
         return InsertResponse(ids=[])
     _check_body_size(body)
+    rows = [
+        {
+            "assessment_id": assessment_id,
+            "vref": item.vref,
+            "word_lengths": item.word_lengths,
+            "char_lengths": item.char_lengths,
+            "word_lengths_z": item.word_lengths_z,
+            "char_lengths_z": item.char_lengths_z,
+        }
+        for item in body
+    ]
     try:
-        rows = [
-            {
-                "assessment_id": assessment_id,
-                "vref": item.vref,
-                "word_lengths": item.word_lengths,
-                "char_lengths": item.char_lengths,
-                "word_lengths_z": item.word_lengths_z,
-                "char_lengths_z": item.char_lengths_z,
-            }
-            for item in body
-        ]
         await _batch_insert(db, TextLengthsTable, rows)
         await db.commit()
         return InsertResponse(ids=[])
@@ -398,18 +398,18 @@ async def push_text_lengths(
         await db.rollback()
         raise HTTPException(
             status_code=400,
-            detail=f"Duplicate or constraint violation inserting {len(body)} text lengths for assessment {assessment_id}",
+            detail=f"Duplicate or constraint violation inserting {len(rows)} text lengths for assessment {assessment_id}",
         )
     except SQLAlchemyError:
         logger.exception(
             "Bulk insert failed for text_lengths_table, assessment_id=%s, item_count=%d",
             assessment_id,
-            len(body),
+            len(rows),
         )
         await db.rollback()
         raise HTTPException(
             status_code=500,
-            detail=f"Database error inserting {len(body)} text lengths for assessment {assessment_id}",
+            detail=f"Database error inserting {len(rows)} text lengths for assessment {assessment_id}",
         )
     except HTTPException:
         raise
@@ -417,12 +417,12 @@ async def push_text_lengths(
         logger.exception(
             "Unexpected error pushing text lengths, assessment_id=%s, item_count=%d",
             assessment_id,
-            len(body),
+            len(rows),
         )
         await db.rollback()
         raise HTTPException(
             status_code=500,
-            detail=f"Unexpected error inserting {len(body)} text lengths for assessment {assessment_id}",
+            detail=f"Unexpected error inserting {len(rows)} text lengths for assessment {assessment_id}",
         )
 
 
@@ -447,15 +447,15 @@ async def push_tfidf_vectors(
     if not body:
         return InsertResponse(ids=[])
     _check_body_size(body)
+    rows = [
+        {
+            "assessment_id": assessment_id,
+            "vref": item.vref,
+            "vector": item.vector,
+        }
+        for item in body
+    ]
     try:
-        rows = [
-            {
-                "assessment_id": assessment_id,
-                "vref": item.vref,
-                "vector": item.vector,
-            }
-            for item in body
-        ]
         await _batch_insert(db, TfidfPcaVector, rows)
         await db.commit()
         return InsertResponse(ids=[])
@@ -463,18 +463,18 @@ async def push_tfidf_vectors(
         await db.rollback()
         raise HTTPException(
             status_code=400,
-            detail=f"Duplicate or constraint violation inserting {len(body)} tfidf vectors for assessment {assessment_id}",
+            detail=f"Duplicate or constraint violation inserting {len(rows)} tfidf vectors for assessment {assessment_id}",
         )
     except SQLAlchemyError:
         logger.exception(
             "Bulk insert failed for tfidf_pca_vector, assessment_id=%s, item_count=%d",
             assessment_id,
-            len(body),
+            len(rows),
         )
         await db.rollback()
         raise HTTPException(
             status_code=500,
-            detail=f"Database error inserting {len(body)} tfidf vectors for assessment {assessment_id}",
+            detail=f"Database error inserting {len(rows)} tfidf vectors for assessment {assessment_id}",
         )
     except HTTPException:
         raise
@@ -482,12 +482,12 @@ async def push_tfidf_vectors(
         logger.exception(
             "Unexpected error pushing tfidf vectors, assessment_id=%s, item_count=%d",
             assessment_id,
-            len(body),
+            len(rows),
         )
         await db.rollback()
         raise HTTPException(
             status_code=500,
-            detail=f"Unexpected error inserting {len(body)} tfidf vectors for assessment {assessment_id}",
+            detail=f"Unexpected error inserting {len(rows)} tfidf vectors for assessment {assessment_id}",
         )
 
 

--- a/assessment_routes/v3/results_push_routes.py
+++ b/assessment_routes/v3/results_push_routes.py
@@ -80,9 +80,8 @@ async def _get_authorized_assessment(
 
 
 async def _batch_insert(db, model_cls, rows):
-    """Batch-insert rows and return their auto-generated IDs.
+    """Batch-insert rows without projecting generated IDs back to the client.
 
-    IDs are returned in the same positional order as the input rows.
     PostgreSQL/asyncpg limits queries to 32,767 parameters, so the batch
     size is computed from the number of columns per row.
     """
@@ -91,13 +90,9 @@ async def _batch_insert(db, model_cls, rows):
     # SQLAlchemy may add columns with server defaults (e.g. 'hide').
     cols_per_row = len(model_cls.__table__.columns)
     batch_size = min(_BATCH_SIZE, _PG_MAX_PARAMS // cols_per_row)
-    inserted_ids = []
     for i in range(0, len(rows), batch_size):
         batch = rows[i : i + batch_size]
-        stmt = insert(model_cls).values(batch).returning(model_cls.id)
-        result = await db.execute(stmt)
-        inserted_ids.extend(r[0] for r in result.fetchall())
-    return inserted_ids
+        await db.execute(insert(model_cls).values(batch))
 
 
 def _build_score_rows(assessment_id: int, items: List[AssessmentResultItem]):
@@ -153,16 +148,17 @@ async def push_results(
     Maximum of 5,000 items per request. For larger datasets, split into
     multiple requests of 5,000 items or fewer.
 
-    Returns the list of inserted row IDs in the same order as the input.
+    Returns an empty ``ids`` list; generated IDs are intentionally not fetched
+    during bulk inserts.
     """
     if not body:
         return InsertResponse(ids=[])
     _check_body_size(body)
     rows = _build_score_rows(assessment_id, body)
     try:
-        ids = await _batch_insert(db, AssessmentResult, rows)
+        await _batch_insert(db, AssessmentResult, rows)
         await db.commit()
-        return InsertResponse(ids=ids)
+        return InsertResponse(ids=[])
     except IntegrityError:
         await db.rollback()
         raise HTTPException(
@@ -210,7 +206,8 @@ async def push_alignment_scores(
     Maximum of 5,000 items per request. For larger datasets, split into
     multiple requests of 5,000 items or fewer.
 
-    Returns the list of inserted row IDs in the same order as the input.
+    Returns an empty ``ids`` list; generated IDs are intentionally not fetched
+    during bulk inserts.
 
     ``hide`` is hardcoded to ``False`` and is not part of ``AlignmentScoreItem``
     — it is a UI-only flag managed by other endpoints, not by the assessment
@@ -240,9 +237,9 @@ async def push_alignment_scores(
             }
         )
     try:
-        ids = await _batch_insert(db, AlignmentTopSourceScores, rows)
+        await _batch_insert(db, AlignmentTopSourceScores, rows)
         await db.commit()
-        return InsertResponse(ids=ids)
+        return InsertResponse(ids=[])
     except IntegrityError:
         await db.rollback()
         raise HTTPException(
@@ -295,7 +292,8 @@ async def push_alignment_threshold_scores(
     Maximum of 5,000 items per request. For larger datasets, split into
     multiple requests of 5,000 items or fewer.
 
-    Returns the list of inserted row IDs in the same order as the input.
+    Returns an empty ``ids`` list; generated IDs are intentionally not fetched
+    during bulk inserts.
 
     ``hide`` is explicitly set to ``False`` for parity with the top-source
     endpoint, so we don't depend on the column's ``server_default`` (added
@@ -325,9 +323,9 @@ async def push_alignment_threshold_scores(
             }
         )
     try:
-        ids = await _batch_insert(db, AlignmentThresholdScores, rows)
+        await _batch_insert(db, AlignmentThresholdScores, rows)
         await db.commit()
-        return InsertResponse(ids=ids)
+        return InsertResponse(ids=[])
     except IntegrityError:
         await db.rollback()
         raise HTTPException(
@@ -375,7 +373,8 @@ async def push_text_lengths(
     Maximum of 5,000 items per request. For larger datasets, split into
     multiple requests of 5,000 items or fewer.
 
-    Returns the list of inserted row IDs in the same order as the input.
+    Returns an empty ``ids`` list; generated IDs are intentionally not fetched
+    during bulk inserts.
     """
     if not body:
         return InsertResponse(ids=[])
@@ -392,9 +391,9 @@ async def push_text_lengths(
             }
             for item in body
         ]
-        ids = await _batch_insert(db, TextLengthsTable, rows)
+        await _batch_insert(db, TextLengthsTable, rows)
         await db.commit()
-        return InsertResponse(ids=ids)
+        return InsertResponse(ids=[])
     except IntegrityError:
         await db.rollback()
         raise HTTPException(
@@ -442,7 +441,8 @@ async def push_tfidf_vectors(
     Maximum of 5,000 items per request. For larger datasets, split into
     multiple requests of 5,000 items or fewer.
 
-    Returns the list of inserted row IDs in the same order as the input.
+    Returns an empty ``ids`` list; generated IDs are intentionally not fetched
+    during bulk inserts.
     """
     if not body:
         return InsertResponse(ids=[])
@@ -456,9 +456,9 @@ async def push_tfidf_vectors(
             }
             for item in body
         ]
-        ids = await _batch_insert(db, TfidfPcaVector, rows)
+        await _batch_insert(db, TfidfPcaVector, rows)
         await db.commit()
-        return InsertResponse(ids=ids)
+        return InsertResponse(ids=[])
     except IntegrityError:
         await db.rollback()
         raise HTTPException(

--- a/test/test_assessment_routes/test_results_push_routes.py
+++ b/test/test_assessment_routes/test_results_push_routes.py
@@ -32,7 +32,7 @@ def push_assessment_id(test_db_session, test_revision_id, test_revision_id_2):
 # ---------------------------------------------------------------------------
 
 
-def test_push_results(client, regular_token1, push_assessment_id):
+def test_push_results(client, regular_token1, push_assessment_id, test_db_session):
     body = [
         {
             "vref": "GEN 1:1",
@@ -53,6 +53,17 @@ def test_push_results(client, regular_token1, push_assessment_id):
     )
     assert response.status_code == 200
     assert response.json()["ids"] == []
+    # Response no longer carries IDs, so confirm rows landed via the DB.
+    test_db_session.expire_all()
+    persisted = (
+        test_db_session.query(AssessmentResult)
+        .filter(
+            AssessmentResult.assessment_id == push_assessment_id,
+            AssessmentResult.vref.in_(["GEN 1:1", "GEN 1:2"]),
+        )
+        .count()
+    )
+    assert persisted == 2
 
 
 def test_push_results_empty_body(client, regular_token1, push_assessment_id):
@@ -319,7 +330,9 @@ def test_push_alignment_threshold_scores_invalid_vref(
 # ---------------------------------------------------------------------------
 
 
-def test_push_text_lengths(client, regular_token1, push_assessment_id):
+def test_push_text_lengths(
+    client, regular_token1, push_assessment_id, test_db_session
+):
     body = [
         {
             "vref": "GEN 1:1",
@@ -343,6 +356,17 @@ def test_push_text_lengths(client, regular_token1, push_assessment_id):
     )
     assert response.status_code == 200
     assert response.json()["ids"] == []
+    # Response no longer carries IDs, so confirm rows landed via the DB.
+    test_db_session.expire_all()
+    persisted = (
+        test_db_session.query(TextLengthsTable)
+        .filter(
+            TextLengthsTable.assessment_id == push_assessment_id,
+            TextLengthsTable.vref.in_(["GEN 1:1", "GEN 1:2"]),
+        )
+        .count()
+    )
+    assert persisted == 2
 
 
 # ---------------------------------------------------------------------------
@@ -350,7 +374,9 @@ def test_push_text_lengths(client, regular_token1, push_assessment_id):
 # ---------------------------------------------------------------------------
 
 
-def test_push_tfidf_vectors(client, regular_token1, push_assessment_id):
+def test_push_tfidf_vectors(
+    client, regular_token1, push_assessment_id, test_db_session
+):
     body = [
         {
             "vref": "GEN 1:1",
@@ -364,6 +390,17 @@ def test_push_tfidf_vectors(client, regular_token1, push_assessment_id):
     )
     assert response.status_code == 200
     assert response.json()["ids"] == []
+    # Response no longer carries IDs, so confirm rows landed via the DB.
+    test_db_session.expire_all()
+    persisted = (
+        test_db_session.query(TfidfPcaVector)
+        .filter(
+            TfidfPcaVector.assessment_id == push_assessment_id,
+            TfidfPcaVector.vref == "GEN 1:1",
+        )
+        .count()
+    )
+    assert persisted == 1
 
 
 # ---------------------------------------------------------------------------
@@ -640,11 +677,14 @@ def test_delete_alignment_threshold_scores_empty_ids(
 def test_delete_text_lengths(
     client, regular_token1, push_assessment_id, test_db_session
 ):
+    # Use a vref unique to this test so the lookup can't pick up rows
+    # inserted by other tests sharing the module-scoped assessment.
+    delete_vref = "GEN 1:30"
     insert_resp = client.post(
         f"{prefix}/assessment/{push_assessment_id}/text-lengths",
         json=[
             {
-                "vref": "GEN 1:3",
+                "vref": delete_vref,
                 "word_lengths": 5.0,
                 "char_lengths": 25.0,
                 "word_lengths_z": 0.3,
@@ -660,7 +700,7 @@ def test_delete_text_lengths(
         for row in test_db_session.query(TextLengthsTable)
         .filter(
             TextLengthsTable.assessment_id == push_assessment_id,
-            TextLengthsTable.vref == "GEN 1:3",
+            TextLengthsTable.vref == delete_vref,
         )
         .all()
     ]
@@ -693,9 +733,12 @@ def test_delete_text_lengths_nonexistent(client, regular_token1):
 def test_delete_tfidf_vectors(
     client, regular_token1, push_assessment_id, test_db_session
 ):
+    # Use a vref unique to this test so the lookup can't pick up rows
+    # inserted by other tests sharing the module-scoped assessment.
+    delete_vref = "GEN 1:31"
     insert_resp = client.post(
         f"{prefix}/assessment/{push_assessment_id}/tfidf-vectors",
-        json=[{"vref": "GEN 1:3", "vector": [0.1] * 300}],
+        json=[{"vref": delete_vref, "vector": [0.1] * 300}],
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert insert_resp.status_code == 200
@@ -705,7 +748,7 @@ def test_delete_tfidf_vectors(
         for row in test_db_session.query(TfidfPcaVector)
         .filter(
             TfidfPcaVector.assessment_id == push_assessment_id,
-            TfidfPcaVector.vref == "GEN 1:3",
+            TfidfPcaVector.vref == delete_vref,
         )
         .all()
     ]

--- a/test/test_assessment_routes/test_results_push_routes.py
+++ b/test/test_assessment_routes/test_results_push_routes.py
@@ -330,9 +330,7 @@ def test_push_alignment_threshold_scores_invalid_vref(
 # ---------------------------------------------------------------------------
 
 
-def test_push_text_lengths(
-    client, regular_token1, push_assessment_id, test_db_session
-):
+def test_push_text_lengths(client, regular_token1, push_assessment_id, test_db_session):
     body = [
         {
             "vref": "GEN 1:1",

--- a/test/test_assessment_routes/test_results_push_routes.py
+++ b/test/test_assessment_routes/test_results_push_routes.py
@@ -1,6 +1,13 @@
 import pytest
 
-from database.models import Assessment
+from database.models import (
+    AlignmentThresholdScores,
+    AlignmentTopSourceScores,
+    Assessment,
+    AssessmentResult,
+    TextLengthsTable,
+    TfidfPcaVector,
+)
 
 prefix = "v3"
 
@@ -45,9 +52,7 @@ def test_push_results(client, regular_token1, push_assessment_id):
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
-    data = response.json()
-    assert len(data["ids"]) == 2
-    assert all(isinstance(i, int) for i in data["ids"])
+    assert response.json()["ids"] == []
 
 
 def test_push_results_empty_body(client, regular_token1, push_assessment_id):
@@ -129,7 +134,7 @@ def test_push_alignment_scores(client, regular_token1, push_assessment_id):
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
-    assert len(response.json()["ids"]) == 1
+    assert response.json()["ids"] == []
 
 
 def test_push_alignment_scores_round_trips_to_get(
@@ -204,7 +209,7 @@ def test_push_alignment_threshold_scores(client, regular_token1, push_assessment
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
-    assert len(response.json()["ids"]) == 2
+    assert response.json()["ids"] == []
 
 
 def test_push_alignment_threshold_scores_round_trips_to_get(
@@ -337,7 +342,7 @@ def test_push_text_lengths(client, regular_token1, push_assessment_id):
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
-    assert len(response.json()["ids"]) == 2
+    assert response.json()["ids"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -358,7 +363,7 @@ def test_push_tfidf_vectors(client, regular_token1, push_assessment_id):
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
-    assert len(response.json()["ids"]) == 1
+    assert response.json()["ids"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -422,7 +427,7 @@ def test_push_ngrams_unauthorized(client, regular_token2, push_assessment_id):
 # ---------------------------------------------------------------------------
 
 
-def test_delete_results(client, regular_token1, push_assessment_id):
+def test_delete_results(client, regular_token1, push_assessment_id, test_db_session):
     # First insert some results to delete
     insert_resp = client.post(
         f"{prefix}/assessment/{push_assessment_id}/results",
@@ -433,7 +438,16 @@ def test_delete_results(client, regular_token1, push_assessment_id):
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert insert_resp.status_code == 200
-    ids = insert_resp.json()["ids"]
+    test_db_session.expire_all()
+    ids = [
+        row.id
+        for row in test_db_session.query(AssessmentResult)
+        .filter(
+            AssessmentResult.assessment_id == push_assessment_id,
+            AssessmentResult.vref.in_(["GEN 1:3", "GEN 1:4"]),
+        )
+        .all()
+    ]
 
     response = client.request(
         "DELETE",
@@ -481,22 +495,38 @@ def test_delete_results_unauthorized(client, regular_token2, push_assessment_id)
 # ---------------------------------------------------------------------------
 
 
-def test_delete_alignment_scores(client, regular_token1, push_assessment_id):
+def test_delete_alignment_scores(
+    client, regular_token1, push_assessment_id, test_db_session
+):
     insert_resp = client.post(
         f"{prefix}/assessment/{push_assessment_id}/alignment-scores",
         json=[
             {
                 "vref": "GEN 1:1",
                 "score": 0.9,
-                "source": "beginning",
-                "target": "mwanzo",
+                "source": "delete-beginning",
+                "target": "delete-mwanzo",
             },
-            {"vref": "GEN 1:2", "score": 0.85, "source": "earth", "target": "dunia"},
+            {
+                "vref": "GEN 1:2",
+                "score": 0.85,
+                "source": "delete-earth",
+                "target": "delete-dunia",
+            },
         ],
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert insert_resp.status_code == 200
-    ids = insert_resp.json()["ids"]
+    test_db_session.expire_all()
+    ids = [
+        row.id
+        for row in test_db_session.query(AlignmentTopSourceScores)
+        .filter(
+            AlignmentTopSourceScores.assessment_id == push_assessment_id,
+            AlignmentTopSourceScores.source.in_(["delete-beginning", "delete-earth"]),
+        )
+        .all()
+    ]
 
     response = client.request(
         "DELETE",
@@ -523,7 +553,9 @@ def test_delete_alignment_scores_nonexistent(client, regular_token1):
 # ---------------------------------------------------------------------------
 
 
-def test_delete_alignment_threshold_scores(client, regular_token1, push_assessment_id):
+def test_delete_alignment_threshold_scores(
+    client, regular_token1, push_assessment_id, test_db_session
+):
     insert_resp = client.post(
         f"{prefix}/assessment/{push_assessment_id}/alignment-threshold-scores",
         json=[
@@ -543,7 +575,17 @@ def test_delete_alignment_threshold_scores(client, regular_token1, push_assessme
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert insert_resp.status_code == 200
-    ids = insert_resp.json()["ids"]
+    test_db_session.expire_all()
+    ids = [
+        row.id
+        for row in test_db_session.query(AlignmentThresholdScores)
+        .filter(
+            AlignmentThresholdScores.assessment_id == push_assessment_id,
+            AlignmentThresholdScores.vref == "GEN 1:8",
+            AlignmentThresholdScores.source == "heaven",
+        )
+        .all()
+    ]
 
     response = client.request(
         "DELETE",
@@ -595,7 +637,9 @@ def test_delete_alignment_threshold_scores_empty_ids(
 # ---------------------------------------------------------------------------
 
 
-def test_delete_text_lengths(client, regular_token1, push_assessment_id):
+def test_delete_text_lengths(
+    client, regular_token1, push_assessment_id, test_db_session
+):
     insert_resp = client.post(
         f"{prefix}/assessment/{push_assessment_id}/text-lengths",
         json=[
@@ -610,7 +654,16 @@ def test_delete_text_lengths(client, regular_token1, push_assessment_id):
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert insert_resp.status_code == 200
-    ids = insert_resp.json()["ids"]
+    test_db_session.expire_all()
+    ids = [
+        row.id
+        for row in test_db_session.query(TextLengthsTable)
+        .filter(
+            TextLengthsTable.assessment_id == push_assessment_id,
+            TextLengthsTable.vref == "GEN 1:3",
+        )
+        .all()
+    ]
 
     response = client.request(
         "DELETE",
@@ -637,14 +690,25 @@ def test_delete_text_lengths_nonexistent(client, regular_token1):
 # ---------------------------------------------------------------------------
 
 
-def test_delete_tfidf_vectors(client, regular_token1, push_assessment_id):
+def test_delete_tfidf_vectors(
+    client, regular_token1, push_assessment_id, test_db_session
+):
     insert_resp = client.post(
         f"{prefix}/assessment/{push_assessment_id}/tfidf-vectors",
         json=[{"vref": "GEN 1:3", "vector": [0.1] * 300}],
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert insert_resp.status_code == 200
-    ids = insert_resp.json()["ids"]
+    test_db_session.expire_all()
+    ids = [
+        row.id
+        for row in test_db_session.query(TfidfPcaVector)
+        .filter(
+            TfidfPcaVector.assessment_id == push_assessment_id,
+            TfidfPcaVector.vref == "GEN 1:3",
+        )
+        .all()
+    ]
 
     response = client.request(
         "DELETE",


### PR DESCRIPTION
## Summary

- Remove `INSERT ... RETURNING id` from the shared v3 bulk result insert helper.
- Return `InsertResponse(ids=[])` from bulk push endpoints that no longer need generated IDs.
- Update result-push tests to assert the new response contract and fetch IDs from the test database when delete tests need them.

## Why

Issue #611 identified generated-ID projection as unnecessary overhead for bulk result-push endpoints, especially `alignment_top_source_scores`, because the current client discards returned IDs.

## Validation

- `pytest test/test_assessment_routes/test_results_push_routes.py` - 38 passed
- `black --check assessment_routes/v3/results_push_routes.py test/test_assessment_routes/test_results_push_routes.py`
- `isort --check assessment_routes/v3/results_push_routes.py test/test_assessment_routes/test_results_push_routes.py --profile black`
- `git diff --check`