### PR TITLE
Return verse-level word-alignment score in train results

### DIFF
--- a/models.py
+++ b/models.py
@@ -1150,6 +1150,11 @@ class TrainingSessionVrefResults(BaseModel):
     vref: str
     semantic_similarity: Optional[Result_v2] = None
     word_alignment: List[WordAlignment] = Field(default_factory=list)
+    # Verse-level aggregate score for word-alignment, written to
+    # `assessment_result` alongside the per-word-pair rows in
+    # `alignment_top_source_scores`. Mirrors the shape of
+    # `semantic_similarity` so clients can treat the two the same way.
+    word_alignment_score: Optional[Result_v2] = None
     tfidf: List[TfidfNeighbour] = Field(default_factory=list)
     # Full lexeme cards (same shape as `GET /v3/agent/lexeme-card`) whose
     # lemma or any surface form intersects this verse on either side.

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1554,7 +1554,7 @@ def test_session_results_filter_by_book_chapter(
     assert verse_results["total_count"] == 1
     assert verse_results["items"][0]["vref"] == "GEN 1:2"
     # No word-alignment job in this session, so the verse-level WA score
-    # field must be absent on every returned vref.
+    # field must be null on every returned vref.
     assert verse_results["items"][0]["word_alignment_score"] is None
 
 

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1410,6 +1410,93 @@ def test_session_results_interleaves_completed_apps(
     assert by_vref["GEN 1:2"]["word_alignment_score"]["score"] == 0.77
 
 
+def test_session_results_word_alignment_verse_score_only_vref_paginates(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """A vref with only a verse-level score (no per-pair rows) must still
+    paginate. This is the reason `assessment_result` is in the per-vref
+    union for word-alignment — without it, vrefs with empty alignments
+    would silently disappear from the page."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_wa_verse_only"},
+        apps=["word-alignment"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    wa_job = payload["training_jobs"][0]
+
+    _advance_assessment_to_finished(client, regular_token1, wa_job["assessment_id"])
+    # GEN 1:1 has both per-pair and verse-level; GEN 1:2 has only the
+    # verse-level score (e.g. an empty verse with no aligned word pairs).
+    _seed_word_alignment(
+        db_session,
+        wa_job["assessment_id"],
+        [("GEN 1:1", "beginning", "principio", 0.91)],
+    )
+    _seed_word_alignment_verse_scores(
+        db_session,
+        wa_job["assessment_id"],
+        [("GEN 1:1", 0.91), ("GEN 1:2", 0.0)],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    assert data["results"]["total_count"] == 2
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    assert set(by_vref) == {"GEN 1:1", "GEN 1:2"}
+    assert by_vref["GEN 1:2"]["word_alignment"] == []
+    assert by_vref["GEN 1:2"]["word_alignment_score"]["score"] == 0.0
+
+
+def test_session_results_word_alignment_verse_score_respects_filter(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """book/chapter/verse filter must scope the new `assessment_result`
+    subquery for word-alignment too — not just the per-pair table."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_wa_verse_filter"},
+        apps=["word-alignment"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    wa_job = payload["training_jobs"][0]
+
+    _advance_assessment_to_finished(client, regular_token1, wa_job["assessment_id"])
+    # Verse-level scores across two books and two chapters; no per-pair
+    # rows so the filter must reach the AssessmentResult subquery.
+    _seed_word_alignment_verse_scores(
+        db_session,
+        wa_job["assessment_id"],
+        [
+            ("GEN 1:1", 0.5),
+            ("GEN 1:2", 0.6),
+            ("GEN 2:1", 0.7),
+            ("EXO 1:1", 0.8),
+        ],
+    )
+
+    chap_results = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"book": "GEN", "chapter": 1},
+        headers=_auth_headers(regular_token1),
+    ).json()["results"]
+    assert chap_results["total_count"] == 2
+    assert {b["vref"] for b in chap_results["items"]} == {"GEN 1:1", "GEN 1:2"}
+    by_vref = {b["vref"]: b for b in chap_results["items"]}
+    assert by_vref["GEN 1:1"]["word_alignment_score"]["score"] == 0.5
+    assert by_vref["GEN 1:2"]["word_alignment_score"]["score"] == 0.6
+
+
 def test_session_results_filter_by_book_chapter(
     client, regular_token1, test_revision_id, test_revision_id_2, db_session
 ):
@@ -1466,6 +1553,9 @@ def test_session_results_filter_by_book_chapter(
     ).json()["results"]
     assert verse_results["total_count"] == 1
     assert verse_results["items"][0]["vref"] == "GEN 1:2"
+    # No word-alignment job in this session, so the verse-level WA score
+    # field must be absent on every returned vref.
+    assert verse_results["items"][0]["word_alignment_score"] is None
 
 
 def test_session_results_pagination_canonical_order(
@@ -2001,6 +2091,9 @@ def test_session_results_word_alignment_only_completed(
     assert only["vref"] == "GEN 1:1"
     assert only["semantic_similarity"] is None
     assert len(only["word_alignment"]) == 1
+    # No verse-level row was seeded — the field stays null, distinct from a
+    # zero-score AssessmentResult row.
+    assert only["word_alignment_score"] is None
 
 
 def test_session_results_admin_can_read_other_owner_session(

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1257,6 +1257,25 @@ def _seed_word_alignment(db_session, assessment_id, rows):
     db_session.commit()
 
 
+def _seed_word_alignment_verse_scores(db_session, assessment_id, vrefs_with_scores):
+    """Verse-level word-alignment aggregate, written to assessment_result
+    by the worker alongside per-pair rows in alignment_top_source_scores."""
+    for vref, score in vrefs_with_scores:
+        book, rest = vref.split(" ")
+        chap, vs = rest.split(":")
+        db_session.add(
+            AssessmentResult(
+                assessment_id=assessment_id,
+                vref=vref,
+                book=book,
+                chapter=int(chap),
+                verse=int(vs),
+                score=score,
+            )
+        )
+    db_session.commit()
+
+
 def _seed_ngrams(db_session, assessment_id, ngrams_with_vrefs):
     """ngrams_with_vrefs: list of (ngram, ngram_size, [vrefs])."""
     for ngram, size, vrefs in ngrams_with_vrefs:
@@ -1362,6 +1381,11 @@ def test_session_results_interleaves_completed_apps(
             ("GEN 1:2", "earth", "tierra", 0.77),
         ],
     )
+    _seed_word_alignment_verse_scores(
+        db_session,
+        wa_job["assessment_id"],
+        [("GEN 1:1", 0.895), ("GEN 1:2", 0.77)],
+    )
 
     response = client.get(
         f"{prefix}/train/status/{session_id}/results",
@@ -1380,8 +1404,10 @@ def test_session_results_interleaves_completed_apps(
         "beginning",
         "god",
     }
+    assert by_vref["GEN 1:1"]["word_alignment_score"]["score"] == 0.895
     assert by_vref["GEN 1:2"]["semantic_similarity"]["score"] == 0.42
     assert len(by_vref["GEN 1:2"]["word_alignment"]) == 1
+    assert by_vref["GEN 1:2"]["word_alignment_score"]["score"] == 0.77
 
 
 def test_session_results_filter_by_book_chapter(

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -833,10 +833,10 @@ async def get_training_session_results(
     per-vref results for every completed job in the session.
 
     Per vref: semantic_similarity score (one row), word_alignment per-word
-    rows (multiple), and tfidf nearest-neighbour vrefs from the source
-    corpus. Ngrams are returned at the top level — each ngram has many
-    vrefs, so nesting them per verse would duplicate the same ngram across
-    every verse it appears in.
+    rows (multiple) plus a verse-level word_alignment_score, and tfidf
+    nearest-neighbour vrefs from the source corpus. Ngrams are returned at
+    the top level — each ngram has many vrefs, so nesting them per verse
+    would duplicate the same ngram across every verse it appears in.
 
     Agent_critique adds `lexeme_cards` per vref: when the session
     includes an agent-critique training type, each vref carries the
@@ -932,6 +932,20 @@ async def get_training_session_results(
                 AlignmentTopSourceScores,
             )
         )
+        # Verse-level aggregate scores live in `assessment_result` alongside
+        # the per-pair rows. Include them in the union so a verse with a
+        # verse-level score but no per-pair rows still paginates.
+        per_vref_subqueries.append(
+            _scope(
+                select(
+                    AssessmentResult.vref,
+                    AssessmentResult.book,
+                    AssessmentResult.chapter,
+                    AssessmentResult.verse,
+                ).where(AssessmentResult.assessment_id == word_align_id),
+                AssessmentResult,
+            )
+        )
 
     if tfidf_id is not None:
         tfidf_q = (
@@ -1016,6 +1030,7 @@ async def get_training_session_results(
             )
 
     word_align_by_vref: dict[str, List[WordAlignment]] = {}
+    word_align_score_by_vref: dict[str, Result_v2] = {}
     if word_align_id is not None and page_vrefs:
         rows = await db.execute(
             select(AlignmentTopSourceScores).where(
@@ -1036,6 +1051,29 @@ async def get_training_session_results(
                     note=r.note,
                     hide=r.hide or False,
                 )
+            )
+
+        score_rows = await db.execute(
+            select(AssessmentResult).where(
+                AssessmentResult.assessment_id == word_align_id,
+                AssessmentResult.vref.in_(page_vrefs),
+            )
+        )
+        for r in score_rows.scalars().all():
+            # First-write-wins on (assessment_id, vref) — same pattern as
+            # sem_sim_by_vref above.
+            if r.vref in word_align_score_by_vref:
+                continue
+            word_align_score_by_vref[r.vref] = Result_v2(
+                id=r.id,
+                assessment_id=r.assessment_id,
+                vref=r.vref,
+                score=float(r.score) if r.score is not None else 0.0,
+                flag=r.flag or False,
+                note=r.note,
+                source=r.source,
+                target=r.target,
+                hide=r.hide or False,
             )
 
     tfidf_by_vref: dict[str, List[TfidfNeighbour]] = {}
@@ -1109,6 +1147,7 @@ async def get_training_session_results(
             vref=v,
             semantic_similarity=sem_sim_by_vref.get(v),
             word_alignment=word_align_by_vref.get(v, []),
+            word_alignment_score=word_align_score_by_vref.get(v),
             tfidf=tfidf_by_vref.get(v, []),
             lexeme_cards=lexeme_cards_by_vref.get(v, []),
         )

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -1058,14 +1058,17 @@ async def get_training_session_results(
             )
 
         score_rows = await db.execute(
-            select(AssessmentResult).where(
+            select(AssessmentResult)
+            .where(
                 AssessmentResult.assessment_id == word_align_id,
                 AssessmentResult.vref.in_(page_vrefs),
             )
+            .order_by(AssessmentResult.id.asc())
         )
         for r in score_rows.scalars().all():
             # First-write-wins on (assessment_id, vref) — same pattern as
-            # sem_sim_by_vref above.
+            # sem_sim_by_vref above. The ORDER BY id ASC pins which row
+            # wins when duplicates exist (no DB uniqueness on the pair).
             if r.vref in word_align_score_by_vref:
                 continue
             word_align_score_by_vref[r.vref] = Result_v2(

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -973,6 +973,10 @@ async def get_training_session_results(
     page_vrefs: List[str] = []
     total_count = 0
     if per_vref_subqueries:
+        # `.union()` (not `.union_all()`) is load-bearing: when both sem-sim
+        # and word-alignment write to `assessment_result` for the same vref,
+        # or when AlignmentTopSourceScores and AssessmentResult both surface
+        # the same word-alignment vref, we want one paginated row, not two.
         union_subq = per_vref_subqueries[0].union(*per_vref_subqueries[1:]).subquery()
         # Apply the BookReference join up front so total_count and the page
         # both see the same row set — without it, vrefs whose `book` doesn't


### PR DESCRIPTION
## Summary

- Add `word_alignment_score` to `TrainingSessionVrefResults` in the train results endpoint (`GET /v3/train/status/{session_id}/results`).
- Read the verse-level aggregate from `assessment_result` keyed by the word-alignment `assessment_id` — the same shape `/v3/compareresults` already consumes — and include those vrefs in the pagination union so a verse with a verse-level score but no per-pair rows still surfaces.
- Mirror the existing `semantic_similarity` plumbing (first-write-wins per vref, `Result_v2` shape) so clients treat the two consistently.

## Test plan

- [x] `pytest test/test_train_routes/test_train_routes.py` (53 passed)
- [x] `test_session_results_interleaves_completed_apps` extended to seed `assessment_result` rows for the word-alignment assessment and assert the new `word_alignment_score` field per vref
- [x] `black --check` / `isort --check-only` clean on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)