### PR TITLE
[codex] Pass finetune for sem-sim training

### DIFF
--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -258,6 +258,7 @@ def test_semantic_similarity_routes_through_runner(
 ):
     """sem-sim must dispatch to ("runner", "run_assessment_runner")."""
     calls = []
+    payloads = []
     response = _create_training_jobs_via_api(
         client,
         regular_token1,
@@ -267,12 +268,24 @@ def test_semantic_similarity_routes_through_runner(
         apps=["semantic-similarity"],
         spawn_by_app={"runner": RuntimeError("runner down")},
         calls=calls,
+        payloads=payloads,
     )
     assert response.status_code == 200
     jobs = response.json()["training_jobs"]
     assert len(jobs) == 1 and jobs[0]["type"] == "semantic-similarity"
     assert jobs[0]["status"] == "failed"
     assert ("runner", "run_assessment_runner") in calls
+    assert jobs[0]["options"] == {
+        "tag": "sem_sim_routing_test",
+        "finetune": True,
+    }
+    runner_spawns = [p for p in payloads if p[0] == "runner"]
+    assert len(runner_spawns) == 1
+    config = runner_spawns[0][1][0]
+    assert config["kwargs"] == {
+        "tag": "sem_sim_routing_test",
+        "finetune": True,
+    }
 
 
 def test_training_job_full_lifecycle_via_runner(
@@ -869,7 +882,10 @@ def test_training_job_creates_assessment_for_all_types(
         assert assessment.reference_id == test_revision_id_2
         assert assessment.status == "queued"
         assert assessment.owner_id == job["owner_id"]
-        assert assessment.kwargs == {"tag": "assessment_creation_test"}
+        expected_kwargs = {"tag": "assessment_creation_test"}
+        if training_type == "semantic-similarity":
+            expected_kwargs["finetune"] = True
+        assert assessment.kwargs == expected_kwargs
         assert assessment.is_training is True
 
 
@@ -1043,6 +1059,40 @@ def test_duplicate_post_does_not_create_duplicate_assessment(
     )
     for a in queued:
         a.status = "failed"
+    db_session.commit()
+
+
+def test_semantic_similarity_duplicate_detection_normalizes_legacy_options(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """Active sem-sim jobs created before finetune injection still de-dupe."""
+    r1 = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        apps=["semantic-similarity"],
+    )
+    assert r1.status_code == 200
+    job = r1.json()["training_jobs"][0]
+
+    db_session.expire_all()
+    legacy_job = db_session.query(TrainingJob).get(job["id"])
+    legacy_assessment = db_session.query(Assessment).get(job["assessment_id"])
+    legacy_job.options = None
+    legacy_assessment.kwargs = None
+    db_session.commit()
+
+    r2 = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        apps=["semantic-similarity"],
+    )
+    assert r2.status_code == 409
+
+    legacy_assessment.status = "failed"
     db_session.commit()
 
 

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -143,6 +143,18 @@ def _build_runner_train_config(
     return config
 
 
+def _training_options_for_type(
+    training_type: str, options: Optional[dict]
+) -> Optional[dict]:
+    """Return per-app training kwargs persisted and sent to the runner."""
+    if training_type != TrainingType.semantic_similarity.value:
+        return options
+
+    sem_sim_options = dict(options or {})
+    sem_sim_options["finetune"] = True
+    return sem_sim_options
+
+
 def _job_out(job: TrainingJob, assessment: Optional[Assessment]) -> TrainingJobOut:
     """Build a TrainingJobOut, sourcing status fields from the linked
     Assessment row (the single channel of truth after #584)."""
@@ -293,6 +305,9 @@ async def create_training_job(
     for training_type in TrainingType:
         if training_type.value not in selected_types:
             continue
+        training_options = _training_options_for_type(
+            training_type.value, job_in.options
+        )
         # Duplicate check per type — "active" means linked Assessment is
         # live (not soft-deleted) and not in a terminal state.
         dup_stmt = (
@@ -310,7 +325,10 @@ async def create_training_job(
         dup_result = await db.execute(dup_stmt)
         duplicate = False
         for existing_job in dup_result.scalars().all():
-            if existing_job.options == job_in.options:
+            existing_options = _training_options_for_type(
+                training_type.value, existing_job.options
+            )
+            if existing_options == training_options:
                 duplicate = True
                 skipped_job_ids.append(existing_job.id)
                 break
@@ -330,7 +348,7 @@ async def create_training_job(
             status="queued",
             requested_time=datetime.utcnow(),
             owner_id=current_user.id,
-            kwargs=job_in.options,
+            kwargs=training_options,
             is_training=True,
         )
         db.add(assessment)
@@ -343,7 +361,7 @@ async def create_training_job(
             target_revision_id=job_in.target_revision_id,
             source_version_id=source_version.id,
             target_version_id=target_version.id,
-            options=job_in.options,
+            options=training_options,
             requested_time=datetime.utcnow(),
             owner_id=current_user.id,
             session_id=session_id,
@@ -387,7 +405,7 @@ async def create_training_job(
                 job_in.target_revision_id,
                 source_version.id,
                 target_version.id,
-                job_in.options,
+                job.options,
             )
             await f.spawn.aio(config, os.getenv("AQUA_DB", ""))
             return job, None


### PR DESCRIPTION
## Summary

- Inject `finetune=True` for `/v3/train` semantic-similarity jobs.
- Persist the normalized sem-sim training options on both `Assessment.kwargs` and `TrainingJob.options` so the runner receives the expected kwargs.
- Normalize active legacy sem-sim job options during duplicate detection so rollout does not enqueue duplicate jobs for the same request.

## Validation

- `PYTHONPATH=/tmp/aqua-api-sem-sim-finetune AQUA_DB=postgresql+asyncpg://dbuser:dbpassword@localhost:5432/dbname OMIT_PREVIOUS_VERSIONS=1 SECRET_KEY=test-secret timeout 120s /home/mark/SIL/aqua-api/.venv/bin/pytest -x test/test_train_routes/test_train_routes.py`
- `48 passed`