### PR TITLE
Sort lexeme card alignment_scores in train-status results

### DIFF
--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1816,6 +1816,7 @@ def _seed_lexeme_cards(db_session, source_version_id, target_version_id, cards):
                 surface_forms=c.get("surface_forms", []),
                 source_surface_forms=c.get("source_surface_forms", []),
                 confidence=c.get("confidence", 0.9),
+                alignment_scores=c.get("alignment_scores"),
             )
         )
     db_session.commit()
@@ -1940,6 +1941,74 @@ def test_session_results_lexeme_cards_when_agent_critique_in_session(
 
     g12_cards = by_vref["GEN 1:2"]["lexeme_cards"]
     assert {c["target_lemma"] for c in g12_cards} == {"ulungu"}, g12_cards
+
+
+def test_session_results_lexeme_cards_alignment_scores_sorted_desc(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_revision_id_2,
+    test_version_id,
+    db_session,
+):
+    """alignment_scores in train-status results must come back ordered
+    by value descending — same contract the /predict path serves. The
+    consolidate/merge path can leave stored scores unsorted, so the
+    train-status read site sorts on the way out.
+    """
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_lexeme_cards_sorted"},
+        apps=["semantic-similarity", "agent-critique"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    sem_sim_job = next(
+        j for j in payload["training_jobs"] if j["type"] == "semantic-similarity"
+    )
+    _advance_assessment_to_finished(
+        client, regular_token1, sem_sim_job["assessment_id"]
+    )
+    _seed_sem_sim_results(db_session, sem_sim_job["assessment_id"], [("GEN 1:3", 0.7)])
+    _seed_verse_text(
+        db_session,
+        sem_sim_job["target_revision_id"],
+        [("GEN 1:3", "ihinkanyilo")],
+    )
+    _seed_verse_text(
+        db_session,
+        sem_sim_job["source_revision_id"],
+        [("GEN 1:3", "light")],
+    )
+    # Stored ascending on purpose — exercises the read-site sort.
+    unsorted_scores = {"low": 0.1, "mid": 0.5, "high": 0.9}
+    _seed_lexeme_cards(
+        db_session,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id,
+        cards=[
+            {
+                "target_lemma": "ihinkanyilo",
+                "source_lemma": "light",
+                "surface_forms": ["ihinkanyilo"],
+                "source_surface_forms": ["light"],
+                "alignment_scores": unsorted_scores,
+            },
+        ],
+    )
+
+    response = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    )
+    assert response.status_code == 200
+    by_vref = {b["vref"]: b for b in response.json()["results"]["items"]}
+    cards = by_vref["GEN 1:3"]["lexeme_cards"]
+    assert len(cards) == 1
+    assert list(cards[0]["alignment_scores"].keys()) == ["high", "mid", "low"]
 
 
 def test_session_results_lexeme_cards_empty_when_no_agent_critique(

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1803,7 +1803,7 @@ def test_session_results_tfidf_top_k_param(
 def _seed_lexeme_cards(db_session, source_version_id, target_version_id, cards):
     """Insert AgentLexemeCard rows. `cards` is a list of dicts with keys
     target_lemma, source_lemma, surface_forms, source_surface_forms,
-    confidence."""
+    confidence, alignment_scores."""
     from database.models import AgentLexemeCard
 
     for c in cards:

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -427,6 +427,15 @@ async def _build_lexeme_card_matches_by_vref(
     for card in cards:
         if card.id not in matched_card_id_set:
             continue
+        # Sort alignment_scores by value descending so clients see the
+        # same ordering they get from the /predict path. Writes already
+        # sort on POST/PATCH, but the consolidate/merge path skips that,
+        # so enforce it on read to keep the contract consistent.
+        alignment_scores = card.alignment_scores
+        if alignment_scores:
+            alignment_scores = dict(
+                sorted(alignment_scores.items(), key=lambda x: x[1], reverse=True)
+            )
         out_by_card_id[card.id] = LexemeCardOut.model_validate(
             {
                 "id": card.id,
@@ -442,7 +451,7 @@ async def _build_lexeme_card_matches_by_vref(
                     float(card.confidence) if card.confidence is not None else None
                 ),
                 "english_lemma": card.english_lemma,
-                "alignment_scores": card.alignment_scores,
+                "alignment_scores": alignment_scores,
                 "created_at": card.created_at,
                 "last_updated": card.last_updated,
                 "last_user_edit": card.last_user_edit,


### PR DESCRIPTION
## Summary
- `_build_lexeme_card_matches_by_vref` was passing `card.alignment_scores` straight from the DB. Storage is usually descending because POST/PATCH on `/v3/agent/lexeme-card` sort on write, but the consolidate/merge path in `agent_routes.py` skips that, so order is not a guaranteed invariant — and even if it were, the read site shouldn't depend on a write-time invariant the API doesn't otherwise enforce.
- Sort on read in the train-status path so clients see the same value-descending order they already get from `/v3/predict`.

## Test plan
- [x] New test `test_session_results_lexeme_cards_alignment_scores_sorted_desc` seeds a card with ascending `alignment_scores` and asserts the response key order is descending
- [x] All 56 existing `test_train_routes` tests still pass
- [x] `make linting` (black + isort + flake8) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)