### PR TITLE
Derive eflomal version IDs from revision_id/reference_id

### DIFF
--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -179,7 +179,11 @@ async def get_assessments(
 
 # Helper function to call assessment runner
 async def call_assessment_runner(
-    assessment: AssessmentIn, return_all_results: bool, modal_env: str
+    assessment: AssessmentIn,
+    return_all_results: bool,
+    modal_env: str,
+    source_version_id: Optional[int] = None,
+    target_version_id: Optional[int] = None,
 ):
     logger.info(
         "Calling Modal runner",
@@ -203,6 +207,8 @@ async def call_assessment_runner(
         for key in ("first_vref", "last_vref"):
             if key in config["kwargs"]:
                 config[key] = config["kwargs"][key]
+    config["source_version_id"] = source_version_id
+    config["target_version_id"] = target_version_id
     config["return_all_results"] = return_all_results
     await f.spawn.aio(config, os.getenv("AQUA_DB", ""))
 
@@ -216,7 +222,7 @@ async def add_assessment(
     ),
     use_eflomal: Optional[bool] = Query(
         None,
-        description="Run eflomal-based word alignment. Requires source_version_id and target_version_id.",
+        description="Run eflomal-based word alignment. Source/target version IDs are derived from reference_id/revision_id.",
     ),
     force: bool = Query(
         False,
@@ -237,7 +243,8 @@ async def add_assessment(
     - semantic-similarity (requires reference)
     - sentence-length
     - word-alignment (requires reference; can optionally run eflomal-based alignment
-      when `use_eflomal=true` and `source_version_id` and `target_version_id` are provided)
+      when `use_eflomal=true`. Source/target version IDs are derived from
+      reference_id and revision_id respectively.)
     - ngrams
     - tfidf
     - text-lengths
@@ -295,19 +302,28 @@ async def add_assessment(
         a.kwargs = combined_kwargs
         parsed_kwargs = combined_kwargs
 
-    # Eflomal word-alignment requires source and target version IDs
+    # Eflomal word-alignment derives source/target version IDs from the
+    # reference and revision rows. Mapping per train_routes #620:
+    #   source_version_id ← bible_version_id of reference_id
+    #   target_version_id ← bible_version_id of revision_id
     is_eflomal = a.kwargs and a.kwargs.get("use_eflomal")
+    source_version_id: Optional[int] = None
+    target_version_id: Optional[int] = None
     if is_eflomal:
         if a.type != "word-alignment":
             raise HTTPException(
                 status_code=400,
                 detail="use_eflomal is only valid for word-alignment assessments.",
             )
-        if a.source_version_id is None or a.target_version_id is None:
+        revision = await db.get(BibleRevision, a.revision_id)
+        reference = await db.get(BibleRevision, a.reference_id)
+        if revision is None or reference is None:
             raise HTTPException(
-                status_code=400,
-                detail="Eflomal word-alignment requires source_version_id and target_version_id.",
+                status_code=404,
+                detail="revision_id or reference_id does not exist.",
             )
+        source_version_id = reference.bible_version_id
+        target_version_id = revision.bible_version_id
 
     # Check for already-completed assessment (force=true bypasses this)
     if not force:
@@ -461,7 +477,13 @@ async def add_assessment(
 
     # Dispatch to Modal runner (fire-and-forget via spawn)
     try:
-        await call_assessment_runner(a, return_all_results, resolved_modal_env)
+        await call_assessment_runner(
+            a,
+            return_all_results,
+            resolved_modal_env,
+            source_version_id=source_version_id,
+            target_version_id=target_version_id,
+        )
     except Exception as e:
         logger.error(
             "Modal runner dispatch failed",

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -306,7 +306,17 @@ async def add_assessment(
     # reference and revision rows. Mapping per train_routes #620:
     #   source_version_id ← bible_version_id of reference_id
     #   target_version_id ← bible_version_id of revision_id
-    is_eflomal = a.kwargs and a.kwargs.get("use_eflomal")
+    # Strict-bool check: a caller could route around the typed query param
+    # by passing `use_eflomal: 1` (or "true", etc.) via extra_kwargs. The
+    # dedup SQL uses JSONB containment which is strictly typed, so a
+    # truthy-but-non-bool value would silently bypass dedup. Reject it.
+    use_eflomal_kw = a.kwargs.get("use_eflomal") if a.kwargs else None
+    if use_eflomal_kw is not None and not isinstance(use_eflomal_kw, bool):
+        raise HTTPException(
+            status_code=400,
+            detail="use_eflomal must be a boolean.",
+        )
+    is_eflomal = use_eflomal_kw is True
     source_version_id: Optional[int] = None
     target_version_id: Optional[int] = None
     if is_eflomal:

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -316,12 +316,11 @@ async def add_assessment(
                 detail="use_eflomal is only valid for word-alignment assessments.",
             )
         revision = await db.get(BibleRevision, a.revision_id)
+        if revision is None or revision.deleted:
+            raise HTTPException(status_code=404, detail="revision_id does not exist.")
         reference = await db.get(BibleRevision, a.reference_id)
-        if revision is None or reference is None:
-            raise HTTPException(
-                status_code=404,
-                detail="revision_id or reference_id does not exist.",
-            )
+        if reference is None or reference.deleted:
+            raise HTTPException(status_code=404, detail="reference_id does not exist.")
         source_version_id = reference.bible_version_id
         target_version_id = revision.bible_version_id
 

--- a/models.py
+++ b/models.py
@@ -284,8 +284,6 @@ class AssessmentIn(BaseModel):
     revision_id: int
     reference_id: Optional[int] = None
     type: AssessmentType
-    source_version_id: Optional[int] = None
-    target_version_id: Optional[int] = None
     kwargs: Optional[Dict[str, Any]] = None
 
     @field_validator("kwargs")

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1408,7 +1408,111 @@ def test_use_eflomal_wrong_type(client, regular_token1, db_session, test_db_sess
 def test_use_eflomal_unknown_revision(
     client, regular_token1, db_session, test_db_session
 ):
-    """use_eflomal=true with a non-existent revision_id or reference_id returns 404."""
+    """use_eflomal=true with a non-existent revision_id or reference_id returns 404
+    with a side-specific detail."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+    reference_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+
+        # Bogus revision_id, valid reference_id
+        bad_revision = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": 999_999_999,
+                "reference_id": reference_id,
+                "type": "word-alignment",
+                "use_eflomal": True,
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert bad_revision.status_code == 404
+        assert bad_revision.json()["detail"] == "revision_id does not exist."
+
+        # Valid revision_id, bogus reference_id
+        bad_reference = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": 999_999_999,
+                "type": "word-alignment",
+                "use_eflomal": True,
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert bad_reference.status_code == 404
+        assert bad_reference.json()["detail"] == "reference_id does not exist."
+
+
+def test_use_eflomal_deleted_revision_returns_404(
+    client, regular_token1, db_session, test_db_session
+):
+    """Soft-deleted revision_id or reference_id returns 404, not silently passing."""
+    from database.models import BibleRevision as BibleRevisionModel
+
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+    reference_id = upload_revision(client, regular_token1, version_id)
+
+    # Soft-delete the revision row
+    deleted_rev = (
+        test_db_session.query(BibleRevisionModel)
+        .filter(BibleRevisionModel.id == revision_id)
+        .one()
+    )
+    deleted_rev.deleted = True
+    test_db_session.commit()
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "word-alignment",
+                "use_eflomal": True,
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "revision_id does not exist."
+
+        # And the symmetric case: soft-deleted reference
+        deleted_rev.deleted = False
+        deleted_ref = (
+            test_db_session.query(BibleRevisionModel)
+            .filter(BibleRevisionModel.id == reference_id)
+            .one()
+        )
+        deleted_ref.deleted = True
+        test_db_session.commit()
+
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "word-alignment",
+                "use_eflomal": True,
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "reference_id does not exist."
+
+
+def test_use_eflomal_word_alignment_missing_reference_returns_400(
+    client, regular_token1, db_session, test_db_session
+):
+    """word-alignment + use_eflomal=true with no reference_id hits the
+    reference-required guard (400), never the eflomal lookup (404)."""
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
 
@@ -1420,13 +1524,44 @@ def test_use_eflomal_unknown_revision(
             f"{prefix}/assessment",
             params={
                 "revision_id": revision_id,
-                "reference_id": 999_999_999,
                 "type": "word-alignment",
                 "use_eflomal": True,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
-    assert response.status_code == 404
+        assert response.status_code == 400
+        assert "reference_id" in response.json()["detail"]
+
+
+def test_use_eflomal_via_extra_kwargs_derives_version_ids(
+    client, regular_token1, db_session, test_db_session
+):
+    """A caller can activate eflomal by injecting use_eflomal into extra_kwargs
+    instead of the dedicated query param. The same version-ID derivation must fire."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "word-alignment",
+                "extra_kwargs": '{"use_eflomal": true}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        assert mock_runner.await_count == 1
+        kwargs = mock_runner.await_args.kwargs
+        assert kwargs["source_version_id"] == source_version_id
+        assert kwargs["target_version_id"] == target_version_id
 
 
 def test_use_eflomal_derives_version_ids(
@@ -1453,11 +1588,39 @@ def test_use_eflomal_derives_version_ids(
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
-    assert response.status_code == 200, response.text
-    assert mock_runner.await_count == 1
-    kwargs = mock_runner.await_args.kwargs
-    assert kwargs["source_version_id"] == source_version_id
-    assert kwargs["target_version_id"] == target_version_id
+        assert response.status_code == 200, response.text
+        assert mock_runner.await_count == 1
+        kwargs = mock_runner.await_args.kwargs
+        assert kwargs["source_version_id"] == source_version_id
+        assert kwargs["target_version_id"] == target_version_id
+
+
+def test_non_eflomal_word_alignment_forwards_null_version_ids(
+    client, regular_token1, db_session, test_db_session
+):
+    """Non-eflomal word-alignment must forward source/target_version_id=None to the
+    runner (not the revisions' bible_version_id) — only eflomal triggers derivation."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+    reference_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "word-alignment",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        kwargs = mock_runner.await_args.kwargs
+        assert kwargs["source_version_id"] is None
+        assert kwargs["target_version_id"] is None
 
 
 def test_use_eflomal_dedup_separate_from_regular(

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1533,6 +1533,36 @@ def test_use_eflomal_word_alignment_missing_reference_returns_400(
         assert "reference_id" in response.json()["detail"]
 
 
+def test_use_eflomal_non_bool_in_extra_kwargs_returns_400(
+    client, regular_token1, db_session, test_db_session
+):
+    """A truthy-but-non-bool use_eflomal in extra_kwargs (e.g. 1, "true") must
+    be rejected with 400. Otherwise it would trigger the derivation path while
+    silently bypassing the JSONB-strict dedup filter."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+    reference_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        for bad_value in ('"true"', "1", "0"):
+            response = client.post(
+                f"{prefix}/assessment",
+                params={
+                    "revision_id": revision_id,
+                    "reference_id": reference_id,
+                    "type": "word-alignment",
+                    "extra_kwargs": '{"use_eflomal": ' + bad_value + "}",
+                },
+                headers={"Authorization": f"Bearer {regular_token1}"},
+            )
+            assert response.status_code == 400, (bad_value, response.text)
+            assert "use_eflomal" in response.json()["detail"]
+        assert mock_runner.await_count == 0
+
+
 def test_use_eflomal_via_extra_kwargs_derives_version_ids(
     client, regular_token1, db_session, test_db_session
 ):

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1398,8 +1398,6 @@ def test_use_eflomal_wrong_type(client, regular_token1, db_session, test_db_sess
                 "revision_id": revision_id,
                 "type": "sentence-length",
                 "use_eflomal": True,
-                "source_version_id": 1,
-                "target_version_id": 2,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
@@ -1407,20 +1405,44 @@ def test_use_eflomal_wrong_type(client, regular_token1, db_session, test_db_sess
     assert "use_eflomal" in response.json()["detail"]
 
 
-def test_use_eflomal_missing_versions(
+def test_use_eflomal_unknown_revision(
     client, regular_token1, db_session, test_db_session
 ):
-    """use_eflomal=true without source_version_id or target_version_id returns 400."""
+    """use_eflomal=true with a non-existent revision_id or reference_id returns 404."""
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
-    reference_id = upload_revision(client, regular_token1, version_id)
 
     with patch(
         f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
     ) as mock_runner:
         mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": 999_999_999,
+                "type": "word-alignment",
+                "use_eflomal": True,
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+    assert response.status_code == 404
 
-        # Missing both version IDs
+
+def test_use_eflomal_derives_version_ids(
+    client, regular_token1, db_session, test_db_session
+):
+    """use_eflomal=true derives source/target version IDs from reference_id/revision_id
+    and forwards them to the runner."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
         response = client.post(
             f"{prefix}/assessment",
             params={
@@ -1431,22 +1453,11 @@ def test_use_eflomal_missing_versions(
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
-        assert response.status_code == 400
-        assert "version_id" in response.json()["detail"].lower()
-
-        # Missing only target_version_id
-        response = client.post(
-            f"{prefix}/assessment",
-            params={
-                "revision_id": revision_id,
-                "reference_id": reference_id,
-                "type": "word-alignment",
-                "use_eflomal": True,
-                "source_version_id": 1,
-            },
-            headers={"Authorization": f"Bearer {regular_token1}"},
-        )
-        assert response.status_code == 400
+    assert response.status_code == 200, response.text
+    assert mock_runner.await_count == 1
+    kwargs = mock_runner.await_args.kwargs
+    assert kwargs["source_version_id"] == source_version_id
+    assert kwargs["target_version_id"] == target_version_id
 
 
 def test_use_eflomal_dedup_separate_from_regular(
@@ -1465,8 +1476,6 @@ def test_use_eflomal_dedup_separate_from_regular(
     eflomal_params = {
         **base_params,
         "use_eflomal": True,
-        "source_version_id": version_id,
-        "target_version_id": version_id,
     }
 
     with patch(
@@ -1528,8 +1537,6 @@ def test_kwargs_returned_in_assessment_response(
                 "reference_id": reference_id,
                 "type": "word-alignment",
                 "use_eflomal": True,
-                "source_version_id": version_id,
-                "target_version_id": version_id,
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )


### PR DESCRIPTION
## Summary

- `POST /v3/assessment` no longer asks callers to supply `source_version_id` and `target_version_id` when `use_eflomal=true`. The route now derives them from the revisions' `bible_version_id` FKs (same mapping the eflomal/tfidf push validators already use: source ← reference, target ← revision) and forwards them to the Modal runner.
- 400-when-versions-missing is replaced with a 404-when-revision-missing — invalid revision IDs are now caught at request time instead of after the runner spawns.
- Artifact push/pull endpoints (TF-IDF, `eflomal-priors`, etc.) still take version IDs explicitly because they don't have a revision in scope. Only the assessment-creation entry point is simplified.

## Why

The two version-ID params became redundant after the version-id keying migration (`daef302`). `BibleRevision.bible_version_id` is non-nullable, so given the revision IDs (already required for word-alignment) the version IDs are deterministically derivable in two `db.get()` calls. Forcing callers to pass them duplicated information the API already had and added a 400-error class that nothing in the wild benefits from.

## Test plan

- [x] `test/test_assessment_routes/test_assessment_routes.py` — full file, 42 tests pass
- [x] `test/test_assessment_routes/test_eflomal_routes.py` + `test/test_train_routes/` — 98 tests pass (confirms the train-side runner config path, which builds its own dict, is unaffected)
- [x] New `test_use_eflomal_derives_version_ids` constructs revisions under two distinct versions and asserts the runner receives the correctly-mapped IDs (regression guard against an accidental source/target swap)
- [x] `black` + `isort` clean
- [ ] Smoke check on dev: POST a `use_eflomal=true&force=true` word-alignment without `source_version_id` / `target_version_id` and confirm the runner kicks off

🤖 Generated with [Claude Code](https://claude.com/claude-code)