### PR TITLE
Make revision_id optional on POST /agent/lexeme-card (#640)

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -21,6 +21,7 @@ from database.models import (
     AgentTranslation,
     AgentWordAlignment,
     BibleRevision,
+    BibleVersion,
 )
 from database.models import UserDB as UserModel
 from models import (
@@ -566,6 +567,27 @@ async def add_lexeme_card(
                         f"is not in the card's version pair "
                         f"({card.source_version_id}, {card.target_version_id})"
                     ),
+                )
+        else:
+            # No revision context, so the in-pair check above can't validate
+            # the version FKs as a side effect. Verify both up front so an
+            # unknown ID surfaces as 404 instead of a 500 from the FK
+            # IntegrityError on commit.
+            requested_versions = {card.source_version_id, card.target_version_id}
+            found_versions = set(
+                (
+                    await db.scalars(
+                        select(BibleVersion.id).where(
+                            BibleVersion.id.in_(requested_versions)
+                        )
+                    )
+                ).all()
+            )
+            missing = requested_versions - found_versions
+            if missing:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Bible version(s) not found: {sorted(missing)}",
                 )
 
         # Sort alignment_scores by value in descending order (highest scores first)

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -4,6 +4,7 @@ import datetime
 import socket
 import time
 import unicodedata
+from typing import Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, Request, status
@@ -477,7 +478,7 @@ async def add_critique_issues(
 @router.post("/agent/lexeme-card", response_model=LexemeCardOut)
 async def add_lexeme_card(
     card: LexemeCardIn,
-    revision_id: int,
+    revision_id: Optional[int] = None,
     replace_existing: bool = False,
     is_user_edit: bool = False,
     db: AsyncSession = Depends(get_db),
@@ -492,7 +493,10 @@ async def add_lexeme_card(
 
     Input:
     - card: LexemeCardIn - The lexeme card data
-    - revision_id: int (required) - The Bible revision ID that the examples come from
+    - revision_id: int (optional) - The Bible revision ID that the examples come
+      from. Required only when `card.examples` is non-empty (top-level examples
+      are stored in a revision-scoped table). May be omitted for example-less
+      writes; the card itself is keyed only by version pair.
     - replace_existing: bool (optional, default=False) - If True, replaces list fields
       (surface_forms, senses) with new data and replaces examples for this revision_id.
       If False, appends new data to existing lists.
@@ -526,34 +530,44 @@ async def add_lexeme_card(
         from sqlalchemy.dialects.postgresql import insert as pg_insert
         from sqlalchemy.sql import func
 
-        # Examples must come from a revision in either the card's source or
-        # target version. The GET endpoint relies on this invariant when it
-        # filters examples by `BibleVersion.id IN (source_version_id,
-        # target_version_id)`; without this check, examples tied to revisions
-        # outside the pair would be silently invisible to all non-admin
-        # callers.
-        revision_version_id = await db.scalar(
-            select(BibleRevision.bible_version_id).where(
-                BibleRevision.id == revision_id
-            )
-        )
-        if revision_version_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Revision {revision_id} not found",
-            )
-        if revision_version_id not in {
-            card.source_version_id,
-            card.target_version_id,
-        }:
+        # Top-level `card.examples` are the only revision-scoped payload
+        # (they go to AgentLexemeCardExample, which carries the revision FK).
+        # Refuse to silently drop examples a caller bothered to send.
+        if card.examples and revision_id is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=(
-                    f"revision_id={revision_id} (version {revision_version_id}) "
-                    f"is not in the card's version pair "
-                    f"({card.source_version_id}, {card.target_version_id})"
-                ),
+                detail="revision_id is required when the card carries examples.",
             )
+
+        if revision_id is not None:
+            # Examples must come from a revision in either the card's source or
+            # target version. The GET endpoint relies on this invariant when it
+            # filters examples by `BibleVersion.id IN (source_version_id,
+            # target_version_id)`; without this check, examples tied to revisions
+            # outside the pair would be silently invisible to all non-admin
+            # callers.
+            revision_version_id = await db.scalar(
+                select(BibleRevision.bible_version_id).where(
+                    BibleRevision.id == revision_id
+                )
+            )
+            if revision_version_id is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Revision {revision_id} not found",
+                )
+            if revision_version_id not in {
+                card.source_version_id,
+                card.target_version_id,
+            }:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail=(
+                        f"revision_id={revision_id} (version {revision_version_id}) "
+                        f"is not in the card's version pair "
+                        f"({card.source_version_id}, {card.target_version_id})"
+                    ),
+                )
 
         # Sort alignment_scores by value in descending order (highest scores first)
         sorted_alignment_scores = None
@@ -602,39 +616,43 @@ async def add_lexeme_card(
                 existing_card.source_surface_forms = card.source_surface_forms
                 existing_card.senses = card.senses
 
-                # For examples: delete existing examples for this revision and add new ones
-                if card.examples is not None:
-                    # Delete existing examples for this lexeme card + revision
-                    delete_query = delete(AgentLexemeCardExample).where(
-                        AgentLexemeCardExample.lexeme_card_id == existing_card.id,
-                        AgentLexemeCardExample.revision_id == revision_id,
-                    )
-                    await db.execute(delete_query)
-
-                    # Add new examples; ON CONFLICT DO NOTHING silently skips any
-                    # duplicate (source_text, target_text) pairs within the payload.
-                    example_records = [
-                        {
-                            "lexeme_card_id": existing_card.id,
-                            "revision_id": revision_id,
-                            "source_text": example.get("source", ""),
-                            "target_text": example.get("target", ""),
-                        }
-                        for example in card.examples
-                    ]
-                    if example_records:
-                        await db.execute(
-                            pg_insert(AgentLexemeCardExample).values(example_records)
-                            # Relies on ix_agent_lexeme_card_examples_unique
-                            .on_conflict_do_nothing()
+                # For examples: delete existing examples for this revision and add new ones.
+                # When revision_id is None, the caller has no revision context
+                # (validated above to imply no examples), so leave the examples
+                # table untouched.
+                if revision_id is not None:
+                    if card.examples is not None:
+                        # Delete existing examples for this lexeme card + revision
+                        delete_query = delete(AgentLexemeCardExample).where(
+                            AgentLexemeCardExample.lexeme_card_id == existing_card.id,
+                            AgentLexemeCardExample.revision_id == revision_id,
                         )
-                else:
-                    # If examples is None and replace_existing=True, remove this revision's examples
-                    delete_query = delete(AgentLexemeCardExample).where(
-                        AgentLexemeCardExample.lexeme_card_id == existing_card.id,
-                        AgentLexemeCardExample.revision_id == revision_id,
-                    )
-                    await db.execute(delete_query)
+                        await db.execute(delete_query)
+
+                        # Add new examples; ON CONFLICT DO NOTHING silently skips any
+                        # duplicate (source_text, target_text) pairs within the payload.
+                        example_records = [
+                            {
+                                "lexeme_card_id": existing_card.id,
+                                "revision_id": revision_id,
+                                "source_text": example.get("source", ""),
+                                "target_text": example.get("target", ""),
+                            }
+                            for example in card.examples
+                        ]
+                        if example_records:
+                            await db.execute(
+                                pg_insert(AgentLexemeCardExample).values(example_records)
+                                # Relies on ix_agent_lexeme_card_examples_unique
+                                .on_conflict_do_nothing()
+                            )
+                    else:
+                        # If examples is None and replace_existing=True, remove this revision's examples
+                        delete_query = delete(AgentLexemeCardExample).where(
+                            AgentLexemeCardExample.lexeme_card_id == existing_card.id,
+                            AgentLexemeCardExample.revision_id == revision_id,
+                        )
+                        await db.execute(delete_query)
             else:
                 # Append new data to existing lists
                 if card.surface_forms:
@@ -661,7 +679,7 @@ async def add_lexeme_card(
                 # Use ON CONFLICT DO NOTHING so duplicates (already inserted for
                 # the same lexeme_card / revision / source / target) are silently
                 # skipped instead of raising IntegrityError.
-                if card.examples:
+                if card.examples and revision_id is not None:
                     example_records = [
                         {
                             "lexeme_card_id": existing_card.id,
@@ -680,23 +698,25 @@ async def add_lexeme_card(
             await db.commit()
             await db.refresh(existing_card)
 
-            # Query examples for this revision_id, ordered by ID (insertion order)
-            examples_query = (
-                select(AgentLexemeCardExample)
-                .where(
-                    AgentLexemeCardExample.lexeme_card_id == existing_card.id,
-                    AgentLexemeCardExample.revision_id == revision_id,
+            # Query examples for this revision_id, ordered by ID (insertion order).
+            # Without a revision_id there's no scope to query against, so return [].
+            if revision_id is None:
+                examples_list = []
+            else:
+                examples_query = (
+                    select(AgentLexemeCardExample)
+                    .where(
+                        AgentLexemeCardExample.lexeme_card_id == existing_card.id,
+                        AgentLexemeCardExample.revision_id == revision_id,
+                    )
+                    .order_by(AgentLexemeCardExample.id)
                 )
-                .order_by(AgentLexemeCardExample.id)
-            )
-            examples_result = await db.execute(examples_query)
-            examples_objs = examples_result.scalars().all()
-
-            # Convert to list of dicts
-            examples_list = [
-                {"source": ex.source_text, "target": ex.target_text}
-                for ex in examples_objs
-            ]
+                examples_result = await db.execute(examples_query)
+                examples_objs = examples_result.scalars().all()
+                examples_list = [
+                    {"source": ex.source_text, "target": ex.target_text}
+                    for ex in examples_objs
+                ]
 
             # Return card with only the examples for this revision_id
             card_dict = {
@@ -750,7 +770,7 @@ async def add_lexeme_card(
 
             # Add examples to the separate table. Use ON CONFLICT DO NOTHING to
             # tolerate duplicate (source_text, target_text) entries in the payload.
-            if card.examples:
+            if card.examples and revision_id is not None:
                 example_records = [
                     {
                         "lexeme_card_id": lexeme_card.id,
@@ -769,23 +789,25 @@ async def add_lexeme_card(
             await db.commit()
             await db.refresh(lexeme_card)
 
-            # Query examples for this revision_id, ordered by ID (insertion order)
-            examples_query = (
-                select(AgentLexemeCardExample)
-                .where(
-                    AgentLexemeCardExample.lexeme_card_id == lexeme_card.id,
-                    AgentLexemeCardExample.revision_id == revision_id,
+            # Query examples for this revision_id, ordered by ID (insertion order).
+            # Without a revision_id there's no scope to query against, so return [].
+            if revision_id is None:
+                examples_list = []
+            else:
+                examples_query = (
+                    select(AgentLexemeCardExample)
+                    .where(
+                        AgentLexemeCardExample.lexeme_card_id == lexeme_card.id,
+                        AgentLexemeCardExample.revision_id == revision_id,
+                    )
+                    .order_by(AgentLexemeCardExample.id)
                 )
-                .order_by(AgentLexemeCardExample.id)
-            )
-            examples_result = await db.execute(examples_query)
-            examples_objs = examples_result.scalars().all()
-
-            # Convert to list of dicts
-            examples_list = [
-                {"source": ex.source_text, "target": ex.target_text}
-                for ex in examples_objs
-            ]
+                examples_result = await db.execute(examples_query)
+                examples_objs = examples_result.scalars().all()
+                examples_list = [
+                    {"source": ex.source_text, "target": ex.target_text}
+                    for ex in examples_objs
+                ]
 
             # Return card with only the examples for this revision_id
             card_dict = {

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -642,7 +642,9 @@ async def add_lexeme_card(
                         ]
                         if example_records:
                             await db.execute(
-                                pg_insert(AgentLexemeCardExample).values(example_records)
+                                pg_insert(AgentLexemeCardExample).values(
+                                    example_records
+                                )
                                 # Relies on ix_agent_lexeme_card_examples_unique
                                 .on_conflict_do_nothing()
                             )

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -4,7 +4,6 @@ import datetime
 import socket
 import time
 import unicodedata
-from typing import Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, Request, status
@@ -478,7 +477,7 @@ async def add_critique_issues(
 @router.post("/agent/lexeme-card", response_model=LexemeCardOut)
 async def add_lexeme_card(
     card: LexemeCardIn,
-    revision_id: Optional[int] = None,
+    revision_id: int | None = None,
     replace_existing: bool = False,
     is_user_edit: bool = False,
     db: AsyncSession = Depends(get_db),
@@ -530,9 +529,9 @@ async def add_lexeme_card(
         from sqlalchemy.dialects.postgresql import insert as pg_insert
         from sqlalchemy.sql import func
 
-        # Top-level `card.examples` are the only revision-scoped payload
-        # (they go to AgentLexemeCardExample, which carries the revision FK).
-        # Refuse to silently drop examples a caller bothered to send.
+        # Top-level `card.examples` are revision-scoped (they write to
+        # AgentLexemeCardExample, which carries the revision FK). An empty
+        # list is treated as "no examples" and accepted without a revision.
         if card.examples and revision_id is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
@@ -649,7 +648,8 @@ async def add_lexeme_card(
                                 .on_conflict_do_nothing()
                             )
                     else:
-                        # If examples is None and replace_existing=True, remove this revision's examples
+                        # examples is None: caller explicitly wants this
+                        # revision's examples wiped. Delete without re-inserting.
                         delete_query = delete(AgentLexemeCardExample).where(
                             AgentLexemeCardExample.lexeme_card_id == existing_card.id,
                             AgentLexemeCardExample.revision_id == revision_id,

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1038,6 +1038,27 @@ def test_add_lexeme_card_examples_with_unknown_revision_id_fails(
     assert "999999" in response.json()["detail"]
 
 
+def test_add_lexeme_card_unknown_version_id_without_revision_id_returns_404(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+):
+    """Without revision_id, an unknown version_id must surface as 404 — not a 500 from FK violation."""
+    response = client.post(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "bogus_version_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": 999998,
+        },
+    )
+
+    assert response.status_code == 404
+    assert "999998" in response.json()["detail"]
+
+
 def test_add_lexeme_card_empty_examples_without_revision_id_succeeds(
     client,
     regular_token1,

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1038,6 +1038,171 @@ def test_add_lexeme_card_examples_with_unknown_revision_id_fails(
     assert "999999" in response.json()["detail"]
 
 
+def test_add_lexeme_card_empty_examples_without_revision_id_succeeds(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+    test_version_id_2,
+):
+    """An explicit empty `examples` list is treated as 'no examples' — no revision_id needed."""
+    response = client.post(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "empty_examples_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "examples": [],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["examples"] == []
+
+
+def test_add_lexeme_card_sense_examples_without_revision_id_succeeds(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+    test_version_id_2,
+):
+    """Sense-level examples live in the senses JSONB column and aren't revision-scoped."""
+    response = client.post(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "sense_examples_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "senses": [
+                {
+                    "definition": "to drink",
+                    "examples": ["I drink water", "She drinks tea"],
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["senses"][0]["examples"] == ["I drink water", "She drinks tea"]
+    assert data["examples"] == []
+
+
+def test_add_lexeme_card_upsert_replace_no_revision_preserves_prior_examples(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """replace_existing=true upsert without revision_id must NOT touch prior-revision examples."""
+    target_lemma = "preserve_replace_lemma"
+
+    # Seed: create the card with one example bound to test_revision_id.
+    seed = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": target_lemma,
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "examples": [{"source": "I drink", "target": "Ninakunywa"}],
+        },
+    )
+    assert seed.status_code == 200
+    assert len(seed.json()["examples"]) == 1
+
+    # Re-POST the same card without a revision_id and with replace_existing=true.
+    # Without a revision context, the examples table must be left alone, and
+    # the response must surface examples=[] (no scope to fetch from).
+    upsert = client.post(
+        "/v3/agent/lexeme-card?replace_existing=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": target_lemma,
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "pos": "verb",
+        },
+    )
+    assert upsert.status_code == 200
+    assert upsert.json()["examples"] == []
+    assert upsert.json()["pos"] == "verb"
+
+    # Re-fetch with the original revision_id: the seeded example is still there.
+    refetch = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": target_lemma,
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+        },
+    )
+    assert refetch.status_code == 200
+    assert len(refetch.json()["examples"]) == 1
+    assert refetch.json()["examples"][0]["target"] == "Ninakunywa"
+
+
+def test_add_lexeme_card_upsert_append_no_revision_preserves_prior_examples(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Append-mode upsert without revision_id must NOT drop prior-revision examples."""
+    target_lemma = "preserve_append_lemma"
+
+    seed = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": target_lemma,
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "surface_forms": ["original_form"],
+            "examples": [{"source": "I drink", "target": "Ninakunywa"}],
+        },
+    )
+    assert seed.status_code == 200
+    assert len(seed.json()["examples"]) == 1
+
+    # Append-mode upsert (replace_existing default false) without revision_id.
+    upsert = client.post(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": target_lemma,
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "surface_forms": ["appended_form"],
+        },
+    )
+    assert upsert.status_code == 200
+    assert upsert.json()["examples"] == []
+    assert "appended_form" in upsert.json()["surface_forms"]
+    assert "original_form" in upsert.json()["surface_forms"]
+
+    refetch = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": target_lemma,
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+        },
+    )
+    assert refetch.status_code == 200
+    assert len(refetch.json()["examples"]) == 1
+    assert refetch.json()["examples"][0]["target"] == "Ninakunywa"
+
+
 def test_add_lexeme_card_different_languages(
     client,
     regular_token1,

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -966,6 +966,78 @@ def test_add_lexeme_card_revision_not_in_version_pair(
     assert "version pair" in response.json()["detail"].lower()
 
 
+def test_add_lexeme_card_without_revision_id_succeeds(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+    test_version_id_2,
+):
+    """A card with no examples may omit revision_id — it is purely version-keyed."""
+    response = client.post(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "water",
+            "target_lemma": "no_rev_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "senses": [{"definition": "the clear liquid", "examples": []}],
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["target_lemma"] == "no_rev_lemma"
+    assert data["examples"] == []
+
+
+def test_add_lexeme_card_examples_without_revision_id_fails(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+    test_version_id_2,
+):
+    """Sending examples without a revision_id is rejected — the examples table is revision-keyed."""
+    response = client.post(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "needs_rev_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "examples": [{"source": "water", "target": "maji"}],
+        },
+    )
+
+    assert response.status_code == 422
+    assert "revision_id" in response.json()["detail"].lower()
+
+
+def test_add_lexeme_card_examples_with_unknown_revision_id_fails(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+    test_version_id_2,
+):
+    """A revision_id pointing to a nonexistent revision still returns 404 when supplied."""
+    response = client.post(
+        "/v3/agent/lexeme-card?revision_id=999999",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "bogus_rev_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "examples": [{"source": "water", "target": "maji"}],
+        },
+    )
+
+    assert response.status_code == 404
+    assert "999999" in response.json()["detail"]
+
+
 def test_add_lexeme_card_different_languages(
     client,
     regular_token1,


### PR DESCRIPTION
## Summary

- `POST /agent/lexeme-card` now treats `revision_id` as `Optional[int] = None` instead of required. The lexeme card itself is keyed by `(target_lemma, source_version_id, target_version_id)`; only top-level `card.examples` are revision-scoped (they write to `AgentLexemeCardExample`), so a `revision_id` is only required when those are present.
- Validation: if `card.examples` is non-empty but `revision_id` is omitted → 422 with a clear message. If `revision_id` is supplied, the existing exists-and-in-pair checks still run unchanged. Example writes and the post-op example query no-op when `revision_id` is `None`.
- Unblocks predict()'s LLM-discovered-lexeme path in aqua-assessments, which has version_ids but no revision context and was being forced into the `revision_id or 0` fallback that surfaced as `404 Revision 0 not found`.

Closes #640.

## Test plan

- [x] Existing 101 lexeme-card tests pass unchanged
- [x] New `test_add_lexeme_card_without_revision_id_succeeds` — example-less card without `revision_id` returns 200 and `examples=[]`
- [x] New `test_add_lexeme_card_examples_without_revision_id_fails` — card with `examples` but no `revision_id` returns 422 mentioning `revision_id`
- [x] New `test_add_lexeme_card_examples_with_unknown_revision_id_fails` — `revision_id=999999` with examples returns 404 (validation still fires when `revision_id` is provided)
- [x] `test_lexeme_card_access_control.py` (3 tests) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)