### PR TITLE
Switch TF-IDF push validator to derive source_version_id from revision_id

### DIFF
--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -161,19 +161,30 @@ async def _assessment_source_version_id(
 ) -> int:
     """Resolve `source_version_id` from an Assessment row.
 
-    train_routes (post #620) maps `source_revision_id → reference_id`
-    (source = reference language, the side we're translating *from*),
-    so the source version comes from `assessment.reference_id`.
+    TF-IDF is a single-corpus assessment: `assessment.revision_id` *is*
+    the corpus the vectors are computed over. The `source_version_id`
+    stored on TfidfArtifactRun therefore needs to match the language
+    of `revision_id`, not `reference_id` — predict-time clients look
+    up artifacts by the version of the corpus they want neighbours
+    from, which is whatever `revision_id` was at training time.
+
+    The train route after aqua-api#620 puts the user's translation
+    (target side) on `revision_id` — exactly what tfidf vectorises in
+    that flow — and standalone `POST /assessment` callers also pass
+    the corpus revision as `revision_id`. Both flows therefore agree:
+    derive from `revision_id`.
+
+    aqua-api#622 briefly switched this to `reference_id` to match a
+    perceived eflomal-style source/target split. That was wrong for
+    tfidf — it broke the standalone path (no `reference_id` required
+    by AssessmentIn) and stored the wrong `source_version_id` on
+    train-flow artifacts (the source side's version, not the
+    vectorised corpus's version), so predict-time lookups by the
+    corpus version returned 404. This restores the pre-#622 derivation.
     """
-    if assessment.reference_id is None:
-        raise HTTPException(
-            status_code=400,
-            detail="TF-IDF push requires an assessment reference_id "
-            "(the source-side revision)",
-        )
     source_version_id = await db.scalar(
         select(BibleRevision.bible_version_id).where(
-            BibleRevision.id == assessment.reference_id
+            BibleRevision.id == assessment.revision_id
         )
     )
     if source_version_id is None:
@@ -225,8 +236,8 @@ async def push_tfidf_artifacts(
     ):
         raise HTTPException(
             status_code=422,
-            detail="source_version_id does not match the assessment's "
-            "source-side version",
+            detail="source_version_id does not match the version of "
+            "the assessment's corpus revision",
         )
 
     try:
@@ -487,8 +498,8 @@ async def init_tfidf_artifacts_upload(
     ):
         raise HTTPException(
             status_code=422,
-            detail="source_version_id does not match the assessment's "
-            "source-side version",
+            detail="source_version_id does not match the version of "
+            "the assessment's corpus revision",
         )
     _validate_vectorizer_shapes(body)
 

--- a/test/test_assessment_routes/test_tfidf_artifact_routes.py
+++ b/test/test_assessment_routes/test_tfidf_artifact_routes.py
@@ -153,7 +153,7 @@ def non_tfidf_assessment_id(test_db_session, test_revision_id, test_revision_id_
     return assessment.id
 
 
-def test_tfidf_artifact_push_validator_uses_post620_mapping(
+def test_tfidf_artifact_push_validator_derives_source_from_revision(
     client,
     admin_token,
     test_db_session,
@@ -161,32 +161,38 @@ def test_tfidf_artifact_push_validator_uses_post620_mapping(
     test_version_id,
     test_version_id_2,
 ):
-    """Regression for the bug uncovered after train_routes #620.
+    """TF-IDF is single-corpus: the artifact's `source_version_id` must
+    match the version of `assessment.revision_id` (the corpus the
+    vectors were trained on), regardless of `assessment.reference_id`.
 
-    Workers send `source_version_id` = source-side version. The push
-    validator must derive that from `assessment.reference_id` (post #620
-    that's the source revision), not from `assessment.revision_id`.
+    Built with two distinct versions and a `reference_id` that points
+    at the *other* version so a regression that reverts to deriving
+    from `reference_id` (the brief #622 behaviour) would let the wrong
+    version slip through silently. The canonical body must pass; a
+    body whose `source_version_id` matches `reference_id`'s version
+    instead of `revision_id`'s version must fail.
 
-    Built with two distinct versions so a regression that reads from the
-    wrong assessment field surfaces as a 422 instead of silently passing.
-    Uses admin_token because test_version_id_2 has no group access wired
-    up in the fixtures.
+    Uses admin_token because test_version_id_2 has no group access
+    wired up in the fixtures.
     """
     from database.models import BibleRevision
 
-    ref_rev = BibleRevision(
+    other_rev = BibleRevision(
         bible_version_id=test_version_id_2,
-        name="tfidf-validator-regression-ref",
+        name="tfidf-validator-regression-other",
         published=False,
     )
-    test_db_session.add(ref_rev)
+    test_db_session.add(other_rev)
     test_db_session.commit()
-    test_db_session.refresh(ref_rev)
+    test_db_session.refresh(other_rev)
 
-    # Per train_routes #620: revision_id = target side, reference_id = source side.
+    # revision_id is the corpus → its version (test_version_id) is what
+    # the validator must derive. reference_id deliberately points at a
+    # different version so a "derive from reference_id" regression is
+    # visible.
     assessment = Assessment(
         revision_id=test_revision_id,
-        reference_id=ref_rev.id,
+        reference_id=other_rev.id,
         type="tfidf",
         status="running",
     )
@@ -196,7 +202,7 @@ def test_tfidf_artifact_push_validator_uses_post620_mapping(
 
     headers = {"Authorization": f"Bearer {admin_token}"}
 
-    body = _make_artifact_body(source_version_id=test_version_id_2)
+    body = _make_artifact_body(source_version_id=test_version_id)
     response = client.post(
         f"{prefix}/assessment/{assessment.id}/tfidf-artifacts",
         json=body,
@@ -204,16 +210,52 @@ def test_tfidf_artifact_push_validator_uses_post620_mapping(
     )
     assert response.status_code == 200, response.json()
 
-    # And the wrong source version must now fail — proves the validator
-    # is actually distinguishing source vs. target.
-    swapped = _make_artifact_body(source_version_id=test_version_id)
+    # Sending reference_id's version instead of revision_id's version
+    # must 422 — proves the validator is reading the right side.
+    swapped = _make_artifact_body(source_version_id=test_version_id_2)
     bad = client.post(
         f"{prefix}/assessment/{assessment.id}/tfidf-artifacts",
         json=swapped,
         headers=headers,
     )
     assert bad.status_code == 422
-    assert "source-side" in bad.json()["detail"]
+    assert "corpus revision" in bad.json()["detail"]
+
+
+def test_tfidf_artifact_push_works_without_reference_id(
+    client,
+    admin_token,
+    test_db_session,
+    test_revision_id,
+    test_version_id,
+):
+    """Standalone `POST /assessment?revision_id=…&type=tfidf` doesn't
+    require `reference_id` (TF-IDF is single-corpus). The artifact push
+    that follows must succeed even when `assessment.reference_id is
+    None`, with `source_version_id` resolved from `revision_id`.
+
+    Regression for the user-visible breakage where the demo notebook's
+    standalone TF-IDF POST died at push time with
+    "TF-IDF push requires an assessment reference_id".
+    """
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=None,
+        type="tfidf",
+        status="running",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+
+    headers = {"Authorization": f"Bearer {admin_token}"}
+    body = _make_artifact_body(source_version_id=test_version_id)
+    response = client.post(
+        f"{prefix}/assessment/{assessment.id}/tfidf-artifacts",
+        json=body,
+        headers=headers,
+    )
+    assert response.status_code == 200, response.json()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

TF-IDF is single-corpus: `assessment.revision_id` is the corpus the vectors are computed over. The artifact's stored `source_version_id` therefore needs to match `revision_id`'s version, not `reference_id`'s.

aqua-api#622 briefly switched the validator to derive from `reference_id` to mirror the eflomal source/target split. That broke two flows:

- **Standalone `POST /assessment?revision_id=…&type=tfidf`** — `AssessmentIn` doesn't require `reference_id`, so the push validator's `reference_id is None` guard 400'd every standalone run with `"TF-IDF push requires an assessment reference_id"`. The user just hit this on revision 1592 in the demo notebook.
- **`/v3/train` flow** — the artifact got stored with `source_version_id` = source-side version (post-#620 `reference_id`), but the actual vectors are over `revision_id` = target side (the user's translation). Predict-time lookups by the corpus version then 404'd because the stored value doesn't match.

This PR reverts that piece of #622 specifically for TF-IDF: derive from `revision_id`. Both flows now agree.

eflomal stays as-is — it genuinely is bilingual (source-side and target-side artifacts in the same row), so #622's reference_id derivation there was correct.

## Tests

- Replaced `test_tfidf_artifact_push_validator_uses_post620_mapping` with `test_tfidf_artifact_push_validator_derives_source_from_revision`. The new test still uses two distinct versions and asserts the canonical body passes 200 *and* a body matching `reference_id`'s version (the wrong derivation) fails 422 — so a regression that flips back to `reference_id` is caught immediately.
- Added `test_tfidf_artifact_push_works_without_reference_id` pinning the standalone flow that was broken — `assessment.reference_id = None`, push must 200.

`pytest test/test_assessment_routes/test_tfidf_artifact_routes.py` — 38 passing.

## Test plan

- [x] `pytest test/test_assessment_routes/test_tfidf_artifact_routes.py` — 38 passing
- [x] Verified live on dev: queued `POST /assessment?revision_id=1592&reference_id=1592&type=tfidf` (workaround for the existing bug) finished cleanly. After this lands, the same call without `reference_id` should also work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)