### PR TITLE
Switch /v3/textsearch to version_id keying with per-vref best-revision pick

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -119,8 +119,10 @@ def _side_subquery(
         )
         if ilike_pattern is not None:
             q = q.where(_nfc_sql(vt.text).ilike(ilike_pattern))
+        # br.id.desc() is a stable tie-breaker so the per-vref pick is
+        # deterministic when two revisions share the same date.
         q = q.distinct(vt.book, vt.chapter, vt.verse).order_by(
-            vt.book, vt.chapter, vt.verse, br.date.desc()
+            vt.book, vt.chapter, vt.verse, br.date.desc(), br.id.desc()
         )
     else:
         q = select(*select_cols).where(
@@ -140,14 +142,20 @@ async def search_revision_text(
     version_id: Optional[int] = Query(
         default=None,
         description=(
-            "Bible version id; searches the latest non-empty revision per verse "
-            "across all accessible revisions for this version."
+            "Bible version id; per (book, chapter, verse) returns the latest "
+            "non-empty revision whose text matches the search term, with older "
+            "revisions filling gaps where the latest revision is empty or "
+            "doesn't contain the term."
         ),
     ),
     comparison_revision_id: Optional[int] = None,
     comparison_version_id: Optional[int] = Query(
         default=None,
-        description="Bible version id for comparison text (per-vref latest non-empty)",
+        description=(
+            "Bible version id for comparison text; per (book, chapter, verse) "
+            "returns the latest non-empty revision (no search-term filter on "
+            "the comparison side)."
+        ),
     ),
     limit: int = Query(default=10, ge=1, le=1000),
     random: bool = False,

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -35,7 +35,7 @@ def _nfc_sql(col):
 
 def _authorized_revisions_select(
     user: UserModel,
-    iso: Optional[str] = None,
+    version_id: Optional[int] = None,
     revision_id: Optional[int] = None,
 ):
     """Return a SELECT of revision IDs the user may access, optionally scoped.
@@ -45,8 +45,8 @@ def _authorized_revisions_select(
     standalone to distinguish "no access" (empty) from "no text matches"
     (non-empty) when the main search returns zero rows.
     """
-    if iso is None and revision_id is None:
-        raise ValueError("at least one of iso or revision_id must be provided")
+    if version_id is None and revision_id is None:
+        raise ValueError("at least one of version_id or revision_id must be provided")
     q = (
         select(BibleRevision.id)
         .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
@@ -57,8 +57,8 @@ def _authorized_revisions_select(
     )
     if revision_id is not None:
         q = q.where(BibleRevision.id == revision_id)
-    elif iso is not None:
-        q = q.where(BibleVersion.iso_language == iso)
+    elif version_id is not None:
+        q = q.where(BibleVersion.id == version_id)
 
     if not user.is_admin:
         user_groups_subq = (
@@ -75,22 +75,79 @@ def _authorized_revisions_select(
     return q
 
 
+def _side_subquery(
+    user: UserModel,
+    version_id: Optional[int],
+    revision_id: Optional[int],
+    ilike_pattern: Optional[str],
+):
+    """Build a subquery yielding one verse_text row per (book, chapter, verse).
+
+    For ``version_id``, applies ``DISTINCT ON (book, chapter, verse)`` ordered
+    by ``bible_revision.date DESC`` so the latest non-empty revision wins per
+    vref, with older revisions filling gaps where the latest revision lacks
+    the verse (empty text or no row).
+
+    For ``revision_id``, simply filters by revision id (one row per vref by
+    construction). Empty-text rows are excluded in both modes.
+
+    Authorization is enforced inline via :func:`_authorized_revisions_select`,
+    so unauthorized callers get an empty subquery (zero rows).
+    """
+    auth_revs = _authorized_revisions_select(
+        user, version_id=version_id, revision_id=revision_id
+    )
+
+    vt = aliased(VerseText)
+    select_cols = [
+        vt.id.label("id"),
+        vt.book.label("book"),
+        vt.chapter.label("chapter"),
+        vt.verse.label("verse"),
+        vt.text.label("text"),
+    ]
+
+    if version_id is not None:
+        br = aliased(BibleRevision)
+        q = (
+            select(*select_cols)
+            .join(br, br.id == vt.revision_id)
+            .where(
+                vt.revision_id.in_(auth_revs),
+                vt.text != "",
+            )
+        )
+        if ilike_pattern is not None:
+            q = q.where(_nfc_sql(vt.text).ilike(ilike_pattern))
+        q = q.distinct(vt.book, vt.chapter, vt.verse).order_by(
+            vt.book, vt.chapter, vt.verse, br.date.desc()
+        )
+    else:
+        q = select(*select_cols).where(
+            vt.revision_id.in_(auth_revs),
+            vt.text != "",
+        )
+        if ilike_pattern is not None:
+            q = q.where(_nfc_sql(vt.text).ilike(ilike_pattern))
+
+    return q.subquery()
+
+
 @router.get("/textsearch")
 async def search_revision_text(
     term: str = Query(..., min_length=1, max_length=200),
     revision_id: Optional[int] = None,
-    iso: Optional[str] = Query(
+    version_id: Optional[int] = Query(
         default=None,
-        min_length=3,
-        max_length=3,
-        description="ISO 639-3 code; searches all accessible revisions for this language",
+        description=(
+            "Bible version id; searches the latest non-empty revision per verse "
+            "across all accessible revisions for this version."
+        ),
     ),
     comparison_revision_id: Optional[int] = None,
-    comparison_iso: Optional[str] = Query(
+    comparison_version_id: Optional[int] = Query(
         default=None,
-        min_length=3,
-        max_length=3,
-        description="ISO 639-3 code for comparison text",
+        description="Bible version id for comparison text (per-vref latest non-empty)",
     ),
     limit: int = Query(default=10, ge=1, le=1000),
     random: bool = False,
@@ -117,32 +174,33 @@ async def search_revision_text(
     not cross a word boundary. The term must contain at least one visible
     (non-whitespace, non-format) character.
 
-    Provide either ``revision_id`` or ``iso`` (not both).  When ``iso`` is
-    given, all accessible revisions for that language are searched and results
-    are deduplicated by verse location (book, chapter, verse).  When multiple
-    revisions cover the same verse, one is chosen arbitrarily.
+    Provide exactly one of ``revision_id`` or ``version_id``.  When
+    ``version_id`` is given, results are deduplicated by verse location
+    (book, chapter, verse): for each verse, the most recent non-empty
+    revision belonging to that version is chosen.  Older revisions only
+    fill gaps where the most recent revision lacks the verse.
 
-    Similarly, provide either ``comparison_revision_id`` or ``comparison_iso``
-    for parallel text.  When ``comparison_iso`` resolves to multiple revisions,
-    one comparison text per verse is returned (non-deterministic choice).
+    Optionally provide at most one of ``comparison_revision_id`` or
+    ``comparison_version_id`` for parallel text. The same per-vref
+    best-revision pick applies to ``comparison_version_id``.
     """
     request_start = time.perf_counter()
 
     # --- validate parameter combinations ---------------------------------
-    if revision_id is not None and iso is not None:
+    if revision_id is not None and version_id is not None:
         raise HTTPException(
             status_code=400,
-            detail="Provide either revision_id or iso, not both",
+            detail="Provide either revision_id or version_id, not both",
         )
-    if revision_id is None and iso is None:
+    if revision_id is None and version_id is None:
         raise HTTPException(
             status_code=400,
-            detail="Either revision_id or iso is required",
+            detail="Either revision_id or version_id is required",
         )
-    if comparison_revision_id is not None and comparison_iso is not None:
+    if comparison_revision_id is not None and comparison_version_id is not None:
         raise HTTPException(
             status_code=400,
-            detail="Provide either comparison_revision_id or comparison_iso, not both",
+            detail="Provide either comparison_revision_id or comparison_version_id, not both",
         )
 
     # Parse `*` wildcards. A leading/trailing `*` drops the word boundary
@@ -182,23 +240,6 @@ async def search_revision_text(
             detail="Term must contain at least one visible character",
         )
 
-    # Build authorization subqueries (executed inline with the search query
-    # so auth + search are a single DB round-trip in the success case).
-    main_auth_select = _authorized_revisions_select(
-        current_user, iso=iso, revision_id=revision_id
-    )
-    comp_auth_select = None
-    if comparison_revision_id is not None or comparison_iso is not None:
-        comp_auth_select = _authorized_revisions_select(
-            current_user,
-            iso=comparison_iso,
-            revision_id=comparison_revision_id,
-        )
-
-    use_dedup = iso is not None
-    use_comparison = comp_auth_select is not None
-    comp_dedup = comparison_iso is not None
-
     # Normalize each piece to NFC so accented characters match regardless
     # of whether the query or stored text uses composed vs decomposed forms.
     normalized_pieces = [unicodedata.normalize("NFC", p) for p in pieces]
@@ -214,63 +255,48 @@ async def search_revision_text(
     ]
     like_pattern = "%" + "%".join(escaped_pieces) + "%"
 
-    # Build the base query
-    vt1_alias = aliased(VerseText, name="vt1")
-
+    # Build per-side subqueries. Each subquery produces one row per
+    # (book, chapter, verse): a single revision pick for revision_id mode
+    # or the date-DESC latest non-empty pick for version_id mode.
+    main_sub = _side_subquery(
+        current_user,
+        version_id=version_id,
+        revision_id=revision_id,
+        ilike_pattern=like_pattern,
+    )
+    use_comparison = (
+        comparison_revision_id is not None or comparison_version_id is not None
+    )
     if use_comparison:
-        vt2_alias = aliased(VerseText, name="vt2")
-
-        select_cols = [
-            vt1_alias.id.label("id"),
-            vt1_alias.book.label("book"),
-            vt1_alias.chapter.label("chapter"),
-            vt1_alias.verse.label("verse"),
-            vt1_alias.text.label("main_text"),
-            vt2_alias.text.label("comparison_text"),
-        ]
-
-        search_query = (
-            select(*select_cols)
-            .join(
-                vt2_alias,
-                (vt2_alias.book == vt1_alias.book)
-                & (vt2_alias.chapter == vt1_alias.chapter)
-                & (vt2_alias.verse == vt1_alias.verse)
-                & (vt2_alias.revision_id.in_(comp_auth_select)),
-            )
-            .where(
-                vt1_alias.revision_id.in_(main_auth_select),
-                _nfc_sql(vt1_alias.text).ilike(like_pattern),
-                vt1_alias.text != "",
-                vt2_alias.text != "",
+        comp_sub = _side_subquery(
+            current_user,
+            version_id=comparison_version_id,
+            revision_id=comparison_revision_id,
+            ilike_pattern=None,
+        )
+        search_query = select(
+            main_sub.c.id.label("id"),
+            main_sub.c.book.label("book"),
+            main_sub.c.chapter.label("chapter"),
+            main_sub.c.verse.label("verse"),
+            main_sub.c.text.label("main_text"),
+            comp_sub.c.text.label("comparison_text"),
+        ).select_from(
+            main_sub.join(
+                comp_sub,
+                (comp_sub.c.book == main_sub.c.book)
+                & (comp_sub.c.chapter == main_sub.c.chapter)
+                & (comp_sub.c.verse == main_sub.c.verse),
             )
         )
-
-        if use_dedup or comp_dedup:
-            search_query = search_query.distinct(
-                vt1_alias.book,
-                vt1_alias.chapter,
-                vt1_alias.verse,
-            )
     else:
         search_query = select(
-            vt1_alias.id.label("id"),
-            vt1_alias.book.label("book"),
-            vt1_alias.chapter.label("chapter"),
-            vt1_alias.verse.label("verse"),
-            vt1_alias.text.label("main_text"),
-        ).where(
-            vt1_alias.revision_id.in_(main_auth_select),
-            _nfc_sql(vt1_alias.text).ilike(like_pattern),
-            vt1_alias.text != "",
-        )
-
-        if use_dedup:
-            search_query = search_query.distinct(
-                vt1_alias.book,
-                vt1_alias.chapter,
-                vt1_alias.verse,
-            )
+            main_sub.c.id.label("id"),
+            main_sub.c.book.label("book"),
+            main_sub.c.chapter.label("chapter"),
+            main_sub.c.verse.label("verse"),
+            main_sub.c.text.label("main_text"),
+        ).select_from(main_sub)
 
     # Cap the DB result set. The Python-side whole-word filter may discard
     # ilike matches that aren't whole words, so we overfetch to give enough
@@ -285,25 +311,26 @@ async def search_revision_text(
     sql_limit = min(limit * 10 * len(pieces), SQL_LIMIT_ABS_CAP)
     search_query = search_query.limit(sql_limit)
 
-    # Apply ordering.  DISTINCT ON requires the leading ORDER BY columns to
-    # match, so when dedup is active we always order by (book, chapter, verse)
-    # first.  For random mode with dedup, we wrap the deduped result as a
-    # subquery and randomise the outer query.
-    needs_dedup = use_dedup or comp_dedup
-    if needs_dedup:
-        search_query = search_query.order_by(
-            vt1_alias.book, vt1_alias.chapter, vt1_alias.verse
-        )
-        if random:
-            sub = search_query.subquery()
-            search_query = select(sub).order_by(func.random())
+    # Apply ordering on the outer query. Per-side dedup is already handled
+    # inside main_sub / comp_sub, so the outer query is free to randomize
+    # without violating DISTINCT ON's leading-column rule.
+    if random:
+        search_query = search_query.order_by(func.random())
     else:
-        if random:
-            search_query = search_query.order_by(func.random())
-        else:
-            search_query = search_query.order_by(
-                vt1_alias.book, vt1_alias.chapter, vt1_alias.verse
-            )
+        search_query = search_query.order_by(
+            main_sub.c.book, main_sub.c.chapter, main_sub.c.verse
+        )
+
+    main_auth_select = _authorized_revisions_select(
+        current_user, version_id=version_id, revision_id=revision_id
+    )
+    comp_auth_select = None
+    if use_comparison:
+        comp_auth_select = _authorized_revisions_select(
+            current_user,
+            version_id=comparison_version_id,
+            revision_id=comparison_revision_id,
+        )
 
     try:
         # Execute the query
@@ -315,10 +342,13 @@ async def search_revision_text(
         if not rows:
             auth_row = (await db.execute(main_auth_select.limit(1))).scalars().first()
             if auth_row is None:
-                if iso is not None:
+                if version_id is not None:
                     raise HTTPException(
                         status_code=404,
-                        detail=f"No accessible revisions found for iso '{iso}'",
+                        detail=(
+                            f"No accessible revisions found for version_id "
+                            f"'{version_id}'"
+                        ),
                     )
                 # revision_id path: non-admins get 403 (unauthorized or
                 # non-existent — indistinguishable by design). Admins are
@@ -335,12 +365,12 @@ async def search_revision_text(
                     (await db.execute(comp_auth_select.limit(1))).scalars().first()
                 )
                 if comp_auth_row is None:
-                    if comparison_iso is not None:
+                    if comparison_version_id is not None:
                         raise HTTPException(
                             status_code=404,
                             detail=(
-                                f"No accessible revisions found for comparison iso "
-                                f"'{comparison_iso}'"
+                                f"No accessible revisions found for "
+                                f"comparison_version_id '{comparison_version_id}'"
                             ),
                         )
                     if not current_user.is_admin:
@@ -397,10 +427,10 @@ async def search_revision_text(
                 "method": "GET",
                 "path": "/textsearch",
                 "revision_id": revision_id,
-                "iso": iso,
+                "version_id": version_id,
                 "term": term,
                 "comparison_revision_id": comparison_revision_id,
-                "comparison_iso": comparison_iso,
+                "comparison_version_id": comparison_version_id,
                 "limit": limit,
                 "random": random,
                 "results_returned": len(filtered_results),
@@ -424,7 +454,7 @@ async def search_revision_text(
                 "method": "GET",
                 "path": "/textsearch",
                 "revision_id": revision_id,
-                "iso": iso,
+                "version_id": version_id,
                 "term": term,
             },
         )

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -177,12 +177,17 @@ async def search_revision_text(
     Provide exactly one of ``revision_id`` or ``version_id``.  When
     ``version_id`` is given, results are deduplicated by verse location
     (book, chapter, verse): for each verse, the most recent non-empty
-    revision belonging to that version is chosen.  Older revisions only
-    fill gaps where the most recent revision lacks the verse.
+    *matching* revision belonging to that version is chosen.  The ILIKE
+    prefilter is applied before per-vref dedup, so older revisions fill
+    gaps where the most recent revision lacks the verse (empty text) or
+    doesn't contain the search term — i.e. results surface the term wherever
+    it appears in the version's history, preferring the newer wording when
+    multiple revisions match.
 
     Optionally provide at most one of ``comparison_revision_id`` or
-    ``comparison_version_id`` for parallel text. The same per-vref
-    best-revision pick applies to ``comparison_version_id``.
+    ``comparison_version_id`` for parallel text. For ``comparison_version_id``
+    the same per-vref pick applies (latest non-empty wins; the search term
+    is only required on the main side, not on the comparison).
     """
     request_start = time.perf_counter()
 

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -953,32 +953,33 @@ def test_search_accented_uppercase_query(client, regular_token1, test_db_session
     ), f"Expected uppercase accented query to match; got {data}"
 
 
-def test_search_accented_via_iso_multi_revision(
+def test_search_accented_via_version_multi_revision(
     client, regular_token1, test_db_session
 ):
-    """Accented search via iso= must match across NFD-stored revisions and dedup."""
+    """Accented search via version_id must dedup across NFD-stored revisions."""
     user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
     group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
 
     nfd_word = unicodedata.normalize("NFD", "ásaatile")
 
-    # Two eng versions, both with the same accented word on the same verse
-    rev_ids = []
-    for i, abbrev in enumerate(("IsoAccA", "IsoAccB")):
-        version = BibleVersion(
-            name=f"Iso Accent {i}",
-            iso_language="eng",
-            iso_script="Latn",
-            abbreviation=abbrev,
-            owner_id=user1.id,
-            is_reference=False,
-        )
-        test_db_session.add(version)
-        test_db_session.commit()
-        test_db_session.refresh(version)
+    # One eng version with two revisions, both holding the same accented word
+    # on the same verse — per-vref dedup should collapse to one result.
+    version = BibleVersion(
+        name="Version Accent",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="VAC",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add(version)
+    test_db_session.commit()
+    test_db_session.refresh(version)
 
+    rev_ids = []
+    for i, day_offset in enumerate((1, 2)):
         revision = BibleRevision(
-            date=date.today(),
+            date=date(2024, 1, day_offset),
             bible_version_id=version.id,
             published=True,
             machine_translation=False,
@@ -997,17 +998,17 @@ def test_search_accented_via_iso_multi_revision(
                 verse=2,
             )
         )
-        test_db_session.add(
-            BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
-        )
         rev_ids.append(revision.id)
+    test_db_session.add(
+        BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+    )
     test_db_session.commit()
     assert len(rev_ids) == 2, f"Expected 2 revisions to be created, got {rev_ids}"
 
     nfc_query = unicodedata.normalize("NFC", "ásaatile")
     response = client.get(
         "/v3/textsearch",
-        params={"iso": "eng", "term": nfc_query, "limit": 10},
+        params={"version_id": version.id, "term": nfc_query, "limit": 10},
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1023,11 +1024,16 @@ def test_search_accented_via_iso_multi_revision(
     assert len(refs) == len(set(refs)), "Expected deduplicated results"
 
 
-# --- ISO-based search tests ---
+# --- version_id-based search tests ---
 
 
-def setup_iso_search_test_data(db_session):
-    """Setup test data for ISO-based search with multiple revisions per language."""
+def setup_version_search_test_data(db_session):
+    """Set up multi-revision data for version_id-based search.
+
+    One English version with two revisions (older + newer), each holding the
+    same set of vrefs with different wording. The newer revision should win
+    the per-vref pick. Plus a Swahili version for comparison_version_id.
+    """
     user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
     group1 = db_session.query(Group).filter(Group.name == "Group1").first()
 
@@ -1039,46 +1045,37 @@ def setup_iso_search_test_data(db_session):
         db_session.add(IsoLanguage(iso639="swh", name="Swahili"))
         db_session.commit()
 
-    # --- Two English versions (same language) with overlapping verses ---
-    eng_version_a = BibleVersion(
-        name="ISO Test Eng A",
+    eng_version = BibleVersion(
+        name="Version Search Eng",
         iso_language="eng",
         iso_script="Latn",
-        abbreviation="IEA",
+        abbreviation="VSE",
         owner_id=user1.id,
         is_reference=False,
     )
-    eng_version_b = BibleVersion(
-        name="ISO Test Eng B",
-        iso_language="eng",
-        iso_script="Latn",
-        abbreviation="IEB",
-        owner_id=user1.id,
-        is_reference=False,
-    )
-    db_session.add_all([eng_version_a, eng_version_b])
+    db_session.add(eng_version)
     db_session.commit()
-    db_session.refresh(eng_version_a)
-    db_session.refresh(eng_version_b)
+    db_session.refresh(eng_version)
 
-    eng_rev_a = BibleRevision(
-        date=date.today(),
-        bible_version_id=eng_version_a.id,
+    # Older revision wording
+    eng_rev_old = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=eng_version.id,
         published=True,
         machine_translation=False,
     )
-    eng_rev_b = BibleRevision(
-        date=date.today(),
-        bible_version_id=eng_version_b.id,
+    # Newer revision wording — should win the per-vref pick
+    eng_rev_new = BibleRevision(
+        date=date(2024, 6, 1),
+        bible_version_id=eng_version.id,
         published=True,
         machine_translation=False,
     )
-    db_session.add_all([eng_rev_a, eng_rev_b])
+    db_session.add_all([eng_rev_old, eng_rev_new])
     db_session.commit()
-    db_session.refresh(eng_rev_a)
-    db_session.refresh(eng_rev_b)
+    db_session.refresh(eng_rev_old)
+    db_session.refresh(eng_rev_new)
 
-    # Revision A has GEN 1:1 and GEN 1:3
     for book, chapter, verse, text in [
         ("GEN", 1, 1, "In the beginning God created the heaven and the earth."),
         ("GEN", 1, 3, "And God said, Let there be light: and there was light."),
@@ -1086,7 +1083,7 @@ def setup_iso_search_test_data(db_session):
         db_session.add(
             VerseText(
                 text=text,
-                revision_id=eng_rev_a.id,
+                revision_id=eng_rev_old.id,
                 verse_reference=f"{book} {chapter}:{verse}",
                 book=book,
                 chapter=chapter,
@@ -1094,7 +1091,6 @@ def setup_iso_search_test_data(db_session):
             )
         )
 
-    # Revision B has the same verses (different wording) — dedup should collapse
     for book, chapter, verse, text in [
         ("GEN", 1, 1, "In the beginning God made the heavens and the earth."),
         ("GEN", 1, 3, "Then God said, Let there be light, and there was light."),
@@ -1102,7 +1098,7 @@ def setup_iso_search_test_data(db_session):
         db_session.add(
             VerseText(
                 text=text,
-                revision_id=eng_rev_b.id,
+                revision_id=eng_rev_new.id,
                 verse_reference=f"{book} {chapter}:{verse}",
                 book=book,
                 chapter=chapter,
@@ -1110,12 +1106,11 @@ def setup_iso_search_test_data(db_session):
             )
         )
 
-    # --- Swahili version for comparison_iso ---
     swh_version = BibleVersion(
-        name="ISO Test Swahili",
+        name="Version Search Swahili",
         iso_language="swh",
         iso_script="Latn",
-        abbreviation="ISW",
+        abbreviation="VSW",
         owner_id=user1.id,
         is_reference=False,
     )
@@ -1124,7 +1119,7 @@ def setup_iso_search_test_data(db_session):
     db_session.refresh(swh_version)
 
     swh_rev = BibleRevision(
-        date=date.today(),
+        date=date(2024, 1, 1),
         bible_version_id=swh_version.id,
         published=True,
         machine_translation=False,
@@ -1148,8 +1143,8 @@ def setup_iso_search_test_data(db_session):
             )
         )
 
-    # Grant access to all versions
-    for version in [eng_version_a, eng_version_b, swh_version]:
+    # Grant access for testuser1 (group1) to both versions
+    for version in [eng_version, swh_version]:
         db_session.add(
             BibleVersionAccess(
                 bible_version_id=version.id,
@@ -1160,19 +1155,21 @@ def setup_iso_search_test_data(db_session):
     db_session.commit()
 
     return {
-        "eng_rev_a": eng_rev_a.id,
-        "eng_rev_b": eng_rev_b.id,
+        "eng_version": eng_version.id,
+        "eng_rev_old": eng_rev_old.id,
+        "eng_rev_new": eng_rev_new.id,
+        "swh_version": swh_version.id,
         "swh_rev": swh_rev.id,
     }
 
 
-def test_search_by_iso(client, regular_token1, test_db_session):
-    """Test searching by ISO code across all revisions for a language."""
-    setup_iso_search_test_data(test_db_session)
+def test_search_by_version_id(client, regular_token1, test_db_session):
+    """version_id collapses multi-revision matches to one row per (book, chapter, verse)."""
+    ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",
-        params={"iso": "eng", "term": "God", "limit": 10},
+        params={"version_id": ids["eng_version"], "term": "God", "limit": 10},
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1180,19 +1177,160 @@ def test_search_by_iso(client, regular_token1, test_db_session):
     data = response.json()
     assert data["total_count"] > 0
 
-    # Both revisions have GEN 1:1 and GEN 1:3 with "God" — dedup should
-    # return at most one result per (book, chapter, verse)
+    # Both revisions have GEN 1:1 and GEN 1:3 with "God" — dedup picks one
+    # row per (book, chapter, verse).
     refs = [(r["book"], r["chapter"], r["verse"]) for r in data["results"]]
     assert len(refs) == len(set(refs)), "Expected deduplicated results"
 
 
-def test_search_by_iso_with_comparison_iso(client, regular_token1, test_db_session):
-    """Test iso + comparison_iso returns parallel text."""
-    setup_iso_search_test_data(test_db_session)
+def test_search_version_id_picks_latest_revision_text(
+    client, regular_token1, test_db_session
+):
+    """For each verse, version_id mode returns the newest revision's text."""
+    ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",
-        params={"iso": "eng", "comparison_iso": "swh", "term": "God", "limit": 10},
+        params={"version_id": ids["eng_version"], "term": "God", "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    by_ref = {(r["book"], r["chapter"], r["verse"]): r["main_text"] for r in data["results"]}
+
+    # Newer revision wording is "made the heavens" / "Then God said".
+    # Older is "created the heaven" / "And God said".
+    assert ("GEN", 1, 1) in by_ref
+    assert "made the heavens" in by_ref[("GEN", 1, 1)], (
+        f"Expected newer revision wording at GEN 1:1; got {by_ref[('GEN', 1, 1)]!r}"
+    )
+    assert ("GEN", 1, 3) in by_ref
+    assert "Then God said" in by_ref[("GEN", 1, 3)], (
+        f"Expected newer revision wording at GEN 1:3; got {by_ref[('GEN', 1, 3)]!r}"
+    )
+
+
+def test_search_version_id_falls_back_when_latest_empty(
+    client, regular_token1, test_db_session
+):
+    """Older revision fills the gap when the latest revision lacks the verse.
+
+    Lacking = stored as empty text. The per-vref pick excludes empty rows,
+    so the date-DESC pick falls through to the older non-empty revision.
+    """
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+
+    version = BibleVersion(
+        name="Fallback Version",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="FBV",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add(version)
+    test_db_session.commit()
+    test_db_session.refresh(version)
+
+    rev_old = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+    )
+    rev_new = BibleRevision(
+        date=date(2024, 6, 1),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add_all([rev_old, rev_new])
+    test_db_session.commit()
+    test_db_session.refresh(rev_old)
+    test_db_session.refresh(rev_new)
+
+    # GEN 1:1 — older has text, newer is empty (gap)
+    test_db_session.add(
+        VerseText(
+            text="In the beginning God created the heaven and the earth.",
+            revision_id=rev_old.id,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
+    test_db_session.add(
+        VerseText(
+            text="",
+            revision_id=rev_new.id,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
+    # GEN 1:2 — both revisions have text; newer should win
+    test_db_session.add(
+        VerseText(
+            text="And God moved over the deep.",
+            revision_id=rev_old.id,
+            verse_reference="GEN 1:2",
+            book="GEN",
+            chapter=1,
+            verse=2,
+        )
+    )
+    test_db_session.add(
+        VerseText(
+            text="The Spirit of God hovered over the waters.",
+            revision_id=rev_new.id,
+            verse_reference="GEN 1:2",
+            book="GEN",
+            chapter=1,
+            verse=2,
+        )
+    )
+    test_db_session.add(
+        BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+    )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"version_id": version.id, "term": "God", "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    by_ref = {(r["book"], r["chapter"], r["verse"]): r["main_text"] for r in data["results"]}
+
+    assert ("GEN", 1, 1) in by_ref, (
+        f"Expected GEN 1:1 (older) to fall through when newer is empty; got {data}"
+    )
+    assert "created the heaven" in by_ref[("GEN", 1, 1)]
+    # GEN 1:2: newer wording wins
+    assert ("GEN", 1, 2) in by_ref
+    assert "Spirit of God" in by_ref[("GEN", 1, 2)]
+
+
+def test_search_by_version_id_with_comparison_version_id(
+    client, regular_token1, test_db_session
+):
+    """version_id main + comparison_version_id returns per-vref-paired latest text."""
+    ids = setup_version_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "version_id": ids["eng_version"],
+            "comparison_version_id": ids["swh_version"],
+            "term": "God",
+            "limit": 10,
+        },
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1203,18 +1341,23 @@ def test_search_by_iso_with_comparison_iso(client, regular_token1, test_db_sessi
     for result in data["results"]:
         assert "comparison_text" in result
         assert result["comparison_text"], "Expected non-empty comparison text"
+        # Main side should reflect the newer revision wording
+        assert (
+            "made the heavens" in result["main_text"]
+            or "Then God said" in result["main_text"]
+        ), f"Expected newer-revision wording on main side, got {result['main_text']!r}"
 
 
-def test_search_by_iso_with_comparison_revision_id(
+def test_search_by_version_id_with_comparison_revision_id(
     client, regular_token1, test_db_session
 ):
-    """Test iso for main + comparison_revision_id for comparison."""
-    ids = setup_iso_search_test_data(test_db_session)
+    """version_id main + comparison_revision_id returns parallel text."""
+    ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",
         params={
-            "iso": "eng",
+            "version_id": ids["eng_version"],
             "comparison_revision_id": ids["swh_rev"],
             "term": "God",
             "limit": 10,
@@ -1228,17 +1371,40 @@ def test_search_by_iso_with_comparison_revision_id(
     assert "comparison_text" in data["results"][0]
 
 
-def test_search_iso_and_revision_id_mutually_exclusive(
+def test_search_by_revision_id_with_comparison_version_id(
     client, regular_token1, test_db_session
 ):
-    """Providing both revision_id and iso should return 400."""
-    ids = setup_iso_search_test_data(test_db_session)
+    """revision_id main + comparison_version_id returns parallel text via comp pick."""
+    ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",
         params={
-            "revision_id": ids["eng_rev_a"],
-            "iso": "eng",
+            "revision_id": ids["eng_rev_new"],
+            "comparison_version_id": ids["swh_version"],
+            "term": "God",
+            "limit": 10,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] > 0
+    assert "comparison_text" in data["results"][0]
+
+
+def test_search_version_id_and_revision_id_mutually_exclusive(
+    client, regular_token1, test_db_session
+):
+    """Providing both revision_id and version_id should return 400."""
+    ids = setup_version_search_test_data(test_db_session)
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "revision_id": ids["eng_rev_new"],
+            "version_id": ids["eng_version"],
             "term": "God",
         },
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -1247,18 +1413,18 @@ def test_search_iso_and_revision_id_mutually_exclusive(
     assert response.status_code == 400
 
 
-def test_search_comparison_iso_and_revision_id_mutually_exclusive(
+def test_search_comparison_version_id_and_revision_id_mutually_exclusive(
     client, regular_token1, test_db_session
 ):
-    """Providing both comparison_revision_id and comparison_iso should return 400."""
-    ids = setup_iso_search_test_data(test_db_session)
+    """Providing both comparison_revision_id and comparison_version_id returns 400."""
+    ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",
         params={
-            "revision_id": ids["eng_rev_a"],
+            "revision_id": ids["eng_rev_new"],
             "comparison_revision_id": ids["swh_rev"],
-            "comparison_iso": "swh",
+            "comparison_version_id": ids["swh_version"],
             "term": "God",
         },
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -1267,8 +1433,10 @@ def test_search_comparison_iso_and_revision_id_mutually_exclusive(
     assert response.status_code == 400
 
 
-def test_search_neither_revision_id_nor_iso(client, regular_token1, test_db_session):
-    """Omitting both revision_id and iso should return 400."""
+def test_search_neither_revision_id_nor_version_id(
+    client, regular_token1, test_db_session
+):
+    """Omitting both revision_id and version_id should return 400."""
     response = client.get(
         "/v3/textsearch",
         params={"term": "God"},
@@ -1278,13 +1446,15 @@ def test_search_neither_revision_id_nor_iso(client, regular_token1, test_db_sess
     assert response.status_code == 400
 
 
-def test_search_iso_no_accessible_revisions(client, regular_token2, test_db_session):
-    """Searching an ISO the user has no access to should return 404."""
-    setup_iso_search_test_data(test_db_session)
+def test_search_version_id_no_accessible_revisions(
+    client, regular_token2, test_db_session
+):
+    """Searching a version the user has no access to returns 404."""
+    ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",
-        params={"iso": "eng", "term": "God"},
+        params={"version_id": ids["eng_version"], "term": "God"},
         headers={"Authorization": f"Bearer {regular_token2}"},
     )
 
@@ -1292,13 +1462,18 @@ def test_search_iso_no_accessible_revisions(client, regular_token2, test_db_sess
     assert response.status_code == 404
 
 
-def test_search_by_iso_random(client, regular_token1, test_db_session):
-    """Test ISO search with random=True does not crash (DISTINCT ON + random fix)."""
-    setup_iso_search_test_data(test_db_session)
+def test_search_by_version_id_random(client, regular_token1, test_db_session):
+    """version_id search with random=True dedups and randomises without crashing."""
+    ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
         "/v3/textsearch",
-        params={"iso": "eng", "term": "God", "limit": 10, "random": True},
+        params={
+            "version_id": ids["eng_version"],
+            "term": "God",
+            "limit": 10,
+            "random": True,
+        },
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -1794,13 +1969,20 @@ def test_search_wildcard_invisible_chars_rejected(
     assert response.status_code == 400
 
 
-def test_search_wildcard_via_iso(client, regular_token1, test_db_session):
-    """Wildcard parsing works on the iso= path (exercises DISTINCT ON)."""
-    _setup_morpheme_search_data(test_db_session)
+def test_search_wildcard_via_version_id(client, regular_token1, test_db_session):
+    """Wildcard parsing works on the version_id path (exercises DISTINCT ON)."""
+    revision_id = _setup_morpheme_search_data(test_db_session)
+    # Look up the version_id for the revision created in the morpheme fixture.
+    version_id = (
+        test_db_session.query(BibleRevision)
+        .filter(BibleRevision.id == revision_id)
+        .first()
+        .bible_version_id
+    )
 
     response = client.get(
         "/v3/textsearch",
-        params={"iso": "eng", "term": "*bhʉlany*", "limit": 20},
+        params={"version_id": version_id, "term": "*bhʉlany*", "limit": 20},
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1118,15 +1118,22 @@ def setup_version_search_test_data(db_session):
     db_session.commit()
     db_session.refresh(swh_version)
 
-    swh_rev = BibleRevision(
+    swh_rev_old = BibleRevision(
         date=date(2024, 1, 1),
         bible_version_id=swh_version.id,
         published=True,
         machine_translation=False,
     )
-    db_session.add(swh_rev)
+    swh_rev_new = BibleRevision(
+        date=date(2024, 6, 1),
+        bible_version_id=swh_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    db_session.add_all([swh_rev_old, swh_rev_new])
     db_session.commit()
-    db_session.refresh(swh_rev)
+    db_session.refresh(swh_rev_old)
+    db_session.refresh(swh_rev_new)
 
     for book, chapter, verse, text in [
         ("GEN", 1, 1, "Hapo mwanzo Mungu aliumba mbingu na dunia."),
@@ -1135,13 +1142,27 @@ def setup_version_search_test_data(db_session):
         db_session.add(
             VerseText(
                 text=text,
-                revision_id=swh_rev.id,
+                revision_id=swh_rev_old.id,
                 verse_reference=f"{book} {chapter}:{verse}",
                 book=book,
                 chapter=chapter,
                 verse=verse,
             )
         )
+    # Newer Swahili revision: distinct wording so we can verify the comp pick
+    # picks the newer revision per vref. GEN 1:1 has new wording; GEN 1:3
+    # is left to the older revision (newer revision lacks it) so the
+    # comp-side fallback path is also exercised.
+    db_session.add(
+        VerseText(
+            text="Mwanzoni Mungu aliumba mbingu na nchi.",
+            revision_id=swh_rev_new.id,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
 
     # Grant access for testuser1 (group1) to both versions
     for version in [eng_version, swh_version]:
@@ -1159,7 +1180,9 @@ def setup_version_search_test_data(db_session):
         "eng_rev_old": eng_rev_old.id,
         "eng_rev_new": eng_rev_new.id,
         "swh_version": swh_version.id,
-        "swh_rev": swh_rev.id,
+        "swh_rev": swh_rev_old.id,
+        "swh_rev_old": swh_rev_old.id,
+        "swh_rev_new": swh_rev_new.id,
     }
 
 
@@ -1328,7 +1351,13 @@ def test_search_version_id_falls_back_when_latest_empty(
 def test_search_by_version_id_with_comparison_version_id(
     client, regular_token1, test_db_session
 ):
-    """version_id main + comparison_version_id returns per-vref-paired latest text."""
+    """version_id main + comparison_version_id returns per-vref-paired latest text.
+
+    Verifies both sides perform the per-vref date-DESC pick:
+    - Main: newer eng revision wins (different wording from older).
+    - Comp: GEN 1:1 has newer swh revision wording; GEN 1:3 falls back to
+      the older swh revision because the newer one lacks GEN 1:3.
+    """
     ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
@@ -1344,16 +1373,19 @@ def test_search_by_version_id_with_comparison_version_id(
 
     assert response.status_code == 200
     data = response.json()
-    assert data["total_count"] > 0
+    by_ref = {(r["book"], r["chapter"], r["verse"]): r for r in data["results"]}
 
-    for result in data["results"]:
-        assert "comparison_text" in result
-        assert result["comparison_text"], "Expected non-empty comparison text"
-        # Main side should reflect the newer revision wording
-        assert (
-            "made the heavens" in result["main_text"]
-            or "Then God said" in result["main_text"]
-        ), f"Expected newer-revision wording on main side, got {result['main_text']!r}"
+    # Main side: newer revision wording on both verses
+    assert "made the heavens" in by_ref[("GEN", 1, 1)]["main_text"]
+    assert "Then God said" in by_ref[("GEN", 1, 3)]["main_text"]
+    # Comp side: GEN 1:1 — newer swh wording; GEN 1:3 — older swh wording
+    # (newer swh has no GEN 1:3, so it falls through to the older revision).
+    assert by_ref[("GEN", 1, 1)]["comparison_text"] == (
+        "Mwanzoni Mungu aliumba mbingu na nchi."
+    )
+    assert by_ref[("GEN", 1, 3)]["comparison_text"] == (
+        "Mungu akasema, Iwe nuru, ikawa nuru."
+    )
 
 
 def test_search_by_version_id_with_comparison_revision_id(
@@ -1382,7 +1414,7 @@ def test_search_by_version_id_with_comparison_revision_id(
 def test_search_by_revision_id_with_comparison_version_id(
     client, regular_token1, test_db_session
 ):
-    """revision_id main + comparison_version_id returns parallel text via comp pick."""
+    """revision_id main + comparison_version_id pairs against comp's per-vref pick."""
     ids = setup_version_search_test_data(test_db_session)
 
     response = client.get(
@@ -1398,8 +1430,236 @@ def test_search_by_revision_id_with_comparison_version_id(
 
     assert response.status_code == 200
     data = response.json()
-    assert data["total_count"] > 0
-    assert "comparison_text" in data["results"][0]
+    by_ref = {(r["book"], r["chapter"], r["verse"]): r for r in data["results"]}
+    # Comp side picks the newer swh revision for GEN 1:1 and the older one
+    # for GEN 1:3 (newer revision doesn't include GEN 1:3).
+    assert by_ref[("GEN", 1, 1)]["comparison_text"] == (
+        "Mwanzoni Mungu aliumba mbingu na nchi."
+    )
+    assert by_ref[("GEN", 1, 3)]["comparison_text"] == (
+        "Mungu akasema, Iwe nuru, ikawa nuru."
+    )
+
+
+def test_search_comparison_version_id_unauthorized_returns_404(
+    client, regular_token2, test_db_session
+):
+    """Authorized main + unauthorized comparison_version_id with no main matches → 404.
+
+    Main has access (so the auth_row check passes), no rows survive the JOIN
+    because comp side is empty, then the comp auth follow-up fires the
+    version-id 404 branch.
+    """
+    user2 = test_db_session.query(UserDB).filter(UserDB.username == "testuser2").first()
+    group2 = test_db_session.query(Group).filter(Group.name == "Group2").first()
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+
+    if (
+        test_db_session.query(IsoLanguage).filter(IsoLanguage.iso639 == "swh").first()
+        is None
+    ):
+        test_db_session.add(IsoLanguage(iso639="swh", name="Swahili"))
+        test_db_session.commit()
+
+    main_version = BibleVersion(
+        name="Auth Comp VID Main",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="ACVM",
+        owner_id=user2.id,
+        is_reference=False,
+    )
+    comp_version = BibleVersion(
+        name="Auth Comp VID Comp",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="ACVC",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add_all([main_version, comp_version])
+    test_db_session.commit()
+    test_db_session.refresh(main_version)
+    test_db_session.refresh(comp_version)
+
+    main_revision = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=main_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    comp_revision = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=comp_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add_all([main_revision, comp_revision])
+    test_db_session.commit()
+    test_db_session.refresh(main_revision)
+    test_db_session.refresh(comp_revision)
+
+    test_db_session.add(
+        VerseText(
+            text="Nothing matches the search term here.",
+            revision_id=main_revision.id,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
+    test_db_session.add_all(
+        [
+            BibleVersionAccess(bible_version_id=main_version.id, group_id=group2.id),
+            BibleVersionAccess(bible_version_id=comp_version.id, group_id=group1.id),
+        ]
+    )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "version_id": main_version.id,
+            "comparison_version_id": comp_version.id,
+            "term": "zyxwvu-no-match",
+            "limit": 5,
+        },
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert response.status_code == 404
+    assert "comparison_version_id" in response.json()["detail"]
+
+
+def test_search_version_id_excludes_deleted_revisions(
+    client, regular_token1, test_db_session
+):
+    """A revision flagged ``deleted=True`` must not contribute to the per-vref pick."""
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+
+    version = BibleVersion(
+        name="Deleted Rev Version",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="DRV",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add(version)
+    test_db_session.commit()
+    test_db_session.refresh(version)
+
+    rev_kept = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+    )
+    rev_deleted = BibleRevision(
+        date=date(2024, 6, 1),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+        deleted=True,
+    )
+    test_db_session.add_all([rev_kept, rev_deleted])
+    test_db_session.commit()
+    test_db_session.refresh(rev_kept)
+    test_db_session.refresh(rev_deleted)
+
+    # Both have GEN 1:1 with "God"; the deleted revision is newer. The
+    # per-vref pick must skip the deleted revision and return the kept one.
+    test_db_session.add_all(
+        [
+            VerseText(
+                text="In the beginning God created the heaven and the earth.",
+                revision_id=rev_kept.id,
+                verse_reference="GEN 1:1",
+                book="GEN",
+                chapter=1,
+                verse=1,
+            ),
+            VerseText(
+                text="Deleted-revision wording about God should not appear.",
+                revision_id=rev_deleted.id,
+                verse_reference="GEN 1:1",
+                book="GEN",
+                chapter=1,
+                verse=1,
+            ),
+        ]
+    )
+    test_db_session.add(
+        BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+    )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"version_id": version.id, "term": "God", "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 1
+    assert "created the heaven" in data["results"][0]["main_text"]
+
+
+def test_search_version_id_all_empty_rows_returns_200_empty(
+    client, regular_token1, test_db_session
+):
+    """A version whose only verses have empty text must 200-empty (not 404)."""
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+
+    version = BibleVersion(
+        name="All-Empty Version",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="AEV",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add(version)
+    test_db_session.commit()
+    test_db_session.refresh(version)
+
+    revision = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add(revision)
+    test_db_session.commit()
+    test_db_session.refresh(revision)
+
+    test_db_session.add(
+        VerseText(
+            text="",
+            revision_id=revision.id,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
+    test_db_session.add(
+        BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+    )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={"version_id": version.id, "term": "God", "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_count"] == 0
+    assert data["results"] == []
 
 
 def test_search_version_id_and_revision_id_mutually_exclusive(

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1197,18 +1197,20 @@ def test_search_version_id_picks_latest_revision_text(
 
     assert response.status_code == 200
     data = response.json()
-    by_ref = {(r["book"], r["chapter"], r["verse"]): r["main_text"] for r in data["results"]}
+    by_ref = {
+        (r["book"], r["chapter"], r["verse"]): r["main_text"] for r in data["results"]
+    }
 
     # Newer revision wording is "made the heavens" / "Then God said".
     # Older is "created the heaven" / "And God said".
     assert ("GEN", 1, 1) in by_ref
-    assert "made the heavens" in by_ref[("GEN", 1, 1)], (
-        f"Expected newer revision wording at GEN 1:1; got {by_ref[('GEN', 1, 1)]!r}"
-    )
+    assert (
+        "made the heavens" in by_ref[("GEN", 1, 1)]
+    ), f"Expected newer revision wording at GEN 1:1; got {by_ref[('GEN', 1, 1)]!r}"
     assert ("GEN", 1, 3) in by_ref
-    assert "Then God said" in by_ref[("GEN", 1, 3)], (
-        f"Expected newer revision wording at GEN 1:3; got {by_ref[('GEN', 1, 3)]!r}"
-    )
+    assert (
+        "Then God said" in by_ref[("GEN", 1, 3)]
+    ), f"Expected newer revision wording at GEN 1:3; got {by_ref[('GEN', 1, 3)]!r}"
 
 
 def test_search_version_id_falls_back_when_latest_empty(
@@ -1306,9 +1308,15 @@ def test_search_version_id_falls_back_when_latest_empty(
 
     assert response.status_code == 200
     data = response.json()
-    by_ref = {(r["book"], r["chapter"], r["verse"]): r["main_text"] for r in data["results"]}
+    by_ref = {
+        (r["book"], r["chapter"], r["verse"]): r["main_text"] for r in data["results"]
+    }
 
-    assert ("GEN", 1, 1) in by_ref, (
+    assert (
+        "GEN",
+        1,
+        1,
+    ) in by_ref, (
         f"Expected GEN 1:1 (older) to fall through when newer is empty; got {data}"
     )
     assert "created the heaven" in by_ref[("GEN", 1, 1)]


### PR DESCRIPTION
## Summary

- Drops `iso=` / `comparison_iso=` from `/v3/textsearch` (they expanded to every accessible revision per language and dedup-ordered the entire result set, producing 14–30s p95 latency at concurrency=1).
- Adds `version_id` / `comparison_version_id` query params. Per (book, chapter, verse), `DISTINCT ON` ordered by `bible_revision.date DESC` picks the latest non-empty revision, with older revisions filling gaps where the latest revision lacks the verse.
- Mutex stays one-per-side: exactly one of `version_id` / `revision_id` for main; at most one of `comparison_version_id` / `comparison_revision_id` for comparison.

Fixes #642.

## Test plan

- [x] All 54 tests in `test/test_assessment_routes/test_search_routes.py` pass locally
- [x] New tests cover: latest-revision pick, fallback to older when latest is empty, parallel pairs with `comparison_version_id`, all 400/404 paths
- [x] `pre-commit run` (black + isort) clean
- [ ] Verify p95 latency drops on dev once deployed (issue called out 14.8s avg / 28.7s p95 for the iso path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)