### PR TITLE
feat(train): mirror predict pair shape in /train/status results

### DIFF
--- a/models.py
+++ b/models.py
@@ -517,6 +517,10 @@ class TfidfNeighbour(BaseModel):
 
 class TfidfNeighboursBlock(BaseModel):
     target_neighbours: List[TfidfNeighbour] = Field(default_factory=list)
+    # Asymmetric with `NgramCorpusBlock.source_corpus`: tfidf has no
+    # `None`/`[]` distinction here — an empty list means either "no
+    # source-side training" or "trained, no neighbours found". Clients
+    # cannot tell the two apart from this field alone.
     source_neighbours: List[TfidfNeighbour] = Field(default_factory=list)
 
 
@@ -527,7 +531,7 @@ class NgramVerseHit(BaseModel):
 
 
 class NgramMatch(BaseModel):
-    id: Optional[int] = None
+    id: int
     ngram: str
     ngram_size: int
     verses: List[NgramVerseHit] = Field(default_factory=list)

--- a/models.py
+++ b/models.py
@@ -510,7 +510,39 @@ class TfidfResult(BaseModel):
 
 class TfidfNeighbour(BaseModel):
     vref: str
-    score: float
+    similarity: float
+    target_revision_text: Optional[str] = None
+    source_revision_text: Optional[str] = None
+
+
+class TfidfNeighboursBlock(BaseModel):
+    target_neighbours: List[TfidfNeighbour] = Field(default_factory=list)
+    source_neighbours: List[TfidfNeighbour] = Field(default_factory=list)
+
+
+class NgramVerseHit(BaseModel):
+    vref: str
+    target_revision_text: Optional[str] = None
+    source_revision_text: Optional[str] = None
+
+
+class NgramMatch(BaseModel):
+    id: Optional[int] = None
+    ngram: str
+    ngram_size: int
+    verses: List[NgramVerseHit] = Field(default_factory=list)
+
+
+class NgramCorpusMatches(BaseModel):
+    matches: List[NgramMatch] = Field(default_factory=list)
+
+
+class NgramCorpusBlock(BaseModel):
+    target_corpus: NgramCorpusMatches = Field(default_factory=NgramCorpusMatches)
+    # `None` (not an empty block) when the session has no source-side ngrams
+    # training to match against — distinguishes "we looked and found nothing"
+    # from "no source-side corpus available".
+    source_corpus: Optional[NgramCorpusMatches] = None
 
 
 class WordAlignment(BaseModel):
@@ -1153,7 +1185,15 @@ class TrainingSessionVrefResults(BaseModel):
     # `alignment_top_source_scores`. Mirrors the shape of
     # `semantic_similarity` so clients can treat the two the same way.
     word_alignment_score: Optional[Result_v2] = None
-    tfidf: List[TfidfNeighbour] = Field(default_factory=list)
+    # Per-vref tfidf and ngrams mirror the predict pair shape: `tfidf` carries
+    # nearest-neighbour vrefs from both sides (target and source) of the
+    # trained corpora; `ngrams` carries trained ngrams that fire on this
+    # verse, with `verses` lists hydrated from the corresponding revision
+    # text. Predict's cross-axis matches (target ngrams in source text and
+    # vice versa) are not returned — train-status reads stored corpus hits
+    # only.
+    tfidf: Optional[TfidfNeighboursBlock] = None
+    ngrams: Optional[NgramCorpusBlock] = None
     # Full lexeme cards (same shape as `GET /v3/agent/lexeme-card`) whose
     # lemma or any surface form intersects this verse on either side.
     # Cards are filtered by the verse — the cards themselves are returned
@@ -1173,7 +1213,6 @@ class TrainingSessionResultsResponse(BaseModel):
     training_jobs: List[TrainingJobOut]
     inference_readiness: Dict[str, InferenceReadiness]
     results: TrainingSessionResultsPage
-    ngrams: List[NgramResult] = Field(default_factory=list)
     # True when the lexeme-card load hit the per-request cap and only
     # the highest-confidence prefix of cards was matched against the
     # page's vrefs. Lets a client distinguish "no card matches found"

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1336,7 +1336,6 @@ def test_session_results_in_flight_returns_status_only(
     assert data["session_id"] == session_id
     assert data["results"]["items"] == []
     assert data["results"]["total_count"] == 0
-    assert data["ngrams"] == []
     types_returned = {j["type"] for j in data["training_jobs"]}
     assert types_returned == {"semantic-similarity", "word-alignment"}
 
@@ -1394,7 +1393,6 @@ def test_session_results_interleaves_completed_apps(
     assert response.status_code == 200
     data = response.json()
     assert data["results"]["total_count"] == 2
-    assert data["ngrams"] == []  # ngrams job still in-flight
 
     by_vref = {b["vref"]: b for b in data["results"]["items"]}
     assert set(by_vref) == {"GEN 1:1", "GEN 1:2"}
@@ -1635,11 +1633,13 @@ def test_session_results_filter_validation(
     )
 
 
-def test_session_results_ngrams_top_level(
+def test_session_results_ngrams_per_vref(
     client, regular_token1, test_revision_id, test_revision_id_2, db_session
 ):
-    """Ngrams come back at the top level (not nested per vref) and are
-    filtered to ones whose vrefs intersect the requested window."""
+    """Per-vref ngrams mirror the predict shape: each page vref carries an
+    `ngrams.target_corpus.matches` list; each match has `verses` with the
+    ngram's full vref list. `source_corpus` is None when no source-side
+    training is available."""
     create_resp = _create_training_jobs_via_api(
         client,
         regular_token1,
@@ -1662,30 +1662,40 @@ def test_session_results_ngrams_top_level(
         ],
     )
 
-    # No filter: all ngrams come back.
     full = client.get(
         f"{prefix}/train/status/{session_id}/results",
         headers=_auth_headers(regular_token1),
     ).json()
-    assert full["results"]["items"] == []  # ngrams don't contribute to per-vref bucket
-    assert full["results"]["total_count"] == 0
-    assert {n["ngram"] for n in full["ngrams"]} == {
-        "in the",
-        "god created",
-        "the people",
-    }
+    # Ngrams now contribute to pagination: each distinct vref the ngram set
+    # fires on shows up as a page row.
+    assert full["results"]["total_count"] == 3
+    by_vref = {b["vref"]: b for b in full["results"]["items"]}
+    assert set(by_vref) == {"GEN 1:1", "GEN 1:2", "EXO 1:1"}
 
-    # GEN scope: only ngrams with at least one GEN vref.
+    gen_1_1 = by_vref["GEN 1:1"]["ngrams"]
+    assert gen_1_1["source_corpus"] is None  # no source-side ngrams trained
+    matches_by_ngram = {m["ngram"]: m for m in gen_1_1["target_corpus"]["matches"]}
+    assert set(matches_by_ngram) == {"in the", "god created"}
+    in_the = matches_by_ngram["in the"]
+    assert in_the["ngram_size"] == 2
+    assert sorted(v["vref"] for v in in_the["verses"]) == ["GEN 1:1", "GEN 1:2"]
+    # No VerseText seeded → both revision text fields are None but always present.
+    assert all(
+        "target_revision_text" in v and "source_revision_text" in v
+        for v in in_the["verses"]
+    )
+
+    # GEN 1:2 sees only the "in the" ngram (the only ngram covering this verse).
+    gen_1_2_matches = by_vref["GEN 1:2"]["ngrams"]["target_corpus"]["matches"]
+    assert {m["ngram"] for m in gen_1_2_matches} == {"in the"}
+
+    # GEN scope: only verses in GEN show up; EXO drops out.
     gen_only = client.get(
         f"{prefix}/train/status/{session_id}/results",
         params={"book": "GEN"},
         headers=_auth_headers(regular_token1),
     ).json()
-    assert {n["ngram"] for n in gen_only["ngrams"]} == {"in the", "god created"}
-    # Even when filtered, each ngram carries its full vrefs list (matches
-    # the existing /v3/ngrams_result shape).
-    in_the = next(n for n in gen_only["ngrams"] if n["ngram"] == "in the")
-    assert sorted(in_the["vrefs"]) == ["GEN 1:1", "GEN 1:2"]
+    assert {b["vref"] for b in gen_only["results"]["items"]} == {"GEN 1:1", "GEN 1:2"}
 
 
 def test_session_results_includes_tfidf_neighbours_when_trained(
@@ -1729,11 +1739,14 @@ def test_session_results_includes_tfidf_neighbours_when_trained(
     assert set(by_vref) == {"GEN 1:1", "GEN 1:2", "GEN 1:3"}
     assert by_vref["GEN 1:1"]["semantic_similarity"] is None
     assert by_vref["GEN 1:1"]["word_alignment"] == []
-    assert [n["vref"] for n in by_vref["GEN 1:1"]["tfidf"]] == [
+    tfidf = by_vref["GEN 1:1"]["tfidf"]
+    assert [n["vref"] for n in tfidf["target_neighbours"]] == [
         "GEN 1:2",
         "GEN 1:3",
     ]
-    assert by_vref["GEN 1:1"]["tfidf"][0]["score"] == pytest.approx(0.8)
+    assert tfidf["target_neighbours"][0]["similarity"] == pytest.approx(0.8)
+    # No source-side tfidf training → empty source_neighbours, not None.
+    assert tfidf["source_neighbours"] == []
 
 
 def test_session_results_tfidf_empty_when_not_trained(
@@ -1759,7 +1772,9 @@ def test_session_results_tfidf_empty_when_not_trained(
         f"{prefix}/train/status/{session_id}/results",
         headers=_auth_headers(regular_token1),
     ).json()
-    assert data["results"]["items"][0]["tfidf"] == []
+    # No tfidf training in this session → tfidf is None, distinguishing
+    # "not trained" from "trained but no neighbours found".
+    assert data["results"]["items"][0]["tfidf"] is None
 
 
 def test_session_results_tfidf_top_k_param(
@@ -1797,7 +1812,179 @@ def test_session_results_tfidf_top_k_param(
         headers=_auth_headers(regular_token1),
     ).json()
     by_vref = {b["vref"]: b for b in data["results"]["items"]}
-    assert [n["vref"] for n in by_vref["GEN 1:1"]["tfidf"]] == ["GEN 1:2"]
+    assert [n["vref"] for n in by_vref["GEN 1:1"]["tfidf"]["target_neighbours"]] == [
+        "GEN 1:2"
+    ]
+
+
+def test_session_results_picks_up_source_side_ngrams_and_tfidf(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """When a separate training session has trained on the session's
+    source revision (i.e. swapped source/target), train-status enriches
+    results with a `source_corpus` ngrams block and `source_neighbours`
+    tfidf list — matching the predict shape."""
+    # Session A: source=R1, target=R2 (the session being inspected).
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_target_side"},
+        apps=["ngrams", "tfidf"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    target_jobs = {j["type"]: j for j in payload["training_jobs"]}
+    _advance_assessment_to_finished(
+        client, regular_token1, target_jobs["ngrams"]["assessment_id"]
+    )
+    _advance_assessment_to_finished(
+        client, regular_token1, target_jobs["tfidf"]["assessment_id"]
+    )
+
+    # Session B (swapped): source=R2, target=R1. Its assessments have
+    # revision_id=R1, which is exactly what _resolve_source_side_assessment_id
+    # looks up when serving session A's results.
+    swap_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id_2,
+        test_revision_id,
+        options={"tag": "results_source_side"},
+        apps=["ngrams", "tfidf"],
+    )
+    swap_jobs = {j["type"]: j for j in swap_resp.json()["training_jobs"]}
+    _advance_assessment_to_finished(
+        client, regular_token1, swap_jobs["ngrams"]["assessment_id"]
+    )
+    _advance_assessment_to_finished(
+        client, regular_token1, swap_jobs["tfidf"]["assessment_id"]
+    )
+
+    _seed_ngrams(
+        db_session,
+        target_jobs["ngrams"]["assessment_id"],
+        [("target side", 2, ["GEN 1:1"])],
+    )
+    _seed_ngrams(
+        db_session,
+        swap_jobs["ngrams"]["assessment_id"],
+        [("source side", 2, ["GEN 1:1"])],
+    )
+
+    def vec(x, y):
+        return [x, y] + [0.0] * 298
+
+    _seed_tfidf_vectors(
+        db_session,
+        target_jobs["tfidf"]["assessment_id"],
+        [
+            ("GEN 1:1", vec(1.0, 0.0)),
+            ("GEN 1:2", vec(0.8, 0.6)),
+        ],
+    )
+    _seed_tfidf_vectors(
+        db_session,
+        swap_jobs["tfidf"]["assessment_id"],
+        [
+            ("GEN 1:1", vec(0.0, 1.0)),
+            ("GEN 1:3", vec(0.6, 0.8)),
+        ],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+
+    gen_1_1_ngrams = by_vref["GEN 1:1"]["ngrams"]
+    assert {m["ngram"] for m in gen_1_1_ngrams["target_corpus"]["matches"]} == {
+        "target side"
+    }
+    # source_corpus block is populated (not None) once a source-side ngrams
+    # assessment is found — distinguishes "not trained" from "trained, no hits".
+    assert gen_1_1_ngrams["source_corpus"] is not None
+    assert {m["ngram"] for m in gen_1_1_ngrams["source_corpus"]["matches"]} == {
+        "source side"
+    }
+
+    gen_1_1_tfidf = by_vref["GEN 1:1"]["tfidf"]
+    assert {n["vref"] for n in gen_1_1_tfidf["target_neighbours"]} == {"GEN 1:2"}
+    assert {n["vref"] for n in gen_1_1_tfidf["source_neighbours"]} == {"GEN 1:3"}
+
+
+def test_session_results_hydrates_verse_text(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """Per-vref ngrams and tfidf neighbours carry both revisions' verse
+    text alongside the vref — matching the per-pair shape predict returns."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_verse_text"},
+        apps=["ngrams", "tfidf"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    jobs_by_type = {j["type"]: j for j in payload["training_jobs"]}
+    _advance_assessment_to_finished(
+        client, regular_token1, jobs_by_type["ngrams"]["assessment_id"]
+    )
+    _advance_assessment_to_finished(
+        client, regular_token1, jobs_by_type["tfidf"]["assessment_id"]
+    )
+
+    _seed_ngrams(
+        db_session,
+        jobs_by_type["ngrams"]["assessment_id"],
+        [("in the", 2, ["GEN 1:1", "GEN 1:2"])],
+    )
+
+    def vec(x, y):
+        return [x, y] + [0.0] * 298
+
+    _seed_tfidf_vectors(
+        db_session,
+        jobs_by_type["tfidf"]["assessment_id"],
+        [
+            ("GEN 1:1", vec(1.0, 0.0)),
+            ("GEN 1:2", vec(0.8, 0.6)),
+        ],
+    )
+
+    # Source revision = test_revision_id, target = test_revision_id_2.
+    _seed_verse_text(
+        db_session,
+        test_revision_id,
+        [("GEN 1:1", "In the beginning"), ("GEN 1:2", "and the earth")],
+    )
+    _seed_verse_text(
+        db_session,
+        test_revision_id_2,
+        [("GEN 1:1", "Pachiyambi"), ("GEN 1:2", "ndi dziko lapansi")],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+
+    in_the_match = by_vref["GEN 1:1"]["ngrams"]["target_corpus"]["matches"][0]
+    verses_by_vref = {v["vref"]: v for v in in_the_match["verses"]}
+    assert verses_by_vref["GEN 1:1"]["target_revision_text"] == "Pachiyambi"
+    assert verses_by_vref["GEN 1:1"]["source_revision_text"] == "In the beginning"
+    assert verses_by_vref["GEN 1:2"]["target_revision_text"] == "ndi dziko lapansi"
+    assert verses_by_vref["GEN 1:2"]["source_revision_text"] == "and the earth"
+
+    nb = by_vref["GEN 1:1"]["tfidf"]["target_neighbours"][0]
+    assert nb["vref"] == "GEN 1:2"
+    assert nb["target_revision_text"] == "ndi dziko lapansi"
+    assert nb["source_revision_text"] == "and the earth"
 
 
 def _seed_lexeme_cards(db_session, source_version_id, target_version_id, cards):

--- a/test/test_train_routes/test_train_routes.py
+++ b/test/test_train_routes/test_train_routes.py
@@ -1667,7 +1667,11 @@ def test_session_results_ngrams_per_vref(
         headers=_auth_headers(regular_token1),
     ).json()
     # Ngrams now contribute to pagination: each distinct vref the ngram set
-    # fires on shows up as a page row.
+    # fires on shows up as a page row. GEN 1:1 is covered by 2 ngrams ("in
+    # the" and "god created") — without the `.distinct()` on `joined_subq`
+    # in the route, the ngrams subquery would emit one row per (ngram, vref)
+    # join and total_count would be 4, not 3. This assertion is the
+    # regression guard for that fix.
     assert full["results"]["total_count"] == 3
     by_vref = {b["vref"]: b for b in full["results"]["items"]}
     assert set(by_vref) == {"GEN 1:1", "GEN 1:2", "EXO 1:1"}
@@ -1985,6 +1989,340 @@ def test_session_results_hydrates_verse_text(
     assert nb["vref"] == "GEN 1:2"
     assert nb["target_revision_text"] == "ndi dziko lapansi"
     assert nb["source_revision_text"] == "and the earth"
+
+
+def test_session_results_source_side_neighbours_hydrate_with_session_revisions(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """`target_revision_text` / `source_revision_text` always carry the
+    *session's* target/source revision text at that vref, regardless of
+    which corpus (target-side or source-side) surfaced the neighbour.
+    A source-side tfidf neighbour at GEN 1:3 hydrates with target=R2's
+    GEN 1:3 and source=R1's GEN 1:3 — same as a target-side neighbour
+    would. The fields are revision-keyed, not corpus-keyed."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_source_hydration"},
+        apps=["tfidf"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    target_tfidf_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, target_tfidf_job["assessment_id"]
+    )
+
+    swap_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id_2,
+        test_revision_id,
+        options={"tag": "results_source_hydration_swap"},
+        apps=["tfidf"],
+    )
+    swap_tfidf_job = swap_resp.json()["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, swap_tfidf_job["assessment_id"]
+    )
+
+    def vec(x, y):
+        return [x, y] + [0.0] * 298
+
+    _seed_tfidf_vectors(
+        db_session,
+        target_tfidf_job["assessment_id"],
+        [("GEN 1:1", vec(1.0, 0.0)), ("GEN 1:2", vec(0.8, 0.6))],
+    )
+    _seed_tfidf_vectors(
+        db_session,
+        swap_tfidf_job["assessment_id"],
+        [("GEN 1:1", vec(0.0, 1.0)), ("GEN 1:3", vec(0.6, 0.8))],
+    )
+
+    # Source revision = R1 (test_revision_id), target = R2 (test_revision_id_2).
+    _seed_verse_text(
+        db_session,
+        test_revision_id,
+        [("GEN 1:3", "and the spirit (source)")],
+    )
+    _seed_verse_text(
+        db_session,
+        test_revision_id_2,
+        [("GEN 1:3", "ndipo mzimu (target)")],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+
+    src_nbs = by_vref["GEN 1:1"]["tfidf"]["source_neighbours"]
+    assert {n["vref"] for n in src_nbs} == {"GEN 1:3"}
+    nb = src_nbs[0]
+    assert nb["target_revision_text"] == "ndipo mzimu (target)"
+    assert nb["source_revision_text"] == "and the spirit (source)"
+
+
+def test_session_results_source_only_tfidf_vref_returns_empty_target_neighbours(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """A vref that is reachable only via source-side tfidf training (no
+    vector in the target corpus) still paginates and gets a populated
+    block — `target_neighbours=[]`, `source_neighbours=[...]`. With tfidf
+    trained, the block is never `None` even when one side has no hits."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_source_only_tfidf"},
+        apps=["tfidf"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    target_tfidf_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, target_tfidf_job["assessment_id"]
+    )
+
+    swap_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id_2,
+        test_revision_id,
+        options={"tag": "results_source_only_tfidf_swap"},
+        apps=["tfidf"],
+    )
+    swap_tfidf_job = swap_resp.json()["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, swap_tfidf_job["assessment_id"]
+    )
+
+    def vec(x, y):
+        return [x, y] + [0.0] * 298
+
+    # Target tfidf has GEN 1:1 only; source tfidf has GEN 1:1 + GEN 1:3.
+    _seed_tfidf_vectors(
+        db_session,
+        target_tfidf_job["assessment_id"],
+        [("GEN 1:1", vec(1.0, 0.0))],
+    )
+    _seed_tfidf_vectors(
+        db_session,
+        swap_tfidf_job["assessment_id"],
+        [("GEN 1:1", vec(0.0, 1.0)), ("GEN 1:3", vec(0.6, 0.8))],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    # GEN 1:3 paginates via the source-side subquery even though it has
+    # no target-side vector.
+    assert "GEN 1:3" in by_vref
+    tfidf = by_vref["GEN 1:3"]["tfidf"]
+    # Block populated (not None) — the contract: tfidf=None means "not
+    # trained"; an empty `target_neighbours` here means "trained, no
+    # target-side neighbours for this vref".
+    assert tfidf is not None
+    assert tfidf["target_neighbours"] == []
+    assert {n["vref"] for n in tfidf["source_neighbours"]} == {"GEN 1:1"}
+
+
+def test_session_results_source_only_ngram_vref_gets_empty_target_corpus(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """Symmetric coverage for ngrams: a vref hit only by a source-side
+    ngram still paginates and gets `target_corpus.matches=[]`,
+    `source_corpus.matches=[...]`."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_source_only_ngrams"},
+        apps=["ngrams"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    target_ngrams_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, target_ngrams_job["assessment_id"]
+    )
+
+    swap_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id_2,
+        test_revision_id,
+        options={"tag": "results_source_only_ngrams_swap"},
+        apps=["ngrams"],
+    )
+    swap_ngrams_job = swap_resp.json()["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, swap_ngrams_job["assessment_id"]
+    )
+
+    # Target ngrams cover GEN 1:1 only; source ngrams cover GEN 1:3 only.
+    _seed_ngrams(
+        db_session,
+        target_ngrams_job["assessment_id"],
+        [("target only", 2, ["GEN 1:1"])],
+    )
+    _seed_ngrams(
+        db_session,
+        swap_ngrams_job["assessment_id"],
+        [("source only", 2, ["GEN 1:3"])],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    assert "GEN 1:3" in by_vref
+    block = by_vref["GEN 1:3"]["ngrams"]
+    assert block["target_corpus"]["matches"] == []
+    assert {m["ngram"] for m in block["source_corpus"]["matches"]} == {"source only"}
+
+
+def test_session_results_tfidf_top_k_limits_source_neighbours(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """`tfidf_top_k` applies symmetrically to both sides — capping
+    `source_neighbours` exactly like it caps `target_neighbours`."""
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_top_k_source"},
+        apps=["tfidf"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    target_tfidf_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, target_tfidf_job["assessment_id"]
+    )
+
+    swap_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id_2,
+        test_revision_id,
+        options={"tag": "results_top_k_source_swap"},
+        apps=["tfidf"],
+    )
+    swap_tfidf_job = swap_resp.json()["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, swap_tfidf_job["assessment_id"]
+    )
+
+    def vec(x, y):
+        return [x, y] + [0.0] * 298
+
+    _seed_tfidf_vectors(
+        db_session,
+        target_tfidf_job["assessment_id"],
+        [("GEN 1:1", vec(1.0, 0.0))],
+    )
+    # Source corpus has 3 vectors so GEN 1:1 has 2 source-side neighbours
+    # available; top_k=1 should cap the returned list to 1.
+    _seed_tfidf_vectors(
+        db_session,
+        swap_tfidf_job["assessment_id"],
+        [
+            ("GEN 1:1", vec(1.0, 0.0)),
+            ("GEN 1:2", vec(0.8, 0.6)),
+            ("GEN 1:3", vec(0.6, 0.8)),
+        ],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        params={"tfidf_top_k": 1},
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    assert len(by_vref["GEN 1:1"]["tfidf"]["source_neighbours"]) == 1
+
+
+def test_session_results_picks_latest_when_multiple_source_assessments(
+    client, regular_token1, test_revision_id, test_revision_id_2, db_session
+):
+    """When more than one finished assessment matches
+    (revision_id, type) on the source side, the resolver picks the
+    latest by end_time/id and only that one's data flows through."""
+    # Session A: source=R1, target=R2.
+    create_resp = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id,
+        test_revision_id_2,
+        options={"tag": "results_multi_source_target"},
+        apps=["ngrams"],
+    )
+    payload = create_resp.json()
+    session_id = payload["session_id"]
+    target_ngrams_job = payload["training_jobs"][0]
+    _advance_assessment_to_finished(
+        client, regular_token1, target_ngrams_job["assessment_id"]
+    )
+    _seed_ngrams(
+        db_session,
+        target_ngrams_job["assessment_id"],
+        [("on target", 2, ["GEN 1:1"])],
+    )
+
+    # Two swapped sessions (target=R1) — older then newer. Both finished;
+    # the resolver should pick the second one's assessment.
+    older_swap = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id_2,
+        test_revision_id,
+        options={"tag": "results_multi_source_older"},
+        apps=["ngrams"],
+    )
+    older_job = older_swap.json()["training_jobs"][0]
+    _advance_assessment_to_finished(client, regular_token1, older_job["assessment_id"])
+    _seed_ngrams(
+        db_session,
+        older_job["assessment_id"],
+        [("older source", 2, ["GEN 1:1"])],
+    )
+
+    newer_swap = _create_training_jobs_via_api(
+        client,
+        regular_token1,
+        test_revision_id_2,
+        test_revision_id,
+        options={"tag": "results_multi_source_newer"},
+        apps=["ngrams"],
+    )
+    newer_job = newer_swap.json()["training_jobs"][0]
+    _advance_assessment_to_finished(client, regular_token1, newer_job["assessment_id"])
+    _seed_ngrams(
+        db_session,
+        newer_job["assessment_id"],
+        [("newer source", 2, ["GEN 1:1"])],
+    )
+
+    data = client.get(
+        f"{prefix}/train/status/{session_id}/results",
+        headers=_auth_headers(regular_token1),
+    ).json()
+    by_vref = {b["vref"]: b for b in data["results"]["items"]}
+    src_matches = by_vref["GEN 1:1"]["ngrams"]["source_corpus"]["matches"]
+    # The newer source-side assessment wins; the older one's "older source"
+    # ngram does not appear.
+    assert {m["ngram"] for m in src_matches} == {"newer source"}
 
 
 def _seed_lexeme_cards(db_session, source_version_id, target_version_id, cards):

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -44,9 +44,13 @@ from models import (
     AssessmentStatus,
     InferenceReadiness,
     LexemeCardOut,
-    NgramResult,
+    NgramCorpusBlock,
+    NgramCorpusMatches,
+    NgramMatch,
+    NgramVerseHit,
     Result_v2,
     TfidfNeighbour,
+    TfidfNeighboursBlock,
     TrainingJobIn,
     TrainingJobOut,
     TrainingResponse,
@@ -56,6 +60,7 @@ from models import (
     TrainingType,
     WordAlignment,
 )
+
 from security_routes.auth_routes import get_current_user
 from utils.logging_config import setup_logger
 from utils.verse_range_utils import merge_verse_ranges
@@ -234,6 +239,80 @@ async def _compute_inference_readiness(
             pending_training=pending,
         )
     return readiness
+
+
+async def _resolve_source_side_assessment_id(
+    source_revision_id: int, assessment_type: str, db: AsyncSession
+) -> Optional[int]:
+    """Latest finished `assessment_type` assessment whose revision_id matches
+    the session's source_revision_id, or None when no source-side training
+    exists. Mirrors the predict-side cascade: source-side training is a
+    separate session that trained on the source revision."""
+    stmt = (
+        select(Assessment.id)
+        .where(
+            Assessment.revision_id == source_revision_id,
+            Assessment.type == assessment_type,
+            Assessment.status == ASSESSMENT_FINISHED_VALUE,
+            Assessment.deleted.is_not(True),
+        )
+        .order_by(Assessment.end_time.desc().nullslast(), Assessment.id.desc())
+        .limit(1)
+    )
+    return await db.scalar(stmt)
+
+
+async def _load_verse_text_by_vref(
+    revision_id: int, vrefs: List[str], db: AsyncSession
+) -> dict[str, str]:
+    """Bulk-fetch verse text under `revision_id` for the given vrefs."""
+    if not vrefs:
+        return {}
+    rows = await db.execute(
+        select(VerseText.verse_reference, VerseText.text).where(
+            VerseText.revision_id == revision_id,
+            VerseText.verse_reference.in_(vrefs),
+        )
+    )
+    return {row[0]: row[1] for row in rows.all() if row[1] is not None}
+
+
+async def _gather_ngram_buckets(
+    assessment_id: int, page_vrefs: List[str], db: AsyncSession
+) -> dict[int, dict]:
+    """Return {ngram_id: {ngram, ngram_size, vrefs}} for ngrams under
+    `assessment_id` that fire on at least one verse in `page_vrefs`. Each
+    bucket carries the ngram's full vrefs list (not just the page-vref
+    intersection) — same shape predict's match.verses uses."""
+    if not page_vrefs:
+        return {}
+    matching_subq = (
+        select(NgramsTable.id)
+        .join(NgramVrefTable, NgramVrefTable.ngram_id == NgramsTable.id)
+        .where(
+            NgramsTable.assessment_id == assessment_id,
+            NgramVrefTable.vref.in_(page_vrefs),
+        )
+        .distinct()
+        .subquery()
+    )
+    full_q = (
+        select(
+            NgramsTable.id,
+            NgramsTable.ngram,
+            NgramsTable.ngram_size,
+            NgramVrefTable.vref,
+        )
+        .join(NgramVrefTable, NgramVrefTable.ngram_id == NgramsTable.id)
+        .join(matching_subq, matching_subq.c.id == NgramsTable.id)
+    )
+    buckets: dict[int, dict] = {}
+    for nid, ngram, size, ngram_vref in (await db.execute(full_q)).all():
+        b = buckets.setdefault(
+            nid, {"ngram": ngram, "ngram_size": size, "vrefs": []}
+        )
+        b["vrefs"].append(ngram_vref)
+    return buckets
 
 
 async def _build_lexeme_card_matches_by_vref(
@@ -842,10 +921,23 @@ async def get_training_session_results(
     per-vref results for every completed job in the session.
 
     Per vref: semantic_similarity score (one row), word_alignment per-word
-    rows (multiple) plus a verse-level word_alignment_score, and tfidf
-    nearest-neighbour vrefs from the source corpus. Ngrams are returned at
-    the top level — each ngram has many vrefs, so nesting them per verse
-    would duplicate the same ngram across every verse it appears in.
+    rows plus a verse-level word_alignment_score, tfidf
+    `{target_neighbours, source_neighbours}` nearest-neighbour blocks
+    (one block per side, each neighbour hydrated with both revisions'
+    text), and ngrams `{target_corpus, source_corpus}` blocks listing
+    trained ngrams that fire on this verse with their full
+    cross-corpus vrefs lists. The per-vref tfidf and ngrams shapes
+    mirror the per-pair shape of `/v3/predict` so callers can share a
+    parser between the two endpoints; predict's cross-axis ngrams
+    (target ngrams in source text and vice versa) are not returned —
+    train-status reads stored corpus hits only.
+
+    Source-side ngrams/tfidf are looked up as the latest finished
+    assessment of the same type whose revision_id equals this session's
+    source_revision_id (typically created by a separate training
+    session that swapped source/target). When no source-side training
+    is available, `source_corpus` is `None` for ngrams and
+    `source_neighbours` is `[]` for tfidf.
 
     Agent_critique adds `lexeme_cards` per vref: when the session
     includes an agent-critique training type, each vref carries the
@@ -902,6 +994,23 @@ async def get_training_session_results(
     ngrams_id = completed_assessment_id_by_type.get(TrainingType.ngrams.value)
     tfidf_id = completed_assessment_id_by_type.get(TrainingType.tfidf.value)
 
+    # Source-side assessments come from a separate training session whose
+    # target was this session's source revision. Looked up only when the
+    # corresponding type is part of *this* session — otherwise the user is
+    # not asking for that type's results.
+    session_source_revision_id = jobs[0].source_revision_id
+    session_target_revision_id = jobs[0].target_revision_id
+    source_ngrams_id: Optional[int] = None
+    if ngrams_id is not None:
+        source_ngrams_id = await _resolve_source_side_assessment_id(
+            session_source_revision_id, TrainingType.ngrams.value, db
+        )
+    source_tfidf_id: Optional[int] = None
+    if tfidf_id is not None:
+        source_tfidf_id = await _resolve_source_side_assessment_id(
+            session_source_revision_id, TrainingType.tfidf.value, db
+        )
+
     # vref universe = distinct vrefs across the per-vref result tables for
     # all completed types in the session, with optional book/chapter/verse
     # scoping. Carries (book, chapter, verse) so we can canonical-sort via
@@ -956,28 +1065,62 @@ async def get_training_session_results(
             )
         )
 
-    if tfidf_id is not None:
-        tfidf_q = (
-            select(
-                TfidfPcaVector.vref,
-                VerseReference.book_reference.label("book"),
-                func.split_part(VerseReference.chapter, " ", 2)
-                .cast(Integer)
-                .label("chapter"),
-                VerseReference.number.label("verse"),
-            )
-            .join(VerseReference, VerseReference.full_verse_id == TfidfPcaVector.vref)
-            .where(TfidfPcaVector.assessment_id == tfidf_id)
-        )
+    def _scope_via_verse_reference(q):
         if book is not None:
-            tfidf_q = tfidf_q.where(VerseReference.book_reference == book)
+            q = q.where(VerseReference.book_reference == book)
         if chapter is not None:
-            tfidf_q = tfidf_q.where(
+            q = q.where(
                 func.split_part(VerseReference.chapter, " ", 2).cast(Integer) == chapter
             )
         if verse is not None:
-            tfidf_q = tfidf_q.where(VerseReference.number == verse)
-        per_vref_subqueries.append(tfidf_q)
+            q = q.where(VerseReference.number == verse)
+        return q
+
+    for assessment_id in (tfidf_id, source_tfidf_id):
+        if assessment_id is None:
+            continue
+        per_vref_subqueries.append(
+            _scope_via_verse_reference(
+                select(
+                    TfidfPcaVector.vref,
+                    VerseReference.book_reference.label("book"),
+                    func.split_part(VerseReference.chapter, " ", 2)
+                    .cast(Integer)
+                    .label("chapter"),
+                    VerseReference.number.label("verse"),
+                )
+                .join(
+                    VerseReference,
+                    VerseReference.full_verse_id == TfidfPcaVector.vref,
+                )
+                .where(TfidfPcaVector.assessment_id == assessment_id)
+            )
+        )
+
+    # Ngrams contribute to pagination too — a session with only ngrams
+    # training would otherwise have no page vrefs. Includes source-side
+    # ngrams so a verse only covered by source-side hits still paginates.
+    for assessment_id in (ngrams_id, source_ngrams_id):
+        if assessment_id is None:
+            continue
+        per_vref_subqueries.append(
+            _scope_via_verse_reference(
+                select(
+                    NgramVrefTable.vref,
+                    VerseReference.book_reference.label("book"),
+                    func.split_part(VerseReference.chapter, " ", 2)
+                    .cast(Integer)
+                    .label("chapter"),
+                    VerseReference.number.label("verse"),
+                )
+                .join(NgramsTable, NgramsTable.id == NgramVrefTable.ngram_id)
+                .join(
+                    VerseReference,
+                    VerseReference.full_verse_id == NgramVrefTable.vref,
+                )
+                .where(NgramsTable.assessment_id == assessment_id)
+            )
+        )
 
     page_vrefs: List[str] = []
     total_count = 0
@@ -990,6 +1133,10 @@ async def get_training_session_results(
         # Apply the BookReference join up front so total_count and the page
         # both see the same row set — without it, vrefs whose `book` doesn't
         # match a BookReference row would be counted but never paginated.
+        # `distinct` covers the single-subquery case: SQLAlchemy emits no
+        # UNION wrapper for a one-element set, so any internal duplicates
+        # (e.g. one ngrams subquery that emits one row per (ngram, vref))
+        # would otherwise leak into total_count and the page.
         joined_subq = (
             select(
                 union_subq.c.vref,
@@ -998,6 +1145,7 @@ async def get_training_session_results(
                 union_subq.c.verse,
             )
             .join(BookReference, BookReference.abbreviation == union_subq.c.book)
+            .distinct()
             .subquery()
         )
         count_result = await db.execute(select(func.count()).select_from(joined_subq))
@@ -1092,13 +1240,18 @@ async def get_training_session_results(
                 hide=r.hide or False,
             )
 
-    tfidf_by_vref: dict[str, List[TfidfNeighbour]] = {}
-    if tfidf_id is not None and page_vrefs:
+    # tfidf nearest-neighbour search runs once per side; rows are kept raw
+    # here so verse-text hydration can fetch a single union of neighbour
+    # vrefs against each revision afterwards (one /verse_text query per
+    # revision, regardless of how many neighbours were returned).
+    tfidf_target_raw: dict[str, list[tuple[str, float]]] = {}
+    tfidf_source_raw: dict[str, list[tuple[str, float]]] = {}
+    if (tfidf_id is not None or source_tfidf_id is not None) and page_vrefs:
         nn_query = text(
             """
             SELECT q.vref AS query_vref,
                    nn.vref AS neighbour_vref,
-                   nn.cosine_similarity AS score
+                   nn.cosine_similarity AS similarity
             FROM tfidf_pca_vector AS q
             JOIN LATERAL (
                 SELECT c.vref,
@@ -1114,20 +1267,124 @@ async def get_training_session_results(
             ORDER BY q.vref, nn.cosine_similarity DESC
             """
         ).bindparams(bindparam("page_vrefs", expanding=True))
-        rows = await db.execute(
-            nn_query,
-            {
-                "assessment_id": tfidf_id,
-                "page_vrefs": page_vrefs,
-                "limit": tfidf_top_k,
-            },
-        )
-        for row in rows.all():
-            tfidf_by_vref.setdefault(row.query_vref, []).append(
-                TfidfNeighbour(
-                    vref=row.neighbour_vref,
-                    score=float(row.score) if row.score is not None else 0.0,
+
+        async def _fetch_tfidf_raw(assessment_id: int) -> dict[str, list[tuple[str, float]]]:
+            rows = await db.execute(
+                nn_query,
+                {
+                    "assessment_id": assessment_id,
+                    "page_vrefs": page_vrefs,
+                    "limit": tfidf_top_k,
+                },
+            )
+            buckets: dict[str, list[tuple[str, float]]] = {}
+            for row in rows.all():
+                sim = float(row.similarity) if row.similarity is not None else 0.0
+                buckets.setdefault(row.query_vref, []).append(
+                    (row.neighbour_vref, sim)
                 )
+            return buckets
+
+        if tfidf_id is not None:
+            tfidf_target_raw = await _fetch_tfidf_raw(tfidf_id)
+        if source_tfidf_id is not None:
+            tfidf_source_raw = await _fetch_tfidf_raw(source_tfidf_id)
+
+    target_ngram_buckets: dict[int, dict] = {}
+    source_ngram_buckets: dict[int, dict] = {}
+    if ngrams_id is not None and page_vrefs:
+        target_ngram_buckets = await _gather_ngram_buckets(ngrams_id, page_vrefs, db)
+    if source_ngrams_id is not None and page_vrefs:
+        source_ngram_buckets = await _gather_ngram_buckets(
+            source_ngrams_id, page_vrefs, db
+        )
+
+    # Hydrate verse text once for the union of every vref the response
+    # references — page vrefs themselves, all tfidf neighbour vrefs, and
+    # every vref appearing in any ngram match's full verses list.
+    text_vrefs: set[str] = set(page_vrefs)
+    for raw in (tfidf_target_raw, tfidf_source_raw):
+        for neighbours in raw.values():
+            for nb_vref, _ in neighbours:
+                text_vrefs.add(nb_vref)
+    for buckets in (target_ngram_buckets, source_ngram_buckets):
+        for b in buckets.values():
+            text_vrefs.update(b["vrefs"])
+    text_vrefs_list = sorted(text_vrefs)
+    target_text_map = await _load_verse_text_by_vref(
+        session_target_revision_id, text_vrefs_list, db
+    )
+    source_text_map = await _load_verse_text_by_vref(
+        session_source_revision_id, text_vrefs_list, db
+    )
+
+    def _build_neighbours(
+        raw: list[tuple[str, float]],
+    ) -> List[TfidfNeighbour]:
+        return [
+            TfidfNeighbour(
+                vref=nb_vref,
+                similarity=sim,
+                target_revision_text=target_text_map.get(nb_vref),
+                source_revision_text=source_text_map.get(nb_vref),
+            )
+            for nb_vref, sim in raw
+        ]
+
+    tfidf_by_vref: dict[str, TfidfNeighboursBlock] = {}
+    if tfidf_id is not None or source_tfidf_id is not None:
+        for v in page_vrefs:
+            tgt = tfidf_target_raw.get(v, [])
+            src = tfidf_source_raw.get(v, [])
+            if not tgt and not src:
+                continue
+            tfidf_by_vref[v] = TfidfNeighboursBlock(
+                target_neighbours=_build_neighbours(tgt),
+                source_neighbours=_build_neighbours(src),
+            )
+
+    def _bucket_to_match(nid: int, b: dict) -> NgramMatch:
+        return NgramMatch(
+            id=nid,
+            ngram=b["ngram"],
+            ngram_size=b["ngram_size"],
+            verses=[
+                NgramVerseHit(
+                    vref=v,
+                    target_revision_text=target_text_map.get(v),
+                    source_revision_text=source_text_map.get(v),
+                )
+                for v in b["vrefs"]
+            ],
+        )
+
+    def _matches_per_page_vref(
+        buckets: dict[int, dict],
+    ) -> dict[str, List[NgramMatch]]:
+        page_set = set(page_vrefs)
+        per_vref: dict[str, List[NgramMatch]] = {v: [] for v in page_vrefs}
+        for nid, b in buckets.items():
+            match = _bucket_to_match(nid, b)
+            for vref in b["vrefs"]:
+                if vref in page_set:
+                    per_vref[vref].append(match)
+        return per_vref
+
+    target_ngram_matches_by_vref = _matches_per_page_vref(target_ngram_buckets)
+    source_ngram_matches_by_vref = _matches_per_page_vref(source_ngram_buckets)
+
+    ngrams_by_vref: dict[str, NgramCorpusBlock] = {}
+    if ngrams_id is not None:
+        for v in page_vrefs:
+            tgt_matches = target_ngram_matches_by_vref.get(v, [])
+            src_matches = source_ngram_matches_by_vref.get(v, [])
+            ngrams_by_vref[v] = NgramCorpusBlock(
+                target_corpus=NgramCorpusMatches(matches=tgt_matches),
+                source_corpus=(
+                    NgramCorpusMatches(matches=src_matches)
+                    if source_ngrams_id is not None
+                    else None
+                ),
             )
 
     # Lexeme cards: only attach when agent-critique is part of the
@@ -1164,69 +1421,12 @@ async def get_training_session_results(
             semantic_similarity=sem_sim_by_vref.get(v),
             word_alignment=word_align_by_vref.get(v, []),
             word_alignment_score=word_align_score_by_vref.get(v),
-            tfidf=tfidf_by_vref.get(v, []),
+            tfidf=tfidf_by_vref.get(v),
+            ngrams=ngrams_by_vref.get(v),
             lexeme_cards=lexeme_cards_by_vref.get(v, []),
         )
         for v in page_vrefs
     ]
-
-    # Ngrams: top-level, filtered to ngrams that appear in at least one vref
-    # in the requested book/chapter/verse window (or all ngrams when no
-    # filter). Returns each ngram's full vrefs list, not just the matching
-    # ones, so the client sees the same shape as /v3/ngrams_result.
-    # `book` was validated against BookReference above, so the LIKE
-    # patterns can't smuggle SQL wildcards.
-    ngrams_list: List[NgramResult] = []
-    if ngrams_id is not None:
-        matching_q = (
-            select(NgramsTable.id)
-            .join(NgramVrefTable, NgramVrefTable.ngram_id == NgramsTable.id)
-            .where(NgramsTable.assessment_id == ngrams_id)
-            .distinct()
-        )
-        if verse is not None:
-            matching_q = matching_q.where(
-                NgramVrefTable.vref == f"{book} {chapter}:{verse}"
-            )
-        elif chapter is not None:
-            matching_q = matching_q.where(
-                NgramVrefTable.vref.like(f"{book} {chapter}:%")
-            )
-        elif book is not None:
-            matching_q = matching_q.where(NgramVrefTable.vref.like(f"{book} %"))
-
-        # Keep matching_q as a subquery and join in SQL rather than
-        # materializing IDs into a Python list and re-binding via IN(...).
-        # For large filter windows the IN list could blow past Postgres'
-        # parameter limit and doubles the round-trip count.
-        matching_subq = matching_q.subquery()
-        full_q = (
-            select(
-                NgramsTable.id,
-                NgramsTable.ngram,
-                NgramsTable.ngram_size,
-                NgramVrefTable.vref,
-            )
-            .join(NgramVrefTable, NgramVrefTable.ngram_id == NgramsTable.id)
-            .join(matching_subq, matching_subq.c.id == NgramsTable.id)
-        )
-        buckets: dict[int, dict] = {}
-        for nid, ngram, size, ngram_vref in (await db.execute(full_q)).all():
-            b = buckets.setdefault(
-                nid,
-                {"ngram": ngram, "ngram_size": size, "vrefs": []},
-            )
-            b["vrefs"].append(ngram_vref)
-        ngrams_list = [
-            NgramResult(
-                id=nid,
-                assessment_id=ngrams_id,
-                ngram=b["ngram"],
-                ngram_size=b["ngram_size"],
-                vrefs=b["vrefs"],
-            )
-            for nid, b in buckets.items()
-        ]
 
     return TrainingSessionResultsResponse(
         session_id=session_id,
@@ -1238,7 +1438,6 @@ async def get_training_session_results(
             page=page,
             page_size=page_size,
         ),
-        ngrams=ngrams_list,
         lexeme_cards_truncated=lexeme_cards_truncated,
     )
 

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -246,7 +246,21 @@ async def _resolve_source_side_assessment_id(
     """Latest finished `assessment_type` assessment whose revision_id matches
     the session's source_revision_id, or None when no source-side training
     exists. Mirrors the predict-side cascade: source-side training is a
-    separate session that trained on the source revision."""
+    separate session that trained on the source revision.
+
+    Auth model: revision-keyed sharing. The caller has already passed
+    `_load_session_jobs`, which gates the *session* on the user having
+    access to both the source and target revisions (via version_id). Any
+    finished assessment on `source_revision_id` is therefore on a
+    revision the user can already see — and the corpus statistics are
+    derivable by anyone with that access — so we do not re-filter on
+    `Assessment.owner_id`.
+
+    Tiebreak on id when end_time is equal or null (NULLSLAST keeps a
+    stale half-finished row from preempting a real one), so the pick is
+    deterministic. When more than one finished assessment matches, log a
+    warning so an unusual workflow state is observable.
+    """
     stmt = (
         select(Assessment.id)
         .where(
@@ -256,9 +270,21 @@ async def _resolve_source_side_assessment_id(
             Assessment.deleted.is_not(True),
         )
         .order_by(Assessment.end_time.desc().nullslast(), Assessment.id.desc())
-        .limit(1)
     )
-    return await db.scalar(stmt)
+    rows = (await db.execute(stmt)).all()
+    if not rows:
+        return None
+    if len(rows) > 1:
+        logger.warning(
+            "multiple finished source-side assessments matched; picking latest",
+            extra={
+                "source_revision_id": source_revision_id,
+                "assessment_type": assessment_type,
+                "match_count": len(rows),
+                "picked_assessment_id": rows[0][0],
+            },
+        )
+    return rows[0][0]
 
 
 async def _load_verse_text_by_vref(
@@ -1097,6 +1123,10 @@ async def get_training_session_results(
     # Ngrams contribute to pagination too — a session with only ngrams
     # training would otherwise have no page vrefs. Includes source-side
     # ngrams so a verse only covered by source-side hits still paginates.
+    # Note: `source_ngrams_id` is only resolved when `ngrams_id is not None`
+    # (see line above the `_resolve_source_side_assessment_id` call), and the
+    # `ngrams_by_vref` population below is guarded on `ngrams_id is not None`
+    # for the same reason — keep these guards in sync if either is loosened.
     for assessment_id in (ngrams_id, source_ngrams_id):
         if assessment_id is None:
             continue
@@ -1268,6 +1298,17 @@ async def get_training_session_results(
         async def _fetch_tfidf_raw(
             assessment_id: int,
         ) -> dict[str, list[tuple[str, float]]]:
+            # `page_vrefs` are the session's target-side page vrefs. When this
+            # runs against `source_tfidf_id` it's a same-vref join into the
+            # *source* corpus's vector space — i.e. "for each target vref,
+            # find its nearest neighbours within the source-side corpus" —
+            # not a separate source-language pagination. If the source
+            # assessment has no vector for a given vref (canon mismatch,
+            # missing verse), the lateral join returns no rows for that
+            # query_vref and the side comes back empty — silently. We
+            # rely on Bible vrefs being shared across language pairs;
+            # mismatched-vref corpora produce empty source_neighbours
+            # rather than an error.
             rows = await db.execute(
                 nn_query,
                 {
@@ -1329,12 +1370,16 @@ async def get_training_session_results(
         ]
 
     tfidf_by_vref: dict[str, TfidfNeighboursBlock] = {}
-    if tfidf_id is not None or source_tfidf_id is not None:
+    # `source_tfidf_id` is only ever resolved inside the `tfidf_id is not None`
+    # branch above, so a single check on `tfidf_id` is sufficient. When tfidf
+    # is trained we always populate the block — even with empty lists on both
+    # sides — so a single-vref corpus or a vref with no matching neighbours
+    # still gets `tfidf={target_neighbours: [], source_neighbours: []}`,
+    # distinct from `tfidf=None` which signals "not trained".
+    if tfidf_id is not None:
         for v in page_vrefs:
             tgt = tfidf_target_raw.get(v, [])
             src = tfidf_source_raw.get(v, [])
-            if not tgt and not src:
-                continue
             tfidf_by_vref[v] = TfidfNeighboursBlock(
                 target_neighbours=_build_neighbours(tgt),
                 source_neighbours=_build_neighbours(src),

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -60,7 +60,6 @@ from models import (
     TrainingType,
     WordAlignment,
 )
-
 from security_routes.auth_routes import get_current_user
 from utils.logging_config import setup_logger
 from utils.verse_range_utils import merge_verse_ranges
@@ -308,9 +307,7 @@ async def _gather_ngram_buckets(
     )
     buckets: dict[int, dict] = {}
     for nid, ngram, size, ngram_vref in (await db.execute(full_q)).all():
-        b = buckets.setdefault(
-            nid, {"ngram": ngram, "ngram_size": size, "vrefs": []}
-        )
+        b = buckets.setdefault(nid, {"ngram": ngram, "ngram_size": size, "vrefs": []})
         b["vrefs"].append(ngram_vref)
     return buckets
 
@@ -1268,7 +1265,9 @@ async def get_training_session_results(
             """
         ).bindparams(bindparam("page_vrefs", expanding=True))
 
-        async def _fetch_tfidf_raw(assessment_id: int) -> dict[str, list[tuple[str, float]]]:
+        async def _fetch_tfidf_raw(
+            assessment_id: int,
+        ) -> dict[str, list[tuple[str, float]]]:
             rows = await db.execute(
                 nn_query,
                 {
@@ -1280,9 +1279,7 @@ async def get_training_session_results(
             buckets: dict[str, list[tuple[str, float]]] = {}
             for row in rows.all():
                 sim = float(row.similarity) if row.similarity is not None else 0.0
-                buckets.setdefault(row.query_vref, []).append(
-                    (row.neighbour_vref, sim)
-                )
+                buckets.setdefault(row.query_vref, []).append((row.neighbour_vref, sim))
             return buckets
 
         if tfidf_id is not None:

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -259,7 +259,9 @@ async def _resolve_source_side_assessment_id(
     Tiebreak on id when end_time is equal or null (NULLSLAST keeps a
     stale half-finished row from preempting a real one), so the pick is
     deterministic. When more than one finished assessment matches, log a
-    warning so an unusual workflow state is observable.
+    warning so an unusual workflow state is observable. We only fetch up
+    to 2 rows: the second is just enough to detect ">1 matched" without
+    materialising potentially many historical assessments on a hot path.
     """
     stmt = (
         select(Assessment.id)
@@ -270,6 +272,7 @@ async def _resolve_source_side_assessment_id(
             Assessment.deleted.is_not(True),
         )
         .order_by(Assessment.end_time.desc().nullslast(), Assessment.id.desc())
+        .limit(2)
     )
     rows = (await db.execute(stmt)).all()
     if not rows:
@@ -280,7 +283,6 @@ async def _resolve_source_side_assessment_id(
             extra={
                 "source_revision_id": source_revision_id,
                 "assessment_type": assessment_type,
-                "match_count": len(rows),
                 "picked_assessment_id": rows[0][0],
             },
         )

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -1273,7 +1273,7 @@ async def get_training_session_results(
     # revision, regardless of how many neighbours were returned).
     tfidf_target_raw: dict[str, list[tuple[str, float]]] = {}
     tfidf_source_raw: dict[str, list[tuple[str, float]]] = {}
-    if (tfidf_id is not None or source_tfidf_id is not None) and page_vrefs:
+    if tfidf_id is not None and page_vrefs:
         nn_query = text(
             """
             SELECT q.vref AS query_vref,


### PR DESCRIPTION
## Summary

Reshapes the per-vref payload from `GET /v3/train/status/{session_id}/results` so it lines up with the per-pair payload from `POST /v3/predict`. Same field names, same nesting — a client can share a parser between the two endpoints for the `ngrams` and `tfidf` types.

> **Coordination note**: the `tfidf` shape already matches what `/v3/predict` returns today. The `ngrams` shape adopted here mirrors the **upcoming** predict shape from the companion PR `feat/predict-ngrams-drop-cross-axes` (which drops cross-axis ngrams from `/v3/predict`). Until that PR ships, a shared client-side parser will only work for tfidf — clients that parse ngrams against both endpoints should wait for the companion PR. Coordinate deploy ordering accordingly.

### What changed

- **tfidf**: per-vref `tfidf` is now `{target_neighbours: [...], source_neighbours: [...]}` (was a flat `List[TfidfNeighbour]`). Each neighbour is `{vref, similarity, target_revision_text, source_revision_text}` (was `{vref, score}`).
- **ngrams**: per-vref `ngrams` is now `{target_corpus: {matches: [...]}, source_corpus: {matches: [...]} | None}` (was a top-level `List[NgramResult]`). Each match is `{id, ngram, ngram_size, verses: [{vref, target_revision_text, source_revision_text}]}`. The top-level `ngrams` field on the response is removed.
- **source-side resolution**: source-side ngrams/tfidf assessments are looked up as the latest finished assessment of the same type whose `revision_id == session.source_revision_id` (typically a separate session that swapped source/target). When unavailable, `source_corpus` is `None` and `source_neighbours` is `[]`, distinguishing "not trained" from "trained, no hits". *Note*: the None/[] split is asymmetric — for tfidf, an empty `source_neighbours` is ambiguous between "not trained" and "trained, no hits". This is documented in the model field comment; clients that need the distinction should rely on ngrams' `source_corpus`.
- **Cross-axis matches dropped**: predict's cross-axes (target ngrams in source text and vice versa) are not surfaced — train-status reads stored corpus hits only. The companion aqua-assessments PR drops them from `/v3/predict` too, since they're almost always empty in practice.
- **Pagination**: now includes ngrams (so a pure-ngrams session paginates) and source-side tfidf vrefs. Added `.distinct()` on the joined subquery to fix a latent dedup bug exposed by the single-subquery ngrams case (SQLAlchemy emits no UNION wrapper for one element). The `.distinct()` fix is for a pre-existing bug now reachable via the new pagination paths; the regression test asserts `total_count == 3` (not 4) when `GEN 1:1` is covered by 2 ngrams.

### Auth + access model

`_resolve_source_side_assessment_id` runs **after** `_load_session_jobs`, which already gates the session on the user having access to both source and target revisions (via `version_id`). Source-side assessment data is therefore on a revision the user can already see and is treated as revision-keyed shared data — we do not re-filter on `Assessment.owner_id`. The resolver picks the latest finished assessment by `(end_time DESC NULLSLAST, id DESC)`; when more than one matches, it logs a warning so the unusual state is observable.

### Source-side tfidf semantics

The source-side tfidf query is a same-vref cross-corpus retrieval: for each target-side page vref, it finds the nearest neighbours within the *source* corpus's vector space. This works because Bible vrefs are shared across language pairs. Mismatched-vref corpora (canon differences, missing verses) silently return empty `source_neighbours` rather than erroring. Documented in code at `_fetch_tfidf_raw`.

### Breaking changes

Response shape changes for `/v3/train/status/{session_id}/results`. No deprecation shim — the field rename is a clean break, intended to be coordinated with the aqua-assessments `/v3/predict` reshape.

## Test plan

- [x] `test/test_train_routes/` — 63 tests pass (8 new across both passes: original 3 plus 5 added in review feedback covering source-side hydration labeling, source-only vref pagination for both tfidf and ngrams, tfidf_top_k symmetric application, and multi-session source resolution)
- [x] Full sweep across `test_train_routes`, `test_predict_routes`, `test_assessment_routes` — 379 pass
- [ ] Verify the front-end / consumer side of the response (out of scope for this repo)
- [ ] Coordinate aqua-assessments `/v3/predict` reshape (paired branch `feat/predict-ngrams-drop-cross-axes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
