### PR TITLE
test(predict): pin agent translation + critique passthrough

### DIFF
--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -348,6 +348,67 @@ def test_predict_rejects_critique_without_translation(client, regular_token1):
     assert "include_translation" in response.text
 
 
+def test_predict_passes_through_translation_and_critique(client, regular_token1):
+    """When the agent app returns per-pair `translation` and `critique`
+    payloads (driven by `include_translation` / `include_critique`), they
+    must reach the client untouched. `PredictAppResult.data` is typed
+    `Optional[Any]` precisely so any agent-side schema changes flow
+    through without a model bump — but that means a typed-strip regression
+    would be silent. This test pins the passthrough contract."""
+    agent_response = {
+        "pairs": [
+            {
+                "vref": "GEN 1:1",
+                "source_text": "In the beginning...",
+                "target_text": "Hapo mwanzo...",
+                "translation": {
+                    "hyper_literal": "In beginning created God heavens earth.",
+                    "literal": "In the beginning God created the heavens and earth.",
+                    "english_translation": "In the beginning God created the heavens and the earth.",
+                },
+                "critique": {
+                    "omissions": ["the"],
+                    "additions": [],
+                    "replacements": [
+                        {"source": "heavens", "target": "skies", "severity": "low"}
+                    ],
+                },
+                "lexeme_cards": [],
+            }
+        ],
+        "grammar_sketch": "VSO; agreement on nouns.",
+        "source_language_profile": {"family": "Indo-European"},
+        "target_language_profile": {"family": "Bantu"},
+    }
+    with patch(
+        "predict_routes.v3.predict_routes.modal.Function",
+        _make_modal_mock({"agent-critique": agent_response}),
+    ):
+        response = client.post(
+            f"/{prefix}/predict",
+            json=_body(
+                apps=["agent"],
+                include_translation=True,
+                include_critique=True,
+            ),
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    envelope = body["results"]["agent"]
+    assert envelope["status"] == "ok"
+    # Whole agent payload must round-trip unchanged.
+    assert envelope["data"] == agent_response
+    pair = envelope["data"]["pairs"][0]
+    assert pair["translation"]["literal"].startswith("In the beginning")
+    assert pair["critique"]["omissions"] == ["the"]
+    assert pair["critique"]["replacements"][0]["target"] == "skies"
+    # Top-level companion fields must also survive.
+    assert envelope["data"]["grammar_sketch"] == "VSO; agreement on nouns."
+    assert envelope["data"]["target_language_profile"] == {"family": "Bantu"}
+
+
 def test_predict_duplicate_apps_deduplicated(client, regular_token1):
     """Duplicate entries in `apps` are deduplicated; Modal is called once per app."""
     call_count = {"ngrams": 0}

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -349,12 +349,14 @@ def test_predict_rejects_critique_without_translation(client, regular_token1):
 
 
 def test_predict_passes_through_translation_and_critique(client, regular_token1):
-    """When the agent app returns per-pair `translation` and `critique`
-    payloads (driven by `include_translation` / `include_critique`), they
-    must reach the client untouched. `PredictAppResult.data` is typed
-    `Optional[Any]` precisely so any agent-side schema changes flow
-    through without a model bump — but that means a typed-strip regression
-    would be silent. This test pins the passthrough contract."""
+    """Agent's per-pair translation + critique (driven by
+    include_translation / include_critique) must round-trip to the client
+    untouched. `PredictAppResult.data: Optional[Any]` is the passthrough
+    point; this pins it so a future schema-strip regression is caught."""
+    # Mirror the real agent.predict() return shape from
+    # aqua-assessments/assessments/agent/app.py:2611-2684 — including the
+    # optional `warnings` list — so a future change that strips unknown
+    # top-level keys would fail here.
     agent_response = {
         "pairs": [
             {
@@ -379,6 +381,7 @@ def test_predict_passes_through_translation_and_critique(client, regular_token1)
         "grammar_sketch": "VSO; agreement on nouns.",
         "source_language_profile": {"family": "Indo-European"},
         "target_language_profile": {"family": "Bantu"},
+        "warnings": [],
     }
     with patch(
         "predict_routes.v3.predict_routes.modal.Function",
@@ -395,18 +398,12 @@ def test_predict_passes_through_translation_and_critique(client, regular_token1)
         )
 
     assert response.status_code == 200, response.text
-    body = response.json()
-    envelope = body["results"]["agent"]
+    envelope = response.json()["results"]["agent"]
     assert envelope["status"] == "ok"
-    # Whole agent payload must round-trip unchanged.
+    # Deep equality on the whole agent payload — every key, including
+    # nested translation/critique fields and top-level grammar_sketch /
+    # language profiles / warnings, must round-trip untouched.
     assert envelope["data"] == agent_response
-    pair = envelope["data"]["pairs"][0]
-    assert pair["translation"]["literal"].startswith("In the beginning")
-    assert pair["critique"]["omissions"] == ["the"]
-    assert pair["critique"]["replacements"][0]["target"] == "skies"
-    # Top-level companion fields must also survive.
-    assert envelope["data"]["grammar_sketch"] == "VSO; agreement on nouns."
-    assert envelope["data"]["target_language_profile"] == {"family": "Bantu"}
 
 
 def test_predict_duplicate_apps_deduplicated(client, regular_token1):

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -353,10 +353,10 @@ def test_predict_passes_through_translation_and_critique(client, regular_token1)
     include_translation / include_critique) must round-trip to the client
     untouched. `PredictAppResult.data: Optional[Any]` is the passthrough
     point; this pins it so a future schema-strip regression is caught."""
-    # Mirror the real agent.predict() return shape from
-    # aqua-assessments/assessments/agent/app.py:2611-2684 — including the
-    # optional `warnings` list — so a future change that strips unknown
-    # top-level keys would fail here.
+    # Mirror the real agent.predict() return shape — pairs carrying
+    # translation/critique/lexeme_cards plus top-level grammar_sketch,
+    # language profiles, and an optional `warnings` list — so a future
+    # change that strips unknown top-level keys would fail here.
     agent_response = {
         "pairs": [
             {


### PR DESCRIPTION
## Summary

Verifies that when `include_translation=True` / `include_critique=True` are sent on `POST /v3/predict`, the agent app's per-pair `translation` and `critique` payloads (plus the top-level `grammar_sketch`, language profiles, and `warnings`) reach the client untouched.

The plumbing is already correct — `PredictAppResult.data` is typed `Optional[Any]` precisely so the agent can evolve its response shape without an aqua-api model bump. But that permissiveness means a future regression that silently strips the agent payload would not be caught by existing tests. This pins the contract.

### What's tested

- Mock Modal returns a realistic agent response: `pairs` carrying `translation` (`hyper_literal`/`literal`/`english_translation`), `critique` (`omissions`/`additions`/`replacements`), and `lexeme_cards`; plus `grammar_sketch`, `source_language_profile`, `target_language_profile`, and `warnings: []` at the envelope level.
- Assertion: deep equality on the entire `data` payload — every key, including all nested fields, must round-trip untouched. A typed-strip that drops any field would fail the equality.

## Test plan

- [x] `pytest test/test_predict_routes/` — 43 pass (1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
