### PR TITLE
Add integration test notebook (existing version 1291 / revision 2023)

### DIFF
--- a/notebooks/integration_test_demo.ipynb
+++ b/notebooks/integration_test_demo.ipynb
@@ -1,0 +1,222 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Aqua API — Integration test (existing revision)\n\nSame flow as `train_predict_demo.ipynb`, but reuses an existing version + revision in the API instead of creating fresh ones each run. Intended for repeatable integration testing — keeps repeated runs from accumulating throwaway data.\n\n1. **Authenticate** with credentials loaded from `.env` (via `python-dotenv`).\n2. **Look up the reference revision** to align against (NIV, revision id `1592`).\n3. **Trigger training** for all available apps against the existing target (`VERSION_ID=1291`, `REVISION_ID=2023`).\n4. **Poll training status** until every job reaches a terminal state.\n5. **Inspect training results** — interleaved per-vref scores from each app.\n6. **Run `/predict`** on a sample verse pair using the artifacts you just trained.\n\nSet the following in your `.env` (or export them in the parent shell) before running:\n\n```\nAQUA_USERNAME=...\nAQUA_PASSWORD=...\n```\n\n> The Aqua API uses the [vref convention](https://github.com/BibleNLP/ebible/blob/main/metadata/vref.txt) — every revision is a 41,899-line text file where line N corresponds to canonical verse reference N."
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13e0fee1",
+   "source": "## What each app does\n\nThe training / predict fan-out covers five apps. Each scores a `(source_text, target_text)` pair on a different dimension; the design intent is that they're complementary rather than redundant.\n\n| App | What it does | Strength |\n| --- | --- | --- |\n| **semantic-similarity** | Compares sentence-pair embeddings from a fine-tuned model. | Catches meaning drift even when the two sides share no surface vocabulary (e.g. a paraphrase that lost the actual meaning). |\n| **tfidf** | Builds a [TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) + truncated-SVD encoder over the corpus and returns the nearest-neighbour verses to a query — i.e. the verses whose wording is most similar. | Useful when reviewing a verse: surfaces other places in the corpus that read similarly, so the translator can check consistency or pull comparable renderings. |\n| **word-alignment** | Word-level alignment between source and target. With `use_eflomal=true` it uses [eflomal](https://github.com/robertostling/eflomal) (statistical alignment); otherwise FastAlign. | Surfaces added words, omitted words, and systematic mistranslations of specific terms. |\n| **ngrams** | Mines frequent multi-word phrases from the training corpus, so translators can compare translation consistency of those phrases. | Catches verses that are missing the recurring phrases your translation team usually uses. |\n| **agent-critique** *(likely to be renamed `ai-notes`)* | LLM-driven pipeline. Produces structured per-verse issues (omissions, additions, replacements, severity), an automatic back-translation, lexeme cards, and a grammar sketch. | Surfaces semantic and theological issues a statistical model would miss, plus the back-translation / lexeme / grammar artefacts give human reviewers context to work from. Most expensive of the five — call it via `/predict` on the verses you actually want inspected, not over the whole training set. |\n\nYou can fan out to a subset by passing `apps=[...]` on `/train` or `/predict`. Omit it to run all five.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5279d509",
+   "metadata": {},
+   "outputs": [],
+   "source": "import json\nimport os\nimport time\nfrom pathlib import Path\n\nimport requests\nfrom dotenv import load_dotenv\n\n\ndef check(resp):\n    \"\"\"Like ``resp.raise_for_status()`` but surfaces the response body so a\n    422 from Pydantic actually tells you which field it didn't like.\"\"\"\n    if not resp.ok:\n        raise RuntimeError(\n            f\"{resp.request.method} {resp.url} -> \"\n            f\"{resp.status_code}: {resp.text}\"\n        )\n    return resp\n\n\n# Load AQUA_USERNAME / AQUA_PASSWORD from `.env` at the repo root, falling\n# back to whatever is already in the parent shell.\nload_dotenv()"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c87aacfc",
+   "metadata": {},
+   "source": [
+    "## 0. Configure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "732e1846",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Choose the environment you want to hit.\nBASE_URL = \"https://cp3by92k8p.us-east-1.awsapprunner.com\"  # development\n# BASE_URL = \"https://tmv9bz5v4q.us-east-1.awsapprunner.com\"  # production\n\n# All v3 routes are reachable at /latest/ as well — we use /latest/ here.\nPREFIX = \"latest\"\n\nUSERNAME = os.environ[\"AQUA_USERNAME\"]\nPASSWORD = os.environ[\"AQUA_PASSWORD\"]\n\n# Existing target to train + predict against. Created once in the dev\n# environment; integration runs reuse these IDs rather than re-uploading.\nVERSION_ID = 1291\nREVISION_ID = 2023\n\n# Reference revision to align against. 1592 is the NIV in the dev DB.\nREFERENCE_REVISION_ID = 1592"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "faf609e8",
+   "metadata": {},
+   "source": [
+    "## 1. Authenticate\n",
+    "\n",
+    "`POST /latest/token` with form-encoded credentials returns a Bearer token. Every subsequent request includes that token in the `Authorization` header."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "238bce6e",
+   "metadata": {},
+   "outputs": [],
+   "source": "resp = check(requests.post(\n    f\"{BASE_URL}/{PREFIX}/token\",\n    data={\"username\": USERNAME, \"password\": PASSWORD},\n))\nTOKEN = resp.json()[\"access_token\"]\nAUTH = {\"Authorization\": f\"Bearer {TOKEN}\"}\nprint(f\"Got token (length: {len(TOKEN)}) for {USERNAME}\")"
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9511e86c",
+   "metadata": {},
+   "source": "## 2. Resolve the reference (NIV) version_id\n\nBoth `/train` and `/predict` are keyed on **versions**. By default the API picks the latest non-deleted revision under the version when training, so a fresh upload to the same version automatically becomes the next training input.\n\nIf you need to pin training to a specific revision (e.g. retraining against an older draft for comparison), pass `source_revision_id` / `target_revision_id` instead — see the next cell.\n\nWe need the NIV's `bible_version_id` for the train + predict steps below. If you already know it, you can hardcode `REFERENCE_VERSION_ID` directly. Otherwise, the lookup below scans your accessible revisions for `id == REFERENCE_REVISION_ID`."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98a4f33e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = check(requests.get(f\"{BASE_URL}/{PREFIX}/revision\", headers=AUTH))\n",
+    "revisions = resp.json()\n",
+    "\n",
+    "ref = next((r for r in revisions if r[\"id\"] == REFERENCE_REVISION_ID), None)\n",
+    "if ref is None:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Revision {REFERENCE_REVISION_ID} is not in your accessible-revisions list. \"\n",
+    "        \"Ask your admin to grant your group access to the NIV reference version, \"\n",
+    "        \"or set REFERENCE_VERSION_ID directly below.\"\n",
+    "    )\n",
+    "REFERENCE_VERSION_ID = ref[\"bible_version_id\"]\n",
+    "print(\n",
+    "    f\"Reference (revision {REFERENCE_REVISION_ID}) lives under \"\n",
+    "    f\"version_id {REFERENCE_VERSION_ID}\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5c05e79",
+   "metadata": {},
+   "source": "## 3. Trigger training\n\n`POST /latest/train` queues training jobs for every app at once and returns a `session_id` you can poll. Pass `apps=[...]` to restrict to specific apps; omit it to train all of them.\n\nThe pair is identified by **`source_version_id` / `target_version_id`** — the API resolves each side to its latest non-deleted revision. To pin a side to a specific revision (e.g. retrain against an older draft), swap that side's `*_version_id` for `*_revision_id`; you can mix the two across sides.\n\n`use_eflomal=true` opts the word-alignment app into the eflomal alignment path."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "206f3ff6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_payload = {\n",
+    "    \"source_version_id\": REFERENCE_VERSION_ID,    # NIV reference (latest revision)\n",
+    "    \"target_version_id\": VERSION_ID,              # your translation (latest revision)\n",
+    "    \"options\": {\"use_eflomal\": True},             # Will probably become default soon\n",
+    "    # To pin a side to a specific revision instead of \"latest under the version\":\n",
+    "    # \"source_revision_id\": REFERENCE_REVISION_ID,\n",
+    "    # \"target_revision_id\": REVISION_ID,\n",
+    "    # \"apps\": [\"semantic-similarity\", \"word-alignment\"]  # optional subset\n",
+    "}\n",
+    "\n",
+    "resp = check(requests.post(\n",
+    "    f\"{BASE_URL}/{PREFIX}/train\",\n",
+    "    json=train_payload,\n",
+    "    headers=AUTH,\n",
+    "))\n",
+    "training_response = resp.json()\n",
+    "SESSION_ID = training_response[\"session_id\"]\n",
+    "print(f\"Session id: {SESSION_ID}\")\n",
+    "for job in training_response[\"training_jobs\"]:\n",
+    "    print(f\"  job {job['id']:>4}  {job['type']:<22}  status={job['status']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e46ee72",
+   "metadata": {},
+   "source": "## 4. Poll training status\n\n`GET /latest/train/status?session_id=...` returns the same payload shape as `/train`, so you can watch each job tick from `queued` → `running` → `finished` (or `failed`).\n\nTypical durations on dev:\n\n| App | Typical |\n| --- | --- |\n| semantic-similarity | ~20-40 min |\n| tfidf | ~1–2 min |\n| ngrams | ~3 min |\n| word-alignment (eflomal) | ~10–15 min |\n| agent-critique | ~10-15 min |"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b13c68fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TERMINAL = {\"finished\", \"failed\", \"cancelled\"}\n",
+    "POLL_INTERVAL = 30  # seconds\n",
+    "\n",
+    "while True:\n",
+    "    resp = check(requests.get(\n",
+    "        f\"{BASE_URL}/{PREFIX}/train/status\",\n",
+    "        params={\"session_id\": SESSION_ID},\n",
+    "        headers=AUTH,\n",
+    "    ))\n",
+    "    jobs = resp.json()[\"training_jobs\"]\n",
+    "\n",
+    "    print(f\"[{time.strftime('%H:%M:%S')}]\")\n",
+    "    for job in jobs:\n",
+    "        pct = (\n",
+    "            f\"{job['percent_complete']:>5.1f}%\"\n",
+    "            if job.get(\"percent_complete\") is not None\n",
+    "            else \"   ?  \"\n",
+    "        )\n",
+    "        detail = job.get(\"status_detail\") or \"\"\n",
+    "        print(\n",
+    "            f\"  {job['type']:<22}  {job['status']:<9}  {pct}  {detail}\"\n",
+    "        )\n",
+    "\n",
+    "    if all(j[\"status\"] in TERMINAL for j in jobs):\n",
+    "        break\n",
+    "    time.sleep(POLL_INTERVAL)\n",
+    "\n",
+    "print(\"\\nAll jobs terminal.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cee08a20",
+   "metadata": {},
+   "source": "## 5. Inspect training results\n\n`GET /latest/train/status/{session_id}/results` returns per-verse rows from every completed app, interleaved by `vref`. You can filter by `book` / `chapter` / `verse` and paginate with `page` + `page_size`.\n\nConceptually these results are `/predict` run over **the whole training text** — every app scores every verse you uploaded against the reference, so you get a free pre-scored pass over your translation as a side effect of training. That holds for `semantic-similarity`, `tfidf`, `word-alignment`, and `ngrams`.\n\nThe exception is **`agent-critique`**: running it on the entire submitted text would be prohibitively expensive (it's an LLM-driven critique loop). Training only fits the agent artifacts; it does not return per-verse agent results here. To get agent-critique scores for specific verses, call `/predict` (next section) with `apps=[\"agent-critique\"]` and the verses you actually want critiqued.\n\nWe filter to a single chapter (Luke 1) just to keep the preview small."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e57cf2cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resp = check(requests.get(\n",
+    "    f\"{BASE_URL}/{PREFIX}/train/status/{SESSION_ID}/results\",\n",
+    "    params={\"book\": \"LUK\", \"chapter\": 1, \"page\": 1, \"page_size\": 10},\n",
+    "    headers=AUTH,\n",
+    "))\n",
+    "results = resp.json()\n",
+    "print(json.dumps(results, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0be10332",
+   "metadata": {},
+   "source": "## 6. Run `/predict` on a sample verse pair\n\nOnce training is done, `/predict` scores arbitrary `(source_text, target_text)` pairs against the trained artifacts. The expectation is that each pair is either a **brand-new draft verse** that was not in the training data, or a **revised version of a verse** that was — so you can score quality after each translator edit without retraining.\n\nThroughout the API the convention is **`source` = reference language (what you're translating *from*), `target` = the translation being scored (what you're translating *to*)**. Here that means `source_text` / `source_version_id` is the NIV English side, and `target_text` / `target_version_id` is the existing target translation.\n\n- `pairs` — list of `{vref, source_text, target_text}`. **Scoring runs on the strings**: ngrams checks overlap with the trained ngram set, semantic-similarity compares text embeddings, and so on. `vref` is an optional convenience identifier — the API echoes it back alongside each pair's results so you can match scores to verses on the client side, but it does not drive scoring.\n- `source_version_id` / `target_version_id` — the version pair the artifacts were trained under. Both `/train` and `/predict` are **keyed on versions**: training artifacts are shared across every revision within a version (so a fresh revision of an in-progress translation reuses the same trained models without retraining), but they don't leak across versions — two different versions in the same language are isolated, and you'll need to train each one separately.\n- `apps` — optional list to fan out to a subset.\n\nBelow we score two pairs at GEN 1:1: the first uses the NIV English source paired with the actual target rendering of GEN 1:1 (a known-good match), the second pairs the English GEN 1:2 source with the target's GEN 1:3 text (deliberately wrong: same language, different verse) so you can see the score collapse."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b24d670b",
+   "metadata": {},
+   "outputs": [],
+   "source": "# Fetch the actual GEN 1:1 and GEN 1:3 text from the existing target\n# revision via /verse — keeps the predict pair grounded in the same\n# corpus the training artifacts were fit on.\ndef get_verse(revision_id: int, book: str, chapter: int, verse: int) -> str:\n    resp = check(requests.get(\n        f\"{BASE_URL}/{PREFIX}/verse\",\n        params={\n            \"revision_id\": revision_id,\n            \"book\": book,\n            \"chapter\": chapter,\n            \"verse\": verse,\n        },\n        headers=AUTH,\n    ))\n    rows = resp.json()\n    if not rows:\n        raise RuntimeError(f\"No verse text for {book} {chapter}:{verse} in revision {revision_id}\")\n    return rows[0][\"text\"]\n\n\ntarget_gen_1_1 = get_verse(REVISION_ID, \"GEN\", 1, 1)\ntarget_gen_1_3 = get_verse(REVISION_ID, \"GEN\", 1, 3)\nprint(f\"GEN 1:1 (target): {target_gen_1_1!r}\")\nprint(f\"GEN 1:3 (target, used as the bad pair): {target_gen_1_3!r}\")\n\n# A reasonable English rendering of GEN 1:1 / 1:2 to use as the source side.\nENGLISH_GEN_1_1 = (\n    \"In the beginning God created the heavens and the earth.\"\n)\nENGLISH_GEN_1_2 = (\n    \"Now the earth was formless and void, and darkness was over the surface of the deep. \"\n    \"And the Spirit of God was hovering over the surface of the waters.\"\n)\n\npredict_payload = {\n    \"pairs\": [\n        {\n            \"vref\": \"GEN 1:1\",\n            \"source_text\": ENGLISH_GEN_1_1,\n            \"target_text\": target_gen_1_1,\n        },\n        {\n            \"vref\": \"GEN 1:2\",\n            \"source_text\": ENGLISH_GEN_1_2,\n            # Deliberately wrong: target is GEN 1:3's text under English GEN 1:2,\n            # so every app should score it low.\n            \"target_text\": target_gen_1_3,\n        },\n    ],\n    \"source_version_id\": REFERENCE_VERSION_ID,  # NIV\n    \"target_version_id\": VERSION_ID,             # existing target translation\n    # \"apps\": [\"semantic-similarity\", \"ngrams\"],  # optional subset\n    # The two flags below opt the agent-critique app into its heavier\n    # passes. Both default to False; flipping either to True will add\n    # roughly 30–45s to the total predict latency.\n    # \"include_translation\": True,  # run the LLM back-translation pass\n    # \"include_critique\": True,     # per-verse critique (requires include_translation=True)\n}\n\nresp = check(requests.post(\n    f\"{BASE_URL}/{PREFIX}/predict\",\n    json=predict_payload,\n    headers=AUTH,\n))\npredictions = resp.json()\n\n# Save the full response to a file so it's easy to inspect later.\noutput_path = Path(\"predict_output.json\")\noutput_path.write_text(\n    json.dumps(predictions, indent=2, ensure_ascii=False),\n    encoding=\"utf-8\",\n)\nprint(f\"Saved full predict response to {output_path.resolve()}\")\n\n# Per-app status summary so the cell is still informative without\n# dumping the whole payload.\nfor app_name, result in predictions.get(\"results\", {}).items():\n    status_str = result.get(\"status\", \"?\")\n    note = \"\"\n    if status_str == \"ok\":\n        n_pairs = len(result.get(\"data\", {}).get(\"pairs\", []))\n        note = f\"({n_pairs} pair(s) returned)\"\n    elif result.get(\"error\"):\n        note = f\"error: {result['error']}\"\n    print(f\"  {app_name:<20} {status_str:<6} {note}\")"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Personal integration-test variant of `train_predict_demo.ipynb` that reuses the existing dev-env target (`VERSION_ID=1291`, `REVISION_ID=2023`) instead of creating a fresh Chichewa version on each run. Designed to be re-runnable without accumulating throwaway data.

### Differences from the demo

- **Auth**: loads `AQUA_USERNAME` / `AQUA_PASSWORD` from `.env` via `python-dotenv` (no more `getpass` prompt).
- **Target**: hardcoded to `VERSION_ID=1291` / `REVISION_ID=2023` — drops the create-version + upload-revision sections entirely.
- **Predict pair**: fetches GEN 1:1 / GEN 1:3 target text via `GET /v3/verse` instead of stashing `REVISION_LINES` from a fresh upload.
- **Cleanup section dropped** — nothing to clean up when the target is shared and persistent.
- Section numbers re-flowed 1–6 to match the slimmer flow.

### Setup

```
AQUA_USERNAME=...
AQUA_PASSWORD=...
```

## Test plan

- [ ] End-to-end run on dev with my Mark credentials: train fans out, status polls to terminal, results paginate, predict returns scored pairs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)