### PR TITLE
Return matching lexeme cards in train results when agent-critique is in session

### DIFF
--- a/models.py
+++ b/models.py
@@ -1139,30 +1139,16 @@ class TrainingResponse(BaseModel):
     inference_readiness: Dict[str, InferenceReadiness]
 
 
-class TrainingSessionLexemeCard(BaseModel):
-    """Compact lexeme-card view returned alongside per-vref training results.
-
-    Carries just the fields a client needs to surface the card next to the
-    verse — id (for follow-up `/v3/agent/lexeme-card/{id}` lookups), the
-    lemma pair, and the surface forms that actually intersected the
-    verse text. The full list of every form on the card is available via
-    the dedicated lexeme-card endpoints.
-    """
-
-    id: int
-    target_lemma: str
-    source_lemma: Optional[str] = None
-    matched_target_forms: List[str] = Field(default_factory=list)
-    matched_source_forms: List[str] = Field(default_factory=list)
-    confidence: Optional[float] = None
-
-
 class TrainingSessionVrefResults(BaseModel):
     vref: str
     semantic_similarity: Optional[Result_v2] = None
     word_alignment: List[WordAlignment] = Field(default_factory=list)
     tfidf: List[TfidfNeighbour] = Field(default_factory=list)
-    lexeme_cards: List[TrainingSessionLexemeCard] = Field(default_factory=list)
+    # Full lexeme cards (same shape as `GET /v3/agent/lexeme-card`) whose
+    # lemma or any surface form intersects this verse on either side.
+    # Cards are filtered by the verse — the cards themselves are returned
+    # in full, not a subset of their fields.
+    lexeme_cards: List[LexemeCardOut] = Field(default_factory=list)
 
 
 class TrainingSessionResultsPage(BaseModel):

--- a/models.py
+++ b/models.py
@@ -1139,11 +1139,30 @@ class TrainingResponse(BaseModel):
     inference_readiness: Dict[str, InferenceReadiness]
 
 
+class TrainingSessionLexemeCard(BaseModel):
+    """Compact lexeme-card view returned alongside per-vref training results.
+
+    Carries just the fields a client needs to surface the card next to the
+    verse — id (for follow-up `/v3/agent/lexeme-card/{id}` lookups), the
+    lemma pair, and the surface forms that actually intersected the
+    verse text. The full list of every form on the card is available via
+    the dedicated lexeme-card endpoints.
+    """
+
+    id: int
+    target_lemma: str
+    source_lemma: Optional[str] = None
+    matched_target_forms: List[str] = Field(default_factory=list)
+    matched_source_forms: List[str] = Field(default_factory=list)
+    confidence: Optional[float] = None
+
+
 class TrainingSessionVrefResults(BaseModel):
     vref: str
     semantic_similarity: Optional[Result_v2] = None
     word_alignment: List[WordAlignment] = Field(default_factory=list)
     tfidf: List[TfidfNeighbour] = Field(default_factory=list)
+    lexeme_cards: List[TrainingSessionLexemeCard] = Field(default_factory=list)
 
 
 class TrainingSessionResultsPage(BaseModel):

--- a/models.py
+++ b/models.py
@@ -1164,6 +1164,11 @@ class TrainingSessionResultsResponse(BaseModel):
     inference_readiness: Dict[str, InferenceReadiness]
     results: TrainingSessionResultsPage
     ngrams: List[NgramResult] = Field(default_factory=list)
+    # True when the lexeme-card load hit the per-request cap and only
+    # the highest-confidence prefix of cards was matched against the
+    # page's vrefs. Lets a client distinguish "no card matches found"
+    # from "we didn't look at every card".
+    lexeme_cards_truncated: bool = False
 
 
 class EflomalDictionaryItem(BaseModel):

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1812,10 +1812,15 @@ def test_session_results_lexeme_cards_when_agent_critique_in_session(
     g11_lemmas = {c["target_lemma"] for c in g11_cards}
     assert g11_lemmas == {"abhinji"}, g11_cards
     abhinji = g11_cards[0]
-    assert abhinji["matched_target_forms"] == ["abhinji"]
-    assert abhinji["matched_source_forms"] == ["many"]
+    # Full card shape (LexemeCardOut) — surface_forms is the card's
+    # complete list, not just the forms that matched the verse.
+    assert abhinji["target_lemma"] == "abhinji"
     assert abhinji["source_lemma"] == "many"
+    assert abhinji["surface_forms"] == ["abhinji"]
+    assert abhinji["source_surface_forms"] == ["many"]
     assert abhinji["confidence"] == pytest.approx(0.95)
+    assert isinstance(abhinji["id"], int)
+    assert "examples" in abhinji  # always present (possibly empty)
 
     g12_cards = by_vref["GEN 1:2"]["lexeme_cards"]
     assert {c["target_lemma"] for c in g12_cards} == {"ulungu"}, g12_cards

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1684,6 +1684,194 @@ def test_session_results_tfidf_top_k_param(
     assert [n["vref"] for n in by_vref["GEN 1:1"]["tfidf"]] == ["GEN 1:2"]
 
 
+def _seed_lexeme_cards(db_session, source_version_id, target_version_id, cards):
+    """Insert AgentLexemeCard rows. `cards` is a list of dicts with keys
+    target_lemma, source_lemma, surface_forms, source_surface_forms,
+    confidence."""
+    from database.models import AgentLexemeCard
+
+    for c in cards:
+        db_session.add(
+            AgentLexemeCard(
+                target_lemma=c["target_lemma"],
+                source_lemma=c.get("source_lemma"),
+                source_version_id=source_version_id,
+                target_version_id=target_version_id,
+                surface_forms=c.get("surface_forms", []),
+                source_surface_forms=c.get("source_surface_forms", []),
+                confidence=c.get("confidence", 0.9),
+            )
+        )
+    db_session.commit()
+
+
+def _seed_verse_text(db_session, revision_id, verses):
+    """Insert VerseText rows. `verses` is a list of (vref, text) tuples
+    with vref like 'GEN 1:1'."""
+    from database.models import VerseText
+
+    for vref, text in verses:
+        book, rest = vref.split(" ", 1)
+        chapter, verse = rest.split(":", 1)
+        db_session.add(
+            VerseText(
+                text=text,
+                revision_id=revision_id,
+                verse_reference=vref,
+                book=book,
+                chapter=int(chapter),
+                verse=int(verse),
+            )
+        )
+    db_session.commit()
+
+
+def test_session_results_lexeme_cards_when_agent_critique_in_session(
+    client, regular_token1, test_revision_id, test_revision_id_2, test_version_id,
+    db_session,
+):
+    """When the session includes agent-critique, each vref in the result
+    page carries the lexeme cards whose lemma/surface forms intersect
+    that verse's text on either side. Cards without a hit are dropped.
+    """
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_lexeme_cards"},
+        apps=["semantic-similarity", "agent-critique"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    sem_sim_job = next(
+        j for j in payload["training_jobs"] if j["type"] == "semantic-similarity"
+    )
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
+    _seed_sem_sim_results(
+        db_session, sem_sim_job["assessment_id"], [("GEN 1:1", 0.9), ("GEN 1:2", 0.8)]
+    )
+    _seed_verse_text(
+        db_session,
+        sem_sim_job["target_revision_id"],
+        [("GEN 1:1", "abhantu abhinji bhasimbile"), ("GEN 1:2", "ulungu abhumbile")],
+    )
+    _seed_verse_text(
+        db_session,
+        sem_sim_job["source_revision_id"],
+        [("GEN 1:1", "many people wrote"), ("GEN 1:2", "God created")],
+    )
+    # source_version_id / target_version_id on training jobs are denormalized
+    # from the chosen revisions' bible_version_id. The test fixtures put
+    # both revisions under test_version_id, so source = target = test_version_id.
+    _seed_lexeme_cards(
+        db_session,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id,
+        cards=[
+            {
+                "target_lemma": "abhinji",
+                "source_lemma": "many",
+                "surface_forms": ["abhinji"],
+                "source_surface_forms": ["many"],
+                "confidence": 0.95,
+            },
+            {
+                "target_lemma": "ulungu",
+                "source_lemma": "god",
+                "surface_forms": ["ulungu"],
+                "source_surface_forms": ["god"],
+                "confidence": 0.92,
+            },
+            {
+                # No match in either verse — must be dropped.
+                "target_lemma": "kitabu",
+                "source_lemma": "book",
+                "surface_forms": ["kitabu"],
+                "source_surface_forms": ["book"],
+                "confidence": 0.50,
+            },
+        ],
+    )
+
+    response = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    )
+    assert response.status_code == 200
+    by_vref = {b["vref"]: b for b in response.json()["results"]["items"]}
+    assert set(by_vref) == {"GEN 1:1", "GEN 1:2"}
+
+    g11_cards = by_vref["GEN 1:1"]["lexeme_cards"]
+    g11_lemmas = {c["target_lemma"] for c in g11_cards}
+    assert g11_lemmas == {"abhinji"}, g11_cards
+    abhinji = g11_cards[0]
+    assert abhinji["matched_target_forms"] == ["abhinji"]
+    assert abhinji["matched_source_forms"] == ["many"]
+    assert abhinji["source_lemma"] == "many"
+    assert abhinji["confidence"] == pytest.approx(0.95)
+
+    g12_cards = by_vref["GEN 1:2"]["lexeme_cards"]
+    assert {c["target_lemma"] for c in g12_cards} == {"ulungu"}, g12_cards
+
+
+def test_session_results_lexeme_cards_empty_when_no_agent_critique(
+    client, regular_token1, test_revision_id, test_revision_id_2, test_version_id,
+    db_session,
+):
+    """Sessions without an agent-critique training type return
+    `lexeme_cards = []` even if cards exist for the version pair —
+    surfacing them only on agent-aware sessions keeps the response
+    minimal for callers who didn't ask for the LLM pipeline.
+    """
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_no_agent"},
+        apps=["semantic-similarity"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    sem_sim_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
+    _seed_sem_sim_results(db_session, sem_sim_job["assessment_id"], [("GEN 1:1", 0.9)])
+    _seed_verse_text(
+        db_session,
+        sem_sim_job["target_revision_id"],
+        [("GEN 1:1", "abhinji bhasimbile")],
+    )
+    # Use a target_lemma distinct from the prior test's seed — cards
+    # persist across tests in the module-scoped db_session and the
+    # unique index on (lower(target_lemma), version_pair) would
+    # otherwise raise.
+    _seed_lexeme_cards(
+        db_session,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id,
+        cards=[
+            {
+                "target_lemma": "bhasimbile",
+                "source_lemma": "wrote",
+                "surface_forms": ["bhasimbile"],
+                "source_surface_forms": ["wrote"],
+            }
+        ],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    assert by_vref["GEN 1:1"]["lexeme_cards"] == []
+
+
 def test_session_results_unknown_book_returns_400(
     client, regular_token1, test_revision_id, test_revision_id_2
 ):

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1727,7 +1727,11 @@ def _seed_verse_text(db_session, revision_id, verses):
 
 
 def test_session_results_lexeme_cards_when_agent_critique_in_session(
-    client, regular_token1, test_revision_id, test_revision_id_2, test_version_id,
+    client,
+    regular_token1,
+    test_revision_id,
+    test_revision_id_2,
+    test_version_id,
     db_session,
 ):
     """When the session includes agent-critique, each vref in the result
@@ -1818,7 +1822,11 @@ def test_session_results_lexeme_cards_when_agent_critique_in_session(
 
 
 def test_session_results_lexeme_cards_empty_when_no_agent_critique(
-    client, regular_token1, test_revision_id, test_revision_id_2, test_version_id,
+    client,
+    regular_token1,
+    test_revision_id,
+    test_revision_id_2,
+    test_version_id,
     db_session,
 ):
     """Sessions without an agent-critique training type return

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -3,6 +3,7 @@ __version__ = "v3"
 import asyncio
 import os
 import socket
+import unicodedata
 import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -268,6 +269,13 @@ async def _build_lexeme_card_matches_by_vref(
     # Bulk-load full cards for the (source, target) pair. Confidence
     # ordering mirrors the predict path so a client paging through
     # results sees the same cards an LLM would see at predict time.
+    # Hard cap keeps memory + match cost bounded for large corpora; the
+    # current scheme is in-memory intersection over the whole card set,
+    # so an unbounded load would degrade slowly as a version pair
+    # accumulates cards over multiple runs. A DB-side filter using the
+    # GIN index on `surface_forms` is the right fix if we ever blow
+    # past this — flagged in the docstring above.
+    LEXEME_CARD_LIMIT = 10_000
     cards_q = (
         select(AgentLexemeCard)
         .where(
@@ -275,10 +283,20 @@ async def _build_lexeme_card_matches_by_vref(
             AgentLexemeCard.target_version_id == target_version_id,
         )
         .order_by(AgentLexemeCard.confidence.desc().nullslast())
+        .limit(LEXEME_CARD_LIMIT)
     )
     cards = (await db.execute(cards_q)).scalars().all()
     if not cards:
         return {}
+    if len(cards) >= LEXEME_CARD_LIMIT:
+        logger.warning(
+            "lexeme card cap hit on /train/status results",
+            extra={
+                "source_version_id": source_version_id,
+                "target_version_id": target_version_id,
+                "limit": LEXEME_CARD_LIMIT,
+            },
+        )
 
     # Bulk-load source + target verse text for the page in two queries.
     # `vref` on the per-app result tables matches `verse_reference` in
@@ -299,11 +317,27 @@ async def _build_lexeme_card_matches_by_vref(
     }
 
     # Pre-tokenize each verse once; per-vref matching is a set lookup.
+    # NFC-normalise verse text before tokenising — `_tokenize_words`
+    # walks the raw codepoint stream, but `LexemeCardIn` NFC-normalises
+    # forms at write time. Without this, a verse stored as NFD
+    # (Devanagari, Arabic with full diacritics, Ethiopic with combining
+    # marks) would tokenise to NFD strings and never match the NFC
+    # forms on the card, silently producing zero matches.
     target_tokens_by_vref: dict[str, set[str]] = {
-        v: set(_tokenize_words(target_text_by_vref.get(v, ""))) for v in page_vrefs
+        v: set(
+            _tokenize_words(
+                unicodedata.normalize("NFC", target_text_by_vref.get(v, ""))
+            )
+        )
+        for v in page_vrefs
     }
     source_tokens_by_vref: dict[str, set[str]] = {
-        v: set(_tokenize_words(source_text_by_vref.get(v, ""))) for v in page_vrefs
+        v: set(
+            _tokenize_words(
+                unicodedata.normalize("NFC", source_text_by_vref.get(v, ""))
+            )
+        )
+        for v in page_vrefs
     }
 
     # First pass: which cards match which vrefs, by id, preserving the
@@ -381,8 +415,9 @@ async def _build_lexeme_card_matches_by_vref(
         )
 
     # Build LexemeCardOut once per matched card, then attach the same
-    # object to each vref it matched. Cards are read-only at this point,
-    # so sharing the Pydantic instance across vrefs is safe.
+    # object to each vref it matched. The response serializer doesn't
+    # mutate the model in place, so sharing the Pydantic instance
+    # across vrefs is safe.
     out_by_card_id: dict[int, LexemeCardOut] = {}
     for card in cards:
         if card.id not in matched_card_id_set:
@@ -1043,15 +1078,16 @@ async def get_training_session_results(
     has_agent_critique = any(j.type == TrainingType.agent_critique.value for j in jobs)
     if has_agent_critique and page_vrefs:
         # source_version_id / target_version_id are denormalized onto
-        # TrainingJob, so any session job carries the right pair —
-        # session jobs all share the same (source, target) by construction.
-        any_job = jobs[0]
+        # every TrainingJob in a session and create_training_job
+        # constructs them from the same (source_revision, target_revision)
+        # pair — so any session job carries the right ids.
+        session_job = jobs[0]
         lexeme_cards_by_vref = await _build_lexeme_card_matches_by_vref(
             page_vrefs=page_vrefs,
-            source_revision_id=any_job.source_revision_id,
-            target_revision_id=any_job.target_revision_id,
-            source_version_id=any_job.source_version_id,
-            target_version_id=any_job.target_version_id,
+            source_revision_id=session_job.source_revision_id,
+            target_revision_id=session_job.target_revision_id,
+            source_version_id=session_job.source_version_id,
+            target_version_id=session_job.target_version_id,
             user=current_user,
             db=db,
         )

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -5,7 +5,7 @@ import os
 import socket
 import uuid
 from datetime import datetime
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 import fastapi
 import modal
@@ -19,6 +19,7 @@ from assessment_routes.v3.results_query_routes import validate_parameters
 from database.dependencies import get_db
 from database.models import (
     AgentLexemeCard,
+    AgentLexemeCardExample,
     AlignmentTopSourceScores,
     Assessment,
     AssessmentResult,
@@ -41,13 +42,13 @@ from models import (
     ASSESSMENT_TERMINAL_STATUSES,
     AssessmentStatus,
     InferenceReadiness,
+    LexemeCardOut,
     NgramResult,
     Result_v2,
     TfidfNeighbour,
     TrainingJobIn,
     TrainingJobOut,
     TrainingResponse,
-    TrainingSessionLexemeCard,
     TrainingSessionResultsPage,
     TrainingSessionResultsResponse,
     TrainingSessionVrefResults,
@@ -240,19 +241,21 @@ async def _build_lexeme_card_matches_by_vref(
     target_revision_id: int,
     source_version_id: int,
     target_version_id: int,
+    user: UserModel,
     db: AsyncSession,
-) -> dict[str, List[TrainingSessionLexemeCard]]:
+) -> dict[str, List[LexemeCardOut]]:
     """For each vref in `page_vrefs`, return the lexeme cards (for the
     given (source_version_id, target_version_id) pair) whose lemma or any
     surface form intersects the verse text on either side.
 
-    Mirrors the agent's predict-time matching: lower-cased, Unicode-aware
-    tokenization (via _tokenize_words from verse_routes); a card is
-    relevant if its target_lemma / surface_forms appears in the target
-    verse, OR its source_lemma / source_surface_forms appears in the
-    source verse. The returned card carries only the matched forms (not
-    the full surface-form list) so a verse with one hit doesn't drag the
-    card's whole vocabulary into every page.
+    Cards are filtered by the verse — only cards with at least one
+    matching form on either side are returned — but each returned card
+    is the full LexemeCardOut shape (same as `GET /v3/agent/lexeme-card`)
+    so the client gets the entire card, not just the forms that matched.
+
+    Examples are loaded once for the union of matched cards and filtered
+    by the user's revision access in the version pair, mirroring the
+    `GET /v3/agent/lexeme-card` endpoint.
     """
     # Reuse the existing tokenizer from bible_routes — it's the canonical
     # word-form definition used by /verse-counts etc., so cards stay
@@ -262,25 +265,18 @@ async def _build_lexeme_card_matches_by_vref(
     if not page_vrefs:
         return {}
 
-    # Bulk-load cards for the (source, target) pair. Confidence ordering
-    # mirrors the predict path so a client paging through results sees the
-    # same cards an LLM would see at predict time.
+    # Bulk-load full cards for the (source, target) pair. Confidence
+    # ordering mirrors the predict path so a client paging through
+    # results sees the same cards an LLM would see at predict time.
     cards_q = (
-        select(
-            AgentLexemeCard.id,
-            AgentLexemeCard.target_lemma,
-            AgentLexemeCard.source_lemma,
-            AgentLexemeCard.surface_forms,
-            AgentLexemeCard.source_surface_forms,
-            AgentLexemeCard.confidence,
-        )
+        select(AgentLexemeCard)
         .where(
             AgentLexemeCard.source_version_id == source_version_id,
             AgentLexemeCard.target_version_id == target_version_id,
         )
         .order_by(AgentLexemeCard.confidence.desc().nullslast())
     )
-    cards = (await db.execute(cards_q)).all()
+    cards = (await db.execute(cards_q)).scalars().all()
     if not cards:
         return {}
 
@@ -310,9 +306,10 @@ async def _build_lexeme_card_matches_by_vref(
         v: set(_tokenize_words(source_text_by_vref.get(v, ""))) for v in page_vrefs
     }
 
-    matches_by_vref: dict[str, List[TrainingSessionLexemeCard]] = {
-        v: [] for v in page_vrefs
-    }
+    # First pass: which cards match which vrefs, by id, preserving the
+    # confidence-DESC order from the cards query.
+    matched_card_ids_by_vref: dict[str, List[int]] = {v: [] for v in page_vrefs}
+    matched_card_id_set: set[int] = set()
     for card in cards:
         target_lemma = (card.target_lemma or "").lower()
         source_lemma = (card.source_lemma or "").lower() if card.source_lemma else ""
@@ -330,23 +327,93 @@ async def _build_lexeme_card_matches_by_vref(
             continue
 
         for vref in page_vrefs:
-            t_hits = sorted(target_forms & target_tokens_by_vref[vref])
-            s_hits = sorted(source_forms & source_tokens_by_vref[vref])
-            if not t_hits and not s_hits:
-                continue
-            matches_by_vref[vref].append(
-                TrainingSessionLexemeCard(
-                    id=card.id,
-                    target_lemma=card.target_lemma,
-                    source_lemma=card.source_lemma,
-                    matched_target_forms=t_hits,
-                    matched_source_forms=s_hits,
-                    confidence=(
-                        float(card.confidence) if card.confidence is not None else None
-                    ),
-                )
+            if (target_forms & target_tokens_by_vref[vref]) or (
+                source_forms & source_tokens_by_vref[vref]
+            ):
+                matched_card_ids_by_vref[vref].append(card.id)
+                matched_card_id_set.add(card.id)
+
+    if not matched_card_id_set:
+        return {v: [] for v in page_vrefs}
+
+    # Batch-load examples for the union of matched cards. Filter to
+    # examples from revisions the user can access in the source/target
+    # version (same rule as GET /v3/agent/lexeme-card).
+    examples_by_card: dict[int, List[Dict[str, Any]]] = {
+        cid: [] for cid in matched_card_id_set
+    }
+    examples_conditions = [
+        AgentLexemeCardExample.lexeme_card_id.in_(list(matched_card_id_set)),
+    ]
+    if not user.is_admin:
+        authorized_revisions = (
+            select(BibleRevision.id)
+            .distinct()
+            .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
+            .join(
+                BibleVersionAccess,
+                BibleVersionAccess.bible_version_id == BibleVersion.id,
             )
-    return matches_by_vref
+            .join(UserGroup, UserGroup.group_id == BibleVersionAccess.group_id)
+            .where(
+                UserGroup.user_id == user.id,
+                BibleVersion.id.in_([source_version_id, target_version_id]),
+            )
+        )
+        examples_conditions.append(
+            AgentLexemeCardExample.revision_id.in_(authorized_revisions)
+        )
+    examples_q = (
+        select(
+            AgentLexemeCardExample.lexeme_card_id,
+            AgentLexemeCardExample.source_text,
+            AgentLexemeCardExample.target_text,
+        )
+        .where(*examples_conditions)
+        .order_by(
+            AgentLexemeCardExample.lexeme_card_id,
+            AgentLexemeCardExample.id,
+        )
+    )
+    for row in (await db.execute(examples_q)).all():
+        examples_by_card[row.lexeme_card_id].append(
+            {"source": row.source_text, "target": row.target_text}
+        )
+
+    # Build LexemeCardOut once per matched card, then attach the same
+    # object to each vref it matched. Cards are read-only at this point,
+    # so sharing the Pydantic instance across vrefs is safe.
+    out_by_card_id: dict[int, LexemeCardOut] = {}
+    for card in cards:
+        if card.id not in matched_card_id_set:
+            continue
+        out_by_card_id[card.id] = LexemeCardOut.model_validate(
+            {
+                "id": card.id,
+                "source_lemma": card.source_lemma,
+                "target_lemma": card.target_lemma,
+                "source_version_id": card.source_version_id,
+                "target_version_id": card.target_version_id,
+                "pos": card.pos,
+                "surface_forms": card.surface_forms,
+                "source_surface_forms": card.source_surface_forms,
+                "senses": card.senses,
+                "confidence": (
+                    float(card.confidence) if card.confidence is not None else None
+                ),
+                "english_lemma": card.english_lemma,
+                "alignment_scores": card.alignment_scores,
+                "created_at": card.created_at,
+                "last_updated": card.last_updated,
+                "last_user_edit": card.last_user_edit,
+                "examples": examples_by_card[card.id],
+            }
+        )
+
+    return {
+        v: [out_by_card_id[cid] for cid in matched_card_ids_by_vref[v]]
+        for v in page_vrefs
+    }
 
 
 async def _get_accessible_version_ids(
@@ -972,7 +1039,7 @@ async def get_training_session_results(
     # them by including the type). Match each page vref against the
     # cards' lemma + surface forms on either side; cards without a hit
     # against this verse are dropped.
-    lexeme_cards_by_vref: dict[str, List[TrainingSessionLexemeCard]] = {}
+    lexeme_cards_by_vref: dict[str, List[LexemeCardOut]] = {}
     has_agent_critique = any(j.type == TrainingType.agent_critique.value for j in jobs)
     if has_agent_critique and page_vrefs:
         # source_version_id / target_version_id are denormalized onto
@@ -985,6 +1052,7 @@ async def get_training_session_results(
             target_revision_id=any_job.target_revision_id,
             source_version_id=any_job.source_version_id,
             target_version_id=any_job.target_version_id,
+            user=current_user,
             db=db,
         )
 

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -304,12 +304,10 @@ async def _build_lexeme_card_matches_by_vref(
 
     # Pre-tokenize each verse once; per-vref matching is a set lookup.
     target_tokens_by_vref: dict[str, set[str]] = {
-        v: set(_tokenize_words(target_text_by_vref.get(v, "")))
-        for v in page_vrefs
+        v: set(_tokenize_words(target_text_by_vref.get(v, ""))) for v in page_vrefs
     }
     source_tokens_by_vref: dict[str, set[str]] = {
-        v: set(_tokenize_words(source_text_by_vref.get(v, "")))
-        for v in page_vrefs
+        v: set(_tokenize_words(source_text_by_vref.get(v, ""))) for v in page_vrefs
     }
 
     matches_by_vref: dict[str, List[TrainingSessionLexemeCard]] = {
@@ -321,14 +319,11 @@ async def _build_lexeme_card_matches_by_vref(
         target_forms = {target_lemma} | {
             f.lower() for f in (card.surface_forms or []) if isinstance(f, str) and f
         }
-        source_forms = (
-            ({source_lemma} if source_lemma else set())
-            | {
-                f.lower()
-                for f in (card.source_surface_forms or [])
-                if isinstance(f, str) and f
-            }
-        )
+        source_forms = ({source_lemma} if source_lemma else set()) | {
+            f.lower()
+            for f in (card.source_surface_forms or [])
+            if isinstance(f, str) and f
+        }
         target_forms.discard("")
         source_forms.discard("")
         if not target_forms and not source_forms:
@@ -978,9 +973,7 @@ async def get_training_session_results(
     # cards' lemma + surface forms on either side; cards without a hit
     # against this verse are dropped.
     lexeme_cards_by_vref: dict[str, List[TrainingSessionLexemeCard]] = {}
-    has_agent_critique = any(
-        j.type == TrainingType.agent_critique.value for j in jobs
-    )
+    has_agent_critique = any(j.type == TrainingType.agent_critique.value for j in jobs)
     if has_agent_critique and page_vrefs:
         # source_version_id / target_version_id are denormalized onto
         # TrainingJob, so any session job carries the right pair —

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -244,7 +244,7 @@ async def _build_lexeme_card_matches_by_vref(
     target_version_id: int,
     user: UserModel,
     db: AsyncSession,
-) -> dict[str, List[LexemeCardOut]]:
+) -> tuple[dict[str, List[LexemeCardOut]], bool]:
     """For each vref in `page_vrefs`, return the lexeme cards (for the
     given (source_version_id, target_version_id) pair) whose lemma or any
     surface form intersects the verse text on either side.
@@ -257,6 +257,10 @@ async def _build_lexeme_card_matches_by_vref(
     Examples are loaded once for the union of matched cards and filtered
     by the user's revision access in the version pair, mirroring the
     `GET /v3/agent/lexeme-card` endpoint.
+
+    Returns `(matches_by_vref, truncated)` — the second element is True
+    when the card load hit the per-request cap, signalling that only
+    the highest-confidence prefix of cards was matched.
     """
     # Reuse the existing tokenizer from bible_routes — it's the canonical
     # word-form definition used by /verse-counts etc., so cards stay
@@ -264,7 +268,7 @@ async def _build_lexeme_card_matches_by_vref(
     from bible_routes.v3.verse_routes import _tokenize_words
 
     if not page_vrefs:
-        return {}
+        return {}, False
 
     # Bulk-load full cards for the (source, target) pair. Confidence
     # ordering mirrors the predict path so a client paging through
@@ -286,9 +290,10 @@ async def _build_lexeme_card_matches_by_vref(
         .limit(LEXEME_CARD_LIMIT)
     )
     cards = (await db.execute(cards_q)).scalars().all()
+    truncated = len(cards) >= LEXEME_CARD_LIMIT
     if not cards:
-        return {}
-    if len(cards) >= LEXEME_CARD_LIMIT:
+        return {}, truncated
+    if truncated:
         logger.warning(
             "lexeme card cap hit on /train/status results",
             extra={
@@ -445,10 +450,13 @@ async def _build_lexeme_card_matches_by_vref(
             }
         )
 
-    return {
-        v: [out_by_card_id[cid] for cid in matched_card_ids_by_vref[v]]
-        for v in page_vrefs
-    }
+    return (
+        {
+            v: [out_by_card_id[cid] for cid in matched_card_ids_by_vref[v]]
+            for v in page_vrefs
+        },
+        truncated,
+    )
 
 
 async def _get_accessible_version_ids(
@@ -1075,6 +1083,7 @@ async def get_training_session_results(
     # cards' lemma + surface forms on either side; cards without a hit
     # against this verse are dropped.
     lexeme_cards_by_vref: dict[str, List[LexemeCardOut]] = {}
+    lexeme_cards_truncated = False
     has_agent_critique = any(j.type == TrainingType.agent_critique.value for j in jobs)
     if has_agent_critique and page_vrefs:
         # source_version_id / target_version_id are denormalized onto
@@ -1082,7 +1091,10 @@ async def get_training_session_results(
         # constructs them from the same (source_revision, target_revision)
         # pair — so any session job carries the right ids.
         session_job = jobs[0]
-        lexeme_cards_by_vref = await _build_lexeme_card_matches_by_vref(
+        (
+            lexeme_cards_by_vref,
+            lexeme_cards_truncated,
+        ) = await _build_lexeme_card_matches_by_vref(
             page_vrefs=page_vrefs,
             source_revision_id=session_job.source_revision_id,
             target_revision_id=session_job.target_revision_id,
@@ -1172,6 +1184,7 @@ async def get_training_session_results(
             page_size=page_size,
         ),
         ngrams=ngrams_list,
+        lexeme_cards_truncated=lexeme_cards_truncated,
     )
 
 

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import aliased, selectinload
 from assessment_routes.v3.results_query_routes import validate_parameters
 from database.dependencies import get_db
 from database.models import (
+    AgentLexemeCard,
     AlignmentTopSourceScores,
     Assessment,
     AssessmentResult,
@@ -46,6 +47,7 @@ from models import (
     TrainingJobIn,
     TrainingJobOut,
     TrainingResponse,
+    TrainingSessionLexemeCard,
     TrainingSessionResultsPage,
     TrainingSessionResultsResponse,
     TrainingSessionVrefResults,
@@ -230,6 +232,126 @@ async def _compute_inference_readiness(
             pending_training=pending,
         )
     return readiness
+
+
+async def _build_lexeme_card_matches_by_vref(
+    page_vrefs: List[str],
+    source_revision_id: int,
+    target_revision_id: int,
+    source_version_id: int,
+    target_version_id: int,
+    db: AsyncSession,
+) -> dict[str, List[TrainingSessionLexemeCard]]:
+    """For each vref in `page_vrefs`, return the lexeme cards (for the
+    given (source_version_id, target_version_id) pair) whose lemma or any
+    surface form intersects the verse text on either side.
+
+    Mirrors the agent's predict-time matching: lower-cased, Unicode-aware
+    tokenization (via _tokenize_words from verse_routes); a card is
+    relevant if its target_lemma / surface_forms appears in the target
+    verse, OR its source_lemma / source_surface_forms appears in the
+    source verse. The returned card carries only the matched forms (not
+    the full surface-form list) so a verse with one hit doesn't drag the
+    card's whole vocabulary into every page.
+    """
+    # Reuse the existing tokenizer from bible_routes — it's the canonical
+    # word-form definition used by /verse-counts etc., so cards stay
+    # consistent with what shows up in the rest of the API.
+    from bible_routes.v3.verse_routes import _tokenize_words
+
+    if not page_vrefs:
+        return {}
+
+    # Bulk-load cards for the (source, target) pair. Confidence ordering
+    # mirrors the predict path so a client paging through results sees the
+    # same cards an LLM would see at predict time.
+    cards_q = (
+        select(
+            AgentLexemeCard.id,
+            AgentLexemeCard.target_lemma,
+            AgentLexemeCard.source_lemma,
+            AgentLexemeCard.surface_forms,
+            AgentLexemeCard.source_surface_forms,
+            AgentLexemeCard.confidence,
+        )
+        .where(
+            AgentLexemeCard.source_version_id == source_version_id,
+            AgentLexemeCard.target_version_id == target_version_id,
+        )
+        .order_by(AgentLexemeCard.confidence.desc().nullslast())
+    )
+    cards = (await db.execute(cards_q)).all()
+    if not cards:
+        return {}
+
+    # Bulk-load source + target verse text for the page in two queries.
+    # `vref` on the per-app result tables matches `verse_reference` in
+    # verse_text (both are the canonical "BOOK C:V" string).
+    target_text_q = select(VerseText.verse_reference, VerseText.text).where(
+        VerseText.revision_id == target_revision_id,
+        VerseText.verse_reference.in_(page_vrefs),
+    )
+    source_text_q = select(VerseText.verse_reference, VerseText.text).where(
+        VerseText.revision_id == source_revision_id,
+        VerseText.verse_reference.in_(page_vrefs),
+    )
+    target_text_by_vref = {
+        row[0]: row[1] or "" for row in (await db.execute(target_text_q)).all()
+    }
+    source_text_by_vref = {
+        row[0]: row[1] or "" for row in (await db.execute(source_text_q)).all()
+    }
+
+    # Pre-tokenize each verse once; per-vref matching is a set lookup.
+    target_tokens_by_vref: dict[str, set[str]] = {
+        v: set(_tokenize_words(target_text_by_vref.get(v, "")))
+        for v in page_vrefs
+    }
+    source_tokens_by_vref: dict[str, set[str]] = {
+        v: set(_tokenize_words(source_text_by_vref.get(v, "")))
+        for v in page_vrefs
+    }
+
+    matches_by_vref: dict[str, List[TrainingSessionLexemeCard]] = {
+        v: [] for v in page_vrefs
+    }
+    for card in cards:
+        target_lemma = (card.target_lemma or "").lower()
+        source_lemma = (card.source_lemma or "").lower() if card.source_lemma else ""
+        target_forms = {target_lemma} | {
+            f.lower() for f in (card.surface_forms or []) if isinstance(f, str) and f
+        }
+        source_forms = (
+            ({source_lemma} if source_lemma else set())
+            | {
+                f.lower()
+                for f in (card.source_surface_forms or [])
+                if isinstance(f, str) and f
+            }
+        )
+        target_forms.discard("")
+        source_forms.discard("")
+        if not target_forms and not source_forms:
+            continue
+
+        for vref in page_vrefs:
+            t_hits = sorted(target_forms & target_tokens_by_vref[vref])
+            s_hits = sorted(source_forms & source_tokens_by_vref[vref])
+            if not t_hits and not s_hits:
+                continue
+            matches_by_vref[vref].append(
+                TrainingSessionLexemeCard(
+                    id=card.id,
+                    target_lemma=card.target_lemma,
+                    source_lemma=card.source_lemma,
+                    matched_target_forms=t_hits,
+                    matched_source_forms=s_hits,
+                    confidence=(
+                        float(card.confidence) if card.confidence is not None else None
+                    ),
+                )
+            )
+    return matches_by_vref
 
 
 async def _get_accessible_version_ids(
@@ -609,8 +731,14 @@ async def get_training_session_results(
     rows (multiple), and tfidf nearest-neighbour vrefs from the source
     corpus. Ngrams are returned at the top level — each ngram has many
     vrefs, so nesting them per verse would duplicate the same ngram across
-    every verse it appears in. Agent_critique training runs produce
-    nothing the client wants here.
+    every verse it appears in.
+
+    Agent_critique adds `lexeme_cards` per vref: when the session
+    includes an agent-critique training type, each vref carries the
+    lexeme cards (filtered to those whose lemma/surface forms intersect
+    the verse text on either side) that were produced for the (source,
+    target) version pair. Sessions without agent-critique return an
+    empty list there.
     """
     await validate_parameters(
         book, chapter, verse, aggregate=None, page=page, page_size=page_size
@@ -843,12 +971,37 @@ async def get_training_session_results(
                 )
             )
 
+    # Lexeme cards: only attach when agent-critique is part of the
+    # session (whether finished, running, or failed — cards may already
+    # exist on disk from prior runs and the user explicitly asked for
+    # them by including the type). Match each page vref against the
+    # cards' lemma + surface forms on either side; cards without a hit
+    # against this verse are dropped.
+    lexeme_cards_by_vref: dict[str, List[TrainingSessionLexemeCard]] = {}
+    has_agent_critique = any(
+        j.type == TrainingType.agent_critique.value for j in jobs
+    )
+    if has_agent_critique and page_vrefs:
+        # source_version_id / target_version_id are denormalized onto
+        # TrainingJob, so any session job carries the right pair —
+        # session jobs all share the same (source, target) by construction.
+        any_job = jobs[0]
+        lexeme_cards_by_vref = await _build_lexeme_card_matches_by_vref(
+            page_vrefs=page_vrefs,
+            source_revision_id=any_job.source_revision_id,
+            target_revision_id=any_job.target_revision_id,
+            source_version_id=any_job.source_version_id,
+            target_version_id=any_job.target_version_id,
+            db=db,
+        )
+
     results_list = [
         TrainingSessionVrefResults(
             vref=v,
             semantic_similarity=sem_sim_by_vref.get(v),
             word_alignment=word_align_by_vref.get(v, []),
             tfidf=tfidf_by_vref.get(v, []),
+            lexeme_cards=lexeme_cards_by_vref.get(v, []),
         )
         for v in page_vrefs
     ]


### PR DESCRIPTION
## Summary

When a `/v3/train` session includes the `agent-critique` training type (either explicitly via `apps=[...]` or implicitly when running all apps), `GET /train/status/{session_id}/results` now attaches per-vref `lexeme_cards` to each row of the response. Sessions without `agent-critique` continue to return `lexeme_cards: []`.

A card is "relevant" to a vref when its `target_lemma` / `surface_forms` intersect the target verse text, OR its `source_lemma` / `source_surface_forms` intersect the source verse text — same Unicode-aware tokenization (`_tokenize_words` from `bible_routes/v3/verse_routes.py`) the rest of the API uses, with NFC normalisation applied so cards stored as NFC match verses regardless of the verse text's storage form.

**Each returned card is the full `LexemeCardOut` shape** — same fields as `GET /v3/agent/lexeme-card`, including the card's complete `surface_forms`, `source_surface_forms`, `senses`, `confidence`, `alignment_scores`, and (user-auth-filtered) `examples`. Cards are *filtered* by the verse, but their contents are returned in full.

## Implementation

- Cards are bulk-loaded once per request for the (source, target) version pair (capped at 10,000 with a `logger.warning` if the cap is hit). Per-vref matching is set intersection in Python.
- Examples are batch-loaded for the union of matched cards, filtered by user-accessible revisions in the version pair (same rule as `GET /v3/agent/lexeme-card`).
- Reuses the existing `_tokenize_words` from `verse_routes.py` for consistency with `/verse-counts` etc.
- The `has_agent_critique` check looks at the session's training jobs regardless of finished status — cards may already exist on disk from prior runs and the user explicitly opted into the critique app by including the type.

## Test plan

- [x] `test_session_results_lexeme_cards_when_agent_critique_in_session` — full-card shape, intersection-only filter, irrelevant cards dropped.
- [x] `test_session_results_lexeme_cards_empty_when_no_agent_critique` — `lexeme_cards = []` even when cards exist for the version pair.
- [x] `pytest test/test_train_routes/` — 53 passing
- [x] `pytest test/test_train_routes/ test/test_predict_routes/ test/test_assessment_routes/` — 355 passing
- [ ] Smoke after deploy: re-run the demo notebook and confirm `lexeme_cards` populate on LUK 1 results when training includes agent-critique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)