### PR TITLE
Include TF-IDF neighbours in training session results

### DIFF
--- a/models.py
+++ b/models.py
@@ -503,6 +503,11 @@ class TfidfResult(BaseModel):
     }
 
 
+class TfidfNeighbour(BaseModel):
+    vref: str
+    score: float
+
+
 class WordAlignment(BaseModel):
     model_config = {"from_attributes": True}
 
@@ -1138,6 +1143,7 @@ class TrainingSessionVrefResults(BaseModel):
     vref: str
     semantic_similarity: Optional[Result_v2] = None
     word_alignment: List[WordAlignment] = Field(default_factory=list)
+    tfidf: List[TfidfNeighbour] = Field(default_factory=list)
 
 
 class TrainingSessionResultsPage(BaseModel):

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1,12 +1,15 @@
 # test_train_routes.py
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from database.models import (
     AlignmentTopSourceScores,
     Assessment,
     AssessmentResult,
     NgramsTable,
     NgramVrefTable,
+    TfidfPcaVector,
     TrainingJob,
     VerseText,
 )
@@ -1210,6 +1213,18 @@ def _seed_ngrams(db_session, assessment_id, ngrams_with_vrefs):
     db_session.commit()
 
 
+def _seed_tfidf_vectors(db_session, assessment_id, vrefs_with_vectors):
+    for vref, vector in vrefs_with_vectors:
+        db_session.add(
+            TfidfPcaVector(
+                assessment_id=assessment_id,
+                vref=vref,
+                vector=vector,
+            )
+        )
+    db_session.commit()
+
+
 def test_session_results_no_auth(client):
     response = client.get(f"{prefix}/train/status/some-uuid/results")
     assert response.status_code == 401
@@ -1500,6 +1515,118 @@ def test_session_results_ngrams_top_level(
     # the existing /v3/ngrams_result shape).
     in_the = next(n for n in gen_only["ngrams"] if n["ngram"] == "in the")
     assert sorted(in_the["vrefs"]) == ["GEN 1:1", "GEN 1:2"]
+
+
+def test_session_results_includes_tfidf_neighbours_when_trained(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_tfidf"},
+        apps=["tfidf"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    tfidf_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(client, regular_token1, tfidf_job["assessment_id"])
+
+    def vec(x, y):
+        return [x, y] + [0.0] * 298
+
+    _seed_tfidf_vectors(
+        db_session,
+        tfidf_job["assessment_id"],
+        [
+            ("GEN 1:1", vec(1.0, 0.0)),
+            ("GEN 1:2", vec(0.8, 0.6)),
+            ("GEN 1:3", vec(0.6, 0.8)),
+        ],
+    )
+
+    response = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["results"]["total_count"] == 3
+
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    assert set(by_vref) == {"GEN 1:1", "GEN 1:2", "GEN 1:3"}
+    assert by_vref["GEN 1:1"]["semantic_similarity"] is None
+    assert by_vref["GEN 1:1"]["word_alignment"] == []
+    assert [n["vref"] for n in by_vref["GEN 1:1"]["tfidf"]] == [
+        "GEN 1:2",
+        "GEN 1:3",
+    ]
+    assert by_vref["GEN 1:1"]["tfidf"][0]["score"] == pytest.approx(0.8)
+
+
+def test_session_results_tfidf_empty_when_not_trained(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_tfidf_empty"},
+        apps=["semantic-similarity"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    sem_sim_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
+    _seed_sem_sim_results(db_session, sem_sim_job["assessment_id"], [("GEN 1:1", 0.5)])
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    assert data["results"]["items"][0]["tfidf"] == []
+
+
+def test_session_results_tfidf_top_k_param(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_tfidf_top_k"},
+        apps=["tfidf"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    tfidf_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(client, regular_token1, tfidf_job["assessment_id"])
+
+    def vec(x, y):
+        return [x, y] + [0.0] * 298
+
+    _seed_tfidf_vectors(
+        db_session,
+        tfidf_job["assessment_id"],
+        [
+            ("GEN 1:1", vec(1.0, 0.0)),
+            ("GEN 1:2", vec(0.8, 0.6)),
+            ("GEN 1:3", vec(0.6, 0.8)),
+        ],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"tfidf_top_k": 1},
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    assert [n["vref"] for n in by_vref["GEN 1:1"]["tfidf"]] == ["GEN 1:2"]
 
 
 def test_session_results_unknown_book_returns_400(

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -11,7 +11,7 @@ import fastapi
 import modal
 from dotenv import load_dotenv
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import func, select
+from sqlalchemy import Integer, bindparam, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased, selectinload
 
@@ -27,11 +27,13 @@ from database.models import (
     BookReference,
     NgramsTable,
     NgramVrefTable,
+    TfidfPcaVector,
     TrainingJob,
 )
 from database.models import UserDB as UserModel
 from database.models import (
     UserGroup,
+    VerseReference,
     VerseText,
 )
 from models import (
@@ -40,6 +42,7 @@ from models import (
     InferenceReadiness,
     NgramResult,
     Result_v2,
+    TfidfNeighbour,
     TrainingJobIn,
     TrainingJobOut,
     TrainingResponse,
@@ -565,6 +568,7 @@ async def get_training_session_results(
     verse: Optional[int] = None,
     page: Optional[int] = Query(None, ge=1),
     page_size: Optional[int] = Query(None, ge=1, le=1000),
+    tfidf_top_k: int = Query(5, ge=1, le=50),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -572,10 +576,11 @@ async def get_training_session_results(
     per-vref results for every completed job in the session.
 
     Per vref: semantic_similarity score (one row), word_alignment per-word
-    rows (multiple). Ngrams are returned at the top level — each ngram has
-    many vrefs, so nesting them per verse would duplicate the same ngram
-    across every verse it appears in. Tfidf and agent_critique training
-    runs produce nothing the client wants here (vector-only / no vrefs).
+    rows (multiple), and tfidf nearest-neighbour vrefs from the source
+    corpus. Ngrams are returned at the top level — each ngram has many
+    vrefs, so nesting them per verse would duplicate the same ngram across
+    every verse it appears in. Agent_critique training runs produce
+    nothing the client wants here.
     """
     await validate_parameters(
         book, chapter, verse, aggregate=None, page=page, page_size=page_size
@@ -623,6 +628,7 @@ async def get_training_session_results(
         TrainingType.word_alignment.value
     )
     ngrams_id = completed_assessment_id_by_type.get(TrainingType.ngrams.value)
+    tfidf_id = completed_assessment_id_by_type.get(TrainingType.tfidf.value)
 
     # vref universe = distinct vrefs across the per-vref result tables for
     # all completed types in the session, with optional book/chapter/verse
@@ -663,6 +669,29 @@ async def get_training_session_results(
                 AlignmentTopSourceScores,
             )
         )
+
+    if tfidf_id is not None:
+        tfidf_q = (
+            select(
+                TfidfPcaVector.vref,
+                VerseReference.book_reference.label("book"),
+                func.split_part(VerseReference.chapter, " ", 2)
+                .cast(Integer)
+                .label("chapter"),
+                VerseReference.number.label("verse"),
+            )
+            .join(VerseReference, VerseReference.full_verse_id == TfidfPcaVector.vref)
+            .where(TfidfPcaVector.assessment_id == tfidf_id)
+        )
+        if book is not None:
+            tfidf_q = tfidf_q.where(VerseReference.book_reference == book)
+        if chapter is not None:
+            tfidf_q = tfidf_q.where(
+                func.split_part(VerseReference.chapter, " ", 2).cast(Integer) == chapter
+            )
+        if verse is not None:
+            tfidf_q = tfidf_q.where(VerseReference.number == verse)
+        per_vref_subqueries.append(tfidf_q)
 
     page_vrefs: List[str] = []
     total_count = 0
@@ -746,11 +775,50 @@ async def get_training_session_results(
                 )
             )
 
+    tfidf_by_vref: dict[str, List[TfidfNeighbour]] = {}
+    if tfidf_id is not None and page_vrefs:
+        nn_query = text(
+            """
+            SELECT q.vref AS query_vref,
+                   nn.vref AS neighbour_vref,
+                   nn.cosine_similarity AS score
+            FROM tfidf_pca_vector AS q
+            JOIN LATERAL (
+                SELECT c.vref,
+                       inner_product(c.vector, q.vector) AS cosine_similarity
+                FROM tfidf_pca_vector AS c
+                WHERE c.assessment_id = :assessment_id
+                  AND c.vref != q.vref
+                ORDER BY cosine_similarity DESC
+                LIMIT :limit
+            ) AS nn ON true
+            WHERE q.assessment_id = :assessment_id
+              AND q.vref IN :page_vrefs
+            ORDER BY q.vref, nn.cosine_similarity DESC
+            """
+        ).bindparams(bindparam("page_vrefs", expanding=True))
+        rows = await db.execute(
+            nn_query,
+            {
+                "assessment_id": tfidf_id,
+                "page_vrefs": page_vrefs,
+                "limit": tfidf_top_k,
+            },
+        )
+        for row in rows.all():
+            tfidf_by_vref.setdefault(row.query_vref, []).append(
+                TfidfNeighbour(
+                    vref=row.neighbour_vref,
+                    score=float(row.score) if row.score is not None else 0.0,
+                )
+            )
+
     results_list = [
         TrainingSessionVrefResults(
             vref=v,
             semantic_similarity=sem_sim_by_vref.get(v),
             word_alignment=word_align_by_vref.get(v, []),
+            tfidf=tfidf_by_vref.get(v, []),
         )
         for v in page_vrefs
     ]


### PR DESCRIPTION
## Summary
- add a `tfidf` neighbour list to each `/v3/train/status/{session_id}/results` vref item
- include completed TF-IDF vector vrefs in the paginated vref universe
- fetch per-page nearest neighbours with a single lateral query and support `tfidf_top_k`

Closes #616.

## Testing
- train route test suite passed locally with Postgres-backed test DB and a test JWT secret