### PR TITLE
Fix /predict/jobs/{id}: catch builtin TimeoutError on poll

### DIFF
--- a/predict_routes/v3/predict_routes.py
+++ b/predict_routes/v3/predict_routes.py
@@ -336,7 +336,11 @@ async def get_predict_job(
         try:
             fc = modal.FunctionCall.from_id(job.modal_call_id)
             data = await fc.get.aio(timeout=0)
-        except modal.exception.TimeoutError:
+        except (TimeoutError, modal.exception.TimeoutError):
+            # modal._functions.poll_function raises the builtin TimeoutError
+            # (not modal.exception.TimeoutError, which doesn't subclass it)
+            # when timeout=0 hits with no result yet; catch both so the
+            # right modal version doesn't matter.
             response.headers["Retry-After"] = str(_JOB_POLL_INTERVAL_S)
         except Exception as exc:
             logger.warning(

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -657,17 +657,31 @@ def _spawn_agent_and_get_job(client, token, body_overrides=None):
     return response.json()["job"]["id"]
 
 
-def test_predict_job_running_returns_retry_after(client, regular_token1):
+@pytest.mark.parametrize(
+    "timeout_exc",
+    [TimeoutError("not yet"), "modal_timeout"],
+    ids=["builtin_TimeoutError", "modal_exception_TimeoutError"],
+)
+def test_predict_job_running_returns_retry_after(client, regular_token1, timeout_exc):
     """Polling a job whose Modal call hasn't completed yet returns
     status=running with a Retry-After header and the submitted pairs
     echoed back (translation/critique null since the slow path hasn't
-    finished)."""
+    finished).
+
+    Pinned for both exception classes because modal's
+    `_functions.poll_function` raises the builtin `TimeoutError`, not
+    `modal.exception.TimeoutError` (which does NOT subclass it). An
+    earlier version of the route only caught the modal class and
+    silently flipped every still-running poll to status=failed."""
     import modal
+
+    if timeout_exc == "modal_timeout":
+        timeout_exc = modal.exception.TimeoutError("not yet")
 
     job_id = _spawn_agent_and_get_job(client, regular_token1)
 
     fc_mock = AsyncMock()
-    fc_mock.get.aio = AsyncMock(side_effect=modal.exception.TimeoutError("not yet"))
+    fc_mock.get.aio = AsyncMock(side_effect=timeout_exc)
     with patch.object(modal.FunctionCall, "from_id", return_value=fc_mock):
         response = client.get(
             f"/{prefix}/predict/jobs/{job_id}",


### PR DESCRIPTION
## Summary

`modal._functions.poll_function` raises the **builtin** `TimeoutError` when the underlying function call hasn't produced a result yet (`_functions.py:327` does `raise TimeoutError()`). It does **not** raise `modal.exception.TimeoutError` — the two are unrelated classes (`modal.exception.TimeoutError` does not subclass the builtin).

The poll handler in `/predict/jobs/{id}` only caught `modal.exception.TimeoutError`. Result: every still-running poll fell into the generic `except Exception` clause and got marked `status="failed"` with `error="TimeoutError"` on the first poll, even though the Modal call was happily running.

Damien hit this immediately when he ran the demo notebook — see the two `prj_*` rows in the prod `predict_jobs` table with `status=failed`, `error='TimeoutError'`, despite the agent app having completed the translation.

## Fix

Catch both `TimeoutError` (the builtin, which is what modal actually raises) and `modal.exception.TimeoutError` (defensive, in case modal's behavior shifts).

```python
except (TimeoutError, modal.exception.TimeoutError):
    response.headers["Retry-After"] = str(_JOB_POLL_INTERVAL_S)
```

## Cleanup needed after merge

Existing prod rows with `status='failed'` and `error='TimeoutError'` were marked failed by this bug; their underlying Modal calls likely completed successfully. They can be reset to `status='running'` so the next poll picks up the cached Modal result (subject to Modal's output TTL).

## Test plan
- [x] New parametrised test runs the running-state poll with both `TimeoutError` and `modal.exception.TimeoutError` and asserts status=running + Retry-After
- [x] Full predict suite still green (56 passed)
- [x] black + isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)