### PR TITLE
Version-ID keying for train/predict artifacts (#613)

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1742,7 +1742,6 @@ async def get_lexeme_cards(
 
         if card_ids:
             from database.models import (
-                BibleRevision,
                 BibleVersion,
                 BibleVersionAccess,
                 UserGroup,
@@ -2323,7 +2322,7 @@ async def add_agent_translation(
             )
 
         # Derive revision_id, reference_version_id, script from the assessment's reference
-        from database.models import BibleRevision, BibleVersion
+        from database.models import BibleVersion
 
         ref_query = (
             select(
@@ -2462,7 +2461,7 @@ async def add_agent_translations_bulk(
             )
 
         # Derive revision_id, reference_version_id, script from the assessment's reference
-        from database.models import BibleRevision, BibleVersion
+        from database.models import BibleVersion
 
         ref_query = (
             select(
@@ -2578,7 +2577,7 @@ async def get_agent_translations(
       for that revision (no authorization check).
     - reference_version_id: int (optional) - Reference Bible version ID. Required when using revision_id.
     - script: str (optional) - 4-letter ISO 15924 script code. If omitted, returns
-      translations across all scripts for the given language.
+      translations across all scripts for the given reference version.
     - vref: str (optional) - Filter by specific verse reference (e.g., "JHN 1:1")
     - first_vref: str (optional) - Start of verse range (inclusive)
     - last_vref: str (optional) - End of verse range (inclusive)
@@ -2598,7 +2597,6 @@ async def get_agent_translations(
 
         from database.models import (
             Assessment,
-            BibleRevision,
             BibleVersion,
             BookReference,
             VerseReference,

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -81,8 +81,8 @@ async def add_word_alignment(
     Input:
     - source_word: str - The source language word
     - target_word: str - The target language word
-    - source_language: str - ISO 639-3 code for source language
-    - target_language: str - ISO 639-3 code for target language
+    - source_version_id: int - Bible version ID for source
+    - target_version_id: int - Bible version ID for target
     - score: float - NLLB alignment confidence score (default: 0.0)
     - is_human_verified: bool - Whether the alignment is human-verified (default: False)
 
@@ -95,8 +95,8 @@ async def add_word_alignment(
         word_alignment = AgentWordAlignment(
             source_word=alignment.source_word,
             target_word=alignment.target_word,
-            source_language=alignment.source_language,
-            target_language=alignment.target_language,
+            source_version_id=alignment.source_version_id,
+            target_version_id=alignment.target_version_id,
             score=alignment.score,
             is_human_verified=alignment.is_human_verified,
         )
@@ -111,8 +111,8 @@ async def add_word_alignment(
             extra={
                 "method": "POST",
                 "path": "/agent/word-alignment",
-                "source_language": alignment.source_language,
-                "target_language": alignment.target_language,
+                "source_version_id": alignment.source_version_id,
+                "target_version_id": alignment.target_version_id,
                 "duration_s": duration,
             },
         )
@@ -126,8 +126,8 @@ async def add_word_alignment(
             extra={
                 "source_word": alignment.source_word,
                 "target_word": alignment.target_word,
-                "source_language": alignment.source_language,
-                "target_language": alignment.target_language,
+                "source_version_id": alignment.source_version_id,
+                "target_version_id": alignment.target_version_id,
                 "error_type": type(e).__name__,
             },
         )
@@ -147,13 +147,13 @@ async def add_word_alignments_bulk(
     Bulk upsert word alignments.
 
     For each alignment in the request:
-    - If an alignment with the same (source_word, target_word, source_language, target_language) exists,
+    - If an alignment with the same (source_word, target_word, source_version_id, target_version_id) exists,
       update its score, is_human_verified, and last_updated fields.
     - Otherwise, insert a new alignment.
 
     Input:
-    - source_language: str - ISO 639-3 code for source language
-    - target_language: str - ISO 639-3 code for target language
+    - source_version_id: int - Bible version ID for source
+    - target_version_id: int - Bible version ID for target
     - alignments: list - List of alignment items, each with:
       - source_word: str - The source language word
       - target_word: str - The target language word
@@ -177,8 +177,8 @@ async def add_word_alignments_bulk(
                 {
                     "source_word": item.source_word,
                     "target_word": item.target_word,
-                    "source_language": request.source_language,
-                    "target_language": request.target_language,
+                    "source_version_id": request.source_version_id,
+                    "target_version_id": request.target_version_id,
                     "score": item.score,
                     "is_human_verified": item.is_human_verified,
                 }
@@ -198,8 +198,8 @@ async def add_word_alignments_bulk(
 
                 upsert_stmt = insert_stmt.on_conflict_do_update(
                     index_elements=[
-                        "source_language",
-                        "target_language",
+                        "source_version_id",
+                        "target_version_id",
                         "source_word",
                         "target_word",
                     ],
@@ -247,8 +247,8 @@ async def add_word_alignments_bulk(
 
 @router.get("/agent/word-alignment/all", response_model=list[AgentWordAlignmentOut])
 async def get_all_word_alignments(
-    source_language: str,
-    target_language: str,
+    source_version_id: int,
+    target_version_id: int,
     page: int | None = None,
     page_size: int | None = None,
     db: AsyncSession = Depends(get_db),
@@ -258,8 +258,8 @@ async def get_all_word_alignments(
     Get all word alignments for a language pair.
 
     Input:
-    - source_language: str - ISO 639-3 code for source language (required)
-    - target_language: str - ISO 639-3 code for target language (required)
+    - source_version_id: int - Bible version ID for source (required)
+    - target_version_id: int - Bible version ID for target (required)
     - page: int (optional) - Page number (1-indexed)
     - page_size: int (optional) - Number of results per page
 
@@ -279,8 +279,8 @@ async def get_all_word_alignments(
             select(AgentWordAlignment)
             .where(
                 and_(
-                    AgentWordAlignment.source_language == source_language,
-                    AgentWordAlignment.target_language == target_language,
+                    AgentWordAlignment.source_version_id == source_version_id,
+                    AgentWordAlignment.target_version_id == target_version_id,
                 )
             )
             .order_by(AgentWordAlignment.score.desc())
@@ -310,8 +310,8 @@ async def get_all_word_alignments(
             extra={
                 "method": "GET",
                 "path": "/agent/word-alignment/all",
-                "source_language": source_language,
-                "target_language": target_language,
+                "source_version_id": source_version_id,
+                "target_version_id": target_version_id,
                 "page": page,
                 "page_size": page_size,
                 "duration_s": duration,
@@ -485,7 +485,7 @@ async def add_lexeme_card(
     """
     Add a new lexeme card entry or update an existing one.
 
-    Uniqueness is enforced on (target_lemma, source_language, target_language).
+    Uniqueness is enforced on (target_lemma, source_version_id, target_version_id).
     If a card with the same target_lemma and language pair already exists,
     it will be updated instead of creating a duplicate.
 
@@ -501,8 +501,8 @@ async def add_lexeme_card(
     Card fields:
     - source_lemma: str (optional) - The source language lemma for cross-reference
     - target_lemma: str (required) - The target language lemma
-    - source_language: str - ISO 639-3 code for source language
-    - target_language: str - ISO 639-3 code for target language
+    - source_version_id: int - Bible version ID for source
+    - target_version_id: int - Bible version ID for target
     - pos: str (optional) - Part of speech
     - surface_forms: list (optional) - JSON array of target language surface forms
     - source_surface_forms: list (optional) - JSON array of source language surface forms
@@ -532,12 +532,12 @@ async def add_lexeme_card(
                 sorted(card.alignment_scores.items(), key=lambda x: x[1], reverse=True)
             )
 
-        # Check if a lexeme card with the same (target_lemma, source_language, target_language) exists
+        # Check if a lexeme card with the same (target_lemma, source_version_id, target_version_id) exists
         # This enforces uniqueness on target_lemma per language pair (case-insensitive)
         query = select(AgentLexemeCard).where(
             func.lower(AgentLexemeCard.target_lemma) == card.target_lemma.lower(),
-            AgentLexemeCard.source_language == card.source_language,
-            AgentLexemeCard.target_language == card.target_language,
+            AgentLexemeCard.source_version_id == card.source_version_id,
+            AgentLexemeCard.target_version_id == card.target_version_id,
         )
         result = await db.execute(query)
         existing_card = result.scalar_one_or_none()
@@ -673,8 +673,8 @@ async def add_lexeme_card(
                 "id": existing_card.id,
                 "source_lemma": existing_card.source_lemma,
                 "target_lemma": existing_card.target_lemma,
-                "source_language": existing_card.source_language,
-                "target_language": existing_card.target_language,
+                "source_version_id": existing_card.source_version_id,
+                "target_version_id": existing_card.target_version_id,
                 "pos": existing_card.pos,
                 "surface_forms": existing_card.surface_forms,
                 "source_surface_forms": existing_card.source_surface_forms,
@@ -703,8 +703,8 @@ async def add_lexeme_card(
             lexeme_card = AgentLexemeCard(
                 source_lemma=card.source_lemma,
                 target_lemma=card.target_lemma,
-                source_language=card.source_language,
-                target_language=card.target_language,
+                source_version_id=card.source_version_id,
+                target_version_id=card.target_version_id,
                 pos=card.pos,
                 surface_forms=card.surface_forms,
                 source_surface_forms=card.source_surface_forms,
@@ -762,8 +762,8 @@ async def add_lexeme_card(
                 "id": lexeme_card.id,
                 "source_lemma": lexeme_card.source_lemma,
                 "target_lemma": lexeme_card.target_lemma,
-                "source_language": lexeme_card.source_language,
-                "target_language": lexeme_card.target_language,
+                "source_version_id": lexeme_card.source_version_id,
+                "target_version_id": lexeme_card.target_version_id,
                 "pos": lexeme_card.pos,
                 "surface_forms": lexeme_card.surface_forms,
                 "source_surface_forms": lexeme_card.source_surface_forms,
@@ -844,15 +844,15 @@ async def _apply_lexeme_card_patch(
     provided_fields = patch_data.model_fields_set
 
     # Check if changing target_lemma would create a duplicate
-    # Uniqueness is enforced on (LOWER(target_lemma), source_language, target_language)
+    # Uniqueness is enforced on (LOWER(target_lemma), source_version_id, target_version_id)
     if (
         "target_lemma" in provided_fields
         and patch_data.target_lemma.lower() != card.target_lemma.lower()
     ):
         duplicate_query = select(AgentLexemeCard).where(
             func.lower(AgentLexemeCard.target_lemma) == patch_data.target_lemma.lower(),
-            AgentLexemeCard.source_language == card.source_language,
-            AgentLexemeCard.target_language == card.target_language,
+            AgentLexemeCard.source_version_id == card.source_version_id,
+            AgentLexemeCard.target_version_id == card.target_version_id,
             AgentLexemeCard.id != card.id,  # Exclude the current card
         )
         duplicate_result = await db.execute(duplicate_query)
@@ -1007,8 +1007,8 @@ async def _apply_lexeme_card_patch(
         "id": card.id,
         "source_lemma": card.source_lemma,
         "target_lemma": card.target_lemma,
-        "source_language": card.source_language,
-        "target_language": card.target_language,
+        "source_version_id": card.source_version_id,
+        "target_version_id": card.target_version_id,
         "pos": card.pos,
         "surface_forms": card.surface_forms,
         "source_surface_forms": card.source_surface_forms,
@@ -1110,8 +1110,8 @@ async def patch_lexeme_card_by_id(
 async def patch_lexeme_card_by_lemma(
     patch_data: LexemeCardPatch,
     target_lemma: str,
-    source_language: str,
-    target_language: str,
+    source_version_id: int,
+    target_version_id: int,
     source_lemma: str = None,
     list_mode: ListMode = ListMode.append,
     is_user_edit: bool = False,
@@ -1123,8 +1123,8 @@ async def patch_lexeme_card_by_lemma(
 
     Query Parameters:
     - target_lemma: str (required) - The target language lemma
-    - source_language: str (required) - ISO 639-3 code for source language
-    - target_language: str (required) - ISO 639-3 code for target language
+    - source_version_id: int (required) - Bible version ID for source
+    - target_version_id: int (required) - Bible version ID for target
     - source_lemma: str (optional) - The source language lemma
     - list_mode: str (optional, default="append") - How to handle list fields:
       - "append": Add new items to existing lists (no deduplication)
@@ -1161,8 +1161,8 @@ async def patch_lexeme_card_by_lemma(
 
         query = select(AgentLexemeCard).where(
             sql_func.lower(AgentLexemeCard.target_lemma) == target_lemma.lower(),
-            AgentLexemeCard.source_language == source_language,
-            AgentLexemeCard.target_language == target_language,
+            AgentLexemeCard.source_version_id == source_version_id,
+            AgentLexemeCard.target_version_id == target_version_id,
         )
 
         # Only filter by source_lemma if explicitly provided
@@ -1176,8 +1176,8 @@ async def patch_lexeme_card_by_lemma(
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"Lexeme card not found for target_lemma={target_lemma}, "
-                f"source_language={source_language}, "
-                f"target_language={target_language}"
+                f"source_version_id={source_version_id}, "
+                f"target_version_id={target_version_id}"
                 + (f", source_lemma={source_lemma}" if source_lemma else ""),
             )
 
@@ -1200,8 +1200,8 @@ async def patch_lexeme_card_by_lemma(
                 "method": "PATCH",
                 "path": "/agent/lexeme-card",
                 "target_lemma": target_lemma,
-                "source_language": source_language,
-                "target_language": target_language,
+                "source_version_id": source_version_id,
+                "target_version_id": target_version_id,
                 "duration_s": duration,
             },
         )
@@ -1264,8 +1264,8 @@ async def delete_lexeme_card(
 
 @router.post("/agent/lexeme-card/deduplicate")
 async def deduplicate_lexeme_cards(
-    source_language: str,
-    target_language: str,
+    source_version_id: int,
+    target_version_id: int,
     dry_run: bool = True,
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
@@ -1274,8 +1274,8 @@ async def deduplicate_lexeme_cards(
     Find and merge duplicate lexeme cards that differ only by case in target_lemma.
 
     Query Parameters:
-    - source_language: str (required) - ISO 639-3 code for source language
-    - target_language: str (required) - ISO 639-3 code for target language
+    - source_version_id: int (required) - Bible version ID for source
+    - target_version_id: int (required) - Bible version ID for target
     - dry_run: bool (optional, default=True) - If True, only report duplicates without merging
 
     Returns:
@@ -1295,8 +1295,8 @@ async def deduplicate_lexeme_cards(
                 func.count().label("cnt"),
             )
             .where(
-                AgentLexemeCard.source_language == source_language,
-                AgentLexemeCard.target_language == target_language,
+                AgentLexemeCard.source_version_id == source_version_id,
+                AgentLexemeCard.target_version_id == target_version_id,
             )
             .group_by(func.lower(AgentLexemeCard.target_lemma))
             .having(func.count() > 1)
@@ -1325,8 +1325,8 @@ async def deduplicate_lexeme_cards(
                 select(AgentLexemeCard)
                 .where(
                     func.lower(AgentLexemeCard.target_lemma) == lower_lemma,
-                    AgentLexemeCard.source_language == source_language,
-                    AgentLexemeCard.target_language == target_language,
+                    AgentLexemeCard.source_version_id == source_version_id,
+                    AgentLexemeCard.target_version_id == target_version_id,
                 )
                 .order_by(AgentLexemeCard.id)
             )
@@ -1468,8 +1468,8 @@ async def deduplicate_lexeme_cards(
             extra={
                 "method": "POST",
                 "path": "/agent/lexeme-card/deduplicate",
-                "source_language": source_language,
-                "target_language": target_language,
+                "source_version_id": source_version_id,
+                "target_version_id": target_version_id,
                 "dry_run": dry_run,
                 "duration_s": duration,
             },
@@ -1495,8 +1495,8 @@ async def deduplicate_lexeme_cards(
 
 @router.get("/agent/word-alignment", response_model=list[AgentWordAlignmentOut])
 async def get_word_alignments(
-    source_language: str,
-    target_language: str,
+    source_version_id: int,
+    target_version_id: int,
     source_words: str = None,
     target_words: str = None,
     db: AsyncSession = Depends(get_db),
@@ -1506,8 +1506,8 @@ async def get_word_alignments(
     Get word alignments filtered by language pair and optionally by source/target words.
 
     Query Parameters:
-    - source_language: str (required) - ISO 639-3 code for source language
-    - target_language: str (required) - ISO 639-3 code for target language
+    - source_version_id: int (required) - Bible version ID for source
+    - target_version_id: int (required) - Bible version ID for target
     - source_words: str (optional) - Comma-separated list of words to match in source_word
     - target_words: str (optional) - Comma-separated list of words to match in target_word
 
@@ -1530,8 +1530,8 @@ async def get_word_alignments(
         # Start with base query filtered by languages
         query = select(AgentWordAlignment).distinct()
         conditions = [
-            AgentWordAlignment.source_language == source_language,
-            AgentWordAlignment.target_language == target_language,
+            AgentWordAlignment.source_version_id == source_version_id,
+            AgentWordAlignment.target_version_id == target_version_id,
         ]
 
         # Build word filter conditions
@@ -1568,8 +1568,8 @@ async def get_word_alignments(
             extra={
                 "method": "GET",
                 "path": "/agent/word-alignment",
-                "source_language": source_language,
-                "target_language": target_language,
+                "source_version_id": source_version_id,
+                "target_version_id": target_version_id,
                 "source_words": source_words,
                 "target_words": target_words,
                 "duration_s": duration,
@@ -1589,8 +1589,8 @@ async def get_word_alignments(
 
 @router.get("/agent/lexeme-card", response_model=list[LexemeCardOut])
 async def get_lexeme_cards(
-    source_language: str,
-    target_language: str,
+    source_version_id: int,
+    target_version_id: int,
     source_word: str = None,
     target_word: str = None,
     target_words: str = None,
@@ -1605,8 +1605,8 @@ async def get_lexeme_cards(
     the current user has access to.
 
     Query Parameters:
-    - source_language: str (required) - ISO 639-3 code for source language
-    - target_language: str (required) - ISO 639-3 code for target language
+    - source_version_id: int (required) - Bible version ID for source
+    - target_version_id: int (required) - Bible version ID for target
     - source_word: str (optional) - Filter by source_lemma or source_surface_forms
       (case-insensitive exact match)
     - target_word: str (optional) - Filter by target_lemma or surface_forms
@@ -1638,8 +1638,8 @@ async def get_lexeme_cards(
 
         # Base conditions: language pair filter
         conditions = [
-            AgentLexemeCard.source_language == source_language,
-            AgentLexemeCard.target_language == target_language,
+            AgentLexemeCard.source_version_id == source_version_id,
+            AgentLexemeCard.target_version_id == target_version_id,
         ]
 
         # Add POS filter if provided
@@ -1743,9 +1743,7 @@ async def get_lexeme_cards(
                     )
                     .where(
                         UserGroup.user_id == current_user.id,
-                        BibleVersion.iso_language.in_(
-                            [source_language, target_language]
-                        ),
+                        BibleVersion.id.in_([source_version_id, target_version_id]),
                     )
                 )
                 examples_conditions.append(
@@ -1776,8 +1774,8 @@ async def get_lexeme_cards(
                 "id": card.id,
                 "source_lemma": card.source_lemma,
                 "target_lemma": card.target_lemma,
-                "source_language": card.source_language,
-                "target_language": card.target_language,
+                "source_version_id": card.source_version_id,
+                "target_version_id": card.target_version_id,
                 "pos": card.pos,
                 "surface_forms": card.surface_forms,
                 "source_surface_forms": card.source_surface_forms,
@@ -1798,8 +1796,8 @@ async def get_lexeme_cards(
             extra={
                 "method": "GET",
                 "path": "/agent/lexeme-card",
-                "source_language": source_language,
-                "target_language": target_language,
+                "source_version_id": source_version_id,
+                "target_version_id": target_version_id,
                 "source_word": source_word,
                 "target_word": target_word,
                 "target_words": target_words,
@@ -1820,8 +1818,8 @@ async def get_lexeme_cards(
 @router.get("/agent/lexeme-card/check-word")
 async def check_word_in_lexeme_cards(
     word: str,
-    source_language: str,
-    target_language: str,
+    source_version_id: int,
+    target_version_id: int,
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -1830,8 +1828,8 @@ async def check_word_in_lexeme_cards(
 
     Query Parameters:
     - word: str (required) - The word to search for
-    - source_language: str (required) - ISO 639-3 code for source language
-    - target_language: str (required) - ISO 639-3 code for target language
+    - source_version_id: int (required) - Bible version ID for source
+    - target_version_id: int (required) - Bible version ID for target
 
     Returns:
     - count: int - Number of lexeme cards where the word matches (case-insensitive)
@@ -1845,16 +1843,16 @@ async def check_word_in_lexeme_cards(
 
         # Query cards matching by target_lemma (case-insensitive)
         cards_by_lemma = select(AgentLexemeCard.id).where(
-            AgentLexemeCard.source_language == source_language,
-            AgentLexemeCard.target_language == target_language,
+            AgentLexemeCard.source_version_id == source_version_id,
+            AgentLexemeCard.target_version_id == target_version_id,
             func.lower(AgentLexemeCard.target_lemma) == word_lower,
         )
 
         # Query cards where word exists in surface_forms JSONB array (case-insensitive)
         # Use jsonb_typeof to check if it's an array, then jsonb_array_elements_text
         cards_by_surface = select(AgentLexemeCard.id).where(
-            AgentLexemeCard.source_language == source_language,
-            AgentLexemeCard.target_language == target_language,
+            AgentLexemeCard.source_version_id == source_version_id,
+            AgentLexemeCard.target_version_id == target_version_id,
             AgentLexemeCard.surface_forms.isnot(None),
             text(
                 "(jsonb_typeof(agent_lexeme_cards.surface_forms) = 'array' AND "
@@ -1878,8 +1876,8 @@ async def check_word_in_lexeme_cards(
                 "method": "GET",
                 "path": "/agent/lexeme-card/check-word",
                 "word": word,
-                "source_language": source_language,
-                "target_language": target_language,
+                "source_version_id": source_version_id,
+                "target_version_id": target_version_id,
                 "duration_s": duration,
             },
         )
@@ -2294,13 +2292,13 @@ async def add_agent_translation(
                 detail="User not authorized for this assessment",
             )
 
-        # Derive revision_id, language, script from the assessment's reference
+        # Derive revision_id, reference_version_id, script from the assessment's reference
         from database.models import BibleRevision, BibleVersion
 
         ref_query = (
             select(
                 Assessment.revision_id,
-                BibleVersion.iso_language,
+                BibleVersion.id,
                 BibleVersion.iso_script,
             )
             .join(BibleRevision, BibleRevision.id == Assessment.reference_id)
@@ -2312,14 +2310,14 @@ async def add_agent_translation(
         if not ref_row:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Could not determine revision/language/script from assessment",
+                detail="Could not determine revision/reference_version_id/script from assessment",
             )
-        rev_id, lang, scrpt = ref_row
+        rev_id, ref_version_id, scrpt = ref_row
 
-        # Get the next version number scoped to (revision_id, language, script, vref)
+        # Get the next version number scoped to (revision_id, reference_version_id, script, vref)
         version_query = select(func.max(AgentTranslation.version)).where(
             AgentTranslation.revision_id == rev_id,
-            AgentTranslation.language == lang,
+            AgentTranslation.reference_version_id == ref_version_id,
             AgentTranslation.script == scrpt,
             AgentTranslation.vref == translation.vref,
         )
@@ -2337,7 +2335,7 @@ async def add_agent_translation(
         agent_translation = AgentTranslation(
             assessment_id=translation.assessment_id,
             revision_id=rev_id,
-            language=lang,
+            reference_version_id=ref_version_id,
             script=scrpt,
             vref=translation.vref,
             version=next_version,
@@ -2392,7 +2390,7 @@ async def add_agent_translations_bulk(
     Store multiple agent-generated translations in bulk.
 
     All translations in a single request get the same version number, which is
-    auto-incremented based on the max existing version for the revision+language+script.
+    auto-incremented based on the max existing version for the revision+reference version+script.
 
     Input:
     - assessment_id: int - The assessment ID
@@ -2433,13 +2431,13 @@ async def add_agent_translations_bulk(
                 detail="User not authorized for this assessment",
             )
 
-        # Derive revision_id, language, script from the assessment's reference
+        # Derive revision_id, reference_version_id, script from the assessment's reference
         from database.models import BibleRevision, BibleVersion
 
         ref_query = (
             select(
                 Assessment.revision_id,
-                BibleVersion.iso_language,
+                BibleVersion.id,
                 BibleVersion.iso_script,
             )
             .join(BibleRevision, BibleRevision.id == Assessment.reference_id)
@@ -2451,14 +2449,14 @@ async def add_agent_translations_bulk(
         if not ref_row:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="Could not determine revision/language/script from assessment",
+                detail="Could not determine revision/reference_version_id/script from assessment",
             )
-        rev_id, lang, scrpt = ref_row
+        rev_id, ref_version_id, scrpt = ref_row
 
-        # Get the next version number scoped to (revision_id, language, script)
+        # Get the next version number scoped to (revision_id, reference_version_id, script)
         version_query = select(func.max(AgentTranslation.version)).where(
             AgentTranslation.revision_id == rev_id,
-            AgentTranslation.language == lang,
+            AgentTranslation.reference_version_id == ref_version_id,
             AgentTranslation.script == scrpt,
         )
         version_result = await db.execute(version_query)
@@ -2470,7 +2468,7 @@ async def add_agent_translations_bulk(
             AgentTranslation(
                 assessment_id=request.assessment_id,
                 revision_id=rev_id,
-                language=lang,
+                reference_version_id=ref_version_id,
                 script=scrpt,
                 vref=trans.vref,
                 version=next_version,
@@ -2529,7 +2527,7 @@ async def add_agent_translations_bulk(
 async def get_agent_translations(
     assessment_id: int | None = None,
     revision_id: int | None = None,
-    language: str | None = Query(None, min_length=2, max_length=3),
+    reference_version_id: int | None = None,
     script: str | None = Query(None, min_length=4, max_length=4),
     vref: str | None = None,
     first_vref: str | None = None,
@@ -2548,7 +2546,7 @@ async def get_agent_translations(
     - revision_id: int (optional) - The revision ID. If provided without assessment_id,
       returns the latest translation per vref (by created_at) across all assessments
       for that revision (no authorization check).
-    - language: str (optional) - 3-letter ISO 639 language code. Required when using revision_id.
+    - reference_version_id: int (optional) - Reference Bible version ID. Required when using revision_id.
     - script: str (optional) - 4-letter ISO 15924 script code. If omitted, returns
       translations across all scripts for the given language.
     - vref: str (optional) - Filter by specific verse reference (e.g., "JHN 1:1")
@@ -2583,11 +2581,15 @@ async def get_agent_translations(
                 detail="Either assessment_id or revision_id must be provided",
             )
 
-        # Validate language parameter
-        if revision_id is not None and assessment_id is None and language is None:
+        # Validate reference_version_id parameter
+        if (
+            revision_id is not None
+            and assessment_id is None
+            and reference_version_id is None
+        ):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail="language is required when using revision_id",
+                detail="reference_version_id is required when using revision_id",
             )
 
         # If assessment_id is provided, use assessment-specific logic with auth check
@@ -2612,10 +2614,10 @@ async def get_agent_translations(
                     detail="User not authorized for this assessment",
                 )
 
-            # Validate language/script match assessment's reference if provided
-            if language is not None or script is not None:
+            # Validate reference version/script match assessment's reference if provided
+            if reference_version_id is not None or script is not None:
                 ref_query = (
-                    select(BibleVersion.iso_language, BibleVersion.iso_script)
+                    select(BibleVersion.id, BibleVersion.iso_script)
                     .join(
                         BibleRevision,
                         BibleRevision.bible_version_id == BibleVersion.id,
@@ -2625,10 +2627,13 @@ async def get_agent_translations(
                 ref_result = await db.execute(ref_query)
                 ref_row = ref_result.first()
                 if ref_row:
-                    if language is not None and ref_row.iso_language != language:
+                    if (
+                        reference_version_id is not None
+                        and ref_row.id != reference_version_id
+                    ):
                         raise HTTPException(
                             status_code=status.HTTP_400_BAD_REQUEST,
-                            detail="language does not match assessment's reference language",
+                            detail="reference_version_id does not match assessment's reference version",
                         )
                     if script is not None and ref_row.iso_script != script:
                         raise HTTPException(
@@ -2673,7 +2678,9 @@ async def get_agent_translations(
                 query = (
                     select(AgentTranslation)
                     .where(AgentTranslation.revision_id == revision_id)
-                    .where(AgentTranslation.language == language)
+                    .where(
+                        AgentTranslation.reference_version_id == reference_version_id
+                    )
                 )
                 if script is not None:
                     query = query.where(AgentTranslation.script == script)
@@ -2681,7 +2688,7 @@ async def get_agent_translations(
                 # Return only the latest version per vref using MAX(version)
                 base_filters = [
                     AgentTranslation.revision_id == revision_id,
-                    AgentTranslation.language == language,
+                    AgentTranslation.reference_version_id == reference_version_id,
                 ]
                 if script is not None:
                     base_filters.append(AgentTranslation.script == script)
@@ -2700,7 +2707,7 @@ async def get_agent_translations(
                     AgentTranslation.vref == latest_subq.c.vref,
                     AgentTranslation.version == latest_subq.c.max_version,
                     AgentTranslation.revision_id == revision_id,
-                    AgentTranslation.language == language,
+                    AgentTranslation.reference_version_id == reference_version_id,
                 ]
                 if script is not None:
                     join_conditions.append(AgentTranslation.script == script)
@@ -2813,7 +2820,7 @@ async def get_agent_translations(
                 "path": "/agent/translations",
                 "assessment_id": assessment_id,
                 "revision_id": revision_id,
-                "language": language,
+                "reference_version_id": reference_version_id,
                 "script": script,
                 "vref": vref,
                 "duration_s": duration,

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -20,6 +20,7 @@ from database.models import (
     AgentLexemeCardExample,
     AgentTranslation,
     AgentWordAlignment,
+    BibleRevision,
 )
 from database.models import UserDB as UserModel
 from models import (
@@ -524,6 +525,35 @@ async def add_lexeme_card(
         from sqlalchemy import delete, select
         from sqlalchemy.dialects.postgresql import insert as pg_insert
         from sqlalchemy.sql import func
+
+        # Examples must come from a revision in either the card's source or
+        # target version. The GET endpoint relies on this invariant when it
+        # filters examples by `BibleVersion.id IN (source_version_id,
+        # target_version_id)`; without this check, examples tied to revisions
+        # outside the pair would be silently invisible to all non-admin
+        # callers.
+        revision_version_id = await db.scalar(
+            select(BibleRevision.bible_version_id).where(
+                BibleRevision.id == revision_id
+            )
+        )
+        if revision_version_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Revision {revision_id} not found",
+            )
+        if revision_version_id not in {
+            card.source_version_id,
+            card.target_version_id,
+        }:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"revision_id={revision_id} (version {revision_version_id}) "
+                    f"is not in the card's version pair "
+                    f"({card.source_version_id}, {card.target_version_id})"
+                ),
+            )
 
         # Sort alignment_scores by value in descending order (highest scores first)
         sorted_alignment_scores = None

--- a/alembic/migrations/versions/e3a9f5d2c8b1_version_id_keying_migration.py
+++ b/alembic/migrations/versions/e3a9f5d2c8b1_version_id_keying_migration.py
@@ -1,0 +1,625 @@
+"""shift train/predict artifact keying from language to version_id
+
+Revision ID: e3a9f5d2c8b1
+Revises: c1f3a8d2e9b6
+Create Date: 2026-04-30 23:00:00.000000
+
+Implements the schema half of aqua-api#613. Train/predict artifacts have
+been keyed on (source_language, target_language) ISO codes, which causes
+two different bible_version rows in the same language pair to share
+artifacts. After this migration they are keyed on
+(source_version_id, target_version_id) so different versions in the same
+language pair are isolated.
+
+Tables touched:
+  - eflomal_assessment        (backfill via assessment.revision_id/reference_id)
+  - tfidf_artifact_runs       (backfill via assessment chain; source-only)
+  - tfidf_svd_staging         (transient rows; no backfill)
+  - training_job              (backfill via revision FK)
+  - agent_lexeme_cards        (TRUNCATE — no version chain available; rows
+                               will be repopulated from new agent-critique
+                               training runs)
+  - agent_word_alignments     (TRUNCATE — same reason)
+  - agent_translations        (backfill reference_version_id via
+                               assessment.reference_id chain)
+
+The cross-repo aqua-assessments runner must update its lookups in lockstep
+(see sil-ai/aqua-assessments#232).
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "e3a9f5d2c8b1"
+down_revision: Union[str, None] = "c1f3a8d2e9b6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _drop_invalid_index(bind, name: str) -> None:
+    """If a previous CONCURRENTLY build was interrupted Postgres leaves the
+    index in an INVALID state — IF NOT EXISTS will then skip the rebuild
+    and the planner could still try to use the broken one. Detect and drop
+    so this migration is safely retryable. Mirrors the pattern in
+    b7a3e9d6f1c2_drop_training_job_status_fields.py."""
+    is_invalid = bind.exec_driver_sql(
+        f"SELECT 1 FROM pg_class c "
+        f"JOIN pg_index i ON i.indexrelid = c.oid "
+        f"WHERE c.relname = '{name}' AND NOT i.indisvalid"
+    ).scalar()
+    if is_invalid:
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # ------------------------------------------------------------------
+    # Phase 1 — drop language-keyed indexes CONCURRENTLY (no ACCESS
+    # EXCLUSIVE on hot tables during a rolling deploy).
+    # ------------------------------------------------------------------
+    with op.get_context().autocommit_block():
+        for name in (
+            "ix_eflomal_assessment_language_pair",
+            "ix_tfidf_artifact_runs_lang",
+            "ix_tfidf_artifact_runs_lang_created",
+            "ix_training_job_lang_pair",
+            "ix_agent_lexeme_cards_unique_v3",
+            "ix_agent_lexeme_cards_lang_confidence",
+            "ux_agent_word_alignments_lang_words",
+            "ix_agent_word_alignments_lang_source",
+            "ix_agent_word_alignments_lang_target",
+            "ix_agent_word_alignments_lang_score",
+            "ix_agent_translations_unique",
+            "ix_agent_translations_rev_lang_script_vref",
+        ):
+            _drop_invalid_index(bind, name)
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+
+    # ------------------------------------------------------------------
+    # Phase 2 — column changes inside a single transaction so that
+    # backfills + NOT NULL flips are atomic with column adds/drops.
+    # ------------------------------------------------------------------
+
+    # --- eflomal_assessment ---
+    op.add_column(
+        "eflomal_assessment",
+        sa.Column(
+            "source_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "eflomal_assessment",
+        sa.Column(
+            "target_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        """
+        UPDATE eflomal_assessment ea
+        SET source_version_id = src_br.bible_version_id,
+            target_version_id = tgt_br.bible_version_id
+        FROM assessment a
+        JOIN bible_revision src_br ON a.revision_id = src_br.id
+        JOIN bible_revision tgt_br ON a.reference_id = tgt_br.id
+        WHERE a.id = ea.assessment_id
+        """
+    )
+    # Sanity check: every row must have backfilled cleanly. If any rows
+    # are still NULL the alter_column to NOT NULL below will fail —
+    # surface the count up front for easier debugging.
+    orphans = bind.exec_driver_sql(
+        "SELECT COUNT(*) FROM eflomal_assessment "
+        "WHERE source_version_id IS NULL OR target_version_id IS NULL"
+    ).scalar()
+    if orphans:
+        raise RuntimeError(
+            f"eflomal_assessment: {orphans} row(s) failed version_id backfill — "
+            "investigate orphaned rows before re-running"
+        )
+    op.alter_column("eflomal_assessment", "source_version_id", nullable=False)
+    op.alter_column("eflomal_assessment", "target_version_id", nullable=False)
+    op.drop_column("eflomal_assessment", "source_language")
+    op.drop_column("eflomal_assessment", "target_language")
+
+    # --- tfidf_artifact_runs (source only — TF-IDF vectorizers are
+    # source-side artifacts) ---
+    op.add_column(
+        "tfidf_artifact_runs",
+        sa.Column(
+            "source_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        """
+        UPDATE tfidf_artifact_runs tar
+        SET source_version_id = src_br.bible_version_id
+        FROM assessment a
+        JOIN bible_revision src_br ON a.revision_id = src_br.id
+        WHERE a.id = tar.assessment_id
+        """
+    )
+    orphans = bind.exec_driver_sql(
+        "SELECT COUNT(*) FROM tfidf_artifact_runs WHERE source_version_id IS NULL"
+    ).scalar()
+    if orphans:
+        raise RuntimeError(
+            f"tfidf_artifact_runs: {orphans} row(s) failed version_id backfill"
+        )
+    op.alter_column("tfidf_artifact_runs", "source_version_id", nullable=False)
+    op.drop_column("tfidf_artifact_runs", "source_language")
+
+    # --- tfidf_svd_staging (transient; no backfill) ---
+    op.add_column(
+        "tfidf_svd_staging",
+        sa.Column(
+            "source_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=True,
+        ),
+    )
+    op.drop_column("tfidf_svd_staging", "source_language")
+
+    # --- training_job ---
+    op.add_column(
+        "training_job",
+        sa.Column(
+            "source_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column(
+            "target_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        """
+        UPDATE training_job tj
+        SET source_version_id = src_br.bible_version_id,
+            target_version_id = tgt_br.bible_version_id
+        FROM bible_revision src_br, bible_revision tgt_br
+        WHERE src_br.id = tj.source_revision_id
+          AND tgt_br.id = tj.target_revision_id
+        """
+    )
+    orphans = bind.exec_driver_sql(
+        "SELECT COUNT(*) FROM training_job "
+        "WHERE source_version_id IS NULL OR target_version_id IS NULL"
+    ).scalar()
+    if orphans:
+        raise RuntimeError(f"training_job: {orphans} row(s) failed version_id backfill")
+    op.alter_column("training_job", "source_version_id", nullable=False)
+    op.alter_column("training_job", "target_version_id", nullable=False)
+    op.drop_column("training_job", "source_language")
+    op.drop_column("training_job", "target_language")
+
+    # --- agent_lexeme_cards (truncate; CASCADE drops examples) ---
+    # No FK or join chain back to a bible_version — pre-migration rows
+    # cannot be unambiguously assigned to a version pair. Confirmed
+    # acceptable on aqua-api#613: cards rebuild from new agent-critique
+    # training runs.
+    op.execute("DELETE FROM agent_lexeme_cards")  # cascades to examples
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column(
+            "source_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column(
+            "target_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=False,
+        ),
+    )
+    op.drop_column("agent_lexeme_cards", "source_language")
+    op.drop_column("agent_lexeme_cards", "target_language")
+
+    # --- agent_word_alignments (truncate; no dependents) ---
+    op.execute("DELETE FROM agent_word_alignments")
+    op.add_column(
+        "agent_word_alignments",
+        sa.Column(
+            "source_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "agent_word_alignments",
+        sa.Column(
+            "target_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=False,
+        ),
+    )
+    op.drop_column("agent_word_alignments", "source_language")
+    op.drop_column("agent_word_alignments", "target_language")
+
+    # --- agent_translations (single reference_version_id; backfillable) ---
+    op.add_column(
+        "agent_translations",
+        sa.Column(
+            "reference_version_id",
+            sa.Integer(),
+            sa.ForeignKey("bible_version.id"),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        """
+        UPDATE agent_translations at
+        SET reference_version_id = ref_br.bible_version_id
+        FROM assessment a
+        JOIN bible_revision ref_br ON a.reference_id = ref_br.id
+        WHERE a.id = at.assessment_id
+        """
+    )
+    orphans = bind.exec_driver_sql(
+        "SELECT COUNT(*) FROM agent_translations WHERE reference_version_id IS NULL"
+    ).scalar()
+    if orphans:
+        raise RuntimeError(
+            f"agent_translations: {orphans} row(s) failed version_id backfill"
+        )
+    op.alter_column("agent_translations", "reference_version_id", nullable=False)
+    op.drop_column("agent_translations", "language")
+
+    # ------------------------------------------------------------------
+    # Phase 3 — rebuild indexes CONCURRENTLY on the new columns. Outside
+    # the column-change transaction so each CREATE INDEX takes only a
+    # SHARE UPDATE EXCLUSIVE lock; readers/writers proceed.
+    # ------------------------------------------------------------------
+    with op.get_context().autocommit_block():
+        for name, table, ddl in (
+            (
+                "ix_eflomal_assessment_version_pair",
+                "eflomal_assessment",
+                "(source_version_id, target_version_id)",
+            ),
+            (
+                "ix_tfidf_artifact_runs_version",
+                "tfidf_artifact_runs",
+                "(source_version_id)",
+            ),
+            (
+                "ix_tfidf_artifact_runs_version_created",
+                "tfidf_artifact_runs",
+                "(source_version_id, created_at)",
+            ),
+            (
+                "ix_training_job_version_pair",
+                "training_job",
+                "(source_version_id, target_version_id)",
+            ),
+            (
+                "ix_agent_lexeme_cards_version_confidence",
+                "agent_lexeme_cards",
+                "(source_version_id, target_version_id, confidence DESC)",
+            ),
+            (
+                "ix_agent_word_alignments_version_source",
+                "agent_word_alignments",
+                "(source_version_id, target_version_id, source_word)",
+            ),
+            (
+                "ix_agent_word_alignments_version_target",
+                "agent_word_alignments",
+                "(source_version_id, target_version_id, target_word)",
+            ),
+            (
+                "ix_agent_word_alignments_version_score",
+                "agent_word_alignments",
+                "(source_version_id, target_version_id, score DESC)",
+            ),
+            (
+                "ix_agent_translations_rev_refversion_script_vref",
+                "agent_translations",
+                "(revision_id, reference_version_id, script, vref)",
+            ),
+        ):
+            _drop_invalid_index(bind, name)
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} " f"ON {table} {ddl}"
+            )
+
+        # Unique constraints replacing the dropped language-keyed unique
+        # indexes. Created CONCURRENTLY for the same lock-avoidance
+        # reason; UNIQUE indexes can be created concurrently in PG.
+        for name, table, ddl in (
+            (
+                "ix_agent_lexeme_cards_unique_v4",
+                "agent_lexeme_cards",
+                "(LOWER(target_lemma), source_version_id, target_version_id)",
+            ),
+            (
+                "ux_agent_word_alignments_version_words",
+                "agent_word_alignments",
+                "(source_version_id, target_version_id, source_word, target_word)",
+            ),
+            (
+                "ix_agent_translations_unique",
+                "agent_translations",
+                "(revision_id, reference_version_id, script, vref, version)",
+            ),
+        ):
+            _drop_invalid_index(bind, name)
+            op.execute(
+                f"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {name} "
+                f"ON {table} {ddl}"
+            )
+
+
+def downgrade() -> None:
+    """Reverses column / index shape but cannot recover truncated rows.
+
+    agent_lexeme_cards and agent_word_alignments lose all rows on upgrade
+    (no version chain to backfill from). Downgrading restores the schema
+    but leaves those tables empty; callers will repopulate from new runs
+    in either direction.
+    """
+    bind = op.get_bind()
+
+    with op.get_context().autocommit_block():
+        for name in (
+            "ix_eflomal_assessment_version_pair",
+            "ix_tfidf_artifact_runs_version",
+            "ix_tfidf_artifact_runs_version_created",
+            "ix_training_job_version_pair",
+            "ix_agent_lexeme_cards_version_confidence",
+            "ix_agent_lexeme_cards_unique_v4",
+            "ix_agent_word_alignments_version_source",
+            "ix_agent_word_alignments_version_target",
+            "ix_agent_word_alignments_version_score",
+            "ux_agent_word_alignments_version_words",
+            "ix_agent_translations_rev_refversion_script_vref",
+            "ix_agent_translations_unique",
+        ):
+            _drop_invalid_index(bind, name)
+            op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {name}")
+
+    # --- agent_translations ---
+    op.add_column(
+        "agent_translations",
+        sa.Column(
+            "language",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        """
+        UPDATE agent_translations at
+        SET language = bv.iso_language
+        FROM bible_version bv
+        WHERE bv.id = at.reference_version_id
+        """
+    )
+    op.alter_column("agent_translations", "language", nullable=False)
+    op.drop_column("agent_translations", "reference_version_id")
+
+    # --- agent_word_alignments — schema restored, rows already gone ---
+    op.add_column(
+        "agent_word_alignments",
+        sa.Column(
+            "source_language",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "agent_word_alignments",
+        sa.Column(
+            "target_language",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=True,
+        ),
+    )
+    op.drop_column("agent_word_alignments", "source_version_id")
+    op.drop_column("agent_word_alignments", "target_version_id")
+
+    # --- agent_lexeme_cards ---
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column(
+            "source_language",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column(
+            "target_language",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=True,
+        ),
+    )
+    op.drop_column("agent_lexeme_cards", "source_version_id")
+    op.drop_column("agent_lexeme_cards", "target_version_id")
+
+    # --- training_job ---
+    op.add_column(
+        "training_job",
+        sa.Column(
+            "source_language",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "training_job",
+        sa.Column(
+            "target_language",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=True,
+        ),
+    )
+    op.execute(
+        """
+        UPDATE training_job tj
+        SET source_language = src_bv.iso_language,
+            target_language = tgt_bv.iso_language
+        FROM bible_version src_bv, bible_version tgt_bv
+        WHERE src_bv.id = tj.source_version_id
+          AND tgt_bv.id = tj.target_version_id
+        """
+    )
+    op.alter_column("training_job", "source_language", nullable=False)
+    op.alter_column("training_job", "target_language", nullable=False)
+    op.drop_column("training_job", "source_version_id")
+    op.drop_column("training_job", "target_version_id")
+
+    # --- tfidf_svd_staging ---
+    op.add_column(
+        "tfidf_svd_staging",
+        sa.Column("source_language", sa.String(3), nullable=True),
+    )
+    op.drop_column("tfidf_svd_staging", "source_version_id")
+
+    # --- tfidf_artifact_runs ---
+    op.add_column(
+        "tfidf_artifact_runs",
+        sa.Column("source_language", sa.String(3), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE tfidf_artifact_runs tar
+        SET source_language = src_bv.iso_language
+        FROM bible_version src_bv
+        WHERE src_bv.id = tar.source_version_id
+        """
+    )
+    op.drop_column("tfidf_artifact_runs", "source_version_id")
+
+    # --- eflomal_assessment ---
+    op.add_column(
+        "eflomal_assessment",
+        sa.Column("source_language", sa.String(3), nullable=True),
+    )
+    op.add_column(
+        "eflomal_assessment",
+        sa.Column("target_language", sa.String(3), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE eflomal_assessment ea
+        SET source_language = src_bv.iso_language,
+            target_language = tgt_bv.iso_language
+        FROM bible_version src_bv, bible_version tgt_bv
+        WHERE src_bv.id = ea.source_version_id
+          AND tgt_bv.id = ea.target_version_id
+        """
+    )
+    op.drop_column("eflomal_assessment", "source_version_id")
+    op.drop_column("eflomal_assessment", "target_version_id")
+
+    # Restore previously-dropped language-keyed indexes
+    with op.get_context().autocommit_block():
+        for name, table, ddl in (
+            (
+                "ix_eflomal_assessment_language_pair",
+                "eflomal_assessment",
+                "(source_language, target_language)",
+            ),
+            (
+                "ix_tfidf_artifact_runs_lang",
+                "tfidf_artifact_runs",
+                "(source_language)",
+            ),
+            (
+                "ix_tfidf_artifact_runs_lang_created",
+                "tfidf_artifact_runs",
+                "(source_language, created_at)",
+            ),
+            (
+                "ix_training_job_lang_pair",
+                "training_job",
+                "(source_language, target_language)",
+            ),
+            (
+                "ix_agent_lexeme_cards_lang_confidence",
+                "agent_lexeme_cards",
+                "(source_language, target_language, confidence DESC)",
+            ),
+            (
+                "ix_agent_word_alignments_lang_source",
+                "agent_word_alignments",
+                "(source_language, target_language, source_word)",
+            ),
+            (
+                "ix_agent_word_alignments_lang_target",
+                "agent_word_alignments",
+                "(source_language, target_language, target_word)",
+            ),
+            (
+                "ix_agent_word_alignments_lang_score",
+                "agent_word_alignments",
+                "(source_language, target_language, score DESC)",
+            ),
+            (
+                "ix_agent_translations_rev_lang_script_vref",
+                "agent_translations",
+                "(revision_id, language, script, vref)",
+            ),
+        ):
+            _drop_invalid_index(bind, name)
+            op.execute(
+                f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} " f"ON {table} {ddl}"
+            )
+        for name, table, ddl in (
+            (
+                "ix_agent_lexeme_cards_unique_v3",
+                "agent_lexeme_cards",
+                "(LOWER(target_lemma), source_language, target_language)",
+            ),
+            (
+                "ux_agent_word_alignments_lang_words",
+                "agent_word_alignments",
+                "(source_language, target_language, source_word, target_word)",
+            ),
+            (
+                "ix_agent_translations_unique",
+                "agent_translations",
+                "(revision_id, language, script, vref, version)",
+            ),
+        ):
+            _drop_invalid_index(bind, name)
+            op.execute(
+                f"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {name} "
+                f"ON {table} {ddl}"
+            )

--- a/alembic/migrations/versions/e3a9f5d2c8b1_version_id_keying_migration.py
+++ b/alembic/migrations/versions/e3a9f5d2c8b1_version_id_keying_migration.py
@@ -161,14 +161,19 @@ def upgrade() -> None:
     op.alter_column("tfidf_artifact_runs", "source_version_id", nullable=False)
     op.drop_column("tfidf_artifact_runs", "source_language")
 
-    # --- tfidf_svd_staging (transient; no backfill) ---
+    # --- tfidf_svd_staging (transient; truncate then add NOT NULL column) ---
+    # Staging rows are abandoned/cleaned up within 24h, so wiping in-flight
+    # uploads at migration time is acceptable. Truncating lets the new column
+    # land NOT NULL — consistent with every other version_id column on the
+    # branch.
+    op.execute("TRUNCATE TABLE tfidf_svd_staging CASCADE")
     op.add_column(
         "tfidf_svd_staging",
         sa.Column(
             "source_version_id",
             sa.Integer(),
             sa.ForeignKey("bible_version.id"),
-            nullable=True,
+            nullable=False,
         ),
     )
     op.drop_column("tfidf_svd_staging", "source_language")
@@ -423,6 +428,14 @@ def downgrade() -> None:
         WHERE bv.id = at.reference_version_id
         """
     )
+    orphans = bind.exec_driver_sql(
+        "SELECT COUNT(*) FROM agent_translations WHERE language IS NULL"
+    ).scalar()
+    if orphans:
+        raise RuntimeError(
+            f"agent_translations downgrade: {orphans} row(s) failed language "
+            "backfill — reference_version_id may point to a deleted bible_version"
+        )
     op.alter_column("agent_translations", "language", nullable=False)
     op.drop_column("agent_translations", "reference_version_id")
 
@@ -499,6 +512,14 @@ def downgrade() -> None:
           AND tgt_bv.id = tj.target_version_id
         """
     )
+    orphans = bind.exec_driver_sql(
+        "SELECT COUNT(*) FROM training_job "
+        "WHERE source_language IS NULL OR target_language IS NULL"
+    ).scalar()
+    if orphans:
+        raise RuntimeError(
+            f"training_job downgrade: {orphans} row(s) failed language backfill"
+        )
     op.alter_column("training_job", "source_language", nullable=False)
     op.alter_column("training_job", "target_language", nullable=False)
     op.drop_column("training_job", "source_version_id")

--- a/alembic/migrations/versions/e3a9f5d2c8b1_version_id_keying_migration.py
+++ b/alembic/migrations/versions/e3a9f5d2c8b1_version_id_keying_migration.py
@@ -218,7 +218,7 @@ def upgrade() -> None:
     # cannot be unambiguously assigned to a version pair. Confirmed
     # acceptable on aqua-api#613: cards rebuild from new agent-critique
     # training runs.
-    op.execute("DELETE FROM agent_lexeme_cards")  # cascades to examples
+    op.execute("TRUNCATE TABLE agent_lexeme_cards CASCADE")
     op.add_column(
         "agent_lexeme_cards",
         sa.Column(
@@ -241,7 +241,7 @@ def upgrade() -> None:
     op.drop_column("agent_lexeme_cards", "target_language")
 
     # --- agent_word_alignments (truncate; no dependents) ---
-    op.execute("DELETE FROM agent_word_alignments")
+    op.execute("TRUNCATE TABLE agent_word_alignments")
     op.add_column(
         "agent_word_alignments",
         sa.Column(

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -216,7 +216,7 @@ async def add_assessment(
     ),
     use_eflomal: Optional[bool] = Query(
         None,
-        description="Run eflomal-based word alignment. Requires source_language and target_language.",
+        description="Run eflomal-based word alignment. Requires source_version_id and target_version_id.",
     ),
     force: bool = Query(
         False,
@@ -237,7 +237,7 @@ async def add_assessment(
     - semantic-similarity (requires reference)
     - sentence-length
     - word-alignment (requires reference; can optionally run eflomal-based alignment
-      when `use_eflomal=true` and `source_language` and `target_language` are provided)
+      when `use_eflomal=true` and `source_version_id` and `target_version_id` are provided)
     - ngrams
     - tfidf
     - text-lengths
@@ -295,7 +295,7 @@ async def add_assessment(
         a.kwargs = combined_kwargs
         parsed_kwargs = combined_kwargs
 
-    # Eflomal word-alignment requires source and target languages
+    # Eflomal word-alignment requires source and target version IDs
     is_eflomal = a.kwargs and a.kwargs.get("use_eflomal")
     if is_eflomal:
         if a.type != "word-alignment":
@@ -303,10 +303,10 @@ async def add_assessment(
                 status_code=400,
                 detail="use_eflomal is only valid for word-alignment assessments.",
             )
-        if not a.source_language or not a.target_language:
+        if not a.source_version_id or not a.target_version_id:
             raise HTTPException(
                 status_code=400,
-                detail="Eflomal word-alignment requires source_language and target_language.",
+                detail="Eflomal word-alignment requires source_version_id and target_version_id.",
             )
 
     # Check for already-completed assessment (force=true bypasses this)

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -303,7 +303,7 @@ async def add_assessment(
                 status_code=400,
                 detail="use_eflomal is only valid for word-alignment assessments.",
             )
-        if not a.source_version_id or not a.target_version_id:
+        if a.source_version_id is None or a.target_version_id is None:
             raise HTTPException(
                 status_code=400,
                 detail="Eflomal word-alignment requires source_version_id and target_version_id.",

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database.dependencies import get_db
 from database.models import (
     Assessment,
+    BibleRevision,
 )
 from database.models import EflomalAssessment as EflomalAssessmentModel
 from database.models import (
@@ -158,6 +159,32 @@ def _build_reverse_dict(
     return result
 
 
+async def _assessment_version_pair(
+    assessment: Assessment, db: AsyncSession
+) -> tuple[int, int]:
+    if assessment.reference_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Eflomal metadata requires an assessment reference_id",
+        )
+    source_version_id = await db.scalar(
+        select(BibleRevision.bible_version_id).where(
+            BibleRevision.id == assessment.revision_id
+        )
+    )
+    target_version_id = await db.scalar(
+        select(BibleRevision.bible_version_id).where(
+            BibleRevision.id == assessment.reference_id
+        )
+    )
+    if source_version_id is None or target_version_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Could not determine source/target version IDs from assessment",
+        )
+    return source_version_id, target_version_id
+
+
 async def _fetch_eflomal_response(
     eflomal: EflomalAssessmentModel, db: AsyncSession
 ) -> EflomalResultsPullResponse:
@@ -210,8 +237,8 @@ async def _fetch_eflomal_response(
 
     return EflomalResultsPullResponse(
         assessment_id=eflomal.assessment_id,
-        source_language=eflomal.source_language,
-        target_language=eflomal.target_language,
+        source_version_id=eflomal.source_version_id,
+        target_version_id=eflomal.target_version_id,
         num_verse_pairs=eflomal.num_verse_pairs,
         num_alignment_links=eflomal.num_alignment_links,
         num_dictionary_entries=eflomal.num_dictionary_entries,
@@ -270,6 +297,25 @@ async def push_eflomal_metadata(
             status_code=400,
             detail=f"Assessment type must be 'word-alignment', got '{assessment.type}'",
         )
+    source_version_id, target_version_id = await _assessment_version_pair(
+        assessment, db
+    )
+    if (
+        body.source_version_id is not None
+        and body.source_version_id != source_version_id
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="source_version_id does not match assessment revision version",
+        )
+    if (
+        body.target_version_id is not None
+        and body.target_version_id != target_version_id
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="target_version_id does not match assessment reference version",
+        )
 
     # 2. Authorize
     if not await is_user_authorized_for_assessment(
@@ -292,8 +338,8 @@ async def push_eflomal_metadata(
     try:
         eflomal_assessment = EflomalAssessmentModel(
             assessment_id=body.assessment_id,
-            source_language=body.source_language,
-            target_language=body.target_language,
+            source_version_id=source_version_id,
+            target_version_id=target_version_id,
             num_verse_pairs=body.num_verse_pairs,
             num_alignment_links=body.num_alignment_links,
             num_dictionary_entries=body.num_dictionary_entries,
@@ -767,22 +813,22 @@ async def push_eflomal_bpe_models(
 )
 async def pull_eflomal_results(
     assessment_id: int | None = None,
-    source_language: str | None = None,
-    target_language: str | None = None,
+    source_version_id: int | None = None,
+    target_version_id: int | None = None,
     current_user: UserModel = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Pull eflomal training artifacts by assessment ID or language pair.
+    """Pull eflomal training artifacts by assessment ID or version pair.
 
-    Provide either assessment_id or both source_language and target_language.
-    When querying by language pair, returns the most recent results.
+    Provide either assessment_id or both source_version_id and target_version_id.
+    When querying by version pair, returns the most recent results.
     """
-    has_languages = source_language is not None or target_language is not None
+    has_versions = source_version_id is not None or target_version_id is not None
 
-    if assessment_id is not None and has_languages:
+    if assessment_id is not None and has_versions:
         raise HTTPException(
             status_code=400,
-            detail="Provide either assessment_id or language pair, not both",
+            detail="Provide either assessment_id or version pair, not both",
         )
 
     if assessment_id is not None:
@@ -797,12 +843,12 @@ async def pull_eflomal_results(
                 status_code=404,
                 detail="No eflomal results found for this assessment",
             )
-    elif source_language is not None and target_language is not None:
+    elif source_version_id is not None and target_version_id is not None:
         result = await db.execute(
             select(EflomalAssessmentModel)
             .where(
-                EflomalAssessmentModel.source_language == source_language,
-                EflomalAssessmentModel.target_language == target_language,
+                EflomalAssessmentModel.source_version_id == source_version_id,
+                EflomalAssessmentModel.target_version_id == target_version_id,
             )
             .order_by(desc(EflomalAssessmentModel.created_at))
             .limit(1)
@@ -811,12 +857,12 @@ async def pull_eflomal_results(
         if eflomal is None:
             raise HTTPException(
                 status_code=404,
-                detail="No eflomal results found for this language pair",
+                detail="No eflomal results found for this version pair",
             )
     else:
         raise HTTPException(
             status_code=400,
-            detail="Provide either assessment_id or both source_language and target_language",
+            detail="Provide either assessment_id or both source_version_id and target_version_id",
         )
 
     if not await is_user_authorized_for_assessment(

--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -20,6 +20,7 @@ from assessment_routes.v3.results_query_routes import build_vector_literal
 from database.dependencies import get_db
 from database.models import (
     Assessment,
+    BibleRevision,
     TfidfArtifactRun,
     TfidfPcaVector,
     TfidfSvd,
@@ -155,6 +156,22 @@ async def _score_against_corpus(
     ]
 
 
+async def _assessment_source_version_id(
+    assessment: Assessment, db: AsyncSession
+) -> int:
+    source_version_id = await db.scalar(
+        select(BibleRevision.bible_version_id).where(
+            BibleRevision.id == assessment.revision_id
+        )
+    )
+    if source_version_id is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Could not determine source_version_id from assessment",
+        )
+    return source_version_id
+
+
 # ---------------------------------------------------------------------------
 # POST — push all artifacts in one transaction (idempotent)
 # ---------------------------------------------------------------------------
@@ -188,6 +205,15 @@ async def push_tfidf_artifacts(
     if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
         raise HTTPException(
             status_code=403, detail="Not authorized for this assessment"
+        )
+    source_version_id = await _assessment_source_version_id(assessment, db)
+    if (
+        body.source_version_id is not None
+        and body.source_version_id != source_version_id
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="source_version_id does not match assessment revision version",
         )
 
     try:
@@ -262,7 +288,7 @@ async def push_tfidf_artifacts(
         db.add(
             TfidfArtifactRun(
                 assessment_id=assessment_id,
-                source_language=body.source_language,
+                source_version_id=source_version_id,
                 n_components=body.n_components,
                 n_word_features=n_word_features,
                 n_char_features=n_char_features,
@@ -438,7 +464,18 @@ async def init_tfidf_artifacts_upload(
     Creates a staging row with the vectorizer and SVD metadata. Returns an
     upload_id that the caller uses to POST chunks and finally commit.
     """
-    await _load_tfidf_assessment_for_upload(assessment_id, current_user, db)
+    assessment = await _load_tfidf_assessment_for_upload(
+        assessment_id, current_user, db
+    )
+    source_version_id = await _assessment_source_version_id(assessment, db)
+    if (
+        body.source_version_id is not None
+        and body.source_version_id != source_version_id
+    ):
+        raise HTTPException(
+            status_code=422,
+            detail="source_version_id does not match assessment revision version",
+        )
     _validate_vectorizer_shapes(body)
 
     # The sweep runs before the staging insert and any rollback here drops
@@ -457,7 +494,7 @@ async def init_tfidf_artifacts_upload(
 
     staging = TfidfSvdStaging(
         assessment_id=assessment_id,
-        source_language=body.source_language,
+        source_version_id=source_version_id,
         n_components=body.n_components,
         n_corpus_vrefs=body.n_corpus_vrefs,
         sklearn_version=body.sklearn_version,
@@ -718,7 +755,7 @@ async def commit_tfidf_artifacts_upload(
         db.add(
             TfidfArtifactRun(
                 assessment_id=assessment_id,
-                source_language=staging.source_language,
+                source_version_id=staging.source_version_id,
                 n_components=staging.n_components,
                 n_word_features=n_word_features,
                 n_char_features=n_char_features,
@@ -840,18 +877,18 @@ async def abort_tfidf_artifacts_upload(
 )
 async def pull_tfidf_artifacts(
     assessment_id: int | None = None,
-    source_language: str | None = None,
+    source_version_id: int | None = None,
     current_user: UserModel = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ):
-    """Fetch TF-IDF encoder artifacts by assessment_id or latest by language.
+    """Fetch TF-IDF encoder artifacts by assessment_id or latest by source version.
 
-    Exactly one of assessment_id or source_language must be provided.
+    Exactly one of assessment_id or source_version_id must be provided.
     """
-    if (assessment_id is None) == (source_language is None):
+    if (assessment_id is None) == (source_version_id is None):
         raise HTTPException(
             status_code=422,
-            detail="Provide exactly one of assessment_id or source_language",
+            detail="Provide exactly one of assessment_id or source_version_id",
         )
 
     if assessment_id is not None:
@@ -863,7 +900,7 @@ async def pull_tfidf_artifacts(
     else:
         run = await db.scalar(
             select(TfidfArtifactRun)
-            .where(TfidfArtifactRun.source_language == source_language)
+            .where(TfidfArtifactRun.source_version_id == source_version_id)
             .order_by(desc(TfidfArtifactRun.created_at))
             .limit(1)
         )
@@ -892,7 +929,7 @@ async def pull_tfidf_artifacts(
 
     return TfidfArtifactsPullResponse(
         assessment_id=run.assessment_id,
-        source_language=run.source_language,
+        source_version_id=run.source_version_id,
         n_components=run.n_components,
         n_word_features=run.n_word_features,
         n_char_features=run.n_char_features,

--- a/database/models.py
+++ b/database/models.py
@@ -174,12 +174,8 @@ class TrainingJob(Base):
     target_revision_id = Column(
         Integer, ForeignKey("bible_revision.id"), nullable=False
     )
-    source_language = Column(
-        String(3), ForeignKey("iso_language.iso639"), nullable=False
-    )
-    target_language = Column(
-        String(3), ForeignKey("iso_language.iso639"), nullable=False
-    )
+    source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
+    target_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
 
     options = Column(JSONB, nullable=True)
 
@@ -202,11 +198,13 @@ class TrainingJob(Base):
 
     source_revision = relationship("BibleRevision", foreign_keys=[source_revision_id])
     target_revision = relationship("BibleRevision", foreign_keys=[target_revision_id])
+    source_version = relationship("BibleVersion", foreign_keys=[source_version_id])
+    target_version = relationship("BibleVersion", foreign_keys=[target_version_id])
     owner = relationship("UserDB")
     assessment = relationship("Assessment", foreign_keys=[assessment_id])
 
     __table_args__ = (
-        Index("ix_training_job_lang_pair", "source_language", "target_language"),
+        Index("ix_training_job_version_pair", "source_version_id", "target_version_id"),
         Index(
             "ix_training_job_revisions_type",
             "source_revision_id",
@@ -448,8 +446,8 @@ class AgentLexemeCard(Base):
     id = Column(Integer, primary_key=True)
     source_lemma = Column(Text)  # Source language lemma for cross-reference
     target_lemma = Column(Text, nullable=False)
-    source_language = Column(String(3), ForeignKey("iso_language.iso639"))
-    target_language = Column(String(3), ForeignKey("iso_language.iso639"))
+    source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
+    target_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
     pos = Column(Text)
     surface_forms = Column(JSONB)  # JSON array of target language surface forms
     source_surface_forms = Column(JSONB)  # JSON array of source language surface forms
@@ -466,17 +464,17 @@ class AgentLexemeCard(Base):
         # Case-insensitive unique constraint to prevent duplicate cards
         # Each LOWER(target_lemma) can only have one card per language pair
         Index(
-            "ix_agent_lexeme_cards_unique_v3",
+            "ix_agent_lexeme_cards_unique_v4",
             func.lower(target_lemma),
-            "source_language",
-            "target_language",
+            "source_version_id",
+            "target_version_id",
             unique=True,
         ),
         # Index for common query pattern: language pair + confidence ordering
         Index(
-            "ix_agent_lexeme_cards_lang_confidence",
-            "source_language",
-            "target_language",
+            "ix_agent_lexeme_cards_version_confidence",
+            "source_version_id",
+            "target_version_id",
             "confidence",
             postgresql_ops={"confidence": "DESC"},
         ),
@@ -557,8 +555,8 @@ class AgentWordAlignment(Base):
     id = Column(Integer, primary_key=True)
     source_word = Column(Text, nullable=False)
     target_word = Column(Text, nullable=False)
-    source_language = Column(String(3), ForeignKey("iso_language.iso639"))
-    target_language = Column(String(3), ForeignKey("iso_language.iso639"))
+    source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
+    target_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
     score = Column(Float, nullable=False, default=0.0)
     is_human_verified = Column(Boolean, default=False)  # False until human-verified
     created_at = Column(TIMESTAMP, default=func.now())
@@ -567,32 +565,32 @@ class AgentWordAlignment(Base):
     __table_args__ = (
         # Unique constraint for atomic upserts
         Index(
-            "ux_agent_word_alignments_lang_words",
-            "source_language",
-            "target_language",
+            "ux_agent_word_alignments_version_words",
+            "source_version_id",
+            "target_version_id",
             "source_word",
             "target_word",
             unique=True,
         ),
         # Index for source word lookups by language pair
         Index(
-            "ix_agent_word_alignments_lang_source",
-            "source_language",
-            "target_language",
+            "ix_agent_word_alignments_version_source",
+            "source_version_id",
+            "target_version_id",
             "source_word",
         ),
         # Index for target word lookups by language pair
         Index(
-            "ix_agent_word_alignments_lang_target",
-            "source_language",
-            "target_language",
+            "ix_agent_word_alignments_version_target",
+            "source_version_id",
+            "target_version_id",
             "target_word",
         ),
         # Index for efficient score-ordered queries
         Index(
-            "ix_agent_word_alignments_lang_score",
-            "source_language",
-            "target_language",
+            "ix_agent_word_alignments_version_score",
+            "source_version_id",
+            "target_version_id",
             score.desc(),
         ),
     )
@@ -677,8 +675,10 @@ class AgentTranslation(Base):
     )
     # revision being translated (assessment.revision_id, i.e. the target text)
     revision_id = Column(Integer, ForeignKey("bible_revision.id"), nullable=False)
-    # reference language/script (from assessment's reference BibleVersion)
-    language = Column(String(3), ForeignKey("iso_language.iso639"), nullable=False)
+    # reference version/script (from assessment's reference BibleVersion)
+    reference_version_id = Column(
+        Integer, ForeignKey("bible_version.id"), nullable=False
+    )
     script = Column(String(4), ForeignKey("iso_script.iso15924"), nullable=False)
     vref = Column(String(20), nullable=False)
     version = Column(Integer, default=1, nullable=False)
@@ -695,7 +695,7 @@ class AgentTranslation(Base):
         Index(
             "ix_agent_translations_unique",
             "revision_id",
-            "language",
+            "reference_version_id",
             "script",
             "vref",
             "version",
@@ -703,9 +703,9 @@ class AgentTranslation(Base):
         ),
         Index("ix_agent_translations_assessment_vref", "assessment_id", "vref"),
         Index(
-            "ix_agent_translations_rev_lang_script_vref",
+            "ix_agent_translations_rev_refversion_script_vref",
             "revision_id",
-            "language",
+            "reference_version_id",
             "script",
             "vref",
         ),
@@ -726,8 +726,8 @@ class EflomalAssessment(Base):
     assessment_id = Column(
         Integer, ForeignKey("assessment.id"), nullable=False, unique=True
     )
-    source_language = Column(String(3), nullable=True)
-    target_language = Column(String(3), nullable=True)
+    source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
+    target_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
     num_verse_pairs = Column(Integer)
     num_alignment_links = Column(Integer)
     num_dictionary_entries = Column(Integer)
@@ -736,9 +736,9 @@ class EflomalAssessment(Base):
 
     __table_args__ = (
         Index(
-            "ix_eflomal_assessment_language_pair",
-            "source_language",
-            "target_language",
+            "ix_eflomal_assessment_version_pair",
+            "source_version_id",
+            "target_version_id",
         ),
     )
 
@@ -1106,7 +1106,7 @@ class TfidfArtifactRun(Base):
         ForeignKey("assessment.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    source_language = Column(String(3), nullable=True)
+    source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
     n_components = Column(Integer, nullable=False)
     n_word_features = Column(Integer, nullable=False)
     n_char_features = Column(Integer, nullable=False)
@@ -1115,8 +1115,12 @@ class TfidfArtifactRun(Base):
     created_at = Column(TIMESTAMP, server_default=func.now())
 
     __table_args__ = (
-        Index("ix_tfidf_artifact_runs_lang", "source_language"),
-        Index("ix_tfidf_artifact_runs_lang_created", "source_language", "created_at"),
+        Index("ix_tfidf_artifact_runs_version", "source_version_id"),
+        Index(
+            "ix_tfidf_artifact_runs_version_created",
+            "source_version_id",
+            "created_at",
+        ),
     )
 
 
@@ -1175,7 +1179,7 @@ class TfidfSvdStaging(Base):
         ForeignKey("assessment.id", ondelete="CASCADE"),
         nullable=False,
     )
-    source_language = Column(String(3), nullable=True)
+    source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=True)
     n_components = Column(Integer, nullable=False)
     n_corpus_vrefs = Column(Integer, nullable=False)
     sklearn_version = Column(Text, nullable=False)

--- a/database/models.py
+++ b/database/models.py
@@ -462,7 +462,7 @@ class AgentLexemeCard(Base):
 
     __table_args__ = (
         # Case-insensitive unique constraint to prevent duplicate cards
-        # Each LOWER(target_lemma) can only have one card per language pair
+        # Each LOWER(target_lemma) can only have one card per version pair
         Index(
             "ix_agent_lexeme_cards_unique_v4",
             func.lower(target_lemma),
@@ -470,7 +470,7 @@ class AgentLexemeCard(Base):
             "target_version_id",
             unique=True,
         ),
-        # Index for common query pattern: language pair + confidence ordering
+        # Index for common query pattern: version pair + confidence ordering
         Index(
             "ix_agent_lexeme_cards_version_confidence",
             "source_version_id",
@@ -572,14 +572,14 @@ class AgentWordAlignment(Base):
             "target_word",
             unique=True,
         ),
-        # Index for source word lookups by language pair
+        # Index for source word lookups by version pair
         Index(
             "ix_agent_word_alignments_version_source",
             "source_version_id",
             "target_version_id",
             "source_word",
         ),
-        # Index for target word lookups by language pair
+        # Index for target word lookups by version pair
         Index(
             "ix_agent_word_alignments_version_target",
             "source_version_id",

--- a/database/models.py
+++ b/database/models.py
@@ -1179,7 +1179,7 @@ class TfidfSvdStaging(Base):
         ForeignKey("assessment.id", ondelete="CASCADE"),
         nullable=False,
     )
-    source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=True)
+    source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
     n_components = Column(Integer, nullable=False)
     n_corpus_vrefs = Column(Integer, nullable=False)
     sklearn_version = Column(Text, nullable=False)

--- a/models.py
+++ b/models.py
@@ -277,8 +277,8 @@ class AssessmentIn(BaseModel):
     revision_id: int
     reference_id: Optional[int] = None
     type: AssessmentType
-    source_language: Optional[str] = None
-    target_language: Optional[str] = None
+    source_version_id: Optional[int] = None
+    target_version_id: Optional[int] = None
     kwargs: Optional[Dict[str, Any]] = None
 
     @field_validator("kwargs")
@@ -336,16 +336,16 @@ class AssessmentOut(BaseModel):
 class SemanticSimilarityRequest(BaseModel):
     text1: str = Field(..., max_length=10000)
     text2: str = Field(..., max_length=10000)
-    source_language: str = Field(..., max_length=10)
-    target_language: str = Field(..., max_length=10)
+    source_version_id: int
+    target_version_id: int
 
     model_config = {
         "json_schema_extra": {
             "example": {
                 "text1": "Hapo mwanzo Mungu aliumba mbingu na dunia.",
                 "text2": "In the beginning God created the heavens and the earth.",
-                "source_language": "swh",
-                "target_language": "eng",
+                "source_version_id": 1,
+                "target_version_id": 2,
             }
         }
     }
@@ -371,8 +371,8 @@ class PredictInput(BaseModel):
     assessment_id: Optional[int] = None
     revision_id: Optional[int] = None
     reference_id: Optional[int] = None
-    source_language: Optional[str] = Field(default=None, max_length=10)
-    target_language: Optional[str] = Field(default=None, max_length=10)
+    source_version_id: Optional[int] = None
+    target_version_id: Optional[int] = None
     limit: Optional[int] = Field(default=None, ge=1, le=10000)
     apps: Optional[List[str]] = None
     include_critique: bool = False
@@ -389,8 +389,8 @@ class PredictInput(BaseModel):
                 ],
                 "revision_id": 1,
                 "reference_id": 2,
-                "source_language": "eng",
-                "target_language": "swh",
+                "source_version_id": 1,
+                "target_version_id": 2,
                 "apps": ["ngrams", "tfidf"],
                 "include_critique": False,
             }
@@ -582,8 +582,8 @@ class TokenData(BaseModel):
 class AgentWordAlignmentIn(BaseModel):
     source_word: str
     target_word: str
-    source_language: str
-    target_language: str
+    source_version_id: int
+    target_version_id: int
     score: float = 0.0
     is_human_verified: bool = False
 
@@ -592,8 +592,8 @@ class AgentWordAlignmentIn(BaseModel):
             "example": {
                 "source_word": "love",
                 "target_word": "amor",
-                "source_language": "eng",
-                "target_language": "spa",
+                "source_version_id": 1,
+                "target_version_id": 2,
                 "score": 0.95,
                 "is_human_verified": False,
             }
@@ -605,8 +605,8 @@ class AgentWordAlignmentOut(BaseModel):
     id: int
     source_word: str
     target_word: str
-    source_language: str
-    target_language: str
+    source_version_id: int
+    target_version_id: int
     score: float
     is_human_verified: bool
     created_at: Optional[datetime.datetime] = None
@@ -618,8 +618,8 @@ class AgentWordAlignmentOut(BaseModel):
                 "id": 1,
                 "source_word": "love",
                 "target_word": "amor",
-                "source_language": "eng",
-                "target_language": "spa",
+                "source_version_id": 1,
+                "target_version_id": 2,
                 "score": 0.95,
                 "is_human_verified": False,
                 "created_at": "2024-06-01T12:00:00",
@@ -638,16 +638,16 @@ class AgentWordAlignmentBulkItem(BaseModel):
 
 
 class AgentWordAlignmentBulkRequest(BaseModel):
-    source_language: str  # ISO 639-3
-    target_language: str  # ISO 639-3
+    source_version_id: int
+    target_version_id: int
     alignments: list[AgentWordAlignmentBulkItem]
 
 
 class LexemeCardIn(BaseModel):
     source_lemma: Optional[str] = None
     target_lemma: str
-    source_language: str
-    target_language: str
+    source_version_id: int
+    target_version_id: int
 
     @field_validator("target_lemma")
     @classmethod
@@ -687,8 +687,8 @@ class LexemeCardIn(BaseModel):
             "example": {
                 "source_lemma": "love",
                 "target_lemma": "amor",
-                "source_language": "eng",
-                "target_language": "spa",
+                "source_version_id": 1,
+                "target_version_id": 2,
                 "pos": "verb",
                 "surface_forms": [
                     "amor",
@@ -727,8 +727,8 @@ class LexemeCardOut(BaseModel):
     id: int
     source_lemma: Optional[str] = None
     target_lemma: str
-    source_language: str
-    target_language: str
+    source_version_id: int
+    target_version_id: int
     pos: Optional[str] = None
     surface_forms: Optional[list] = None
     source_surface_forms: Optional[list] = None  # Source language surface forms
@@ -1043,7 +1043,7 @@ class AgentTranslationOut(BaseModel):
     id: int
     assessment_id: int
     revision_id: int
-    language: str
+    reference_version_id: int
     script: str
     vref: str
     version: int
@@ -1059,7 +1059,7 @@ class AgentTranslationOut(BaseModel):
                 "id": 1,
                 "assessment_id": 123,
                 "revision_id": 456,
-                "language": "eng",
+                "reference_version_id": 789,
                 "script": "Latn",
                 "vref": "JHN 1:1",
                 "version": 1,
@@ -1105,8 +1105,8 @@ class TrainingJobOut(BaseModel):
     type: str
     source_revision_id: int
     target_revision_id: int
-    source_language: str
-    target_language: str
+    source_version_id: int
+    target_version_id: int
     options: Optional[Dict[str, Any]] = None
     requested_time: Optional[datetime.datetime] = None
     owner_id: Optional[int] = None
@@ -1189,8 +1189,8 @@ class EflomalResultsPushRequest(BaseModel):
     """
 
     assessment_id: int
-    source_language: Optional[str] = None
-    target_language: Optional[str] = None
+    source_version_id: Optional[int] = None
+    target_version_id: Optional[int] = None
     num_verse_pairs: int
     num_alignment_links: int
     num_dictionary_entries: int
@@ -1202,8 +1202,8 @@ class EflomalAssessmentOut(BaseModel):
 
     id: int
     assessment_id: int
-    source_language: Optional[str] = None
-    target_language: Optional[str] = None
+    source_version_id: int
+    target_version_id: int
     num_verse_pairs: int
     num_alignment_links: int
     num_dictionary_entries: int
@@ -1242,8 +1242,8 @@ class EflomalResultsPullResponse(BaseModel):
     """
 
     assessment_id: int
-    source_language: Optional[str] = None
-    target_language: Optional[str] = None
+    source_version_id: int
+    target_version_id: int
     num_verse_pairs: int
     num_alignment_links: int
     num_dictionary_entries: int
@@ -1281,7 +1281,7 @@ class TfidfSvdPayload(TfidfSvdMeta):
 
 
 class TfidfArtifactsPushRequest(BaseModel):
-    source_language: Optional[str] = Field(default=None, max_length=3)
+    source_version_id: Optional[int] = None
     n_components: int
     n_corpus_vrefs: int
     sklearn_version: str
@@ -1299,7 +1299,7 @@ class TfidfArtifactsPushResponse(BaseModel):
 
 class TfidfArtifactsPullResponse(BaseModel):
     assessment_id: int
-    source_language: Optional[str] = None
+    source_version_id: int
     n_components: int
     n_word_features: int
     n_char_features: int
@@ -1315,7 +1315,7 @@ class TfidfArtifactsPullResponse(BaseModel):
 
 
 class TfidfArtifactsInitRequest(BaseModel):
-    source_language: Optional[str] = Field(default=None, max_length=3)
+    source_version_id: Optional[int] = None
     n_components: int
     n_corpus_vrefs: int
     sklearn_version: str

--- a/predict_routes/v3/predict_routes.py
+++ b/predict_routes/v3/predict_routes.py
@@ -177,8 +177,8 @@ async def semantic_similarity_inference(
     logger.info(
         "Semantic similarity inference request",
         extra={
-            "source_language": request.source_language,
-            "target_language": request.target_language,
+            "source_version_id": request.source_version_id,
+            "target_version_id": request.target_version_id,
             "modal_env": modal_env,
         },
     )
@@ -190,8 +190,8 @@ async def semantic_similarity_inference(
         result = await f.remote.aio(
             request.text1,
             request.text2,
-            source_language=request.source_language,
-            target_language=request.target_language,
+            source_version_id=request.source_version_id,
+            target_version_id=request.target_version_id,
         )
     except Exception as e:
         logger.error(f"Semantic similarity inference failed: {e}", exc_info=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -127,6 +127,55 @@ def test_revision_id_2(test_db_session):
 
 
 @pytest.fixture(scope="module")
+def test_version_id(test_db_session, test_revision_id):
+    """Bible version ID of the primary test revision (loading_test version).
+
+    Tests that previously used `source_language="eng"` to identify the
+    source version pair use this in the version_id-keyed world. Both
+    test_revision_id and test_revision_id_2 belong to the same version,
+    so this also serves as target_version_id for tests that don't need a
+    distinct second version.
+    """
+    rev = (
+        test_db_session.query(BibleRevision)
+        .filter(BibleRevision.id == test_revision_id)
+        .first()
+    )
+    return rev.bible_version_id
+
+
+@pytest.fixture(scope="module")
+def test_version_id_2(test_db_session):
+    """A second Bible version ID, distinct from test_version_id.
+
+    Used by tests that need two different versions to verify isolation
+    (e.g. unique constraints on (source_version_id, target_version_id),
+    cross-version artifact separation). Created on first use and reused
+    across tests in the same module.
+    """
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    existing = (
+        test_db_session.query(BibleVersion)
+        .filter(BibleVersion.name == "loading_test_2")
+        .first()
+    )
+    if existing:
+        return existing.id
+    version = BibleVersion(
+        name="loading_test_2",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="BLTEST2",
+        owner_id=user1.id if user1 else None,
+        is_reference=False,
+    )
+    test_db_session.add(version)
+    test_db_session.commit()
+    test_db_session.refresh(version)
+    return version.id
+
+
+@pytest.fixture(scope="module")
 def test_assessment_id(test_db_session, test_revision_id, test_revision_id_2):
     """Create and return a test assessment ID for critique tests."""
     # Create a test assessment using the test revisions

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -11,15 +11,17 @@ from database.models import (
 prefix = "v3"
 
 
-def test_add_word_alignment_success(client, regular_token1, db_session):
+def test_add_word_alignment_success(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test successfully adding a word alignment entry"""
 
     # Prepare request data
     alignment_data = {
         "source_word": "love",
         "target_word": "upendo",
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "is_human_verified": False,
     }
 
@@ -36,8 +38,8 @@ def test_add_word_alignment_success(client, regular_token1, db_session):
     # Check response fields
     assert response_data["source_word"] == "love"
     assert response_data["target_word"] == "upendo"
-    assert response_data["source_language"] == "eng"
-    assert response_data["target_language"] == "swh"
+    assert response_data["source_version_id"] == test_version_id
+    assert response_data["target_version_id"] == test_version_id_2
     assert response_data["is_human_verified"] is False
     assert response_data["id"] is not None
     assert response_data["created_at"] is not None
@@ -54,19 +56,21 @@ def test_add_word_alignment_success(client, regular_token1, db_session):
     assert alignment is not None
     assert alignment.source_word == "love"
     assert alignment.target_word == "upendo"
-    assert alignment.source_language == "eng"
-    assert alignment.target_language == "swh"
+    assert alignment.source_version_id == test_version_id
+    assert alignment.target_version_id == test_version_id_2
     assert alignment.is_human_verified is False
 
 
-def test_add_word_alignment_human_verified(client, regular_token1, db_session):
+def test_add_word_alignment_human_verified(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test adding a human-verified word alignment"""
 
     alignment_data = {
         "source_word": "peace",
         "target_word": "amani",
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "is_human_verified": True,
     }
 
@@ -90,14 +94,14 @@ def test_add_word_alignment_human_verified(client, regular_token1, db_session):
     assert alignment.is_human_verified is True
 
 
-def test_add_word_alignment_unauthorized(client):
+def test_add_word_alignment_unauthorized(client, test_version_id, test_version_id_2):
     """Test that unauthorized requests are rejected"""
 
     alignment_data = {
         "source_word": "love",
         "target_word": "amor",
-        "source_language": "eng",
-        "target_language": "spa",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
     }
 
     # Make request without auth token
@@ -109,14 +113,16 @@ def test_add_word_alignment_unauthorized(client):
     assert response.status_code == 401
 
 
-def test_add_word_alignment_missing_fields(client, regular_token1):
+def test_add_word_alignment_missing_fields(
+    client, regular_token1, test_version_id, test_version_id_2
+):
     """Test that requests with missing required fields are rejected"""
 
     # Missing target_word
     alignment_data = {
         "source_word": "love",
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
     }
 
     response = client.post(
@@ -128,7 +134,9 @@ def test_add_word_alignment_missing_fields(client, regular_token1):
     assert response.status_code == 422  # Unprocessable Entity
 
 
-def test_add_word_alignment_different_languages(client, regular_token1, db_session):
+def test_add_word_alignment_different_languages(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test adding word alignment with different language pair."""
     response = client.post(
         "/v3/agent/word-alignment",
@@ -136,8 +144,8 @@ def test_add_word_alignment_different_languages(client, regular_token1, db_sessi
         json={
             "source_word": "kitabu",
             "target_word": "book",
-            "source_language": "swh",
-            "target_language": "eng",
+            "source_version_id": test_version_id_2,
+            "target_version_id": test_version_id,
             "is_human_verified": True,
         },
     )
@@ -146,12 +154,14 @@ def test_add_word_alignment_different_languages(client, regular_token1, db_sessi
     data = response.json()
     assert data["source_word"] == "kitabu"
     assert data["target_word"] == "book"
-    assert data["source_language"] == "swh"
-    assert data["target_language"] == "eng"
+    assert data["source_version_id"] == test_version_id_2
+    assert data["target_version_id"] == test_version_id
     assert data["is_human_verified"] is True
 
 
-def test_get_word_alignments_by_source_words(client, regular_token1, db_session):
+def test_get_word_alignments_by_source_words(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test getting word alignments filtered by source words."""
     # Add some test data
     client.post(
@@ -160,8 +170,8 @@ def test_get_word_alignments_by_source_words(client, regular_token1, db_session)
         json={
             "source_word": "book",
             "target_word": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     client.post(
@@ -170,14 +180,14 @@ def test_get_word_alignments_by_source_words(client, regular_token1, db_session)
         json={
             "source_word": "house",
             "target_word": "nyumba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     # Get alignments by source words
     response = client.get(
-        "/v3/agent/word-alignment?source_language=eng&target_language=swh&source_words=book,house",
+        f"/v3/agent/word-alignment?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_words=book,house",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -189,7 +199,7 @@ def test_get_word_alignments_by_source_words(client, regular_token1, db_session)
 
 
 def test_get_word_alignments_by_source_words_filtered(
-    client, regular_token1, db_session
+    client, regular_token1, db_session, test_version_id, test_version_id_2
 ):
     """Test getting word alignments filtered by specific source words."""
     # Add test data
@@ -199,8 +209,8 @@ def test_get_word_alignments_by_source_words_filtered(
         json={
             "source_word": "book",
             "target_word": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     client.post(
@@ -209,8 +219,8 @@ def test_get_word_alignments_by_source_words_filtered(
         json={
             "source_word": "house",
             "target_word": "nyumba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     client.post(
@@ -219,14 +229,14 @@ def test_get_word_alignments_by_source_words_filtered(
         json={
             "source_word": "car",
             "target_word": "gari",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     # Filter by specific source words
     response = client.get(
-        "/v3/agent/word-alignment?source_language=eng&target_language=swh&source_words=book,house",
+        f"/v3/agent/word-alignment?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_words=book,house",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -238,7 +248,9 @@ def test_get_word_alignments_by_source_words_filtered(
     assert not any(a["source_word"] == "car" for a in data)
 
 
-def test_get_word_alignments_by_target_words(client, regular_token1, db_session):
+def test_get_word_alignments_by_target_words(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test getting word alignments by searching target words."""
     # Add test data
     client.post(
@@ -247,8 +259,8 @@ def test_get_word_alignments_by_target_words(client, regular_token1, db_session)
         json={
             "source_word": "book",
             "target_word": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     client.post(
@@ -257,14 +269,14 @@ def test_get_word_alignments_by_target_words(client, regular_token1, db_session)
         json={
             "source_word": "house",
             "target_word": "nyumba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     # Filter by target words
     response = client.get(
-        "/v3/agent/word-alignment?source_language=eng&target_language=swh&target_words=kitabu",
+        f"/v3/agent/word-alignment?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_words=kitabu",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -274,7 +286,9 @@ def test_get_word_alignments_by_target_words(client, regular_token1, db_session)
     assert any(a["target_word"] == "kitabu" for a in data)
 
 
-def test_get_word_alignments_by_language_pair(client, regular_token1, db_session):
+def test_get_word_alignments_by_language_pair(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test getting word alignments filtered by language pair with source words."""
     # Add test data with different language pairs
     client.post(
@@ -283,8 +297,8 @@ def test_get_word_alignments_by_language_pair(client, regular_token1, db_session
         json={
             "source_word": "book",
             "target_word": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     client.post(
@@ -293,14 +307,14 @@ def test_get_word_alignments_by_language_pair(client, regular_token1, db_session
         json={
             "source_word": "book",
             "target_word": "ɓuuɗu",
-            "source_language": "eng",
-            "target_language": "ngq",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
-    # Filter by language pair and source word
+    # Filter by version pair and source word
     response = client.get(
-        "/v3/agent/word-alignment?source_language=eng&target_language=ngq&source_words=book",
+        f"/v3/agent/word-alignment?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_words=book",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -308,13 +322,13 @@ def test_get_word_alignments_by_language_pair(client, regular_token1, db_session
     data = response.json()
     assert len(data) >= 1
     for alignment in data:
-        assert alignment["source_language"] == "eng"
-        assert alignment["target_language"] == "ngq"
+        assert alignment["source_version_id"] == test_version_id
+        assert alignment["target_version_id"] == test_version_id_2
         assert alignment["source_word"] == "book"
 
 
 def test_get_word_alignments_both_source_and_target_words(
-    client, regular_token1, db_session
+    client, regular_token1, db_session, test_version_id, test_version_id_2
 ):
     """Test getting word alignments with both source and target word filters."""
     # Add test data
@@ -324,8 +338,8 @@ def test_get_word_alignments_both_source_and_target_words(
         json={
             "source_word": "book",
             "target_word": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     client.post(
@@ -334,8 +348,8 @@ def test_get_word_alignments_both_source_and_target_words(
         json={
             "source_word": "book",
             "target_word": "ɓuuɗu",
-            "source_language": "eng",
-            "target_language": "ngq",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     client.post(
@@ -344,14 +358,14 @@ def test_get_word_alignments_both_source_and_target_words(
         json={
             "source_word": "house",
             "target_word": "nyumba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     # Filter by both source and target words
     response = client.get(
-        "/v3/agent/word-alignment?source_language=eng&target_language=swh&source_words=book&target_words=nyumba",
+        f"/v3/agent/word-alignment?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_words=book&target_words=nyumba",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -363,10 +377,12 @@ def test_get_word_alignments_both_source_and_target_words(
     assert any(a["target_word"] == "nyumba" for a in data)
 
 
-def test_get_word_alignments_empty_results(client, regular_token1, db_session):
+def test_get_word_alignments_empty_results(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test getting word alignments with no matching results."""
     response = client.get(
-        "/v3/agent/word-alignment?source_language=eng&target_language=swh&source_words=nonexistent",
+        f"/v3/agent/word-alignment?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_words=nonexistent",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -376,10 +392,12 @@ def test_get_word_alignments_empty_results(client, regular_token1, db_session):
     assert len(data) == 0
 
 
-def test_get_word_alignments_missing_words(client, regular_token1, db_session):
+def test_get_word_alignments_missing_words(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test that getting word alignments requires at least one word filter."""
     response = client.get(
-        "/v3/agent/word-alignment?source_language=eng&target_language=swh",
+        f"/v3/agent/word-alignment?source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -398,22 +416,24 @@ def test_get_word_alignments_missing_languages(client, regular_token1, db_sessio
     assert response.status_code == 422  # Validation error for missing required params
 
 
-def test_get_word_alignments_unauthorized(client):
+def test_get_word_alignments_unauthorized(client, test_version_id, test_version_id_2):
     """Test that getting word alignments requires authentication."""
     response = client.get(
-        "/v3/agent/word-alignment?source_language=eng&target_language=swh&source_words=book"
+        f"/v3/agent/word-alignment?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_words=book"
     )
 
     assert response.status_code == 401
 
 
-def test_add_word_alignment_with_score(client, regular_token1, db_session):
+def test_add_word_alignment_with_score(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test adding a word alignment with a score field."""
     alignment_data = {
         "source_word": "faith",
         "target_word": "imani",
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "score": 0.87,
         "is_human_verified": False,
     }
@@ -440,13 +460,15 @@ def test_add_word_alignment_with_score(client, regular_token1, db_session):
     assert alignment.score == 0.87
 
 
-def test_add_word_alignment_default_score(client, regular_token1, db_session):
+def test_add_word_alignment_default_score(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test that score defaults to 0.0 when not provided."""
     alignment_data = {
         "source_word": "grace",
         "target_word": "neema",
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
     }
 
     response = client.post(
@@ -460,11 +482,13 @@ def test_add_word_alignment_default_score(client, regular_token1, db_session):
     assert data["score"] == 0.0
 
 
-def test_bulk_word_alignment_insert(client, regular_token1, db_session):
+def test_bulk_word_alignment_insert(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test bulk inserting new word alignments."""
     bulk_data = {
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "alignments": [
             {"source_word": "water", "target_word": "maji", "score": 0.95},
             {"source_word": "fire", "target_word": "moto", "score": 0.92},
@@ -489,12 +513,14 @@ def test_bulk_word_alignment_insert(client, regular_token1, db_session):
     assert scores["earth"] == 0.88
 
 
-def test_bulk_word_alignment_upsert(client, regular_token1, db_session):
+def test_bulk_word_alignment_upsert(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test that bulk endpoint updates existing alignments."""
     # First, insert some alignments
     initial_data = {
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "alignments": [
             {"source_word": "sky", "target_word": "anga", "score": 0.70},
             {"source_word": "cloud", "target_word": "wingu", "score": 0.75},
@@ -512,8 +538,8 @@ def test_bulk_word_alignment_upsert(client, regular_token1, db_session):
 
     # Now upsert with updated scores and a new alignment
     update_data = {
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "alignments": [
             {"source_word": "sky", "target_word": "anga", "score": 0.95},  # Update
             {"source_word": "cloud", "target_word": "wingu", "score": 0.90},  # Update
@@ -542,11 +568,13 @@ def test_bulk_word_alignment_upsert(client, regular_token1, db_session):
     assert results["cloud"]["id"] == initial_ids["cloud"]
 
 
-def test_bulk_word_alignment_empty(client, regular_token1):
+def test_bulk_word_alignment_empty(
+    client, regular_token1, test_version_id, test_version_id_2
+):
     """Test bulk endpoint with empty alignments list."""
     bulk_data = {
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "alignments": [],
     }
 
@@ -560,13 +588,15 @@ def test_bulk_word_alignment_empty(client, regular_token1):
     assert response.json() == []
 
 
-def test_get_all_word_alignments(client, regular_token1, db_session):
+def test_get_all_word_alignments(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test getting all word alignments for a language pair."""
     # Insert some alignments with different scores using swh->eng direction
     # to differentiate from other tests that use eng->swh
     bulk_data = {
-        "source_language": "swh",
-        "target_language": "eng",
+        "source_version_id": test_version_id_2,
+        "target_version_id": test_version_id,
         "alignments": [
             {"source_word": "habari", "target_word": "hello", "score": 0.99},
             {"source_word": "kwaheri", "target_word": "goodbye", "score": 0.95},
@@ -583,7 +613,7 @@ def test_get_all_word_alignments(client, regular_token1, db_session):
 
     # Get all alignments
     response = client.get(
-        f"{prefix}/agent/word-alignment/all?source_language=swh&target_language=eng",
+        f"{prefix}/agent/word-alignment/all?source_version_id={test_version_id_2}&target_version_id={test_version_id}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -596,13 +626,15 @@ def test_get_all_word_alignments(client, regular_token1, db_session):
     assert scores == sorted(scores, reverse=True)
 
 
-def test_get_all_word_alignments_with_pagination(client, regular_token1, db_session):
+def test_get_all_word_alignments_with_pagination(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test getting word alignments with pagination."""
     # First, clear any existing eng->swh alignments that might interfere
     # by using unique source words
     bulk_data = {
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "alignments": [
             {"source_word": "pagination_one", "target_word": "moja_pag", "score": 0.91},
             {
@@ -633,7 +665,7 @@ def test_get_all_word_alignments_with_pagination(client, regular_token1, db_sess
 
     # Get page 1 with page_size=2 - filter by looking at results
     response = client.get(
-        f"{prefix}/agent/word-alignment/all?source_language=eng&target_language=swh&page=1&page_size=2",
+        f"{prefix}/agent/word-alignment/all?source_version_id={test_version_id}&target_version_id={test_version_id_2}&page=1&page_size=2",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -645,7 +677,7 @@ def test_get_all_word_alignments_with_pagination(client, regular_token1, db_sess
 
     # Get page 2
     response = client.get(
-        f"{prefix}/agent/word-alignment/all?source_language=eng&target_language=swh&page=2&page_size=2",
+        f"{prefix}/agent/word-alignment/all?source_version_id={test_version_id}&target_version_id={test_version_id_2}&page=2&page_size=2",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -656,10 +688,12 @@ def test_get_all_word_alignments_with_pagination(client, regular_token1, db_sess
     assert data[0]["score"] >= data[1]["score"]
 
 
-def test_get_all_word_alignments_invalid_page(client, regular_token1):
+def test_get_all_word_alignments_invalid_page(
+    client, regular_token1, test_version_id, test_version_id_2
+):
     """Test that invalid page parameter returns error."""
     response = client.get(
-        f"{prefix}/agent/word-alignment/all?source_language=eng&target_language=swh&page=0&page_size=10",
+        f"{prefix}/agent/word-alignment/all?source_version_id={test_version_id}&target_version_id={test_version_id_2}&page=0&page_size=10",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -667,10 +701,12 @@ def test_get_all_word_alignments_invalid_page(client, regular_token1):
     assert "Page must be >= 1" in response.json()["detail"]
 
 
-def test_get_all_word_alignments_unauthorized(client):
+def test_get_all_word_alignments_unauthorized(
+    client, test_version_id, test_version_id_2
+):
     """Test that getting all word alignments requires authentication."""
     response = client.get(
-        f"{prefix}/agent/word-alignment/all?source_language=eng&target_language=swh"
+        f"{prefix}/agent/word-alignment/all?source_version_id={test_version_id}&target_version_id={test_version_id_2}"
     )
 
     assert response.status_code == 401
@@ -679,7 +715,14 @@ def test_get_all_word_alignments_unauthorized(client):
 # Lexeme Card Tests
 
 
-def test_add_lexeme_card_success(client, regular_token1, db_session, test_revision_id):
+def test_add_lexeme_card_success(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
     """Test successfully adding a lexeme card with all fields."""
     response = client.post(
         f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
@@ -687,8 +730,8 @@ def test_add_lexeme_card_success(client, regular_token1, db_session, test_revisi
         json={
             "source_lemma": "love",
             "target_lemma": "upendo",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "noun",
             "surface_forms": ["upendo", "mapendo"],  # Target language (Swahili) forms
             "senses": [
@@ -707,8 +750,8 @@ def test_add_lexeme_card_success(client, regular_token1, db_session, test_revisi
     data = response.json()
     assert data["source_lemma"] == "love"
     assert data["target_lemma"] == "upendo"
-    assert data["source_language"] == "eng"
-    assert data["target_language"] == "swh"
+    assert data["source_version_id"] == test_version_id
+    assert data["target_version_id"] == test_version_id_2
     assert data["pos"] == "noun"
     assert len(data["surface_forms"]) == 2
     assert len(data["senses"]) == 2
@@ -720,7 +763,12 @@ def test_add_lexeme_card_success(client, regular_token1, db_session, test_revisi
 
 
 def test_add_lexeme_card_minimal_fields(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test adding a lexeme card with only required fields."""
     response = client.post(
@@ -728,16 +776,16 @@ def test_add_lexeme_card_minimal_fields(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     assert response.status_code == 200
     data = response.json()
     assert data["target_lemma"] == "kitabu"
-    assert data["source_language"] == "eng"
-    assert data["target_language"] == "swh"
+    assert data["source_version_id"] == test_version_id
+    assert data["target_version_id"] == test_version_id_2
     assert data["source_lemma"] is None
     assert data["pos"] is None
     assert data["surface_forms"] is None
@@ -747,7 +795,12 @@ def test_add_lexeme_card_minimal_fields(
 
 
 def test_add_lexeme_card_with_pos_and_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test adding a lexeme card with part of speech and surface forms."""
     response = client.post(
@@ -756,8 +809,8 @@ def test_add_lexeme_card_with_pos_and_forms(
         json={
             "source_lemma": "run",
             "target_lemma": "kimbia",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "surface_forms": [
                 "kimbia",
@@ -779,7 +832,12 @@ def test_add_lexeme_card_with_pos_and_forms(
 
 
 def test_add_lexeme_card_with_source_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test adding a lexeme card with source surface forms."""
     response = client.post(
@@ -788,8 +846,8 @@ def test_add_lexeme_card_with_source_surface_forms(
         json={
             "source_lemma": "love",
             "target_lemma": "kupenda",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "surface_forms": [
                 "kupenda",
@@ -822,7 +880,12 @@ def test_add_lexeme_card_with_source_surface_forms(
 
 
 def test_add_lexeme_card_with_senses(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test adding a lexeme card with multiple senses."""
     response = client.post(
@@ -830,8 +893,8 @@ def test_add_lexeme_card_with_senses(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "mti",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "senses": [
                 {
                     "definition": "a woody perennial plant",
@@ -850,14 +913,16 @@ def test_add_lexeme_card_with_senses(
     assert data["senses"][1]["definition"] == "a wooden structure"
 
 
-def test_add_lexeme_card_unauthorized(client, test_revision_id):
+def test_add_lexeme_card_unauthorized(
+    client, test_revision_id, test_version_id, test_version_id_2
+):
     """Test that adding a lexeme card requires authentication."""
     response = client.post(
         f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
         json={
             "target_lemma": "test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
@@ -865,7 +930,7 @@ def test_add_lexeme_card_unauthorized(client, test_revision_id):
 
 
 def test_add_lexeme_card_missing_required_fields(
-    client, regular_token1, db_session, test_revision_id
+    client, regular_token1, db_session, test_revision_id, test_version_id
 ):
     """Test that adding a lexeme card without required fields fails."""
     response = client.post(
@@ -873,33 +938,39 @@ def test_add_lexeme_card_missing_required_fields(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "source_lemma": "test",
-            "source_language": "eng",
-            # Missing target_lemma and target_language
+            "source_version_id": test_version_id,
+            # Missing target_lemma and target_version_id
         },
     )
 
     assert response.status_code == 422  # Validation error
 
 
-def test_add_lexeme_card_invalid_language(
+def test_add_lexeme_card_invalid_version_id(
     client, regular_token1, db_session, test_revision_id
 ):
-    """Test that adding a lexeme card with invalid language code fails."""
+    """Lexeme card with non-existent version_id values returns 500 (FK violation)."""
     response = client.post(
         f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "test",
-            "source_language": "invalid",
-            "target_language": "codes",
+            "source_version_id": 999999,
+            "target_version_id": 999998,
         },
     )
 
-    assert response.status_code == 500  # Database foreign key constraint error
+    # FK constraint violation surfaces as 500 — bible_version 999999 doesn't exist.
+    assert response.status_code == 500
 
 
 def test_add_lexeme_card_different_languages(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test adding lexeme cards with different language pairs."""
     response = client.post(
@@ -908,8 +979,8 @@ def test_add_lexeme_card_different_languages(
         json={
             "source_lemma": "water",
             "target_lemma": "njam",
-            "source_language": "eng",
-            "target_language": "ngq",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "noun",
             "confidence": 0.88,
         },
@@ -919,13 +990,18 @@ def test_add_lexeme_card_different_languages(
     data = response.json()
     assert data["source_lemma"] == "water"
     assert data["target_lemma"] == "njam"
-    assert data["source_language"] == "eng"
-    assert data["target_language"] == "ngq"
+    assert data["source_version_id"] == test_version_id
+    assert data["target_version_id"] == test_version_id_2
     assert data["confidence"] == 0.88
 
 
 def test_get_lexeme_cards_by_language_pair(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test getting lexeme cards filtered by language pair."""
     # Add test data
@@ -935,8 +1011,8 @@ def test_get_lexeme_cards_by_language_pair(
         json={
             "source_lemma": "book",
             "target_lemma": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.95,
         },
     )
@@ -946,15 +1022,15 @@ def test_get_lexeme_cards_by_language_pair(
         json={
             "source_lemma": "house",
             "target_lemma": "nyumba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.88,
         },
     )
 
     # Get lexeme cards by language pair
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -969,7 +1045,12 @@ def test_get_lexeme_cards_by_language_pair(
 
 
 def test_get_lexeme_cards_ordered_by_confidence(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that lexeme cards are returned ordered by confidence descending."""
     # Add test data with different confidence scores
@@ -978,8 +1059,8 @@ def test_get_lexeme_cards_ordered_by_confidence(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "low_conf",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.60,
         },
     )
@@ -988,8 +1069,8 @@ def test_get_lexeme_cards_ordered_by_confidence(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "high_conf",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.95,
         },
     )
@@ -998,15 +1079,15 @@ def test_get_lexeme_cards_ordered_by_confidence(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "med_conf",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.75,
         },
     )
 
     # Get all cards
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1028,7 +1109,12 @@ def test_get_lexeme_cards_ordered_by_confidence(
 
 
 def test_get_lexeme_cards_by_source_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test getting lexeme cards filtered by source lemma."""
     # Add test data
@@ -1038,8 +1124,8 @@ def test_get_lexeme_cards_by_source_lemma(
         json={
             "source_lemma": "run",
             "target_lemma": "kimbia",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
         },
     )
@@ -1049,15 +1135,15 @@ def test_get_lexeme_cards_by_source_lemma(
         json={
             "source_lemma": "walk",
             "target_lemma": "tembea",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
         },
     )
 
     # Filter by source lemma
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=run",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=run",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1068,7 +1154,12 @@ def test_get_lexeme_cards_by_source_lemma(
 
 
 def test_get_lexeme_cards_by_target_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test getting lexeme cards filtered by target lemma."""
     # Add test data
@@ -1078,14 +1169,14 @@ def test_get_lexeme_cards_by_target_lemma(
         json={
             "source_lemma": "love",
             "target_lemma": "upendo",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     # Filter by target lemma
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=upendo",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=upendo",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1096,7 +1187,12 @@ def test_get_lexeme_cards_by_target_lemma(
 
 
 def test_get_lexeme_cards_by_target_words(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test filtering lexeme cards by comma-separated target_words."""
     # Add test data with unique lemmas for this test
@@ -1107,14 +1203,14 @@ def test_get_lexeme_cards_by_target_words(
             json={
                 "source_lemma": f"src_{lemma}",
                 "target_lemma": lemma,
-                "source_language": "eng",
-                "target_language": "swh",
+                "source_version_id": test_version_id,
+                "target_version_id": test_version_id_2,
             },
         )
 
     # Filter by two of three target words
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=tw_maji,tw_moto",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_words=tw_maji,tw_moto",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1127,7 +1223,12 @@ def test_get_lexeme_cards_by_target_words(
 
 
 def test_get_lexeme_cards_target_words_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that target_words also matches surface_forms."""
     client.post(
@@ -1136,15 +1237,15 @@ def test_get_lexeme_cards_target_words_surface_forms(
         json={
             "source_lemma": "run_tw_sf",
             "target_lemma": "kimbia_tw_sf",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["anakimbia_tw_sf", "walikimbia_tw_sf"],
         },
     )
 
     # Search by a surface form, not the lemma
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=anakimbia_tw_sf",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_words=anakimbia_tw_sf",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1155,7 +1256,12 @@ def test_get_lexeme_cards_target_words_surface_forms(
 
 
 def test_get_lexeme_cards_target_words_case_insensitive(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that target_words matching is case-insensitive."""
     client.post(
@@ -1164,13 +1270,13 @@ def test_get_lexeme_cards_target_words_case_insensitive(
         json={
             "source_lemma": "god_tw_ci",
             "target_lemma": "tw_mungu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=TW_MUNGU",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_words=TW_MUNGU",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1180,11 +1286,11 @@ def test_get_lexeme_cards_target_words_case_insensitive(
 
 
 def test_get_lexeme_cards_target_words_conflicts_with_target_word(
-    client, regular_token1, db_session
+    client, regular_token1, db_session, test_version_id, test_version_id_2
 ):
     """Test that using both target_word and target_words returns 400."""
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=foo&target_words=bar",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=foo&target_words=bar",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1193,11 +1299,11 @@ def test_get_lexeme_cards_target_words_conflicts_with_target_word(
 
 
 def test_get_lexeme_cards_target_words_all_blank_returns_400(
-    client, regular_token1, db_session
+    client, regular_token1, db_session, test_version_id, test_version_id_2
 ):
     """Test that target_words with only blanks/commas returns 400."""
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=%20,%20,",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_words=%20,%20,",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1206,11 +1312,11 @@ def test_get_lexeme_cards_target_words_all_blank_returns_400(
 
 
 def test_get_lexeme_cards_target_words_empty_string_returns_400(
-    client, regular_token1, db_session
+    client, regular_token1, db_session, test_version_id, test_version_id_2
 ):
     """Test that target_words with an explicit empty value returns 400."""
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_words=",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_words=",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1218,7 +1324,14 @@ def test_get_lexeme_cards_target_words_empty_string_returns_400(
     assert "no valid words" in response.json()["detail"]
 
 
-def test_get_lexeme_cards_by_pos(client, regular_token1, db_session, test_revision_id):
+def test_get_lexeme_cards_by_pos(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
     """Test getting lexeme cards filtered by part of speech."""
     # Add test data
     client.post(
@@ -1226,8 +1339,8 @@ def test_get_lexeme_cards_by_pos(client, regular_token1, db_session, test_revisi
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "verb_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
         },
     )
@@ -1236,15 +1349,15 @@ def test_get_lexeme_cards_by_pos(client, regular_token1, db_session, test_revisi
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "noun_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "noun",
         },
     )
 
     # Filter by POS
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&pos=verb",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&pos=verb",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1255,7 +1368,12 @@ def test_get_lexeme_cards_by_pos(client, regular_token1, db_session, test_revisi
 
 
 def test_get_lexeme_cards_combined_filters(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test getting lexeme cards with multiple filters combined."""
     # Add test data
@@ -1265,8 +1383,8 @@ def test_get_lexeme_cards_combined_filters(
         json={
             "source_lemma": "eat",
             "target_lemma": "kula",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "confidence": 0.92,
         },
@@ -1277,8 +1395,8 @@ def test_get_lexeme_cards_combined_filters(
         json={
             "source_lemma": "eat",
             "target_lemma": "chakula",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "noun",
             "confidence": 0.85,
         },
@@ -1286,7 +1404,7 @@ def test_get_lexeme_cards_combined_filters(
 
     # Filter by source lemma and POS
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=eat&pos=verb",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=eat&pos=verb",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1298,10 +1416,12 @@ def test_get_lexeme_cards_combined_filters(
         assert card["pos"] == "verb"
 
 
-def test_get_lexeme_cards_empty_results(client, regular_token1, db_session):
+def test_get_lexeme_cards_empty_results(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test getting lexeme cards with no matching results."""
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=nonexistent",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=nonexistent",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1324,17 +1444,22 @@ def test_get_lexeme_cards_missing_languages(client, regular_token1, db_session):
     assert response.status_code == 422  # Validation error for missing required params
 
 
-def test_get_lexeme_cards_unauthorized(client):
+def test_get_lexeme_cards_unauthorized(client, test_version_id, test_version_id_2):
     """Test that getting lexeme cards requires authentication."""
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh"
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}"
     )
 
     assert response.status_code == 401
 
 
 def test_get_lexeme_cards_surface_forms_filtering(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that target_word matches both surface_forms and target_lemma."""
     # Add card 1: has "cheza" in surface_forms
@@ -1344,8 +1469,8 @@ def test_get_lexeme_cards_surface_forms_filtering(
         json={
             "source_lemma": "play",
             "target_lemma": "kucheza",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["cheza", "anacheza"],
             "confidence": 0.9,
         },
@@ -1360,8 +1485,8 @@ def test_get_lexeme_cards_surface_forms_filtering(
         json={
             "source_lemma": "dance",
             "target_lemma": "cheza",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["dansa", "anadansa"],
             "confidence": 0.8,
         },
@@ -1376,8 +1501,8 @@ def test_get_lexeme_cards_surface_forms_filtering(
         json={
             "source_lemma": "game",
             "target_lemma": "mchezo",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["mchezo"],
             "examples": [{"source": "Let's play", "target": "Tunacheza sana"}],
             "confidence": 0.85,
@@ -1389,7 +1514,7 @@ def test_get_lexeme_cards_surface_forms_filtering(
     # target_word=cheza should match card1 (surface_forms) and card2 (target_lemma)
     # but NOT card3 (only in example text)
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=cheza",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=cheza",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
@@ -1401,7 +1526,12 @@ def test_get_lexeme_cards_surface_forms_filtering(
 
 
 def test_check_word_matches_target_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test checking if a word matches a target lemma."""
     # Add test data
@@ -1410,14 +1540,14 @@ def test_check_word_matches_target_lemma(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     # Check if word exists
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=kitabu&source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card/check-word?word=kitabu&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1428,7 +1558,12 @@ def test_check_word_matches_target_lemma(
 
 
 def test_check_word_matches_surface_form(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test checking if a word matches a surface form."""
     # Add test data with surface forms (use unique target_lemma to avoid conflicts)
@@ -1437,8 +1572,8 @@ def test_check_word_matches_surface_form(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "penda_surface_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": [
                 "penda_surface_test",
                 "anapenda_surface_test",
@@ -1450,7 +1585,7 @@ def test_check_word_matches_surface_form(
 
     # Check if surface form exists
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=anapenda_surface_test&source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card/check-word?word=anapenda_surface_test&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1461,7 +1596,12 @@ def test_check_word_matches_surface_form(
 
 
 def test_check_word_case_insensitive(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that word checking is case-insensitive."""
     # Add test data
@@ -1470,15 +1610,15 @@ def test_check_word_case_insensitive(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "Kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["Kitabu", "Vitabu"],  # Target language (Swahili) forms
         },
     )
 
     # Check with different case
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=kitabu&source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card/check-word?word=kitabu&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1489,7 +1629,7 @@ def test_check_word_case_insensitive(
 
     # Check surface form with different case
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=VITABU&source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card/check-word?word=VITABU&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1499,10 +1639,12 @@ def test_check_word_case_insensitive(
     assert data["count"] >= 1
 
 
-def test_check_word_not_found(client, regular_token1, db_session):
+def test_check_word_not_found(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test checking a word that doesn't exist."""
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=nonexistentword&source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card/check-word?word=nonexistentword&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1513,7 +1655,12 @@ def test_check_word_not_found(client, regular_token1, db_session):
 
 
 def test_check_word_multiple_matches(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test checking a word that appears in multiple lexeme cards."""
     # Add multiple cards with a shared surface form (use unique target_lemmas)
@@ -1522,8 +1669,8 @@ def test_check_word_multiple_matches(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "kimbia_multi_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["shared_form_multi", "anakimbia_multi"],
         },
     )
@@ -1532,15 +1679,15 @@ def test_check_word_multiple_matches(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "kukimbia_multi_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["kukimbia_multi", "shared_form_multi"],
         },
     )
 
     # Check word that appears in multiple cards
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=shared_form_multi&source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card/check-word?word=shared_form_multi&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1550,47 +1697,42 @@ def test_check_word_multiple_matches(
     assert data["count"] >= 2
 
 
-def test_check_word_filters_by_language(
-    client, regular_token1, db_session, test_revision_id
+def test_check_word_filters_by_version_pair(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
-    """Test that word checking filters by language pair."""
-    # Add card for eng-swh
+    """Word check filters by source/target version_id pair."""
+    # Add card for (test_version_id, test_version_id_2) — the one we'll search for.
     client.post(
         f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
-            "target_lemma": "test_eng_swh",
-            "source_language": "eng",
-            "target_language": "swh",
-        },
-    )
-    # Add card for eng-ngq
-    client.post(
-        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "target_lemma": "test_eng_ngq",
-            "source_language": "eng",
-            "target_language": "ngq",
+            "target_lemma": "test_pair_match",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
-    # Check word only exists in eng-swh
+    # Word exists in the (test_version_id, test_version_id_2) pair
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=test_eng_swh&source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card/check-word?word=test_pair_match&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
-
     assert response.status_code == 200
     data = response.json()
     assert data["count"] >= 1
 
-    # Check same word doesn't appear in eng-ngq
+    # Same word should not appear when querying a different version pair
+    # (target swapped to source). The card is keyed on the ordered pair, so
+    # a flipped query returns zero results.
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=test_eng_swh&source_language=eng&target_language=ngq",
+        f"/v3/agent/lexeme-card/check-word?word=test_pair_match&source_version_id={test_version_id_2}&target_version_id={test_version_id}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
-
     assert response.status_code == 200
     data = response.json()
     assert data["count"] == 0
@@ -1606,10 +1748,10 @@ def test_check_word_missing_parameters(client, regular_token1, db_session):
     assert response.status_code == 422  # Validation error
 
 
-def test_check_word_unauthorized(client):
+def test_check_word_unauthorized(client, test_version_id, test_version_id_2):
     """Test that checking word requires authentication."""
     response = client.get(
-        "/v3/agent/lexeme-card/check-word?word=test&source_language=eng&target_language=swh"
+        f"/v3/agent/lexeme-card/check-word?word=test&source_version_id={test_version_id}&target_version_id={test_version_id_2}"
     )
 
     assert response.status_code == 401
@@ -1619,7 +1761,12 @@ def test_check_word_unauthorized(client):
 
 
 def test_add_lexeme_card_upsert_append_default(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that posting duplicate lexeme card appends by default (replace_existing=False)."""
     # Add initial card
@@ -1629,8 +1776,8 @@ def test_add_lexeme_card_upsert_append_default(
         json={
             "source_lemma": "walk",
             "target_lemma": "tembea",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "surface_forms": ["tembea", "anatembea"],  # Target language (Swahili) forms
             "senses": [{"definition": "move on foot", "examples": ["I walk daily"]}],
@@ -1653,8 +1800,8 @@ def test_add_lexeme_card_upsert_append_default(
         json={
             "source_lemma": "walk",
             "target_lemma": "tembea",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "surface_forms": [
                 "wanatembea",
@@ -1697,14 +1844,19 @@ def test_add_lexeme_card_upsert_append_default(
 
 
 def test_add_lexeme_card_create_with_intra_payload_duplicates(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Creating a new card with duplicate examples in a single payload must not 500."""
     payload = {
         "source_lemma": "jump",
         "target_lemma": "ruka",
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "pos": "verb",
         "examples": [
             {"source": "I jump", "target": "Naruka"},
@@ -1724,7 +1876,12 @@ def test_add_lexeme_card_create_with_intra_payload_duplicates(
 
 
 def test_add_lexeme_card_upsert_append_duplicate_examples_no_500(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Regression for #517: appending examples that already exist for the same
     (lexeme_card_id, revision_id, source_text, target_text) must not 500 on the
@@ -1732,8 +1889,8 @@ def test_add_lexeme_card_upsert_append_duplicate_examples_no_500(
     payload = {
         "source_lemma": "run",
         "target_lemma": "kimbia",
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": test_version_id,
+        "target_version_id": test_version_id_2,
         "pos": "verb",
         "surface_forms": ["kimbia"],
         "examples": [
@@ -1796,7 +1953,12 @@ def test_add_lexeme_card_upsert_append_duplicate_examples_no_500(
 
 
 def test_add_lexeme_card_upsert_append_explicit(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test explicitly setting replace_existing=false appends data."""
     # Add initial card
@@ -1806,8 +1968,8 @@ def test_add_lexeme_card_upsert_append_explicit(
         json={
             "source_lemma": "sing",
             "target_lemma": "imba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["imba", "anaimba"],  # Target language (Swahili) forms
             "senses": [{"definition": "produce musical sounds"}],
             "examples": [{"source": "I sing", "target": "Naimba"}],
@@ -1824,8 +1986,8 @@ def test_add_lexeme_card_upsert_append_explicit(
         json={
             "source_lemma": "sing",
             "target_lemma": "imba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["wanaimba", "aliimba"],  # Target language (Swahili) forms
             "senses": [{"definition": "vocalize melodically"}],
             "examples": [{"source": "She sings", "target": "Anaimba"}],
@@ -1842,7 +2004,12 @@ def test_add_lexeme_card_upsert_append_explicit(
 
 
 def test_add_lexeme_card_upsert_replace(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that replace_existing=true replaces list fields."""
     # Add initial card
@@ -1852,8 +2019,8 @@ def test_add_lexeme_card_upsert_replace(
         json={
             "source_lemma": "dance",
             "target_lemma": "cheza",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "surface_forms": [
                 "cheza",
@@ -1880,8 +2047,8 @@ def test_add_lexeme_card_upsert_replace(
         json={
             "source_lemma": "dance",
             "target_lemma": "cheza",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "surface_forms": [
                 "cheza",
@@ -1924,7 +2091,12 @@ def test_add_lexeme_card_upsert_replace(
 
 
 def test_add_lexeme_card_upsert_source_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that source_surface_forms are properly merged on upsert."""
     # Add initial card with source_surface_forms
@@ -1934,8 +2106,8 @@ def test_add_lexeme_card_upsert_source_surface_forms(
         json={
             "source_lemma": "write",
             "target_lemma": "andika",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "surface_forms": ["andika", "anaandika"],
             "source_surface_forms": ["write", "writes", "writing"],
@@ -1955,8 +2127,8 @@ def test_add_lexeme_card_upsert_source_surface_forms(
         json={
             "source_lemma": "write",
             "target_lemma": "andika",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["write", "wrote", "written"],  # "write" overlaps
         },
     )
@@ -1981,8 +2153,8 @@ def test_add_lexeme_card_upsert_source_surface_forms(
         json={
             "source_lemma": "write",
             "target_lemma": "andika",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["write", "wrote"],  # Replace with just 2 forms
         },
     )
@@ -1995,7 +2167,12 @@ def test_add_lexeme_card_upsert_source_surface_forms(
 
 
 def test_add_lexeme_card_upsert_append_deduplicates_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that appending surface forms deduplicates entries."""
     # Add initial card
@@ -2005,8 +2182,8 @@ def test_add_lexeme_card_upsert_append_deduplicates_surface_forms(
         json={
             "source_lemma": "jump",
             "target_lemma": "ruka",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": [
                 "ruka",
                 "anaruka",
@@ -2022,8 +2199,8 @@ def test_add_lexeme_card_upsert_append_deduplicates_surface_forms(
         json={
             "source_lemma": "jump",
             "target_lemma": "ruka",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": [
                 "ruka",
                 "aliruka",
@@ -2041,7 +2218,12 @@ def test_add_lexeme_card_upsert_append_deduplicates_surface_forms(
 
 
 def test_add_lexeme_card_upsert_append_with_none_values(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test appending when some fields are None."""
     # Add initial card with None values
@@ -2051,8 +2233,8 @@ def test_add_lexeme_card_upsert_append_with_none_values(
         json={
             "source_lemma": "sleep",
             "target_lemma": "lala",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": None,
             "senses": [{"definition": "rest with eyes closed"}],
             "examples": None,
@@ -2069,8 +2251,8 @@ def test_add_lexeme_card_upsert_append_with_none_values(
         json={
             "source_lemma": "sleep",
             "target_lemma": "lala",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["lala", "analala"],  # Target language (Swahili) forms
             "senses": None,
             "examples": [{"source": "I sleep", "target": "Nalala"}],
@@ -2090,7 +2272,12 @@ def test_add_lexeme_card_upsert_append_with_none_values(
 
 
 def test_add_lexeme_card_upsert_replace_with_none_values(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test replacing when new data has None values."""
     # Add initial card
@@ -2100,8 +2287,8 @@ def test_add_lexeme_card_upsert_replace_with_none_values(
         json={
             "source_lemma": "eat",
             "target_lemma": "kula",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": [
                 "kula",
                 "anakula",
@@ -2122,8 +2309,8 @@ def test_add_lexeme_card_upsert_replace_with_none_values(
         json={
             "source_lemma": "eat",
             "target_lemma": "kula",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": None,
             "senses": None,
             "examples": None,
@@ -2145,7 +2332,12 @@ def test_add_lexeme_card_upsert_replace_with_none_values(
 
 
 def test_add_lexeme_card_upsert_updates_last_updated(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that updating a card updates the last_updated timestamp."""
     import time
@@ -2157,8 +2349,8 @@ def test_add_lexeme_card_upsert_updates_last_updated(
         json={
             "source_lemma": "fly",
             "target_lemma": "ruka_timestamp_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
@@ -2176,8 +2368,8 @@ def test_add_lexeme_card_upsert_updates_last_updated(
         json={
             "source_lemma": "fly",
             "target_lemma": "ruka_timestamp_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.88,
         },
     )
@@ -2192,11 +2384,16 @@ def test_add_lexeme_card_upsert_updates_last_updated(
 
 
 def test_add_lexeme_card_upsert_different_unique_keys(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that cards with different unique constraint values are treated separately.
 
-    Uniqueness is determined by (target_lemma, source_language, target_language).
+    Uniqueness is determined by (target_lemma, source_version_id, target_version_id).
     """
     # Add card 1: eng->swh (use unique target_lemma to avoid conflicts with other tests)
     response1 = client.post(
@@ -2205,8 +2402,8 @@ def test_add_lexeme_card_upsert_different_unique_keys(
         json={
             "source_lemma": "book",
             "target_lemma": "kitabu_unique_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["kitabu"],
         },
     )
@@ -2221,8 +2418,8 @@ def test_add_lexeme_card_upsert_different_unique_keys(
         json={
             "source_lemma": "book",
             "target_lemma": "buku_unique_test",  # Different target_lemma
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["buku"],
         },
     )
@@ -2233,7 +2430,7 @@ def test_add_lexeme_card_upsert_different_unique_keys(
     # Should be different cards
     assert card1_id != card2_id
 
-    # Add card 3 with different source_language (different unique key)
+    # Add card 3 with different source_version_id (different unique key)
     # Using swh->eng instead of eng->swh
     response3 = client.post(
         f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
@@ -2241,8 +2438,8 @@ def test_add_lexeme_card_upsert_different_unique_keys(
         json={
             "source_lemma": "kitabu",
             "target_lemma": "kitabu_unique_test",  # Same target_lemma as card 1
-            "source_language": "swh",  # Different source_language
-            "target_language": "eng",  # Different target_language
+            "source_version_id": test_version_id_2,  # Different source_version_id
+            "target_version_id": test_version_id,  # Different target_version_id
             "surface_forms": ["kitabu"],
         },
     )
@@ -2255,7 +2452,12 @@ def test_add_lexeme_card_upsert_different_unique_keys(
 
 
 def test_add_lexeme_card_upsert_empty_lists(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test appending with empty lists."""
     # Add initial card (use unique target_lemma to avoid conflicts with other tests)
@@ -2265,8 +2467,8 @@ def test_add_lexeme_card_upsert_empty_lists(
         json={
             "source_lemma": "play",
             "target_lemma": "cheza_empty_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["cheza", "anacheza"],  # Target language (Swahili) forms
             "senses": [{"definition": "engage in activity"}],
         },
@@ -2282,8 +2484,8 @@ def test_add_lexeme_card_upsert_empty_lists(
         json={
             "source_lemma": "play",
             "target_lemma": "cheza_empty_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": [],  # Empty list
             "senses": [],  # Empty list
             "examples": [],  # Empty list
@@ -2300,7 +2502,13 @@ def test_add_lexeme_card_upsert_empty_lists(
 
 
 def test_add_lexeme_card_multiple_revisions(
-    client, regular_token1, db_session, test_revision_id, test_revision_id_2
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_revision_id_2,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that examples are properly isolated by revision_id."""
     # Add lexeme card with examples for revision 1
@@ -2310,8 +2518,8 @@ def test_add_lexeme_card_multiple_revisions(
         json={
             "source_lemma": "house",
             "target_lemma": "nyumba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "noun",
             "surface_forms": ["nyumba", "nyumba"],
             "senses": [{"definition": "dwelling place"}],
@@ -2339,8 +2547,8 @@ def test_add_lexeme_card_multiple_revisions(
         json={
             "source_lemma": "house",
             "target_lemma": "nyumba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "examples": [
                 {"source": "A red house", "target": "Nyumba nyekundu"},
                 {"source": "Small house", "target": "Nyumba ndogo"},
@@ -2364,7 +2572,7 @@ def test_add_lexeme_card_multiple_revisions(
     # Query the card - should now get examples from ALL revisions the user has access to
     # Since testuser1 has access to both revision 1 and revision 2, we should see all 5 examples
     response3 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=nyumba",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=nyumba",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2388,7 +2596,12 @@ def test_add_lexeme_card_multiple_revisions(
 
 
 def test_get_lexeme_cards_by_source_word_in_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test searching for source_word that matches source_lemma."""
     # Add test data
@@ -2398,15 +2611,15 @@ def test_get_lexeme_cards_by_source_word_in_lemma(
         json={
             "source_lemma": "walk",
             "target_lemma": "tembea",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.90,
         },
     )
 
     # Search by source_word matching source_lemma
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=walk",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=walk",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2417,7 +2630,12 @@ def test_get_lexeme_cards_by_source_word_in_lemma(
 
 
 def test_get_lexeme_cards_by_target_word_in_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test searching for target_word that matches target_lemma."""
     # Add test data
@@ -2427,15 +2645,15 @@ def test_get_lexeme_cards_by_target_word_in_lemma(
         json={
             "source_lemma": "sing",
             "target_lemma": "imba",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.85,
         },
     )
 
     # Search by target_word matching target_lemma
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=imba",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=imba",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2446,7 +2664,12 @@ def test_get_lexeme_cards_by_target_word_in_lemma(
 
 
 def test_get_lexeme_cards_by_source_word_in_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test searching for source_word that matches source_surface_forms."""
     # Add test data with source_surface_forms
@@ -2456,8 +2679,8 @@ def test_get_lexeme_cards_by_source_word_in_surface_forms(
         json={
             "source_lemma": "love_sf_test",
             "target_lemma": "penda_sf_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["loves_sf", "loved_sf", "loving_sf"],
             "confidence": 0.95,
         },
@@ -2465,7 +2688,7 @@ def test_get_lexeme_cards_by_source_word_in_surface_forms(
 
     # Search by source_word matching a source_surface_form
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=loves_sf",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=loves_sf",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2477,7 +2700,12 @@ def test_get_lexeme_cards_by_source_word_in_surface_forms(
 
 
 def test_get_lexeme_cards_by_target_word_in_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test searching for target_word that matches surface_forms."""
     # Add test data with surface_forms
@@ -2487,8 +2715,8 @@ def test_get_lexeme_cards_by_target_word_in_surface_forms(
         json={
             "source_lemma": "peace",
             "target_lemma": "amani_sf_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["amani_sf", "maamani_sf"],
             "confidence": 0.88,
         },
@@ -2496,7 +2724,7 @@ def test_get_lexeme_cards_by_target_word_in_surface_forms(
 
     # Search by target_word matching a surface_form
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=amani_sf",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=amani_sf",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2508,7 +2736,12 @@ def test_get_lexeme_cards_by_target_word_in_surface_forms(
 
 
 def test_get_lexeme_cards_word_search_or_logic(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that word search matches EITHER lemma OR surface_forms (OR logic)."""
     # Add card 1: source_lemma matches "jog_or_test"
@@ -2518,8 +2751,8 @@ def test_get_lexeme_cards_word_search_or_logic(
         json={
             "source_lemma": "jog_or_test",
             "target_lemma": "kimbia_or_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.90,
         },
     )
@@ -2531,8 +2764,8 @@ def test_get_lexeme_cards_word_search_or_logic(
         json={
             "source_lemma": "sprint_or_test",
             "target_lemma": "kukimbia_or_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["jog_or_test", "sprints_or"],
             "confidence": 0.85,
         },
@@ -2540,7 +2773,7 @@ def test_get_lexeme_cards_word_search_or_logic(
 
     # Search for "jog_or_test" - should find both cards (first by lemma, second by surface_forms)
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=jog_or_test",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=jog_or_test",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2553,7 +2786,12 @@ def test_get_lexeme_cards_word_search_or_logic(
 
 
 def test_get_lexeme_cards_word_search_case_insensitive(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that word search is case-insensitive for lemma and surface_forms."""
     # Add test data with mixed-case surface_forms
@@ -2563,8 +2801,8 @@ def test_get_lexeme_cards_word_search_case_insensitive(
         json={
             "source_lemma": "Lord",
             "target_lemma": "Bwana",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["LORD", "Lord"],
             "surface_forms": ["BWANA", "Bwana"],
             "confidence": 0.92,
@@ -2573,7 +2811,7 @@ def test_get_lexeme_cards_word_search_case_insensitive(
 
     # Search for lowercase "lord" — should match "Lord" lemma (case-insensitive)
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=lord",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=lord",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2585,7 +2823,7 @@ def test_get_lexeme_cards_word_search_case_insensitive(
 
     # Search for lowercase "bwana" — should match "bwana" target_lemma (normalized to lowercase)
     response2 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=bwana",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=bwana",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2597,7 +2835,12 @@ def test_get_lexeme_cards_word_search_case_insensitive(
 
 
 def test_get_lexeme_cards_word_search_partial_match(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that partial word matches do NOT return results (exact match only)."""
     # Add test data
@@ -2607,8 +2850,8 @@ def test_get_lexeme_cards_word_search_partial_match(
         json={
             "source_lemma": "rejoice",
             "target_lemma": "furaha_partial",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["rejoicing", "rejoiced"],
             "confidence": 0.87,
         },
@@ -2616,7 +2859,7 @@ def test_get_lexeme_cards_word_search_partial_match(
 
     # Search for "rejoic" (partial) - should NOT match "rejoice", "rejoicing", or "rejoiced"
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=rejoic",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=rejoic",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2634,6 +2877,8 @@ def test_get_lexeme_cards_word_search_respects_user_access(
     db_session,
     test_revision_id,
     test_revision_id_2,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that search finds cards by lemma/surface_forms, but examples are filtered by user access.
 
@@ -2648,8 +2893,8 @@ def test_get_lexeme_cards_word_search_respects_user_access(
         json={
             "source_lemma": "access_test_joy",
             "target_lemma": "furaha_access",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "examples": [
                 {
                     "source": "great joy came",
@@ -2668,8 +2913,8 @@ def test_get_lexeme_cards_word_search_respects_user_access(
         json={
             "source_lemma": "access_test_joy",
             "target_lemma": "furaha_access",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "examples": [
                 {
                     "source": "amazing joy happened",
@@ -2682,7 +2927,7 @@ def test_get_lexeme_cards_word_search_respects_user_access(
 
     # testuser1 searches by lemma — should find the card with examples from BOTH revisions
     response_user1 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=access_test_joy",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=access_test_joy",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response_user1.status_code == 200
@@ -2693,7 +2938,7 @@ def test_get_lexeme_cards_word_search_respects_user_access(
 
     # testuser2 searches by same lemma — should find the card but with NO examples
     response_user2 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=access_test_joy",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=access_test_joy",
         headers={"Authorization": f"Bearer {regular_token2}"},
     )
     assert response_user2.status_code == 200
@@ -2704,7 +2949,12 @@ def test_get_lexeme_cards_word_search_respects_user_access(
 
 
 def test_get_lexeme_cards_combined_word_and_pos_filter(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test combining word search with other filters like POS."""
     # Add verb
@@ -2714,8 +2964,8 @@ def test_get_lexeme_cards_combined_word_and_pos_filter(
         json={
             "source_lemma": "praise_test_verb",
             "target_lemma": "sifa_verb",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "examples": [
                 {"source": "they praise_test_verb God", "target": "wanamsifa Mungu"},
@@ -2731,8 +2981,8 @@ def test_get_lexeme_cards_combined_word_and_pos_filter(
         json={
             "source_lemma": "praise_test_noun",
             "target_lemma": "sifa_noun",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "noun",
             "examples": [
                 {"source": "give praise_test_noun to Him", "target": "mpe sifa"},
@@ -2743,7 +2993,7 @@ def test_get_lexeme_cards_combined_word_and_pos_filter(
 
     # Search for the verb specifically
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=praise_test_verb&pos=verb",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=praise_test_verb&pos=verb",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2757,7 +3007,12 @@ def test_get_lexeme_cards_combined_word_and_pos_filter(
 
 
 def test_get_lexeme_cards_word_search_no_matches(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test word search with no matching results."""
     # Add test data that won't match
@@ -2767,8 +3022,8 @@ def test_get_lexeme_cards_word_search_no_matches(
         json={
             "source_lemma": "hope",
             "target_lemma": "tumaini",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "examples": [
                 {"source": "I have hope", "target": "Nina tumaini"},
             ],
@@ -2778,7 +3033,7 @@ def test_get_lexeme_cards_word_search_no_matches(
 
     # Search for word that doesn't exist
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=xyznonexistent",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=xyznonexistent",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2791,7 +3046,12 @@ def test_get_lexeme_cards_word_search_no_matches(
 
 
 def test_get_lexeme_cards_both_source_and_target_word(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test searching with both source_word and target_word."""
     # Add test data with unique words to avoid contamination
@@ -2801,8 +3061,8 @@ def test_get_lexeme_cards_both_source_and_target_word(
         json={
             "source_lemma": "agape_love",
             "target_lemma": "penda_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "examples": [
                 {"source": "I agape_love mercy", "target": "Napenda_test rehema"},
             ],
@@ -2812,7 +3072,7 @@ def test_get_lexeme_cards_both_source_and_target_word(
 
     # Search by both source and target word
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=agape_love&target_word=penda_test",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=agape_love&target_word=penda_test",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2825,7 +3085,12 @@ def test_get_lexeme_cards_both_source_and_target_word(
 
 
 def test_get_lexeme_cards_source_word_matches_source_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that source_word=running finds card with source_surface_forms containing 'running'."""
     client.post(
@@ -2834,15 +3099,15 @@ def test_get_lexeme_cards_source_word_matches_source_surface_forms(
         json={
             "source_lemma": "run_new_test",
             "target_lemma": "kimbia_new_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["runs_new", "running_new", "ran_new"],
             "confidence": 0.91,
         },
     )
 
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=running_new",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=running_new",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2853,7 +3118,12 @@ def test_get_lexeme_cards_source_word_matches_source_surface_forms(
 
 
 def test_get_lexeme_cards_target_word_matches_target_lemma_without_flag(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that target_word=upendo_nf finds card with target_lemma='upendo_nf'."""
     client.post(
@@ -2862,15 +3132,15 @@ def test_get_lexeme_cards_target_word_matches_target_lemma_without_flag(
         json={
             "source_lemma": "love_nf",
             "target_lemma": "upendo_nf",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.88,
         },
     )
 
     # Should find by target_lemma
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=upendo_nf",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=upendo_nf",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2881,7 +3151,12 @@ def test_get_lexeme_cards_target_word_matches_target_lemma_without_flag(
 
 
 def test_get_lexeme_cards_target_word_case_insensitive_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that 'upendo_ci' matches 'Upendo_ci' target_lemma (case-insensitive)."""
     client.post(
@@ -2890,14 +3165,14 @@ def test_get_lexeme_cards_target_word_case_insensitive_lemma(
         json={
             "source_lemma": "love_ci",
             "target_lemma": "Upendo_ci",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.85,
         },
     )
 
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=upendo_ci",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=upendo_ci",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2908,7 +3183,12 @@ def test_get_lexeme_cards_target_word_case_insensitive_lemma(
 
 
 def test_get_lexeme_cards_source_word_case_insensitive_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that 'love_ci2' matches 'Love_ci2' source_lemma (case-insensitive)."""
     client.post(
@@ -2917,14 +3197,14 @@ def test_get_lexeme_cards_source_word_case_insensitive_lemma(
         json={
             "source_lemma": "Love_ci2",
             "target_lemma": "upendo_ci2",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.85,
         },
     )
 
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=love_ci2",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=love_ci2",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2935,7 +3215,12 @@ def test_get_lexeme_cards_source_word_case_insensitive_lemma(
 
 
 def test_get_lexeme_cards_no_example_text_search(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that a word only in example text is NOT found by word search."""
     client.post(
@@ -2944,8 +3229,8 @@ def test_get_lexeme_cards_no_example_text_search(
         json={
             "source_lemma": "test_no_ex_search",
             "target_lemma": "hakuna_ex_search",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "examples": [
                 {
                     "source": "unique_example_word_xyz in a sentence",
@@ -2958,7 +3243,7 @@ def test_get_lexeme_cards_no_example_text_search(
 
     # Search for a word that only appears in example text
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=unique_example_word_xyz",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=unique_example_word_xyz",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2969,7 +3254,12 @@ def test_get_lexeme_cards_no_example_text_search(
 
 
 def test_get_lexeme_cards_source_and_target_word_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that both source_word and target_word can match via surface forms (AND semantics)."""
     client.post(
@@ -2978,8 +3268,8 @@ def test_get_lexeme_cards_source_and_target_word_surface_forms(
         json={
             "source_lemma": "run_both_sf",
             "target_lemma": "kimbia_both_sf",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["running_both", "runs_both"],
             "surface_forms": ["anakimbia_both", "kukimbia_both"],
             "confidence": 0.90,
@@ -2988,7 +3278,7 @@ def test_get_lexeme_cards_source_and_target_word_surface_forms(
 
     # Both source and target match via surface_forms
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=running_both&target_word=anakimbia_both",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=running_both&target_word=anakimbia_both",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -2999,7 +3289,7 @@ def test_get_lexeme_cards_source_and_target_word_surface_forms(
 
     # Source matches but target does NOT — should not be found
     response2 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=running_both&target_word=nonexistent_sf",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=running_both&target_word=nonexistent_sf",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -3010,7 +3300,12 @@ def test_get_lexeme_cards_source_and_target_word_surface_forms(
 
 
 def test_get_lexeme_cards_null_source_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that a card with NULL source_lemma is found via source_surface_forms match."""
     client.post(
@@ -3018,15 +3313,15 @@ def test_get_lexeme_cards_null_source_lemma(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "kupata_null_src",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "source_surface_forms": ["get_null_src", "gets_null_src"],
             "confidence": 0.70,
         },
     )
 
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=get_null_src",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=get_null_src",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -3038,7 +3333,12 @@ def test_get_lexeme_cards_null_source_lemma(
 
 
 def test_get_lexeme_cards_empty_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that a card with empty/NULL surface_forms only matches via lemma."""
     client.post(
@@ -3047,8 +3347,8 @@ def test_get_lexeme_cards_empty_surface_forms(
         json={
             "source_lemma": "empty_sf_source",
             "target_lemma": "empty_sf_target",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": [],
             "source_surface_forms": [],
             "confidence": 0.65,
@@ -3057,7 +3357,7 @@ def test_get_lexeme_cards_empty_surface_forms(
 
     # Should find by lemma
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=empty_sf_source",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=empty_sf_source",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
@@ -3067,7 +3367,7 @@ def test_get_lexeme_cards_empty_surface_forms(
 
     # Should NOT find by a non-matching word (empty surface_forms won't help)
     response2 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&source_word=nonexistent_empty_sf",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&source_word=nonexistent_empty_sf",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response2.status_code == 200
@@ -3077,7 +3377,12 @@ def test_get_lexeme_cards_empty_surface_forms(
 
 
 def test_get_lexeme_cards_word_filter_respects_language_pair(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that word filtering with surface_forms does not leak cards from other language pairs.
 
@@ -3093,8 +3398,8 @@ def test_get_lexeme_cards_word_filter_respects_language_pair(
         json={
             "source_lemma": "cross_src_eng",
             "target_lemma": shared_word,
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": [shared_word, "crosslang_form_swh"],
             "source_surface_forms": [shared_word, "crosslang_src_form"],
             "confidence": 0.9,
@@ -3109,8 +3414,8 @@ def test_get_lexeme_cards_word_filter_respects_language_pair(
         json={
             "source_lemma": "cross_src_swh",
             "target_lemma": "crosslang_other",
-            "source_language": "swh",
-            "target_language": "eng",
+            "source_version_id": test_version_id_2,
+            "target_version_id": test_version_id,
             "surface_forms": [shared_word, "crosslang_form_eng"],
             "source_surface_forms": [shared_word],
             "confidence": 0.85,
@@ -3120,7 +3425,7 @@ def test_get_lexeme_cards_word_filter_respects_language_pair(
 
     # Query eng->swh with target_word matching the shared word
     response = client.get(
-        f"/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word={shared_word}",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word={shared_word}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
@@ -3132,18 +3437,18 @@ def test_get_lexeme_cards_word_filter_respects_language_pair(
     ), f"Expected to find card with target_lemma='{shared_word}' in eng->swh results"
     # Should only return the eng->swh card, NOT the swh->eng card
     for card in data:
-        assert card["source_language"] == "eng", (
-            f"Expected source_language='eng', got '{card['source_language']}' "
+        assert card["source_version_id"] == test_version_id, (
+            f"Expected source_version_id='eng', got '{card['source_version_id']}' "
             f"(target_lemma='{card['target_lemma']}')"
         )
-        assert card["target_language"] == "swh", (
-            f"Expected target_language='swh', got '{card['target_language']}' "
+        assert card["target_version_id"] == test_version_id_2, (
+            f"Expected target_version_id='swh', got '{card['target_version_id']}' "
             f"(target_lemma='{card['target_lemma']}')"
         )
 
     # Query swh->eng with source_word matching the shared word
     response2 = client.get(
-        f"/v3/agent/lexeme-card?source_language=swh&target_language=eng&source_word={shared_word}",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id_2}&target_version_id={test_version_id}&source_word={shared_word}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response2.status_code == 200
@@ -3155,18 +3460,23 @@ def test_get_lexeme_cards_word_filter_respects_language_pair(
     ), "Expected to find card with source_lemma='cross_src_swh' in swh->eng results"
     # Should only return the swh->eng card, NOT the eng->swh card
     for card in data2:
-        assert card["source_language"] == "swh", (
-            f"Expected source_language='swh', got '{card['source_language']}' "
+        assert card["source_version_id"] == test_version_id_2, (
+            f"Expected source_version_id='swh', got '{card['source_version_id']}' "
             f"(target_lemma='{card['target_lemma']}')"
         )
-        assert card["target_language"] == "eng", (
-            f"Expected target_language='eng', got '{card['target_language']}' "
+        assert card["target_version_id"] == test_version_id, (
+            f"Expected target_version_id='eng', got '{card['target_version_id']}' "
             f"(target_lemma='{card['target_lemma']}')"
         )
 
 
 def test_add_lexeme_card_alignment_scores_sorted_descending(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that alignment_scores are sorted by value in descending order."""
     # Post a lexeme card with unsorted alignment_scores
@@ -3176,8 +3486,8 @@ def test_add_lexeme_card_alignment_scores_sorted_descending(
         json={
             "source_lemma": "test_alignment_sort",
             "target_lemma": "sorted_target",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "alignment_scores": {"a": 0.3, "b": 0.9, "c": 0.5, "d": 0.1},
         },
     )
@@ -3200,8 +3510,8 @@ def test_add_lexeme_card_alignment_scores_sorted_descending(
         json={
             "source_lemma": "test_alignment_sort",
             "target_lemma": "sorted_target",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "alignment_scores": {"x": 0.2, "y": 0.8, "z": 0.5},
         },
     )
@@ -3218,7 +3528,12 @@ def test_add_lexeme_card_alignment_scores_sorted_descending(
 
 
 def test_add_lexeme_card_duplicate_target_lemma_different_source_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test POST returns 409 when target_lemma exists with different source_lemma."""
     # Create first card
@@ -3228,8 +3543,8 @@ def test_add_lexeme_card_duplicate_target_lemma_different_source_lemma(
         json={
             "source_lemma": "first_source",
             "target_lemma": "unique_target",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response1.status_code == 200
@@ -3242,8 +3557,8 @@ def test_add_lexeme_card_duplicate_target_lemma_different_source_lemma(
         json={
             "source_lemma": "different_source",  # Different source_lemma
             "target_lemma": "unique_target",  # Same target_lemma
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
@@ -3254,7 +3569,12 @@ def test_add_lexeme_card_duplicate_target_lemma_different_source_lemma(
 
 
 def test_add_lexeme_card_duplicate_same_source_lemma_upserts(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test POST with same source_lemma and target_lemma upserts (updates existing)."""
     # Create first card
@@ -3264,8 +3584,8 @@ def test_add_lexeme_card_duplicate_same_source_lemma_upserts(
         json={
             "source_lemma": "same_source",
             "target_lemma": "same_target",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.5,
         },
     )
@@ -3279,8 +3599,8 @@ def test_add_lexeme_card_duplicate_same_source_lemma_upserts(
         json={
             "source_lemma": "same_source",  # Same
             "target_lemma": "same_target",  # Same
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.9,  # Updated value
         },
     )
@@ -3292,7 +3612,12 @@ def test_add_lexeme_card_duplicate_same_source_lemma_upserts(
 
 
 def test_patch_lexeme_card_cannot_change_target_lemma_to_duplicate(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH returns 409 when trying to change target_lemma to existing value."""
     # Create first card
@@ -3301,8 +3626,8 @@ def test_patch_lexeme_card_cannot_change_target_lemma_to_duplicate(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "existing_lemma",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response1.status_code == 200
@@ -3314,8 +3639,8 @@ def test_patch_lexeme_card_cannot_change_target_lemma_to_duplicate(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "other_lemma",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response2.status_code == 200
@@ -3336,7 +3661,12 @@ def test_patch_lexeme_card_cannot_change_target_lemma_to_duplicate(
 
 
 def test_patch_lexeme_card_can_keep_same_target_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH allows keeping the same target_lemma (no false positive)."""
     # Create a card
@@ -3345,8 +3675,8 @@ def test_patch_lexeme_card_can_keep_same_target_lemma(
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "target_lemma": "keep_this",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.5,
         },
     )
@@ -3371,7 +3701,12 @@ def test_patch_lexeme_card_can_keep_same_target_lemma(
 
 
 def test_patch_lexeme_card_by_id_append_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by ID with list_mode=append adds surface forms."""
     # Create initial card
@@ -3381,8 +3716,8 @@ def test_patch_lexeme_card_by_id_append_surface_forms(
         json={
             "source_lemma": "patch_test",
             "target_lemma": "kipimo",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["kipimo", "vipimo"],
         },
     )
@@ -3406,7 +3741,12 @@ def test_patch_lexeme_card_by_id_append_surface_forms(
 
 
 def test_patch_lexeme_card_by_id_replace_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by ID with list_mode=replace overwrites surface forms."""
     # Create initial card
@@ -3416,8 +3756,8 @@ def test_patch_lexeme_card_by_id_replace_surface_forms(
         json={
             "source_lemma": "patch_replace_test",
             "target_lemma": "badilisha",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["badilisha", "anabadilisha", "walibadilisha"],
         },
     )
@@ -3440,7 +3780,12 @@ def test_patch_lexeme_card_by_id_replace_surface_forms(
 
 
 def test_patch_lexeme_card_by_id_merge_surface_forms(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by ID with list_mode=merge deduplicates case-insensitively."""
     # Create initial card
@@ -3450,8 +3795,8 @@ def test_patch_lexeme_card_by_id_merge_surface_forms(
         json={
             "source_lemma": "merge_test",
             "target_lemma": "unganisha",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": ["Unganisha", "anaunganisha"],
         },
     )
@@ -3478,7 +3823,12 @@ def test_patch_lexeme_card_by_id_merge_surface_forms(
 
 
 def test_patch_lexeme_card_by_id_scalar_fields(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by ID updates scalar fields only when provided."""
     # Create initial card
@@ -3488,8 +3838,8 @@ def test_patch_lexeme_card_by_id_scalar_fields(
         json={
             "source_lemma": "scalar_test",
             "target_lemma": "skala",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "noun",
             "confidence": 0.5,
             "english_lemma": "scale",
@@ -3517,7 +3867,12 @@ def test_patch_lexeme_card_by_id_scalar_fields(
 
 
 def test_patch_lexeme_card_by_id_alignment_scores_merge(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by ID merges alignment_scores and removes keys with null values."""
     # Create initial card
@@ -3527,8 +3882,8 @@ def test_patch_lexeme_card_by_id_alignment_scores_merge(
         json={
             "source_lemma": "align_test",
             "target_lemma": "pangilia",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "alignment_scores": {"word1": 0.8, "word2": 0.5, "word3": 0.3},
         },
     )
@@ -3554,7 +3909,12 @@ def test_patch_lexeme_card_by_id_alignment_scores_merge(
 
 
 def test_patch_lexeme_card_by_id_examples_with_revision(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by ID adds examples with revision_id."""
     # Create initial card
@@ -3564,8 +3924,8 @@ def test_patch_lexeme_card_by_id_examples_with_revision(
         json={
             "source_lemma": "example_test",
             "target_lemma": "mfano",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "examples": [{"source": "First example", "target": "Mfano wa kwanza"}],
         },
     )
@@ -3595,7 +3955,12 @@ def test_patch_lexeme_card_by_id_examples_with_revision(
 
 
 def test_patch_lexeme_card_by_id_examples_missing_revision_id(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by ID fails when examples are provided without revision_id."""
     # Create initial card
@@ -3605,8 +3970,8 @@ def test_patch_lexeme_card_by_id_examples_missing_revision_id(
         json={
             "source_lemma": "fail_example_test",
             "target_lemma": "mfano_fail",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response.status_code == 200
@@ -3653,7 +4018,12 @@ def test_patch_lexeme_card_by_id_unauthorized(client, test_revision_id):
 
 
 def test_patch_lexeme_card_by_lemma_success(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by lemma lookup works correctly."""
     # Create initial card
@@ -3663,8 +4033,8 @@ def test_patch_lexeme_card_by_lemma_success(
         json={
             "source_lemma": "lemma_lookup_test",
             "target_lemma": "tafuta",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.6,
         },
     )
@@ -3674,8 +4044,8 @@ def test_patch_lexeme_card_by_lemma_success(
     patch_response = client.patch(
         "/v3/agent/lexeme-card"
         "?target_lemma=tafuta"
-        "&source_language=eng"
-        "&target_language=swh"
+        f"&source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}"
         "&source_lemma=lemma_lookup_test",
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
@@ -3691,13 +4061,15 @@ def test_patch_lexeme_card_by_lemma_success(
     assert len(data["surface_forms"]) == 2
 
 
-def test_patch_lexeme_card_by_lemma_not_found(client, regular_token1, db_session):
+def test_patch_lexeme_card_by_lemma_not_found(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Test PATCH by lemma lookup returns 404 for non-existent card."""
     patch_response = client.patch(
         "/v3/agent/lexeme-card"
         "?target_lemma=nonexistent"
-        "&source_language=eng"
-        "&target_language=swh",
+        f"&source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
             "confidence": 0.5,
@@ -3708,7 +4080,12 @@ def test_patch_lexeme_card_by_lemma_not_found(client, regular_token1, db_session
 
 
 def test_patch_lexeme_card_by_lemma_without_source_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test PATCH by lemma lookup works when source_lemma is not provided."""
     # Create initial card WITH a source_lemma
@@ -3718,8 +4095,8 @@ def test_patch_lexeme_card_by_lemma_without_source_lemma(
         json={
             "source_lemma": "some_source",  # Card has source_lemma
             "target_lemma": "lengo_bila",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.6,
         },
     )
@@ -3729,8 +4106,8 @@ def test_patch_lexeme_card_by_lemma_without_source_lemma(
     patch_response = client.patch(
         "/v3/agent/lexeme-card"
         "?target_lemma=lengo_bila"
-        "&source_language=eng"
-        "&target_language=swh",
+        f"&source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}",
         # Note: no source_lemma parameter
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={
@@ -3745,11 +4122,16 @@ def test_patch_lexeme_card_by_lemma_without_source_lemma(
 
 
 def test_post_lexeme_card_duplicate_returns_409_conflict(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test POST returns 409 Conflict when trying to create a duplicate card.
 
-    Uniqueness is determined by (target_lemma, source_language, target_language).
+    Uniqueness is determined by (target_lemma, source_version_id, target_version_id).
     """
     # Create first card (use unique target_lemma to avoid conflicts with other tests)
     response1 = client.post(
@@ -3758,8 +4140,8 @@ def test_post_lexeme_card_duplicate_returns_409_conflict(
         json={
             "source_lemma": "source_one",
             "target_lemma": "shared_target_conflict_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response1.status_code == 200
@@ -3773,8 +4155,8 @@ def test_post_lexeme_card_duplicate_returns_409_conflict(
         json={
             "source_lemma": "source_two",  # Different source_lemma
             "target_lemma": "shared_target_conflict_test",  # Same target_lemma
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
@@ -3786,7 +4168,12 @@ def test_post_lexeme_card_duplicate_returns_409_conflict(
 
 
 def test_patch_lexeme_card_omitted_fields_unchanged(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that omitted fields are not changed by PATCH."""
     # Create initial card with all fields
@@ -3796,8 +4183,8 @@ def test_patch_lexeme_card_omitted_fields_unchanged(
         json={
             "source_lemma": "omit_test",
             "target_lemma": "acha",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "confidence": 0.75,
             "english_lemma": "leave",
@@ -3833,7 +4220,12 @@ def test_patch_lexeme_card_omitted_fields_unchanged(
 
 
 def test_patch_lexeme_card_explicit_null_clears_field(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test that explicitly setting a field to null clears it."""
     # Create initial card
@@ -3843,8 +4235,8 @@ def test_patch_lexeme_card_explicit_null_clears_field(
         json={
             "source_lemma": "null_test",
             "target_lemma": "futa",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "pos": "verb",
             "english_lemma": "clear",
         },
@@ -4979,7 +5371,12 @@ def test_replacement_missing_draft_text_returns_422(
 
 
 def test_post_lexeme_card_without_is_user_edit_has_null_last_user_edit(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """POST without is_user_edit should create card with last_user_edit=NULL."""
     response = client.post(
@@ -4988,8 +5385,8 @@ def test_post_lexeme_card_without_is_user_edit_has_null_last_user_edit(
         json={
             "source_lemma": "house",
             "target_lemma": "nyumba_lue_test_null",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response.status_code == 200
@@ -4998,7 +5395,12 @@ def test_post_lexeme_card_without_is_user_edit_has_null_last_user_edit(
 
 
 def test_post_lexeme_card_with_is_user_edit_sets_last_user_edit(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """POST with is_user_edit=true should create card with last_user_edit set."""
     response = client.post(
@@ -5007,8 +5409,8 @@ def test_post_lexeme_card_with_is_user_edit_sets_last_user_edit(
         json={
             "source_lemma": "tree",
             "target_lemma": "mti_lue_test_set",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response.status_code == 200
@@ -5017,7 +5419,12 @@ def test_post_lexeme_card_with_is_user_edit_sets_last_user_edit(
 
 
 def test_post_lexeme_card_upsert_with_is_user_edit_updates_last_user_edit(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """POST upsert with is_user_edit=true should update last_user_edit."""
     # Create card without is_user_edit
@@ -5027,8 +5434,8 @@ def test_post_lexeme_card_upsert_with_is_user_edit_updates_last_user_edit(
         json={
             "source_lemma": "water",
             "target_lemma": "maji_lue_test_upsert",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response1.status_code == 200
@@ -5041,8 +5448,8 @@ def test_post_lexeme_card_upsert_with_is_user_edit_updates_last_user_edit(
         json={
             "source_lemma": "water",
             "target_lemma": "maji_lue_test_upsert",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.95,
         },
     )
@@ -5052,7 +5459,12 @@ def test_post_lexeme_card_upsert_with_is_user_edit_updates_last_user_edit(
 
 
 def test_patch_lexeme_card_without_is_user_edit_leaves_last_user_edit_unchanged(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """PATCH without is_user_edit should not update last_user_edit."""
     # Create card without is_user_edit
@@ -5062,8 +5474,8 @@ def test_patch_lexeme_card_without_is_user_edit_leaves_last_user_edit_unchanged(
         json={
             "source_lemma": "fire",
             "target_lemma": "moto_lue_test_patch_null",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response1.status_code == 200
@@ -5081,7 +5493,12 @@ def test_patch_lexeme_card_without_is_user_edit_leaves_last_user_edit_unchanged(
 
 
 def test_patch_lexeme_card_with_is_user_edit_updates_last_user_edit(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """PATCH with is_user_edit=true should update last_user_edit."""
     # Create card without is_user_edit
@@ -5091,8 +5508,8 @@ def test_patch_lexeme_card_with_is_user_edit_updates_last_user_edit(
         json={
             "source_lemma": "earth",
             "target_lemma": "ardhi_lue_test_patch_set",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response1.status_code == 200
@@ -5110,7 +5527,12 @@ def test_patch_lexeme_card_with_is_user_edit_updates_last_user_edit(
 
 
 def test_get_lexeme_cards_includes_last_user_edit(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """GET response should include last_user_edit field."""
     # Create card with is_user_edit=true
@@ -5120,13 +5542,13 @@ def test_get_lexeme_cards_includes_last_user_edit(
         json={
             "source_lemma": "wind",
             "target_lemma": "upepo_lue_test_get",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     response = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=upepo_lue_test_get",
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}&target_version_id={test_version_id_2}&target_word=upepo_lue_test_get",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
@@ -5141,7 +5563,12 @@ def test_get_lexeme_cards_includes_last_user_edit(
 
 
 def test_post_lexeme_card_normalizes_target_lemma_to_lowercase(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """POST should normalize target_lemma to lowercase."""
     response = client.post(
@@ -5150,8 +5577,8 @@ def test_post_lexeme_card_normalizes_target_lemma_to_lowercase(
         json={
             "source_lemma": "run",
             "target_lemma": "Kimbia_CI_Test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response.status_code == 200
@@ -5160,7 +5587,12 @@ def test_post_lexeme_card_normalizes_target_lemma_to_lowercase(
 
 
 def test_post_lexeme_card_case_insensitive_duplicate_returns_upsert(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """POST with same target_lemma but different case should upsert, not create duplicate."""
     # Create first card
@@ -5170,8 +5602,8 @@ def test_post_lexeme_card_case_insensitive_duplicate_returns_upsert(
         json={
             "source_lemma": "walk",
             "target_lemma": "tembea_ci_dup",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.5,
         },
     )
@@ -5185,8 +5617,8 @@ def test_post_lexeme_card_case_insensitive_duplicate_returns_upsert(
         json={
             "source_lemma": "walk",
             "target_lemma": "Tembea_CI_Dup",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.9,
         },
     )
@@ -5196,7 +5628,12 @@ def test_post_lexeme_card_case_insensitive_duplicate_returns_upsert(
 
 
 def test_post_lexeme_card_case_insensitive_different_source_lemma_returns_409(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """POST with same target_lemma (different case) but different source_lemma should return 409."""
     # Create first card
@@ -5206,8 +5643,8 @@ def test_post_lexeme_card_case_insensitive_different_source_lemma_returns_409(
         json={
             "source_lemma": "run",
             "target_lemma": "kimbia_ci_409",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
@@ -5218,15 +5655,20 @@ def test_post_lexeme_card_case_insensitive_different_source_lemma_returns_409(
         json={
             "source_lemma": "sprint",
             "target_lemma": "Kimbia_CI_409",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert resp2.status_code == 409
 
 
 def test_patch_lexeme_card_by_lemma_case_insensitive_lookup(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """PATCH by lemma should find the card regardless of case."""
     # Create card
@@ -5236,14 +5678,14 @@ def test_patch_lexeme_card_by_lemma_case_insensitive_lookup(
         json={
             "source_lemma": "eat",
             "target_lemma": "kula_ci_patch",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
     # PATCH using different case
     resp = client.patch(
-        "/v3/agent/lexeme-card?target_lemma=KULA_CI_PATCH&source_language=eng&target_language=swh",
+        f"/v3/agent/lexeme-card?target_lemma=KULA_CI_PATCH&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
         json={"confidence": 0.99},
     )
@@ -5252,7 +5694,12 @@ def test_patch_lexeme_card_by_lemma_case_insensitive_lookup(
 
 
 def test_patch_lexeme_card_normalizes_target_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """PATCH should normalize target_lemma to lowercase when changing it."""
     # Create card
@@ -5262,8 +5709,8 @@ def test_patch_lexeme_card_normalizes_target_lemma(
         json={
             "source_lemma": "drink",
             "target_lemma": "kunywa_ci_norm",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     card_id = resp1.json()["id"]
@@ -5279,7 +5726,12 @@ def test_patch_lexeme_card_normalizes_target_lemma(
 
 
 def test_patch_lexeme_card_case_insensitive_duplicate_check(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """PATCH should reject target_lemma change that creates case-insensitive duplicate."""
     # Create two cards
@@ -5289,8 +5741,8 @@ def test_patch_lexeme_card_case_insensitive_duplicate_check(
         json={
             "source_lemma": "sit",
             "target_lemma": "keti_ci_a",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     card_a_id = resp1.json()["id"]
@@ -5301,8 +5753,8 @@ def test_patch_lexeme_card_case_insensitive_duplicate_check(
         json={
             "source_lemma": "stand",
             "target_lemma": "keti_ci_b",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
 
@@ -5335,22 +5787,24 @@ def _raw_psycopg2(statements):
         conn.close()
 
 
-def test_deduplicate_lexeme_cards_dry_run(client, regular_token1):
+def test_deduplicate_lexeme_cards_dry_run(
+    client, regular_token1, test_version_id, test_version_id_2
+):
     """Deduplicate dry_run should report duplicates without deleting."""
     # Drop unique index, insert case-variant duplicates
     _raw_psycopg2(
         [
-            "DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v3",
-            "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_language, target_language, confidence, created_at, last_updated) "
-            "VALUES ('go', 'enda_dedup_dry', 'eng', 'swh', 0.5, now(), now())",
-            "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_language, target_language, confidence, created_at, last_updated) "
-            "VALUES ('go', 'Enda_Dedup_Dry', 'eng', 'swh', 0.9, now(), now())",
+            "DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v4",
+            "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_version_id, target_version_id, confidence, created_at, last_updated) "
+            f"VALUES ('go', 'enda_dedup_dry', {test_version_id}, {test_version_id_2}, 0.5, now(), now())",
+            "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_version_id, target_version_id, confidence, created_at, last_updated) "
+            f"VALUES ('go', 'Enda_Dedup_Dry', {test_version_id}, {test_version_id_2}, 0.9, now(), now())",
         ]
     )
 
     try:
         resp = client.post(
-            "/v3/agent/lexeme-card/deduplicate?source_language=eng&target_language=swh&dry_run=true",
+            f"/v3/agent/lexeme-card/deduplicate?source_version_id={test_version_id}&target_version_id={test_version_id_2}&dry_run=true",
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
         assert resp.status_code == 200
@@ -5366,7 +5820,10 @@ def test_deduplicate_lexeme_cards_dry_run(client, regular_token1):
         )
         cur = conn.cursor()
         cur.execute(
-            "SELECT COUNT(*) FROM agent_lexeme_cards WHERE LOWER(target_lemma) = 'enda_dedup_dry' AND source_language = 'eng' AND target_language = 'swh'"
+            "SELECT COUNT(*) FROM agent_lexeme_cards "
+            "WHERE LOWER(target_lemma) = 'enda_dedup_dry' "
+            f"AND source_version_id = {test_version_id} "
+            f"AND target_version_id = {test_version_id_2}"
         )
         assert cur.fetchone()[0] == 2
         cur.close()
@@ -5374,29 +5831,34 @@ def test_deduplicate_lexeme_cards_dry_run(client, regular_token1):
     finally:
         _raw_psycopg2(
             [
-                "DELETE FROM agent_lexeme_cards WHERE LOWER(target_lemma) = 'enda_dedup_dry' AND source_language = 'eng' AND target_language = 'swh'",
-                "CREATE UNIQUE INDEX IF NOT EXISTS ix_agent_lexeme_cards_unique_v3 "
-                "ON agent_lexeme_cards (LOWER(target_lemma), source_language, target_language)",
+                "DELETE FROM agent_lexeme_cards "
+                "WHERE LOWER(target_lemma) = 'enda_dedup_dry' "
+                f"AND source_version_id = {test_version_id} "
+                f"AND target_version_id = {test_version_id_2}",
+                "CREATE UNIQUE INDEX IF NOT EXISTS ix_agent_lexeme_cards_unique_v4 "
+                "ON agent_lexeme_cards (LOWER(target_lemma), source_version_id, target_version_id)",
             ]
         )
 
 
-def test_deduplicate_lexeme_cards_merge(client, regular_token1):
+def test_deduplicate_lexeme_cards_merge(
+    client, regular_token1, test_version_id, test_version_id_2
+):
     """Deduplicate with dry_run=false should merge duplicates."""
     # Drop unique index, insert case-variant duplicates
     _raw_psycopg2(
         [
-            "DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v3",
-            "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_language, target_language, confidence, surface_forms, created_at, last_updated) "
-            "VALUES ('come', 'kuja_dedup_merge', 'eng', 'swh', 0.5, '[\"kuja\", \"anakuja\"]'::jsonb, now(), now())",
-            "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_language, target_language, confidence, surface_forms, created_at, last_updated) "
-            "VALUES ('come', 'Kuja_Dedup_Merge', 'eng', 'swh', 0.9, '[\"Kuja\", \"walikuja\"]'::jsonb, now(), now())",
+            "DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v4",
+            "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_version_id, target_version_id, confidence, surface_forms, created_at, last_updated) "
+            f"VALUES ('come', 'kuja_dedup_merge', {test_version_id}, {test_version_id_2}, 0.5, '[\"kuja\", \"anakuja\"]'::jsonb, now(), now())",
+            "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_version_id, target_version_id, confidence, surface_forms, created_at, last_updated) "
+            f"VALUES ('come', 'Kuja_Dedup_Merge', {test_version_id}, {test_version_id_2}, 0.9, '[\"Kuja\", \"walikuja\"]'::jsonb, now(), now())",
         ]
     )
 
     try:
         resp = client.post(
-            "/v3/agent/lexeme-card/deduplicate?source_language=eng&target_language=swh&dry_run=false",
+            f"/v3/agent/lexeme-card/deduplicate?source_version_id={test_version_id}&target_version_id={test_version_id_2}&dry_run=false",
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
         assert resp.status_code == 200
@@ -5414,7 +5876,9 @@ def test_deduplicate_lexeme_cards_merge(client, regular_token1):
         cur = conn.cursor()
         cur.execute(
             "SELECT COUNT(*), MAX(confidence) FROM agent_lexeme_cards "
-            "WHERE LOWER(target_lemma) = 'kuja_dedup_merge' AND source_language = 'eng' AND target_language = 'swh'"
+            "WHERE LOWER(target_lemma) = 'kuja_dedup_merge' "
+            f"AND source_version_id = {test_version_id} "
+            f"AND target_version_id = {test_version_id_2}"
         )
         count, max_conf = cur.fetchone()
         assert count == 1
@@ -5424,17 +5888,22 @@ def test_deduplicate_lexeme_cards_merge(client, regular_token1):
     finally:
         _raw_psycopg2(
             [
-                "DELETE FROM agent_lexeme_cards WHERE LOWER(target_lemma) = 'kuja_dedup_merge' AND source_language = 'eng' AND target_language = 'swh'",
-                "CREATE UNIQUE INDEX IF NOT EXISTS ix_agent_lexeme_cards_unique_v3 "
-                "ON agent_lexeme_cards (LOWER(target_lemma), source_language, target_language)",
+                "DELETE FROM agent_lexeme_cards "
+                "WHERE LOWER(target_lemma) = 'kuja_dedup_merge' "
+                f"AND source_version_id = {test_version_id} "
+                f"AND target_version_id = {test_version_id_2}",
+                "CREATE UNIQUE INDEX IF NOT EXISTS ix_agent_lexeme_cards_unique_v4 "
+                "ON agent_lexeme_cards (LOWER(target_lemma), source_version_id, target_version_id)",
             ]
         )
 
 
-def test_deduplicate_no_duplicates(client, regular_token1, db_session):
+def test_deduplicate_no_duplicates(
+    client, regular_token1, db_session, test_version_id, test_version_id_2
+):
     """Deduplicate should return zeros when no duplicates exist."""
     resp = client.post(
-        "/v3/agent/lexeme-card/deduplicate?source_language=eng&target_language=swh&dry_run=true",
+        f"/v3/agent/lexeme-card/deduplicate?source_version_id={test_version_id}&target_version_id={test_version_id_2}&dry_run=true",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert resp.status_code == 200
@@ -5443,7 +5912,12 @@ def test_deduplicate_no_duplicates(client, regular_token1, db_session):
 
 
 def test_post_lexeme_card_nfc_normalizes_text_fields(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """NFD-encoded text fields are stored as NFC in lexeme cards."""
 
@@ -5464,8 +5938,8 @@ def test_post_lexeme_card_nfc_normalizes_text_fields(
         json={
             "source_lemma": nfd_source_lemma,
             "target_lemma": nfd_lemma,
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "surface_forms": [nfd_surface],
             "source_surface_forms": [nfd_source_lemma],
         },
@@ -5481,7 +5955,12 @@ def test_post_lexeme_card_nfc_normalizes_text_fields(
 
 
 def test_patch_lexeme_card_nfc_normalizes_text_fields(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """PATCH endpoint NFC-normalizes text fields in updates."""
 
@@ -5492,8 +5971,8 @@ def test_patch_lexeme_card_nfc_normalizes_text_fields(
         json={
             "source_lemma": "build",
             "target_lemma": "nfc_patch_test",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response.status_code == 200
@@ -5516,7 +5995,12 @@ def test_patch_lexeme_card_nfc_normalizes_text_fields(
 
 
 def test_post_lexeme_card_nfd_nfc_treated_as_same_lemma(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """NFD and NFC forms of the same target_lemma should be treated as duplicates."""
 
@@ -5530,8 +6014,8 @@ def test_post_lexeme_card_nfd_nfc_treated_as_same_lemma(
         json={
             "source_lemma": "create",
             "target_lemma": nfd_lemma,
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
         },
     )
     assert response.status_code == 200
@@ -5543,8 +6027,8 @@ def test_post_lexeme_card_nfd_nfc_treated_as_same_lemma(
         json={
             "source_lemma": "create",
             "target_lemma": nfc_lemma,
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "confidence": 0.99,
         },
     )
@@ -5555,7 +6039,12 @@ def test_post_lexeme_card_nfd_nfc_treated_as_same_lemma(
 
 
 def test_delete_lexeme_card_success(
-    client, regular_token1, db_session, test_revision_id
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
 ):
     """Test DELETE removes a lexeme card and its examples via cascade."""
     # Create a card with examples
@@ -5565,8 +6054,8 @@ def test_delete_lexeme_card_success(
         json={
             "source_lemma": "remove",
             "target_lemma": "delete_test_target",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
             "examples": [
                 {"source_text": "remove this", "target_text": "ondoa hii"},
             ],

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -946,10 +946,10 @@ def test_add_lexeme_card_missing_required_fields(
     assert response.status_code == 422  # Validation error
 
 
-def test_add_lexeme_card_invalid_version_id(
+def test_add_lexeme_card_revision_not_in_version_pair(
     client, regular_token1, db_session, test_revision_id
 ):
-    """Lexeme card with non-existent version_id values returns 500 (FK violation)."""
+    """Lexeme card whose revision_id isn't in (source_version_id, target_version_id) returns 422."""
     response = client.post(
         f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -960,8 +960,10 @@ def test_add_lexeme_card_invalid_version_id(
         },
     )
 
-    # FK constraint violation surfaces as 500 — bible_version 999999 doesn't exist.
-    assert response.status_code == 500
+    # The revision-pair invariant check rejects the request before it reaches
+    # the FK constraint — explicit 422 with a clear error beats a 500 from PG.
+    assert response.status_code == 422
+    assert "version pair" in response.json()["detail"].lower()
 
 
 def test_add_lexeme_card_different_languages(
@@ -3438,15 +3440,17 @@ def test_get_lexeme_cards_word_filter_respects_language_pair(
     # Should only return the eng->swh card, NOT the swh->eng card
     for card in data:
         assert card["source_version_id"] == test_version_id, (
-            f"Expected source_version_id='eng', got '{card['source_version_id']}' "
+            f"Expected source_version_id={test_version_id}, "
+            f"got {card['source_version_id']} "
             f"(target_lemma='{card['target_lemma']}')"
         )
         assert card["target_version_id"] == test_version_id_2, (
-            f"Expected target_version_id='swh', got '{card['target_version_id']}' "
+            f"Expected target_version_id={test_version_id_2}, "
+            f"got {card['target_version_id']} "
             f"(target_lemma='{card['target_lemma']}')"
         )
 
-    # Query swh->eng with source_word matching the shared word
+    # Query the reversed pair with source_word matching the shared word
     response2 = client.get(
         f"/v3/agent/lexeme-card?source_version_id={test_version_id_2}&target_version_id={test_version_id}&source_word={shared_word}",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -3454,18 +3458,20 @@ def test_get_lexeme_cards_word_filter_respects_language_pair(
     assert response2.status_code == 200
     data2 = response2.json()
     # Verify the correct card IS present (guards against false pass on empty results)
-    assert len(data2) >= 1, "Expected at least one swh->eng card to be returned"
+    assert len(data2) >= 1, "Expected at least one reversed-pair card to be returned"
     assert any(
         c["source_lemma"] == "cross_src_swh" for c in data2
-    ), "Expected to find card with source_lemma='cross_src_swh' in swh->eng results"
-    # Should only return the swh->eng card, NOT the eng->swh card
+    ), "Expected to find card with source_lemma='cross_src_swh' in reversed-pair results"
+    # Should only return the reversed-pair card, NOT the original-direction card
     for card in data2:
         assert card["source_version_id"] == test_version_id_2, (
-            f"Expected source_version_id='swh', got '{card['source_version_id']}' "
+            f"Expected source_version_id={test_version_id_2}, "
+            f"got {card['source_version_id']} "
             f"(target_lemma='{card['target_lemma']}')"
         )
         assert card["target_version_id"] == test_version_id, (
-            f"Expected target_version_id='eng', got '{card['target_version_id']}' "
+            f"Expected target_version_id={test_version_id}, "
+            f"got {card['target_version_id']} "
             f"(target_lemma='{card['target_lemma']}')"
         )
 

--- a/test/test_agent_routes/test_agent_translation.py
+++ b/test/test_agent_routes/test_agent_translation.py
@@ -1,9 +1,21 @@
 # test_agent_translation.py
 """Tests for agent translation storage API endpoints."""
 
-from database.models import AgentTranslation
+from database.models import AgentTranslation, Assessment, BibleRevision
 
 prefix = "v3"
+
+
+def _reference_version_id(db_session, assessment_id):
+    assessment = (
+        db_session.query(Assessment).filter(Assessment.id == assessment_id).one()
+    )
+    revision = (
+        db_session.query(BibleRevision)
+        .filter(BibleRevision.id == assessment.reference_id)
+        .one()
+    )
+    return revision.bible_version_id
 
 
 def test_add_translation_success(
@@ -37,7 +49,9 @@ def test_add_translation_success(
     assert data["created_at"] is not None
     # New denormalized fields
     assert data["revision_id"] is not None
-    assert data["language"] == "eng"
+    assert data["reference_version_id"] == _reference_version_id(
+        db_session, test_assessment_id
+    )
     assert data["script"] == "Latn"
 
     # Verify in database
@@ -49,14 +63,16 @@ def test_add_translation_success(
     assert translation is not None
     assert translation.vref == "JHN 1:1"
     assert translation.version == 1
-    assert translation.language == "eng"
+    assert translation.reference_version_id == _reference_version_id(
+        db_session, test_assessment_id
+    )
     assert translation.script == "Latn"
 
 
 def test_add_translation_version_auto_increment(
     client, regular_token1, test_assessment_id, db_session
 ):
-    """Test that version auto-increments for same revision+language+script+vref."""
+    """Test that version auto-increments for same revision+reference version+script+vref."""
     translation_data = {
         "assessment_id": test_assessment_id,
         "vref": "JHN 1:2",
@@ -214,7 +230,9 @@ def test_add_translations_bulk_success(
     # Verify new fields present
     for t in data:
         assert t["revision_id"] is not None
-        assert t["language"] == "eng"
+        assert t["reference_version_id"] == _reference_version_id(
+            db_session, test_assessment_id
+        )
         assert t["script"] == "Latn"
 
 
@@ -575,9 +593,11 @@ def test_get_translations_by_revision_id(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
+    reference_version_id = _reference_version_id(db_session, assessment1.id)
+
     # Query by revision_id (latest version per vref) — script omitted
     response = client.get(
-        f"{prefix}/agent/translations?revision_id={test_revision_id}&language=eng",
+        f"{prefix}/agent/translations?revision_id={test_revision_id}&reference_version_id={reference_version_id}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -630,8 +650,9 @@ def test_get_translations_by_revision_id_all_versions(
         )
 
     # Query with all_versions=true
+    reference_version_id = _reference_version_id(db_session, assessment.id)
     response = client.get(
-        f"{prefix}/agent/translations?revision_id={test_revision_id}&language=eng&vref=JHN 2:3&all_versions=true",
+        f"{prefix}/agent/translations?revision_id={test_revision_id}&reference_version_id={reference_version_id}&vref=JHN 2:3&all_versions=true",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -703,8 +724,9 @@ def test_get_translations_by_revision_id_with_vref_filter(
         )
 
     # Query by revision_id with vref filter
+    reference_version_id = _reference_version_id(db_session, assessment.id)
     response = client.get(
-        f"{prefix}/agent/translations?revision_id={test_revision_id}&language=eng&vref=JHN 2:6",
+        f"{prefix}/agent/translations?revision_id={test_revision_id}&reference_version_id={reference_version_id}&vref=JHN 2:6",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -745,8 +767,9 @@ def test_get_translations_by_revision_id_with_verse_range(
         )
 
     # Query by revision_id with verse range
+    reference_version_id = _reference_version_id(db_session, assessment.id)
     response = client.get(
-        f"{prefix}/agent/translations?revision_id={test_revision_id}&language=eng&script=Latn&first_vref=JHN 2:11&last_vref=JHN 2:13",
+        f"{prefix}/agent/translations?revision_id={test_revision_id}&reference_version_id={reference_version_id}&script=Latn&first_vref=JHN 2:11&last_vref=JHN 2:13",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -762,30 +785,30 @@ def test_get_translations_by_revision_id_with_verse_range(
     assert "JHN 2:14" not in vrefs
 
 
-def test_get_translations_by_revision_id_requires_language(
+def test_get_translations_by_revision_id_requires_reference_version(
     client, regular_token1, test_revision_id
 ):
-    """Test that revision_id without language returns 400."""
+    """Test that revision_id without reference_version_id returns 400."""
     response = client.get(
         f"{prefix}/agent/translations?revision_id={test_revision_id}",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 400
-    assert "language is required" in response.json()["detail"].lower()
+    assert "reference_version_id is required" in response.json()["detail"].lower()
 
-    # script alone (without language) should also fail
+    # script alone (without reference_version_id) should also fail
     response = client.get(
         f"{prefix}/agent/translations?revision_id={test_revision_id}&script=Latn",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 400
-    assert "language is required" in response.json()["detail"].lower()
+    assert "reference_version_id is required" in response.json()["detail"].lower()
 
 
-def test_get_translations_by_revision_id_with_language_filter(
+def test_get_translations_by_revision_id_with_reference_version_filter(
     client, regular_token1, test_revision_id, db_session
 ):
-    """Test filtering translations by language when querying by revision_id."""
+    """Test filtering translations by reference version when querying by revision_id."""
     from datetime import date
 
     from database.models import (
@@ -836,7 +859,7 @@ def test_get_translations_by_revision_id_with_language_filter(
         .first()
     )
 
-    # Create two assessments for the same revision_id but different reference languages
+    # Create two assessments for the same revision_id but different reference versions
     assessment_eng = Assessment(
         revision_id=test_revision_id,
         reference_id=eng_revision.id,
@@ -876,9 +899,9 @@ def test_get_translations_by_revision_id_with_language_filter(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
-    # Query with language=eng — should only get the eng-reference translation
+    # Query with the eng reference version — should only get the eng-reference translation
     response_eng = client.get(
-        f"{prefix}/agent/translations?revision_id={test_revision_id}&language=eng&script=Latn&vref=JHN 3:1&all_versions=true",
+        f"{prefix}/agent/translations?revision_id={test_revision_id}&reference_version_id={eng_version.id}&script=Latn&vref=JHN 3:1&all_versions=true",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response_eng.status_code == 200
@@ -891,9 +914,9 @@ def test_get_translations_by_revision_id_with_language_filter(
     )
     assert not any(t["draft_text"] == "Swahili ref translation" for t in data_eng)
 
-    # Query with language=swh — should only get the swh-reference translation
+    # Query with the swh reference version — should only get the swh-reference translation
     response_swh = client.get(
-        f"{prefix}/agent/translations?revision_id={test_revision_id}&language=swh&script=Latn&vref=JHN 3:1&all_versions=true",
+        f"{prefix}/agent/translations?revision_id={test_revision_id}&reference_version_id={swh_version.id}&script=Latn&vref=JHN 3:1&all_versions=true",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response_swh.status_code == 200
@@ -907,12 +930,12 @@ def test_get_translations_by_revision_id_with_language_filter(
     assert not any(t["draft_text"] == "English ref translation" for t in data_swh)
 
 
-def test_get_translations_assessment_id_with_wrong_language(
+def test_get_translations_assessment_id_with_wrong_reference_version(
     client, regular_token1, test_assessment_id
 ):
-    """Test that assessment_id with mismatched language returns 400."""
+    """Test that assessment_id with mismatched reference_version_id returns 400."""
     response = client.get(
-        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&language=swh",
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&reference_version_id=999999",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -937,7 +960,7 @@ def test_version_increments_across_assessments(
     client, regular_token1, test_revision_id, test_revision_id_2, db_session
 ):
     """Test that version auto-increments across assessments sharing the same
-    revision+language+script when using the single POST endpoint."""
+    revision+reference version+script when using the single POST endpoint."""
     from database.models import Assessment
 
     # Create two assessments for the same revision
@@ -971,7 +994,7 @@ def test_version_increments_across_assessments(
     assert r1.status_code == 200
     assert r1.json()["version"] == 1
 
-    # POST via assessment2 for same revision+language+script+vref → version 2
+    # POST via assessment2 for same revision+reference version+script+vref → version 2
     r2 = client.post(
         f"{prefix}/agent/translation",
         json={
@@ -989,7 +1012,7 @@ def test_bulk_version_increments_across_assessments(
     client, regular_token1, test_revision_id, test_revision_id_2, db_session
 ):
     """Test that bulk POST version auto-increments across assessments sharing
-    the same revision+language+script."""
+    the same revision+reference version+script."""
     from database.models import Assessment
 
     assessment1 = Assessment(
@@ -1024,7 +1047,7 @@ def test_bulk_version_increments_across_assessments(
     assert r1.status_code == 200
     version1 = r1.json()[0]["version"]
 
-    # Bulk POST via assessment2 for same revision+language+script → next version
+    # Bulk POST via assessment2 for same revision+reference version+script → next version
     r2 = client.post(
         f"{prefix}/agent/translations",
         json={
@@ -1069,8 +1092,9 @@ def test_get_translations_by_revision_id_all_versions_no_script(
         )
 
     # Query with all_versions=true, no script
+    reference_version_id = _reference_version_id(db_session, assessment.id)
     response = client.get(
-        f"{prefix}/agent/translations?revision_id={test_revision_id}&language=eng&vref=JHN 4:5&all_versions=true",
+        f"{prefix}/agent/translations?revision_id={test_revision_id}&reference_version_id={reference_version_id}&vref=JHN 4:5&all_versions=true",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 

--- a/test/test_agent_routes/test_lexeme_card_access_control.py
+++ b/test/test_agent_routes/test_lexeme_card_access_control.py
@@ -37,7 +37,12 @@ def test_lexeme_card_access_control_by_user(
     group1 = db_session.query(Group).filter(Group.name == "Group1").first()
     group2 = db_session.query(Group).filter(Group.name == "Group2").first()
 
-    # Create version3 for Group1
+    # Two versions: one per user. The lexeme card lives at the version pair
+    # (version3, version4) so both users can write to it from their own side
+    # — examples must be tied to a revision in either the source or the
+    # target version of the card. The route's example filter restricts each
+    # user's visible examples to revisions whose version they have access to,
+    # which is the access control we're verifying here.
     version3 = BibleVersion(
         name="test_version_user1",
         iso_language="eng",
@@ -46,10 +51,6 @@ def test_lexeme_card_access_control_by_user(
         owner_id=user1.id,
         is_reference=False,
     )
-    db_session.add(version3)
-    db_session.commit()
-
-    # Create version4 for Group2
     version4 = BibleVersion(
         name="test_version_user2",
         iso_language="eng",
@@ -58,45 +59,36 @@ def test_lexeme_card_access_control_by_user(
         owner_id=user2.id,
         is_reference=False,
     )
-    db_session.add(version4)
+    db_session.add_all([version3, version4])
     db_session.commit()
 
-    # Create revision3 for version3
     revision3 = BibleRevision(
         date=date.today(),
         bible_version_id=version3.id,
         published=False,
         machine_translation=True,
     )
-    db_session.add(revision3)
-    db_session.commit()
-    revision3_id = revision3.id
-
-    # Create revision4 for version4
     revision4 = BibleRevision(
         date=date.today(),
         bible_version_id=version4.id,
         published=False,
         machine_translation=True,
     )
-    db_session.add(revision4)
+    db_session.add_all([revision3, revision4])
     db_session.commit()
+    revision3_id = revision3.id
     revision4_id = revision4.id
 
-    # Give Group1 access to version3
-    access1 = BibleVersionAccess(
-        bible_version_id=version3.id,
-        group_id=group1.id,
+    db_session.add_all(
+        [
+            BibleVersionAccess(bible_version_id=version3.id, group_id=group1.id),
+            BibleVersionAccess(bible_version_id=version4.id, group_id=group2.id),
+        ]
     )
-    db_session.add(access1)
-
-    # Give Group2 access to version4
-    access2 = BibleVersionAccess(
-        bible_version_id=version4.id,
-        group_id=group2.id,
-    )
-    db_session.add(access2)
     db_session.commit()
+
+    source_card_version_id = version3.id
+    target_card_version_id = version4.id
 
     # User 1 adds a lexeme card with examples from revision3
     response1 = client.post(
@@ -105,8 +97,8 @@ def test_lexeme_card_access_control_by_user(
         json={
             "source_lemma": "water",
             "target_lemma": "maji",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": source_card_version_id,
+            "target_version_id": target_card_version_id,
             "pos": "noun",
             "surface_forms": ["maji"],
             "senses": [{"definition": "liquid H2O"}],
@@ -134,8 +126,8 @@ def test_lexeme_card_access_control_by_user(
         json={
             "source_lemma": "water",
             "target_lemma": "maji",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": source_card_version_id,
+            "target_version_id": target_card_version_id,
             "examples": [
                 {"source": "Clean water", "target": "Maji safi"},
                 {"source": "Hot water", "target": "Maji moto"},
@@ -158,7 +150,7 @@ def test_lexeme_card_access_control_by_user(
 
     # Now query as user1 - should only see examples from revision3
     response3 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=maji",
+        f"/v3/agent/lexeme-card?source_version_id={source_card_version_id}&target_version_id={target_card_version_id}&target_word=maji",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -175,7 +167,7 @@ def test_lexeme_card_access_control_by_user(
 
     # Now query as user2 - should only see examples from revision4
     response4 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=maji",
+        f"/v3/agent/lexeme-card?source_version_id={source_card_version_id}&target_version_id={target_card_version_id}&target_word=maji",
         headers={"Authorization": f"Bearer {regular_token2}"},
     )
 
@@ -194,7 +186,7 @@ def test_lexeme_card_access_control_by_user(
     # Now query as admin - should see ALL examples from both revisions (5 total)
     # Admin has access to all revisions in the system
     response5 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=maji",
+        f"/v3/agent/lexeme-card?source_version_id={source_card_version_id}&target_version_id={target_card_version_id}&target_word=maji",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
 
@@ -246,6 +238,7 @@ def test_single_user_multiple_revisions_same_version(
     )
     revision1_id = revisions[0].id
     revision2_id = revisions[1].id
+    card_version_id = version.id
 
     # User1 adds a lexeme card with examples from revision 1
     response1 = client.post(
@@ -254,8 +247,8 @@ def test_single_user_multiple_revisions_same_version(
         json={
             "source_lemma": "book",
             "target_lemma": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": card_version_id,
+            "target_version_id": card_version_id,
             "pos": "noun",
             "surface_forms": ["kitabu"],
             "examples": [
@@ -282,8 +275,8 @@ def test_single_user_multiple_revisions_same_version(
         json={
             "source_lemma": "book",
             "target_lemma": "kitabu",
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": card_version_id,
+            "target_version_id": card_version_id,
             "examples": [
                 {"source": "Buy a book", "target": "Nunua kitabu"},
                 {"source": "Old book", "target": "Kitabu cha zamani"},
@@ -306,7 +299,7 @@ def test_single_user_multiple_revisions_same_version(
 
     # Now query the lexeme card - user1 should see ALL 5 examples from both revisions
     response3 = client.get(
-        "/v3/agent/lexeme-card?source_language=eng&target_language=swh&target_word=kitabu",
+        f"/v3/agent/lexeme-card?source_version_id={card_version_id}&target_version_id={card_version_id}&target_word=kitabu",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 

--- a/test/test_agent_routes/test_lexeme_card_access_control.py
+++ b/test/test_agent_routes/test_lexeme_card_access_control.py
@@ -321,3 +321,81 @@ def test_single_user_multiple_revisions_same_version(
     assert card["examples"][2]["source"] == "Buy a book"
     assert card["examples"][3]["source"] == "Old book"
     assert card["examples"][4]["source"] == "Write a book"
+
+
+def test_lexeme_card_isolated_across_versions_with_same_iso_language(
+    client, admin_token, db_session
+):
+    """A lexeme card stored under (version_a, version_b) must be invisible to a
+    query for (version_c, version_b) even when all three versions share
+    iso_language='eng'. Regression test for aqua-api#613.
+    """
+    from database.models import BibleRevision, BibleVersion, UserDB
+
+    admin = db_session.query(UserDB).filter(UserDB.username == "admin").first()
+    versions = [
+        BibleVersion(
+            name=f"iso_isolation_lexeme_{tag}",
+            iso_language="eng",
+            iso_script="Latn",
+            abbreviation=f"IIL{tag}",
+            owner_id=admin.id,
+            is_reference=False,
+        )
+        for tag in ("a", "b", "c")
+    ]
+    db_session.add_all(versions)
+    db_session.commit()
+    ver_a, ver_b, ver_c = versions
+
+    rev_a = BibleRevision(
+        date=date.today(),
+        bible_version_id=ver_a.id,
+        published=False,
+        machine_translation=True,
+    )
+    db_session.add(rev_a)
+    db_session.commit()
+
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # POST a card under (ver_a, ver_b)
+    target_lemma = "iso_isolation_lex_card"
+    create = client.post(
+        f"/v3/agent/lexeme-card?revision_id={rev_a.id}",
+        headers=headers,
+        json={
+            "source_lemma": "iso_isolation_src",
+            "target_lemma": target_lemma,
+            "source_version_id": ver_a.id,
+            "target_version_id": ver_b.id,
+        },
+    )
+    assert create.status_code == 200, create.text
+
+    # Query under the WRONG source pair (ver_c, ver_b) — must NOT find the card
+    miss = client.get(
+        "/v3/agent/lexeme-card",
+        params={
+            "source_version_id": ver_c.id,
+            "target_version_id": ver_b.id,
+            "target_word": target_lemma,
+        },
+        headers=headers,
+    )
+    assert miss.status_code == 200
+    assert miss.json() == []
+
+    # Sanity: under the correct pair the card is found
+    hit = client.get(
+        "/v3/agent/lexeme-card",
+        params={
+            "source_version_id": ver_a.id,
+            "target_version_id": ver_b.id,
+            "target_word": target_lemma,
+        },
+        headers=headers,
+    )
+    assert hit.status_code == 200
+    assert len(hit.json()) == 1
+    assert hit.json()[0]["target_lemma"] == target_lemma

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1398,8 +1398,8 @@ def test_use_eflomal_wrong_type(client, regular_token1, db_session, test_db_sess
                 "revision_id": revision_id,
                 "type": "sentence-length",
                 "use_eflomal": True,
-                "source_language": "eng",
-                "target_language": "swh",
+                "source_version_id": 1,
+                "target_version_id": 2,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
@@ -1407,10 +1407,10 @@ def test_use_eflomal_wrong_type(client, regular_token1, db_session, test_db_sess
     assert "use_eflomal" in response.json()["detail"]
 
 
-def test_use_eflomal_missing_languages(
+def test_use_eflomal_missing_versions(
     client, regular_token1, db_session, test_db_session
 ):
-    """use_eflomal=true without source_language or target_language returns 400."""
+    """use_eflomal=true without source_version_id or target_version_id returns 400."""
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
     reference_id = upload_revision(client, regular_token1, version_id)
@@ -1420,7 +1420,7 @@ def test_use_eflomal_missing_languages(
     ) as mock_runner:
         mock_runner.return_value = None
 
-        # Missing both languages
+        # Missing both version IDs
         response = client.post(
             f"{prefix}/assessment",
             params={
@@ -1432,9 +1432,9 @@ def test_use_eflomal_missing_languages(
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
         assert response.status_code == 400
-        assert "language" in response.json()["detail"].lower()
+        assert "version_id" in response.json()["detail"].lower()
 
-        # Missing only target_language
+        # Missing only target_version_id
         response = client.post(
             f"{prefix}/assessment",
             params={
@@ -1442,7 +1442,7 @@ def test_use_eflomal_missing_languages(
                 "reference_id": reference_id,
                 "type": "word-alignment",
                 "use_eflomal": True,
-                "source_language": "eng",
+                "source_version_id": 1,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
@@ -1465,8 +1465,8 @@ def test_use_eflomal_dedup_separate_from_regular(
     eflomal_params = {
         **base_params,
         "use_eflomal": True,
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": version_id,
+        "target_version_id": version_id,
     }
 
     with patch(
@@ -1528,8 +1528,8 @@ def test_kwargs_returned_in_assessment_response(
                 "reference_id": reference_id,
                 "type": "word-alignment",
                 "use_eflomal": True,
-                "source_language": "eng",
-                "target_language": "swh",
+                "source_version_id": version_id,
+                "target_version_id": version_id,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -977,3 +977,99 @@ def test_pull_eflomal_results_without_priors_or_bpe(
     # Parent revision/reference IDs come from the Assessment row
     assert data["revision_id"] is not None
     assert data["reference_id"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Cross-version isolation (regression test for aqua-api#613)
+# ---------------------------------------------------------------------------
+
+
+def test_pull_by_version_pair_isolates_versions_with_same_iso_language(
+    client, admin_token, test_db_session
+):
+    """Two bible_versions with the same iso_language must NOT share eflomal artifacts.
+
+    Pre-migration, the GET endpoint matched on (source_language, target_language)
+    so a query for version pair (A, B) would return artifacts from any pair with
+    matching ISO codes — including (C, B) for a different version C in the same
+    language. After version_id keying, the lookup is by (source_version_id,
+    target_version_id) so the artifacts must be isolated.
+
+    Setup creates three eng→eng versions (A, B, C). Pushes eflomal results for
+    pair (A, B). Pulls by pair (C, B) — must 404. Sanity-pulls (A, B) — must 200.
+    """
+    from datetime import date
+
+    from database.models import (
+        Assessment,
+        BibleRevision,
+        BibleVersion,
+        UserDB,
+    )
+
+    user = test_db_session.query(UserDB).filter(UserDB.username == "admin").first()
+    versions = [
+        BibleVersion(
+            name=f"iso_isolation_eflomal_{tag}",
+            iso_language="eng",
+            iso_script="Latn",
+            abbreviation=f"IIE{tag}",
+            owner_id=user.id,
+            is_reference=False,
+        )
+        for tag in ("a", "b", "c")
+    ]
+    test_db_session.add_all(versions)
+    test_db_session.commit()
+    ver_a, ver_b, ver_c = versions
+
+    revs = [
+        BibleRevision(
+            date=date.today(),
+            bible_version_id=v.id,
+            published=False,
+            machine_translation=True,
+        )
+        for v in (ver_a, ver_b, ver_c)
+    ]
+    test_db_session.add_all(revs)
+    test_db_session.commit()
+    rev_a, rev_b, rev_c = revs
+
+    # Pre-create assessment_AB so the push has a valid target.
+    a_ab = Assessment(
+        revision_id=rev_a.id,
+        reference_id=rev_b.id,
+        type="word-alignment",
+        status="running",
+    )
+    test_db_session.add(a_ab)
+    test_db_session.commit()
+    test_db_session.refresh(a_ab)
+
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    push_resp = client.post(
+        f"{prefix}/assessment/eflomal/results",
+        json=_metadata_payload(a_ab.id),
+        headers=headers,
+    )
+    assert push_resp.status_code == 200, push_resp.text
+
+    # Pull by the WRONG version pair (C, B) — must return 404 even though
+    # all three versions share iso_language='eng'.
+    miss_resp = client.get(
+        f"{prefix}/assessment/eflomal/results",
+        params={"source_version_id": ver_c.id, "target_version_id": ver_b.id},
+        headers=headers,
+    )
+    assert miss_resp.status_code == 404, miss_resp.text
+
+    # Sanity: pulling the correct pair (A, B) returns the data we just pushed.
+    hit_resp = client.get(
+        f"{prefix}/assessment/eflomal/results",
+        params={"source_version_id": ver_a.id, "target_version_id": ver_b.id},
+        headers=headers,
+    )
+    assert hit_resp.status_code == 200, hit_resp.text
+    assert hit_resp.json()["assessment_id"] == a_ab.id

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -53,8 +53,8 @@ def _bpe_payload(
 def _metadata_payload(
     assessment_id,
     n_dict=10,
-    source_language=None,
-    target_language=None,
+    source_version_id=None,
+    target_version_id=None,
 ):
     """Build an EflomalResultsPushRequest (metadata-only) payload."""
     payload = {
@@ -64,10 +64,10 @@ def _metadata_payload(
         "num_dictionary_entries": n_dict,
         "num_missing_words": 3,
     }
-    if source_language is not None:
-        payload["source_language"] = source_language
-    if target_language is not None:
-        payload["target_language"] = target_language
+    if source_version_id is not None:
+        payload["source_version_id"] = source_version_id
+    if target_version_id is not None:
+        payload["target_version_id"] = target_version_id
     return payload
 
 
@@ -99,7 +99,9 @@ def _target_word_count_items(n=5):
     return [{"word": f"word_{i}", "count": i + 10} for i in range(n)]
 
 
-def _push_all(client, token, assessment_id, source_language=None, target_language=None):
+def _push_all(
+    client, token, assessment_id, source_version_id=None, target_version_id=None
+):
     """Push metadata + all three data types. Returns the metadata response."""
     headers = {"Authorization": f"Bearer {token}"}
 
@@ -107,8 +109,8 @@ def _push_all(client, token, assessment_id, source_language=None, target_languag
         f"{prefix}/assessment/eflomal/results",
         json=_metadata_payload(
             assessment_id,
-            source_language=source_language,
-            target_language=target_language,
+            source_version_id=source_version_id,
+            target_version_id=target_version_id,
         ),
         headers=headers,
     )
@@ -407,14 +409,13 @@ def test_push_eflomal_data_unauthorized(
 
 
 @pytest.fixture(scope="module")
-def test_eflomal_assessment_language_id(
+def test_eflomal_assessment_version_id(
     test_db_session, test_revision_id, test_revision_id_2
 ):
-    """Dedicated word-alignment assessment for language-based pull tests.
+    """Dedicated word-alignment assessment for version-based pull tests.
 
     Kept separate from test_eflomal_assessment_id so the push tests cannot
-    pre-populate it without language fields (which would trigger idempotency
-    and leave source_language/target_language as NULL).
+    pre-populate it before version-pair pull assertions.
     """
     assessment = Assessment(
         revision_id=test_revision_id,
@@ -429,14 +430,12 @@ def test_eflomal_assessment_language_id(
 
 
 @pytest.fixture(scope="module")
-def _ensure_eflomal_pushed(client, regular_token1, test_eflomal_assessment_language_id):
+def _ensure_eflomal_pushed(client, regular_token1, test_eflomal_assessment_version_id):
     """Ensure eflomal results exist for the test assessment before pull tests run."""
     return _push_all(
         client,
         regular_token1,
-        test_eflomal_assessment_language_id,
-        source_language="eng",
-        target_language="swh",
+        test_eflomal_assessment_version_id,
     )
 
 
@@ -544,24 +543,28 @@ def test_pull_eflomal_results_no_eflomal_data(
 
 
 # ---------------------------------------------------------------------------
-# Pull by language pair (GET /assessment/eflomal/results?source_language=&target_language=)
+# Pull by version pair (GET /assessment/eflomal/results?source_version_id=&target_version_id=)
 # ---------------------------------------------------------------------------
 
 
-def test_pull_eflomal_results_by_language_success(
+def test_pull_eflomal_results_by_version_success(
     client, regular_token1, _ensure_eflomal_pushed
 ):
-    """Pull by language pair returns the same artifacts as pull by assessment_id."""
+    """Pull by version pair returns the same artifacts as pull by assessment_id."""
+    pushed = _ensure_eflomal_pushed
     response = client.get(
         f"{prefix}/assessment/eflomal/results",
-        params={"source_language": "eng", "target_language": "swh"},
+        params={
+            "source_version_id": pushed["source_version_id"],
+            "target_version_id": pushed["target_version_id"],
+        },
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
     data = response.json()
 
-    assert data["source_language"] == "eng"
-    assert data["target_language"] == "swh"
+    assert data["source_version_id"] == pushed["source_version_id"]
+    assert data["target_version_id"] == pushed["target_version_id"]
     assert data["num_verse_pairs"] == 100
     assert data["num_alignment_links"] == 500
     assert data["num_dictionary_entries"] == 10
@@ -576,33 +579,41 @@ def test_pull_eflomal_results_by_language_success(
     assert data["reference_id"] is not None
 
 
-def test_pull_eflomal_results_by_language_not_found(client, regular_token1):
-    """Language pair with no results should return 404."""
+def test_pull_eflomal_results_by_version_not_found(client, regular_token1):
+    """Version pair with no results should return 404."""
     response = client.get(
         f"{prefix}/assessment/eflomal/results",
-        params={"source_language": "eng", "target_language": "zga"},
+        params={"source_version_id": 999998, "target_version_id": 999999},
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 404
 
 
-def test_pull_eflomal_results_by_language_unauthorized(
+def test_pull_eflomal_results_by_version_unauthorized(
     client, regular_token2, _ensure_eflomal_pushed
 ):
     """User without access to the underlying assessment should receive 403."""
+    pushed = _ensure_eflomal_pushed
     response = client.get(
         f"{prefix}/assessment/eflomal/results",
-        params={"source_language": "eng", "target_language": "swh"},
+        params={
+            "source_version_id": pushed["source_version_id"],
+            "target_version_id": pushed["target_version_id"],
+        },
         headers={"Authorization": f"Bearer {regular_token2}"},
     )
     assert response.status_code == 403
 
 
-def test_pull_eflomal_results_by_language_no_auth(client):
+def test_pull_eflomal_results_by_version_no_auth(client, _ensure_eflomal_pushed):
     """Request without auth token should fail (401)."""
+    pushed = _ensure_eflomal_pushed
     response = client.get(
         f"{prefix}/assessment/eflomal/results",
-        params={"source_language": "eng", "target_language": "swh"},
+        params={
+            "source_version_id": pushed["source_version_id"],
+            "target_version_id": pushed["target_version_id"],
+        },
     )
     assert response.status_code == 401
 
@@ -615,25 +626,25 @@ def test_pull_eflomal_results_by_language_no_auth(client):
 def test_pull_eflomal_results_both_selectors(
     client, regular_token1, _ensure_eflomal_pushed
 ):
-    """Providing both assessment_id and language pair should return 400."""
+    """Providing both assessment_id and version pair should return 400."""
     pushed = _ensure_eflomal_pushed
     response = client.get(
         f"{prefix}/assessment/eflomal/results",
         params={
             "assessment_id": pushed["assessment_id"],
-            "source_language": "eng",
-            "target_language": "swh",
+            "source_version_id": pushed["source_version_id"],
+            "target_version_id": pushed["target_version_id"],
         },
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 400
 
 
-def test_pull_eflomal_results_partial_language(client, regular_token1):
-    """Providing only one language param (no assessment_id) should return 400."""
+def test_pull_eflomal_results_partial_version(client, regular_token1):
+    """Providing only one version param (no assessment_id) should return 400."""
     response = client.get(
         f"{prefix}/assessment/eflomal/results",
-        params={"source_language": "eng"},
+        params={"source_version_id": 1},
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 400

--- a/test/test_assessment_routes/test_tfidf_artifact_routes.py
+++ b/test/test_assessment_routes/test_tfidf_artifact_routes.py
@@ -842,3 +842,94 @@ def test_existing_tfidf_result_by_vref_still_works(
     vrefs = [r["vref"] for r in data["results"]]
     assert "GEN 1:2" not in vrefs
     assert set(vrefs) <= {"GEN 1:1", "GEN 1:3"}
+
+
+# ---------------------------------------------------------------------------
+# Cross-version isolation (regression test for aqua-api#613)
+# ---------------------------------------------------------------------------
+
+
+def test_pull_by_source_version_isolates_versions_with_same_iso_language(
+    client, admin_token, test_db_session
+):
+    """Two bible_versions with the same iso_language must NOT share TF-IDF artifacts.
+
+    Pre-migration the GET endpoint matched on source_language. Two different
+    versions that happened to be in the same ISO language would conflate
+    artifacts. After version_id keying, the lookup is by source_version_id and
+    must isolate them.
+    """
+    from datetime import date
+
+    from database.models import (
+        Assessment,
+        BibleRevision,
+        BibleVersion,
+        UserDB,
+    )
+
+    user = test_db_session.query(UserDB).filter(UserDB.username == "admin").first()
+    versions = [
+        BibleVersion(
+            name=f"iso_isolation_tfidf_{tag}",
+            iso_language="eng",
+            iso_script="Latn",
+            abbreviation=f"IIT{tag}",
+            owner_id=user.id,
+            is_reference=False,
+        )
+        for tag in ("a", "c")
+    ]
+    test_db_session.add_all(versions)
+    test_db_session.commit()
+    ver_a, ver_c = versions
+
+    revs = [
+        BibleRevision(
+            date=date.today(),
+            bible_version_id=v.id,
+            published=False,
+            machine_translation=True,
+        )
+        for v in (ver_a, ver_c)
+    ]
+    test_db_session.add_all(revs)
+    test_db_session.commit()
+    rev_a, rev_c = revs
+
+    a_a = Assessment(
+        revision_id=rev_a.id,
+        reference_id=rev_a.id,
+        type="tfidf",
+        status="running",
+    )
+    test_db_session.add(a_a)
+    test_db_session.commit()
+    test_db_session.refresh(a_a)
+
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    # Push artifacts under version A
+    push = client.post(
+        f"{prefix}/assessment/{a_a.id}/tfidf-artifacts",
+        json=_make_artifact_body(),
+        headers=headers,
+    )
+    assert push.status_code == 200, push.text
+
+    # Pull by version C (same iso_language) — must 404, not return version A's data
+    miss = client.get(
+        f"{prefix}/assessment/tfidf/artifacts",
+        params={"source_version_id": ver_c.id},
+        headers=headers,
+    )
+    assert miss.status_code == 404, miss.text
+
+    # Sanity: pull by version A returns the artifacts
+    hit = client.get(
+        f"{prefix}/assessment/tfidf/artifacts",
+        params={"source_version_id": ver_a.id},
+        headers=headers,
+    )
+    assert hit.status_code == 200, hit.text
+    assert hit.json()["assessment_id"] == a_a.id

--- a/test/test_assessment_routes/test_tfidf_artifact_routes.py
+++ b/test/test_assessment_routes/test_tfidf_artifact_routes.py
@@ -36,11 +36,10 @@ def _make_artifact_body(
     n_components: int = 5,
     n_word_features: int = 3,
     n_char_features: int = 4,
-    source_language: str = "swh",
+    source_version_id: int | None = None,
 ) -> dict:
     n_features = n_word_features + n_char_features
-    return {
-        "source_language": source_language,
+    body = {
         "n_components": n_components,
         "n_corpus_vrefs": 42,
         "sklearn_version": "1.6.1",
@@ -73,6 +72,9 @@ def _make_artifact_body(
             "components_b64": _components_b64(n_components, n_features),
         },
     }
+    if source_version_id is not None:
+        body["source_version_id"] = source_version_id
+    return body
 
 
 @pytest.fixture(scope="module")
@@ -180,7 +182,7 @@ def test_tfidf_artifact_round_trip(client, regular_token1, tfidf_assessment_id):
     assert resp.status_code == 200, resp.text
     pulled = resp.json()
     assert pulled["assessment_id"] == tfidf_assessment_id
-    assert pulled["source_language"] == "swh"
+    assert pulled["source_version_id"] is not None
     assert pulled["n_components"] == 5
     assert pulled["n_word_features"] == 3
     assert pulled["n_char_features"] == 4
@@ -209,7 +211,6 @@ def test_tfidf_artifact_idempotency(client, regular_token1, tfidf_assessment_id)
     """Re-posting replaces the artifacts rather than creating duplicates."""
     headers = {"Authorization": f"Bearer {regular_token1}"}
     body = _make_artifact_body(n_word_features=6, n_char_features=8)
-    body["source_language"] = "eng"
 
     resp = client.post(
         f"{prefix}/assessment/{tfidf_assessment_id}/tfidf-artifacts",
@@ -230,7 +231,7 @@ def test_tfidf_artifact_idempotency(client, regular_token1, tfidf_assessment_id)
         params={"assessment_id": tfidf_assessment_id},
         headers=headers,
     ).json()
-    assert pulled["source_language"] == "eng"
+    assert pulled["source_version_id"] is not None
     assert pulled["n_word_features"] == 6
     assert pulled["n_char_features"] == 8
 
@@ -386,23 +387,21 @@ def test_tfidf_artifact_pull_both_selectors(
 ):
     resp = client.get(
         f"{prefix}/assessment/tfidf/artifacts",
-        params={"assessment_id": tfidf_assessment_id, "source_language": "eng"},
+        params={"assessment_id": tfidf_assessment_id, "source_version_id": 1},
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert resp.status_code == 422
 
 
-def test_tfidf_artifact_pull_latest_by_language(
+def test_tfidf_artifact_pull_latest_by_version(
     client, regular_token1, tfidf_assessment_id, tfidf_assessment_id_2
 ):
-    """Two runs with the same source_language — GET by language returns the newer one."""
+    """Two runs with the same source_version_id return the newer one."""
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
-    # First run (older) — already 'eng' from the idempotency test above.
-    # Push a second run for the same language; it must be most recent.
-    body = _make_artifact_body(
-        n_components=7, n_word_features=5, n_char_features=9, source_language="eng"
-    )
+    # First run is already present from earlier tests. Push a second run for
+    # the same source version; it must be most recent.
+    body = _make_artifact_body(n_components=7, n_word_features=5, n_char_features=9)
     body["n_corpus_vrefs"] = 17
     resp = client.post(
         f"{prefix}/assessment/{tfidf_assessment_id_2}/tfidf-artifacts",
@@ -410,10 +409,15 @@ def test_tfidf_artifact_pull_latest_by_language(
         headers=headers,
     )
     assert resp.status_code == 200, resp.text
+    source_version_id = client.get(
+        f"{prefix}/assessment/tfidf/artifacts",
+        params={"assessment_id": tfidf_assessment_id_2},
+        headers=headers,
+    ).json()["source_version_id"]
 
     resp = client.get(
         f"{prefix}/assessment/tfidf/artifacts",
-        params={"source_language": "eng"},
+        params={"source_version_id": source_version_id},
         headers=headers,
     )
     assert resp.status_code == 200

--- a/test/test_assessment_routes/test_tfidf_chunked_upload.py
+++ b/test/test_assessment_routes/test_tfidf_chunked_upload.py
@@ -830,7 +830,12 @@ def test_chunk_oversize_rejected_with_413(
 
 
 def _insert_stale_staging(
-    session, assessment_id: int, *, age_hours: float, with_chunk: bool = True
+    session,
+    assessment_id: int,
+    *,
+    age_hours: float,
+    with_chunk: bool = True,
+    source_version_id: int,
 ) -> uuid.UUID:
     """Drop a hand-crafted staging row (and optional chunk) into the db with a
     backdated created_at, so the sweep treats it as abandoned."""
@@ -839,7 +844,7 @@ def _insert_stale_staging(
     staging = TfidfSvdStaging(
         upload_id=uuid.uuid4(),
         assessment_id=assessment_id,
-        source_version_id=None,
+        source_version_id=source_version_id,
         n_components=4,
         n_corpus_vrefs=1,
         sklearn_version="1.6.1",
@@ -875,6 +880,7 @@ def test_init_sweeps_stale_staging_rows(
     chunk_tfidf_assessment_id,
     chunk_non_tfidf_assessment_id,
     test_db_session,
+    test_version_id,
     monkeypatch,
 ):
     """/init drops staging rows older than the TTL (with their chunks via cascade),
@@ -885,7 +891,10 @@ def test_init_sweeps_stale_staging_rows(
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     stale_id = _insert_stale_staging(
-        test_db_session, chunk_tfidf_assessment_id, age_hours=48
+        test_db_session,
+        chunk_tfidf_assessment_id,
+        age_hours=48,
+        source_version_id=test_version_id,
     )
     # A stale row attached to a different assessment must also be swept —
     # the cleanup is purely time-based, not assessment-scoped.
@@ -894,9 +903,14 @@ def test_init_sweeps_stale_staging_rows(
         chunk_non_tfidf_assessment_id,
         age_hours=72,
         with_chunk=False,
+        source_version_id=test_version_id,
     )
     fresh_id = _insert_stale_staging(
-        test_db_session, chunk_tfidf_assessment_id, age_hours=1, with_chunk=False
+        test_db_session,
+        chunk_tfidf_assessment_id,
+        age_hours=1,
+        with_chunk=False,
+        source_version_id=test_version_id,
     )
 
     info_calls = []

--- a/test/test_assessment_routes/test_tfidf_chunked_upload.py
+++ b/test/test_assessment_routes/test_tfidf_chunked_upload.py
@@ -44,12 +44,12 @@ def _init_body(
     n_word_features: int = 3,
     n_char_features: int = 4,
     total_chunks: int = 4,
-    source_language: str = "swh",
+    source_version_id: int | None = None,
     dtype: str = "float32",
 ) -> dict:
     n_features = n_word_features + n_char_features
     return {
-        "source_language": source_language,
+        "source_version_id": source_version_id,
         "n_components": n_components,
         "n_corpus_vrefs": 42,
         "sklearn_version": "1.6.1",
@@ -537,7 +537,6 @@ def test_commit_replaces_existing_artifacts(
     init_body = _init_body(
         n_components=4, n_word_features=3, n_char_features=4, total_chunks=2
     )
-    init_body["source_language"] = "eng"
     init_body["n_corpus_vrefs"] = 999
 
     upload_id = client.post(
@@ -566,7 +565,8 @@ def test_commit_replaces_existing_artifacts(
         params={"assessment_id": chunk_tfidf_assessment_id},
         headers=headers,
     ).json()
-    assert pulled["source_language"] == "eng"
+    # source_version_id is server-derived from the assessment's revision chain
+    assert pulled["source_version_id"] is not None
     assert pulled["n_corpus_vrefs"] == 999
     assert pulled["n_components"] == 4
     round_tripped = _decode_components(pulled["svd"])
@@ -608,7 +608,7 @@ def test_abort_unauthorized(
 
 
 def _run_single_chunk_upload(
-    client, headers, assessment_id, *, arr, source_language="swh"
+    client, headers, assessment_id, *, arr, source_version_id=None
 ) -> str:
     """Helper: init + 1 chunk + commit a tiny matrix. Returns the upload_id used."""
     body = _init_body(
@@ -616,7 +616,7 @@ def _run_single_chunk_upload(
         n_word_features=3,
         n_char_features=4,
         total_chunks=1,
-        source_language=source_language,
+        source_version_id=source_version_id,
     )
     upload_id = client.post(
         f"{prefix}/assessment/{assessment_id}/tfidf-artifacts/init",
@@ -839,7 +839,7 @@ def _insert_stale_staging(
     staging = TfidfSvdStaging(
         upload_id=uuid.uuid4(),
         assessment_id=assessment_id,
-        source_language="swh",
+        source_version_id=None,
         n_components=4,
         n_corpus_vrefs=1,
         sklearn_version="1.6.1",

--- a/test/test_predict_routes/test_predict_basic_routes.py
+++ b/test/test_predict_routes/test_predict_basic_routes.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, patch
 prefix = "v3"
 
 
-def test_inference_success(client, regular_token1):
+def test_inference_success(client, regular_token1, test_version_id, test_version_id_2):
     """POST /predict/semantic-similarity returns score."""
     with patch("predict_routes.v3.predict_routes.modal.Function") as mock_function_cls:
         mock_fn = AsyncMock()
@@ -16,8 +16,8 @@ def test_inference_success(client, regular_token1):
             json={
                 "text1": "Pakutandika Mulungu apelile kisu na si.",
                 "text2": "Hapo mwanzo Mungu aliumba mbingu na dunia.",
-                "source_language": "zga",
-                "target_language": "swh",
+                "source_version_id": test_version_id,
+                "target_version_id": test_version_id_2,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
@@ -26,7 +26,9 @@ def test_inference_success(client, regular_token1):
     assert response.json() == {"score": 0.85}
 
 
-def test_inference_modal_error_returns_503(client, regular_token1):
+def test_inference_modal_error_returns_503(
+    client, regular_token1, test_version_id, test_version_id_2
+):
     """Modal connection/dispatch errors return 503."""
     with patch("predict_routes.v3.predict_routes.modal.Function") as mock_function_cls:
         mock_fn = AsyncMock()
@@ -38,8 +40,8 @@ def test_inference_modal_error_returns_503(client, regular_token1):
             json={
                 "text1": "hello",
                 "text2": "hola",
-                "source_language": "eng",
-                "target_language": "spa",
+                "source_version_id": test_version_id,
+                "target_version_id": test_version_id_2,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
@@ -48,12 +50,14 @@ def test_inference_modal_error_returns_503(client, regular_token1):
     assert "temporarily unavailable" in response.json()["detail"]
 
 
-def test_inference_no_model_returns_422(client, regular_token1):
+def test_inference_no_model_returns_422(
+    client, regular_token1, test_version_id, test_version_id_2
+):
     """Modal returns error dict when no fine-tuned model exists."""
     with patch("predict_routes.v3.predict_routes.modal.Function") as mock_function_cls:
         mock_fn = AsyncMock()
         mock_fn.remote.aio = AsyncMock(
-            return_value={"error": "No fine-tuned model found for xyz_abc"}
+            return_value={"error": "No fine-tuned model found for 1_2"}
         )
         mock_function_cls.from_name.return_value = mock_fn
 
@@ -62,8 +66,8 @@ def test_inference_no_model_returns_422(client, regular_token1):
             json={
                 "text1": "hello",
                 "text2": "hola",
-                "source_language": "xyz",
-                "target_language": "abc",
+                "source_version_id": test_version_id,
+                "target_version_id": test_version_id_2,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
@@ -90,8 +94,8 @@ def test_inference_no_auth_returns_401(client):
         json={
             "text1": "hello",
             "text2": "hola",
-            "source_language": "eng",
-            "target_language": "spa",
+            "source_version_id": 1,
+            "target_version_id": 2,
         },
     )
 

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -40,7 +40,12 @@ def _make_modal_mock(results_by_app: dict):
     return mock_cls
 
 
-def _body(apps=None, **overrides):
+def _body(
+    source_version_id=1,
+    target_version_id=2,
+    apps=None,
+    **overrides,
+):
     payload = {
         "pairs": [
             {
@@ -49,8 +54,8 @@ def _body(apps=None, **overrides):
                 "target_text": "Hapo mwanzo...",
             }
         ],
-        "source_language": "eng",
-        "target_language": "swh",
+        "source_version_id": source_version_id,
+        "target_version_id": target_version_id,
     }
     if apps is not None:
         payload["apps"] = apps
@@ -223,7 +228,7 @@ def test_predict_missing_pairs_returns_422(client, regular_token1):
     """Missing required `pairs` field returns 422 from pydantic validation."""
     response = client.post(
         f"/{prefix}/predict",
-        json={"source_language": "eng"},
+        json={"source_version_id": 1},
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 422
@@ -260,7 +265,7 @@ def test_predict_forwards_payload_to_modal(client, regular_token1):
     with patch("predict_routes.v3.predict_routes.modal.Function", mock_cls):
         response = client.post(
             f"/{prefix}/predict",
-            json=_body(apps=["ngrams"], source_language=None),
+            json=_body(apps=["ngrams"], source_version_id=None),
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
 
@@ -270,8 +275,8 @@ def test_predict_forwards_payload_to_modal(client, regular_token1):
     payload = captured["payload"]
     assert "apps" not in payload
     assert payload["pairs"][0]["target_text"] == "Hapo mwanzo..."
-    assert payload["source_language"] is None
-    assert payload["target_language"] == "swh"
+    assert payload["source_version_id"] is None
+    assert payload["target_version_id"] == 2
 
 
 @pytest.mark.parametrize(
@@ -412,7 +417,7 @@ def test_predict_training_not_available_returns_not_trained_status(
     """
     from predict_errors import TrainingNotAvailableError
 
-    msg = "No TF-IDF artifacts found (source_language=mgq). Run tfidf assess() first."
+    msg = "No TF-IDF artifacts found (source_version_id=42). Run tfidf assess() first."
     results = {"tfidf": TrainingNotAvailableError(msg)}
     with patch(
         "predict_routes.v3.predict_routes.modal.Function",

--- a/test/test_predict_routes/test_semantic_similarity_integration.py
+++ b/test/test_predict_routes/test_semantic_similarity_integration.py
@@ -42,7 +42,9 @@ GOOD_PAIRS = [
 
 
 @pytest.mark.parametrize("pair", GOOD_PAIRS, ids=[p["vref"] for p in GOOD_PAIRS])
-def test_matched_pair_returns_score(client, regular_token1, pair):
+def test_matched_pair_returns_score(
+    client, regular_token1, pair, test_version_id, test_version_id_2
+):
     """Correctly matched verse pairs should return a valid score."""
     with patch(MOCK_MODULE) as mock_function_cls:
         mock_fn = AsyncMock()
@@ -54,8 +56,8 @@ def test_matched_pair_returns_score(client, regular_token1, pair):
             json={
                 "text1": pair["text1"],
                 "text2": pair["text2"],
-                "source_language": "zga",
-                "target_language": "swh",
+                "source_version_id": test_version_id,
+                "target_version_id": test_version_id_2,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
@@ -64,16 +66,18 @@ def test_matched_pair_returns_score(client, regular_token1, pair):
     data = response.json()
     assert data["score"] == pair["mock_score"]
 
-    # Verify Modal was called with the correct text
+    # Verify Modal was called with the correct text and version IDs
     mock_fn.remote.aio.assert_called_once_with(
         pair["text1"],
         pair["text2"],
-        source_language="zga",
-        target_language="swh",
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
     )
 
 
-def test_mismatched_pair_forwarded_correctly(client, regular_token1):
+def test_mismatched_pair_forwarded_correctly(
+    client, regular_token1, test_version_id, test_version_id_2
+):
     """Mismatched verse pair is forwarded to Modal with correct params."""
     with patch(MOCK_MODULE) as mock_function_cls:
         mock_fn = AsyncMock()
@@ -86,8 +90,8 @@ def test_mismatched_pair_forwarded_correctly(client, regular_token1):
             json={
                 "text1": GOOD_PAIRS[0]["text1"],
                 "text2": GOOD_PAIRS[1]["text2"],
-                "source_language": "zga",
-                "target_language": "swh",
+                "source_version_id": test_version_id,
+                "target_version_id": test_version_id_2,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
@@ -96,12 +100,19 @@ def test_mismatched_pair_forwarded_correctly(client, regular_token1):
     assert response.json()["score"] == 0.12
 
 
-def test_unknown_language_pair_returns_422(client, regular_token1):
-    """Unknown language pair (no trained model) returns 422."""
+def test_unknown_version_pair_returns_422(
+    client, regular_token1, test_version_id, test_version_id_2
+):
+    """Version pair with no trained model returns 422."""
     with patch(MOCK_MODULE) as mock_function_cls:
         mock_fn = AsyncMock()
         mock_fn.remote.aio = AsyncMock(
-            return_value={"error": "No fine-tuned model found for zzz_yyy"}
+            return_value={
+                "error": (
+                    f"No fine-tuned model found for "
+                    f"{test_version_id}_{test_version_id_2}"
+                )
+            }
         )
         mock_function_cls.from_name.return_value = mock_fn
 
@@ -110,35 +121,11 @@ def test_unknown_language_pair_returns_422(client, regular_token1):
             json={
                 "text1": "hello",
                 "text2": "world",
-                "source_language": "zzz",
-                "target_language": "yyy",
+                "source_version_id": test_version_id,
+                "target_version_id": test_version_id_2,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
 
     assert response.status_code == 422
     assert "No fine-tuned model found" in response.json()["detail"]
-
-
-def test_invalid_language_code_returns_422(client, regular_token1):
-    """Path traversal language code returns 422."""
-    with patch(MOCK_MODULE) as mock_function_cls:
-        mock_fn = AsyncMock()
-        mock_fn.remote.aio = AsyncMock(
-            return_value={"error": "Invalid language code: '../etc' / 'eng'"}
-        )
-        mock_function_cls.from_name.return_value = mock_fn
-
-        response = client.post(
-            f"/{prefix}/predict/semantic-similarity",
-            json={
-                "text1": "hello",
-                "text2": "world",
-                "source_language": "../etc",
-                "target_language": "eng",
-            },
-            headers={"Authorization": f"Bearer {regular_token1}"},
-        )
-
-    assert response.status_code == 422
-    assert "Invalid language code" in response.json()["detail"]

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -148,8 +148,8 @@ def test_create_training_job_success(
         assert job["target_revision_id"] == test_revision_id_2
         assert job["status"] == "queued"
         assert job["id"] is not None
-        assert job["source_language"] == "eng"
-        assert job["target_language"] == "eng"
+        assert job["source_version_id"] is not None
+        assert job["target_version_id"] is not None
 
     # Check inference readiness for each trainable assessment app
     readiness = data["inference_readiness"]

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -464,9 +464,9 @@ async def list_training_jobs(
         )
     if type_filter:
         stmt = stmt.where(TrainingJob.type == type_filter)
-    if source_version_id:
+    if source_version_id is not None:
         stmt = stmt.where(TrainingJob.source_version_id == source_version_id)
-    if target_version_id:
+    if target_version_id is not None:
         stmt = stmt.where(TrainingJob.target_version_id == target_version_id)
 
     if not current_user.is_admin:

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -110,8 +110,8 @@ def _build_runner_train_config(
     job: TrainingJob,
     source_revision_id: int,
     target_revision_id: int,
-    source_language: str,
-    target_language: str,
+    source_version_id: int,
+    target_version_id: int,
     options,
 ) -> dict:
     """Config passed to run_assessment_runner for a training job.
@@ -134,8 +134,8 @@ def _build_runner_train_config(
         "revision_id": source_revision_id,
         "reference_id": target_revision_id,
         "type": job.type,
-        "source_language": source_language,
-        "target_language": target_language,
+        "source_version_id": source_version_id,
+        "target_version_id": target_version_id,
         "is_training": True,
     }
     if options:
@@ -151,8 +151,8 @@ def _job_out(job: TrainingJob, assessment: Optional[Assessment]) -> TrainingJobO
         type=job.type,
         source_revision_id=job.source_revision_id,
         target_revision_id=job.target_revision_id,
-        source_language=job.source_language,
-        target_language=job.target_language,
+        source_version_id=job.source_version_id,
+        target_version_id=job.target_version_id,
         options=job.options,
         requested_time=job.requested_time,
         owner_id=job.owner_id,
@@ -258,9 +258,6 @@ async def create_training_job(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Bible version for target revision {job_in.target_revision_id} not found",
         )
-    source_language = source_version.iso_language
-    target_language = target_version.iso_language
-
     # Auth: non-admin users must have group access to both bible versions
     if not current_user.is_admin:
         version_ids = await _get_accessible_version_ids(current_user, db)
@@ -344,8 +341,8 @@ async def create_training_job(
             type=training_type.value,
             source_revision_id=job_in.source_revision_id,
             target_revision_id=job_in.target_revision_id,
-            source_language=source_language,
-            target_language=target_language,
+            source_version_id=source_version.id,
+            target_version_id=target_version.id,
             options=job_in.options,
             requested_time=datetime.utcnow(),
             owner_id=current_user.id,
@@ -388,8 +385,8 @@ async def create_training_job(
                 job,
                 job_in.source_revision_id,
                 job_in.target_revision_id,
-                source_language,
-                target_language,
+                source_version.id,
+                target_version.id,
                 job_in.options,
             )
             await f.spawn.aio(config, os.getenv("AQUA_DB", ""))
@@ -448,8 +445,8 @@ async def create_training_job(
 async def list_training_jobs(
     status_filter: Optional[str] = Query(None, alias="status"),
     type_filter: Optional[str] = Query(None, alias="type"),
-    source_language: Optional[str] = None,
-    target_language: Optional[str] = None,
+    source_version_id: Optional[int] = None,
+    target_version_id: Optional[int] = None,
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -467,10 +464,10 @@ async def list_training_jobs(
         )
     if type_filter:
         stmt = stmt.where(TrainingJob.type == type_filter)
-    if source_language:
-        stmt = stmt.where(TrainingJob.source_language == source_language)
-    if target_language:
-        stmt = stmt.where(TrainingJob.target_language == target_language)
+    if source_version_id:
+        stmt = stmt.where(TrainingJob.source_version_id == source_version_id)
+    if target_version_id:
+        stmt = stmt.where(TrainingJob.target_version_id == target_version_id)
 
     if not current_user.is_admin:
         version_ids = await _get_accessible_version_ids(current_user, db)


### PR DESCRIPTION
## Summary

Implements aqua-api#613: shifts train/predict artifact keying from
`(source_language, target_language)` ISO codes to
`(source_version_id, target_version_id)` to stop cross-version artifact
sharing for different bible_version rows in the same language pair.

Companion cross-repo PR needed in [aqua-assessments#232](https://github.com/sil-ai/aqua-assessments/issues/232).

## Schema (commit 1)

Single Alembic migration (\`e3a9f5d2c8b1\`) covering 7 tables:

| Table | Backfill |
|---|---|
| \`eflomal_assessment\` | via \`assessment → bible_revision → bible_version\` |
| \`tfidf_artifact_runs\` | via assessment chain |
| \`tfidf_svd_staging\` | n/a (transient) |
| \`training_job\` | via revision FK |
| \`agent_lexeme_cards\` | TRUNCATE (rebuilds from new agent-critique runs) |
| \`agent_word_alignments\` | TRUNCATE |
| \`agent_translations\` | via assessment.reference_id chain |

Index rebuilds use \`CONCURRENTLY\`. Upgrade and downgrade both verified
clean against a local dev DB.

## Code (commits 2–4)

- \`database/models.py\`: SQLAlchemy mapper updates for all 7 tables
- \`models.py\`: Pydantic schemas (AssessmentIn, PredictInput,
  SemanticSimilarityRequest, TrainingJobOut, EflomalResultsPushRequest,
  TfidfArtifactsPushRequest, AgentWordAlignment*, LexemeCard*, etc.)
- \`train_routes/v3/train_routes.py\`: \`_build_runner_train_config\`
  emits version_ids; \`GET /train\` filter switches to \`?source_version_id=\`
- \`predict_routes/v3/predict_routes.py\`: forwards version_ids to Modal
- \`assessment_routes/v3/eflomal_routes.py\`: pull-by-version-pair, plus
  validation that pushed version_ids match the assessment chain
- \`assessment_routes/v3/tfidf_artifact_routes.py\`: same pattern
- \`assessment_routes/v3/assessment_routes.py\`: \`use_eflomal\` validation
- \`agent_routes/v3/agent_routes.py\`: full surface — word alignments,
  lexeme cards, translations
- \`test/conftest.py\`: new \`test_version_id\` and \`test_version_id_2\`
  fixtures
- 8 test files updated to use version_ids

## Validation

- \`pytest test/\`: **722 passed** (5m 39s)
- \`alembic upgrade\` + \`alembic downgrade\` clean against local dev DB
- \`black\` / \`isort\` clean

## Deploy notes

This PR cannot deploy alone — \`aqua-assessments\` must update its
runner config readers and artifact-lookup queries in lockstep (see
sil-ai/aqua-assessments#232). After both ship to dev, retraining
two different bible_versions that share an iso_language pair must
produce isolated artifacts.

## Test plan

- [x] Local: full suite green
- [ ] Dev deploy with aqua-assessments PR — verify cross-version isolation
- [ ] Prod deploy in lockstep

🤖 Generated with [Claude Code](https://claude.com/claude-code)