### PR TITLE
Swap revision_id/reference_id mapping in train_routes

### DIFF
--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -881,8 +881,11 @@ def test_training_job_creates_assessment_for_all_types(
         assessment = _get_assessment(db_session, job["assessment_id"])
         assert assessment is not None, f"Assessment row missing for {training_type}"
         assert assessment.type == training_type
-        assert assessment.revision_id == test_revision_id
-        assert assessment.reference_id == test_revision_id_2
+        # train_routes maps target_revision_id → Assessment.revision_id
+        # (the side being assessed) and source_revision_id →
+        # Assessment.reference_id (what it's compared against).
+        assert assessment.revision_id == test_revision_id_2
+        assert assessment.reference_id == test_revision_id
         assert assessment.status == "queued"
         assert assessment.owner_id == job["owner_id"]
         expected_kwargs = {"tag": "assessment_creation_test"}
@@ -940,8 +943,10 @@ def test_trainable_types_route_through_runner_with_is_training(
         # /v3/assessment/{id}/results, which are keyed on Assessment.id. So
         # `id` MUST be the Assessment id, not the TrainingJob id.
         assert config["id"] == jobs[t]["assessment_id"]
-        assert config["revision_id"] == test_revision_id
-        assert config["reference_id"] == test_revision_id_2
+        # See _build_runner_train_config: revision_id gets the target side
+        # (what's being assessed), reference_id gets the source side.
+        assert config["revision_id"] == test_revision_id_2
+        assert config["reference_id"] == test_revision_id
         # Training mode is signaled by is_training=True on the config
         # dict, not by a config["train"] flag — that used to be required
         # by sem-sim's assess() but has been superseded by a `finetune`

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -132,10 +132,19 @@ def _build_runner_train_config(
     caller's `options` → `config["kwargs"]` — aqua-api doesn't hard-code
     them.
     """
+    # Mapping convention: `revision_id` is the side that gets assessed/trained
+    # against (i.e. the user's translation = target), `reference_id` is what
+    # it's being compared to (i.e. the reference = source). This matches the
+    # standard linguistics convention where source = source language /
+    # reference, target = target language / draft, and aligns with how each
+    # app's assess() consumes these fields (e.g. ngrams trains its mined
+    # ngram set on revision_id and matches them against target_text in
+    # predict; sem-sim fine-tunes the "rev" side which is the target
+    # language).
     config = {
         "id": job.assessment_id,
-        "revision_id": source_revision_id,
-        "reference_id": target_revision_id,
+        "revision_id": target_revision_id,
+        "reference_id": source_revision_id,
         "type": job.type,
         "source_version_id": source_version_id,
         "target_version_id": target_version_id,
@@ -344,9 +353,12 @@ async def create_training_job(
         # path. Assessment.status is the single channel of training-run
         # status — runner PATCHes it queued → running (with percent_complete
         # self-loops) → finished.
+        # See _build_runner_train_config for the rationale: revision_id is
+        # the side being assessed (target), reference_id is what it's
+        # compared against (source).
         assessment = Assessment(
-            revision_id=job_in.source_revision_id,
-            reference_id=job_in.target_revision_id,
+            revision_id=job_in.target_revision_id,
+            reference_id=job_in.source_revision_id,
             type=training_type.value,
             status="queued",
             requested_time=datetime.utcnow(),


### PR DESCRIPTION
## Summary

- `_build_runner_train_config` and the paired `Assessment` row now map `target_revision_id → revision_id` and `source_revision_id → reference_id` (previously swapped). This brings train in line with the standard linguistics convention used everywhere else in the API: **source = reference**, **target = the draft being scored**.
- Tests in `test/test_train_routes/test_train_routes.py` updated for the new mapping (assertions on `Assessment.revision_id` / `reference_id` and on the runner config payload).

## Why

Each assessment app's `assess()` consumes `assessment.revision_id` as the side it's actually training/operating on:

- `ngrams.assess` mines its ngram set from `revision_id` and `predict()` matches that set against `target_text` — so `revision_id` must be the target side.
- `semantic-similarity.assess` fine-tunes the "rev" tower on `revision_id`, and at predict time `target_text` goes through the fine-tuned tower — same shape.
- `predict()`'s `(source_text, target_text)` pair convention is "source = reference, target = draft".

The old mapping had `revision_id = source_revision_id`, which inverted this. The `train` and `predict` halves of the API had effectively opposite meanings of "source" and "target", and the demo notebook was passing data in the order that matched `predict` but not `train`.

## Behaviour change

This is **not** backward-compatible at the artifact level: an assessment trained before this PR was keyed on `source_revision_id`, while after this PR it'll be keyed on `target_revision_id`. Running `/train` with the same `source_revision_id` / `target_revision_id` pair as before will now create a fresh assessment (different `revision_id`), so existing trained artifacts won't be reused — callers should retrain.

The downstream apps in `aqua-assessments` already consume `assessment.revision_id` correctly under the new mapping (they were already written assuming `revision_id` = the side being assessed), so no coordinated change is required there for the apps themselves to work — only the artifacts they rebuild will live under the new id.

## Test plan

- [x] `pytest test/test_train_routes/` — 51 passing
- [x] `pytest test/test_predict_routes/` — 38 passing
- [x] `pytest test/test_assessment_routes/` — 264 passing
- [ ] Smoke: re-run the demo notebook end-to-end against dev once `aqua-assessments` is also redeployed (the corresponding ngrams.predict update lives in a separate PR there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)