### PR TITLE
Always derive source/target_version_id at assessment creation

### DIFF
--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -302,10 +302,6 @@ async def add_assessment(
         a.kwargs = combined_kwargs
         parsed_kwargs = combined_kwargs
 
-    # Eflomal word-alignment derives source/target version IDs from the
-    # reference and revision rows. Mapping per train_routes #620:
-    #   source_version_id ← bible_version_id of reference_id
-    #   target_version_id ← bible_version_id of revision_id
     # Strict-bool check: a caller could route around the typed query param
     # by passing `use_eflomal: 1` (or "true", etc.) via extra_kwargs. The
     # dedup SQL uses JSONB containment which is strictly typed, so a
@@ -317,22 +313,32 @@ async def add_assessment(
             detail="use_eflomal must be a boolean.",
         )
     is_eflomal = use_eflomal_kw is True
-    source_version_id: Optional[int] = None
-    target_version_id: Optional[int] = None
-    if is_eflomal:
-        if a.type != "word-alignment":
-            raise HTTPException(
-                status_code=400,
-                detail="use_eflomal is only valid for word-alignment assessments.",
-            )
-        revision = await db.get(BibleRevision, a.revision_id)
-        if revision is None or revision.deleted:
-            raise HTTPException(status_code=404, detail="revision_id does not exist.")
-        reference = await db.get(BibleRevision, a.reference_id)
-        if reference is None or reference.deleted:
-            raise HTTPException(status_code=404, detail="reference_id does not exist.")
-        source_version_id = reference.bible_version_id
-        target_version_id = revision.bible_version_id
+    if is_eflomal and a.type != "word-alignment":
+        raise HTTPException(
+            status_code=400,
+            detail="use_eflomal is only valid for word-alignment assessments.",
+        )
+
+    # Derive source/target version IDs from the reference and revision rows
+    # for every assessment type (not just eflomal). Downstream consumers
+    # (agent runner, eflomal pipeline, version-id-keyed artifact stores) all
+    # require these fields. Mapping:
+    #   source_version_id ← bible_version_id of reference_id
+    #   target_version_id ← bible_version_id of revision_id
+    revision = await db.get(BibleRevision, a.revision_id)
+    if revision is None or revision.deleted:
+        raise HTTPException(status_code=404, detail="revision_id does not exist.")
+    reference = (
+        await db.get(BibleRevision, a.reference_id)
+        if a.reference_id is not None
+        else None
+    )
+    if a.reference_id is not None and (reference is None or reference.deleted):
+        raise HTTPException(status_code=404, detail="reference_id does not exist.")
+    target_version_id: Optional[int] = revision.bible_version_id
+    source_version_id: Optional[int] = (
+        reference.bible_version_id if reference is not None else None
+    )
 
     # Check for already-completed assessment (force=true bypasses this)
     if not force:

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1625,14 +1625,15 @@ def test_use_eflomal_derives_version_ids(
         assert kwargs["target_version_id"] == target_version_id
 
 
-def test_non_eflomal_word_alignment_forwards_null_version_ids(
+def test_non_eflomal_word_alignment_derives_version_ids(
     client, regular_token1, db_session, test_db_session
 ):
-    """Non-eflomal word-alignment must forward source/target_version_id=None to the
-    runner (not the revisions' bible_version_id) — only eflomal triggers derivation."""
-    version_id = create_bible_version(client, regular_token1, db_session)
-    revision_id = upload_revision(client, regular_token1, version_id)
-    reference_id = upload_revision(client, regular_token1, version_id)
+    """Non-eflomal word-alignment must also forward derived source/target_version_id
+    to the runner — derivation now runs for every assessment type, not just eflomal."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
 
     with patch(
         f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
@@ -1649,8 +1650,64 @@ def test_non_eflomal_word_alignment_forwards_null_version_ids(
         )
         assert response.status_code == 200, response.text
         kwargs = mock_runner.await_args.kwargs
+        assert kwargs["source_version_id"] == source_version_id
+        assert kwargs["target_version_id"] == target_version_id
+
+
+def test_agent_critique_derives_version_ids(
+    client, regular_token1, db_session, test_db_session
+):
+    """agent-critique forwards derived source/target_version_id to the runner.
+    Regression for: agent runner failed with 'Could not resolve iso_language for
+    versions (None, None)' when the assessment was persisted with NULL version IDs."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "agent-critique",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        kwargs = mock_runner.await_args.kwargs
+        assert kwargs["source_version_id"] == source_version_id
+        assert kwargs["target_version_id"] == target_version_id
+
+
+def test_no_reference_assessment_derives_target_only(
+    client, regular_token1, db_session, test_db_session
+):
+    """Assessment types that don't require a reference (e.g. sentence-length) still
+    get target_version_id derived from revision_id; source_version_id stays None."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        kwargs = mock_runner.await_args.kwargs
         assert kwargs["source_version_id"] is None
-        assert kwargs["target_version_id"] is None
+        assert kwargs["target_version_id"] == version_id
 
 
 def test_use_eflomal_dedup_separate_from_regular(

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1710,6 +1710,106 @@ def test_no_reference_assessment_derives_target_only(
         assert kwargs["target_version_id"] == version_id
 
 
+def test_non_eflomal_unknown_revision_returns_404(
+    client, regular_token1, db_session, test_db_session
+):
+    """Bogus revision_id or reference_id must 404 for non-eflomal types too —
+    the existence guard is no longer eflomal-only."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+
+        # Bogus revision_id on a no-reference type
+        bad_revision = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": 999_999_999,
+                "type": "sentence-length",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert bad_revision.status_code == 404
+        assert bad_revision.json()["detail"] == "revision_id does not exist."
+
+        # Bogus reference_id on a reference-requiring type
+        bad_reference = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": 999_999_999,
+                "type": "agent-critique",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert bad_reference.status_code == 404
+        assert bad_reference.json()["detail"] == "reference_id does not exist."
+
+        assert mock_runner.await_count == 0
+
+
+def test_non_eflomal_deleted_revision_returns_404(
+    client, regular_token1, db_session, test_db_session
+):
+    """Soft-deleted revision_id or reference_id must 404 for non-eflomal types too."""
+    from database.models import BibleRevision as BibleRevisionModel
+
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+    reference_id = upload_revision(client, regular_token1, version_id)
+
+    deleted_rev = (
+        test_db_session.query(BibleRevisionModel)
+        .filter(BibleRevisionModel.id == revision_id)
+        .one()
+    )
+    deleted_rev.deleted = True
+    test_db_session.commit()
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "agent-critique",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "revision_id does not exist."
+
+        # Symmetric case: soft-deleted reference
+        deleted_rev.deleted = False
+        deleted_ref = (
+            test_db_session.query(BibleRevisionModel)
+            .filter(BibleRevisionModel.id == reference_id)
+            .one()
+        )
+        deleted_ref.deleted = True
+        test_db_session.commit()
+
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "agent-critique",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "reference_id does not exist."
+
+        assert mock_runner.await_count == 0
+
+
 def test_use_eflomal_dedup_separate_from_regular(
     client, regular_token1, db_session, test_db_session
 ):


### PR DESCRIPTION
## Summary
- Hoist the source/target version-ID derivation in `POST /v3/assessment` out of the `if is_eflomal:` branch so it runs for every request that has a `revision_id`. Closes #637.
- The eflomal-only guard (must be `word-alignment`) stays. The eflomal 404-on-missing-revision behavior now also applies to other assessment types, catching mistakes at request time instead of after the runner spawns.
- Mapping (unchanged):
  - `source_version_id ← bible_version_id of reference_id` (or `None` if no `reference_id`)
  - `target_version_id ← bible_version_id of revision_id`

## Why
The version-id keying migration (aqua-api #615 / aqua-assessments #232) made these IDs load-bearing downstream. With them only being populated for eflomal, the agent runner was failing fast on every `agent-critique` assessment with `RuntimeError: Could not resolve iso_language for versions (None, None)`.

## Test plan
- [x] `test_non_eflomal_word_alignment_derives_version_ids` (renamed from `..._forwards_null_version_ids`) — was encoding the bug; now verifies the fix.
- [x] `test_agent_critique_derives_version_ids` — direct regression for the wire-failure case from the issue.
- [x] `test_no_reference_assessment_derives_target_only` — types without a reference (e.g. `sentence-length`): target derived, source `None`.
- [x] All pre-existing eflomal tests still pass (49/49 in `test_assessment_routes.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)