### PR TITLE
Add composite index (assessment_id, id) on ngrams_table

### DIFF
--- a/alembic/migrations/versions/1d460bf9ea55_add_ngrams_composite_index.py
+++ b/alembic/migrations/versions/1d460bf9ea55_add_ngrams_composite_index.py
@@ -18,19 +18,48 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # /v3/ngrams_result paginates ngrams_table directly with
-    # `WHERE assessment_id = :id ORDER BY id LIMIT :n OFFSET :off`. The
-    # existing single-column `assessment_id` index satisfies the WHERE
-    # but forces a separate sort or heap fetch to honour the ORDER BY.
-    # A composite (assessment_id, id) lets Postgres index-walk in id
-    # order while filtering by assessment_id directly off the index —
-    # no sort step, LIMIT short-circuits cleanly. See #650.
-    op.create_index(
-        "ix_ngrams_table_assessment_id_id",
-        "ngrams_table",
-        ["assessment_id", "id"],
-        unique=False,
-    )
+    # `WHERE assessment_id = :id ORDER BY id LIMIT :n OFFSET :off`. A
+    # composite (assessment_id, id) lets Postgres index-walk in id
+    # order while filtering by assessment_id off the index — no sort
+    # step, LIMIT short-circuits cleanly. See #650.
+    #
+    # Concurrent index creation avoids the ShareLock that a plain
+    # CREATE INDEX would take on the table — that lock blocks
+    # concurrent writes (training inserts), which we'd rather not
+    # block during a deploy that touches this migration. CONCURRENTLY
+    # can't run inside a transaction, so wrap the index ops in
+    # alembic's autocommit_block.
+    #
+    # Once the composite is in place, the existing single-column
+    # `ix_ngrams_table_assessment_id` is redundant — any plan that
+    # would use it can use the leading column of the composite — so
+    # drop it to save write amplification on every insert.
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_ngrams_table_assessment_id_id",
+            "ngrams_table",
+            ["assessment_id", "id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "ix_ngrams_table_assessment_id",
+            table_name="ngrams_table",
+            postgresql_concurrently=True,
+        )
 
 
 def downgrade() -> None:
-    op.drop_index("ix_ngrams_table_assessment_id_id", table_name="ngrams_table")
+    with op.get_context().autocommit_block():
+        op.create_index(
+            "ix_ngrams_table_assessment_id",
+            "ngrams_table",
+            ["assessment_id"],
+            unique=False,
+            postgresql_concurrently=True,
+        )
+        op.drop_index(
+            "ix_ngrams_table_assessment_id_id",
+            table_name="ngrams_table",
+            postgresql_concurrently=True,
+        )

--- a/alembic/migrations/versions/1d460bf9ea55_add_ngrams_composite_index.py
+++ b/alembic/migrations/versions/1d460bf9ea55_add_ngrams_composite_index.py
@@ -1,0 +1,36 @@
+"""add composite index (assessment_id, id) on ngrams_table
+
+Revision ID: 1d460bf9ea55
+Revises: c4d8f1a2b9e3
+Create Date: 2026-05-06
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "1d460bf9ea55"
+down_revision: Union[str, None] = "c4d8f1a2b9e3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # /v3/ngrams_result paginates ngrams_table directly with
+    # `WHERE assessment_id = :id ORDER BY id LIMIT :n OFFSET :off`. The
+    # existing single-column `assessment_id` index satisfies the WHERE
+    # but forces a separate sort or heap fetch to honour the ORDER BY.
+    # A composite (assessment_id, id) lets Postgres index-walk in id
+    # order while filtering by assessment_id directly off the index —
+    # no sort step, LIMIT short-circuits cleanly. See #650.
+    op.create_index(
+        "ix_ngrams_table_assessment_id_id",
+        "ngrams_table",
+        ["assessment_id", "id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ngrams_table_assessment_id_id", table_name="ngrams_table")

--- a/alembic/migrations/versions/1d460bf9ea55_add_ngrams_composite_index.py
+++ b/alembic/migrations/versions/1d460bf9ea55_add_ngrams_composite_index.py
@@ -30,36 +30,33 @@ def upgrade() -> None:
     # can't run inside a transaction, so wrap the index ops in
     # alembic's autocommit_block.
     #
+    # We use raw `op.execute` rather than `op.create_index` /
+    # `op.drop_index` so we can use Postgres' `IF [NOT] EXISTS`
+    # forms — the SQLAlchemy 1.4 alembic helpers don't expose those.
+    # The defensive `DROP INDEX IF EXISTS` before the create handles
+    # the case where a prior interrupted CONCURRENTLY attempt left
+    # an INVALID index behind; a re-run otherwise fails on
+    # "relation already exists".
+    #
     # Once the composite is in place, the existing single-column
     # `ix_ngrams_table_assessment_id` is redundant — any plan that
     # would use it can use the leading column of the composite — so
     # drop it to save write amplification on every insert.
     with op.get_context().autocommit_block():
-        op.create_index(
-            "ix_ngrams_table_assessment_id_id",
-            "ngrams_table",
-            ["assessment_id", "id"],
-            unique=False,
-            postgresql_concurrently=True,
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_ngrams_table_assessment_id_id")
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_ngrams_table_assessment_id_id "
+            "ON ngrams_table (assessment_id, id)"
         )
-        op.drop_index(
-            "ix_ngrams_table_assessment_id",
-            table_name="ngrams_table",
-            postgresql_concurrently=True,
-        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_ngrams_table_assessment_id")
 
 
 def downgrade() -> None:
     with op.get_context().autocommit_block():
-        op.create_index(
-            "ix_ngrams_table_assessment_id",
-            "ngrams_table",
-            ["assessment_id"],
-            unique=False,
-            postgresql_concurrently=True,
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_ngrams_table_assessment_id "
+            "ON ngrams_table (assessment_id)"
         )
-        op.drop_index(
-            "ix_ngrams_table_assessment_id_id",
-            table_name="ngrams_table",
-            postgresql_concurrently=True,
-        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_ngrams_table_assessment_id_id")

--- a/database/models.py
+++ b/database/models.py
@@ -75,6 +75,12 @@ class NgramsTable(Base):
 
     vrefs = relationship("NgramVrefTable", back_populates="ngram")
 
+    # /v3/ngrams_result paginates this table directly with
+    # `WHERE assessment_id = :id ORDER BY id LIMIT/OFFSET`. Composite
+    # `(assessment_id, id)` lets Postgres serve that as a single index
+    # walk without a separate sort step. See #650.
+    __table_args__ = (Index("ix_ngrams_table_assessment_id_id", "assessment_id", "id"),)
+
 
 class NgramVrefTable(Base):
     __tablename__ = "ngram_vref_table"

--- a/database/models.py
+++ b/database/models.py
@@ -69,7 +69,11 @@ class NgramsTable(Base):
     __tablename__ = "ngrams_table"
 
     id = Column(Integer, primary_key=True)
-    assessment_id = Column(Integer, ForeignKey("assessment.id"), index=True)
+    # No `index=True` here — the composite below covers any
+    # assessment_id-only filter via its leading column, so a
+    # standalone `assessment_id` index would only add write
+    # amplification.
+    assessment_id = Column(Integer, ForeignKey("assessment.id"))
     ngram = Column(Text)
     ngram_size = Column(Integer)
 


### PR DESCRIPTION
Fixes #650.

## Summary

`/v3/ngrams_result` (post #649) paginates `ngrams_table` directly with `WHERE assessment_id = :id ORDER BY id LIMIT :n OFFSET :off`. The existing single-column `assessment_id` index satisfies the WHERE, but Postgres still has to do a separate sort (or fetch + sort from heap) for the `ORDER BY id`. A composite `(assessment_id, id)` lets it index-walk in id order while filtering by assessment_id directly off the index — no sort step, LIMIT short-circuits cleanly, late-page OFFSETs still cost O(offset) but at index-walk speed rather than heap-fetch speed.

## What this PR does

1. **Adds `ix_ngrams_table_assessment_id_id`** on `(assessment_id, id)` via `CREATE INDEX CONCURRENTLY` (no ShareLock on the table during creation — concurrent training-run inserts aren't blocked).
2. **Drops the now-redundant `ix_ngrams_table_assessment_id`**. The composite covers any plan the single-column did (assessment_id is the leading column), so carrying both costs write amplification on every insert with no query-plan benefit.
3. **Removes `index=True` from the ORM `assessment_id` column** so a fresh `Base.metadata.create_all()` doesn't recreate the now-redundant single-column index. ORM and migrated DB now produce identical schemas.
4. **Idempotent migration.** Uses raw `op.execute(...)` with PG's native `IF [NOT] EXISTS` forms (SQLAlchemy 1.4's alembic helpers don't expose those flags). A defensive `DROP INDEX CONCURRENTLY IF EXISTS` before the create handles INVALID indexes left behind by an interrupted prior CONCURRENTLY attempt — re-running upgrade is now a no-op rather than a hard failure.

## Why now

Closes the loop on the perf work in #648 / #649. The query change was the bulk of the win; the index removes the residual sort cost so `EXPLAIN ANALYZE` will show "Index Scan" / "Index Only Scan" rather than "Bitmap Heap Scan + Sort" or "Index Scan + Sort". Dropping the redundant single-column index in the same migration avoids leaving stale artifacts behind.

## Test plan
- [x] Migration applied cleanly against local Docker DB; `\d ngrams_table` shows only `ix_ngrams_table_assessment_id_id` after upgrade
- [x] Round-trip verified: upgrade → downgrade → upgrade leaves indexes in expected state at each step
- [x] Idempotency verified: re-running upgrade against an already-upgraded DB is a no-op (no "relation already exists" failure)
- [x] Full test suite still green (815 passed)
- [x] `ngrams_result` tests still pass (11/11)
- [x] black + isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)