### PR TITLE
Allow duplicate assessments with different kwargs

### DIFF
--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -276,6 +276,9 @@ async def add_assessment(
             parsed_kwargs = AssessmentIn.validate_kwargs(parsed_kwargs)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
+        # Treat an empty kwargs object the same as no kwargs supplied
+        if not parsed_kwargs:
+            parsed_kwargs = None
         a.kwargs = parsed_kwargs
 
     # Check for duplicate in-progress assessment (admins can bypass)
@@ -296,11 +299,12 @@ async def add_assessment(
             stmt = stmt.where(Assessment.reference_id == a.reference_id)
         else:
             stmt = stmt.where(Assessment.reference_id.is_(None))
-        # SQLAlchemy stores Python None in JSONB columns as the JSON null literal
-        # (not SQL NULL), so match both forms when no kwargs were provided.
         if parsed_kwargs is not None:
             stmt = stmt.where(Assessment.kwargs == parsed_kwargs)
         else:
+            # SQLAlchemy persists Python None to JSONB as the JSON null literal,
+            # so new rows match `== JSON.NULL`. The `is_(None)` arm matches any
+            # legacy rows that were stored as SQL NULL.
             stmt = stmt.where(
                 or_(Assessment.kwargs.is_(None), Assessment.kwargs == JSON.NULL)
             )

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -302,11 +302,17 @@ async def add_assessment(
         if parsed_kwargs is not None:
             stmt = stmt.where(Assessment.kwargs == parsed_kwargs)
         else:
-            # SQLAlchemy persists Python None to JSONB as the JSON null literal,
-            # so new rows match `== JSON.NULL`. The `is_(None)` arm matches any
-            # legacy rows that were stored as SQL NULL.
+            # New rows persist Python None as the JSON null literal (matched
+            # by `== JSON.NULL`). The `is_(None)` arm catches legacy rows
+            # stored as SQL NULL, and `== {}` catches legacy rows where an
+            # empty `extra_kwargs` was persisted as a JSONB empty object
+            # (we now normalize that to None on the request side).
             stmt = stmt.where(
-                or_(Assessment.kwargs.is_(None), Assessment.kwargs == JSON.NULL)
+                or_(
+                    Assessment.kwargs.is_(None),
+                    Assessment.kwargs == JSON.NULL,
+                    Assessment.kwargs == {},
+                )
             )
         result = await db.execute(stmt)
         existing_id = result.scalars().first()

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -12,7 +12,7 @@ from dotenv import load_dotenv
 
 # Third party imports
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import or_, select
+from sqlalchemy import JSON, or_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -296,6 +296,14 @@ async def add_assessment(
             stmt = stmt.where(Assessment.reference_id == a.reference_id)
         else:
             stmt = stmt.where(Assessment.reference_id.is_(None))
+        # SQLAlchemy stores Python None in JSONB columns as the JSON null literal
+        # (not SQL NULL), so match both forms when no kwargs were provided.
+        if parsed_kwargs is not None:
+            stmt = stmt.where(Assessment.kwargs == parsed_kwargs)
+        else:
+            stmt = stmt.where(
+                or_(Assessment.kwargs.is_(None), Assessment.kwargs == JSON.NULL)
+            )
         result = await db.execute(stmt)
         existing_id = result.scalars().first()
         if existing_id is not None:

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -520,10 +520,10 @@ def test_duplicate_assessment_different_type_allowed(
         assert second.status_code == 200
 
 
-def test_duplicate_assessment_different_kwargs_blocked(
+def test_duplicate_assessment_different_kwargs_allowed(
     client, regular_token1, db_session, test_db_session
 ):
-    """Different kwargs on same assessment type should still trigger 409."""
+    """Different kwargs on same assessment type should not trigger 409."""
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
 
@@ -552,7 +552,19 @@ def test_duplicate_assessment_different_kwargs_blocked(
             },
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
-        assert second.status_code == 409
+        assert second.status_code == 200
+
+        # Same kwargs as first should still be blocked.
+        third = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"top_k": 5}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert third.status_code == 409
 
 
 def test_duplicate_assessment_stale_allowed(

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -647,6 +647,45 @@ def test_duplicate_assessment_kwargs_key_order_blocked(
         assert second.status_code == 409
 
 
+def test_duplicate_assessment_legacy_empty_dict_kwargs_blocked(
+    client, regular_token1, db_session, test_db_session
+):
+    """A legacy row with kwargs={} (pre-normalization) still blocks a no-kwargs duplicate."""
+    from sqlalchemy import text
+
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = Mock(status_code=200)
+
+        first = client.post(
+            f"{prefix}/assessment",
+            params={"revision_id": revision_id, "type": "sentence-length"},
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert first.status_code == 200
+        first_id = first.json()[0]["id"]
+
+        # Force the row's kwargs to a JSONB empty object, mimicking rows
+        # persisted before empty-dict normalization was introduced.
+        db_session.execute(
+            text("UPDATE assessment SET kwargs = '{}'::jsonb WHERE id = :id"),
+            {"id": first_id},
+        )
+        db_session.commit()
+
+        second = client.post(
+            f"{prefix}/assessment",
+            params={"revision_id": revision_id, "type": "sentence-length"},
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert second.status_code == 409
+        assert str(first_id) in second.json()["detail"]
+
+
 def test_duplicate_assessment_legacy_sql_null_kwargs_blocked(
     client, regular_token1, db_session, test_db_session
 ):

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -554,7 +554,8 @@ def test_duplicate_assessment_different_kwargs_allowed(
         )
         assert second.status_code == 200
 
-        # Same kwargs as first should still be blocked.
+        # Re-submitting kwargs that match an existing in-progress
+        # assessment should still be blocked.
         third = client.post(
             f"{prefix}/assessment",
             params={
@@ -565,6 +566,124 @@ def test_duplicate_assessment_different_kwargs_allowed(
             headers={"Authorization": f"Bearer {regular_token1}"},
         )
         assert third.status_code == 409
+
+
+def test_duplicate_assessment_kwargs_vs_none_allowed(
+    client, regular_token1, db_session, test_db_session
+):
+    """An in-progress assessment with kwargs should not block one without (and vice versa)."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = Mock(status_code=200)
+
+        with_kwargs = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"top_k": 5}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert with_kwargs.status_code == 200
+
+        without_kwargs = client.post(
+            f"{prefix}/assessment",
+            params={"revision_id": revision_id, "type": "sentence-length"},
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert without_kwargs.status_code == 200
+
+        # And the same is true for an empty-dict kwargs (treated as no kwargs).
+        empty_kwargs = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": "{}",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        # Empty dict normalizes to None, so this collides with the no-kwargs row.
+        assert empty_kwargs.status_code == 409
+
+
+def test_duplicate_assessment_kwargs_key_order_blocked(
+    client, regular_token1, db_session, test_db_session
+):
+    """JSONB equality is structural: same keys/values in different order should 409."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = Mock(status_code=200)
+
+        first = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"a": 1, "b": 2}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert first.status_code == 200
+
+        second = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+                "extra_kwargs": '{"b": 2, "a": 1}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert second.status_code == 409
+
+
+def test_duplicate_assessment_legacy_sql_null_kwargs_blocked(
+    client, regular_token1, db_session, test_db_session
+):
+    """A pre-existing row with SQL NULL kwargs (not JSON null) still blocks a no-kwargs duplicate."""
+    from sqlalchemy import text
+
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = Mock(status_code=200)
+
+        first = client.post(
+            f"{prefix}/assessment",
+            params={"revision_id": revision_id, "type": "sentence-length"},
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert first.status_code == 200
+        first_id = first.json()[0]["id"]
+
+        # Force the row's kwargs to genuine SQL NULL (the ORM stores Python
+        # None as the JSON null literal, so we need raw SQL to test this arm).
+        db_session.execute(
+            text("UPDATE assessment SET kwargs = NULL WHERE id = :id"),
+            {"id": first_id},
+        )
+        db_session.commit()
+
+        second = client.post(
+            f"{prefix}/assessment",
+            params={"revision_id": revision_id, "type": "sentence-length"},
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert second.status_code == 409
+        assert str(first_id) in second.json()["detail"]
 
 
 def test_duplicate_assessment_stale_allowed(


### PR DESCRIPTION
## Summary
- Change the duplicate-assessment check in `POST /v3/assessment` to consider `kwargs` equality, so e.g. `word-alignment` with `use_eflomal=True` no longer 409s when a `use_eflomal=False` run is in progress.
- Same `(revision, reference, type, kwargs)` still 409s as before.
- Handle the SQLAlchemy quirk where Python `None` is persisted to JSONB columns as the JSON `null` literal (not SQL NULL) by matching both forms in the no-kwargs branch.

## Motivation
Reported in chat: a `word-alignment` request with `use_eflomal=True` was rejected with 409 because an earlier assessment (with default kwargs / `use_eflomal=False`) was still in-progress. Different kwargs are distinct configurations and should both be runnable.

## Test plan
- [x] `test_duplicate_assessment_returns_409` — same kwargs (both empty) still 409s
- [x] `test_duplicate_assessment_different_kwargs_allowed` (renamed from `_blocked`) — first run with `top_k=5`, second with `top_k=10` → 200; third with `top_k=5` again → 409
- [x] All other duplicate tests (different type, stale, running, admin bypass) still pass
- [x] Full `test_assessment_routes.py` suite (9 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)