### PR TITLE
Pool DB connections in production; keep NullPool in tests

### DIFF
--- a/database/dependencies.py
+++ b/database/dependencies.py
@@ -5,26 +5,43 @@ import os
 from dotenv import load_dotenv
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.pool import NullPool
 
 # Load environment variables from .env file
 load_dotenv()
 
 DATABASE_URL = os.getenv("AQUA_DB")
 
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        raise ValueError(f"Environment variable {name}={raw!r} is not a valid integer")
+
+
 # Pytest's TestClient spawns a new event loop per request; asyncpg
 # connections can't migrate across loops, so test runs must use NullPool.
 # Production runs a single persistent loop per worker and benefits from
-# pooling — avoids re-running asyncpg+TLS handshake on every request.
+# pooling — avoids the asyncpg+TLS handshake on every request.
+#
+# Default sizing is conservative: 8 uvicorn workers × (2 + 3) = 40 max
+# connections per container, well under the typical DigitalOcean managed
+# Postgres limit (~25 on small tiers, ~97 mid-tier). Tune via env vars if
+# the running tier and replica count have headroom.
 if os.getenv("AQUA_DB_POOLCLASS", "").lower() == "null":
+    from sqlalchemy.pool import NullPool
+
     engine = create_async_engine(DATABASE_URL, poolclass=NullPool)
 else:
     engine = create_async_engine(
         DATABASE_URL,
-        pool_size=int(os.getenv("AQUA_DB_POOL_SIZE", "5")),
-        max_overflow=int(os.getenv("AQUA_DB_MAX_OVERFLOW", "10")),
-        pool_timeout=int(os.getenv("AQUA_DB_POOL_TIMEOUT", "30")),
-        pool_recycle=int(os.getenv("AQUA_DB_POOL_RECYCLE", "1800")),
+        pool_size=_env_int("AQUA_DB_POOL_SIZE", 2),
+        max_overflow=_env_int("AQUA_DB_MAX_OVERFLOW", 3),
+        pool_timeout=_env_int("AQUA_DB_POOL_TIMEOUT", 10),
+        pool_recycle=_env_int("AQUA_DB_POOL_RECYCLE", 1800),
         pool_pre_ping=True,
     )
 AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)

--- a/database/dependencies.py
+++ b/database/dependencies.py
@@ -27,10 +27,13 @@ def _env_int(name: str, default: int) -> int:
 # Production runs a single persistent loop per worker and benefits from
 # pooling — avoids the asyncpg+TLS handshake on every request.
 #
-# Default sizing is conservative: 8 uvicorn workers × (2 + 3) = 40 max
-# connections per container, well under the typical DigitalOcean managed
-# Postgres limit (~25 on small tiers, ~97 mid-tier). Tune via env vars if
-# the running tier and replica count have headroom.
+# Default sizing: with 8 uvicorn workers, steady-state is ~16 conns per
+# container (8 × pool_size 2) and the burst ceiling is 40 (8 × (2 + 3)).
+# DigitalOcean managed Postgres caps connections at roughly 25 on the
+# smallest tiers, ~97 mid-tier, ~197 large. Steady-state fits any tier;
+# the burst ceiling fits comfortably on mid-tier and above. On a small
+# tier, drop AQUA_DB_POOL_SIZE=1 / AQUA_DB_MAX_OVERFLOW=2 (≤24 ceiling)
+# or factor in additional consumers (alembic, batch jobs, replicas).
 if os.getenv("AQUA_DB_POOLCLASS", "").lower() == "null":
     from sqlalchemy.pool import NullPool
 

--- a/database/dependencies.py
+++ b/database/dependencies.py
@@ -29,11 +29,11 @@ def _env_int(name: str, default: int) -> int:
 #
 # Default sizing: with 8 uvicorn workers, steady-state is ~16 conns per
 # container (8 × pool_size 2) and the burst ceiling is 40 (8 × (2 + 3)).
-# DigitalOcean managed Postgres caps connections at roughly 25 on the
-# smallest tiers, ~97 mid-tier, ~197 large. Steady-state fits any tier;
-# the burst ceiling fits comfortably on mid-tier and above. On a small
-# tier, drop AQUA_DB_POOL_SIZE=1 / AQUA_DB_MAX_OVERFLOW=2 (≤24 ceiling)
-# or factor in additional consumers (alembic, batch jobs, replicas).
+# RDS default max_connections is LEAST({DBInstanceClassMemory/9531392},
+# 5000) — roughly 170 on db.t3.small, 340 on db.t3.medium, 675 on
+# db.m5.large — so 40/container leaves comfortable headroom even on
+# small instance classes. Tune the env vars if running many containers
+# or if other consumers (alembic, batch jobs, replicas) eat the budget.
 if os.getenv("AQUA_DB_POOLCLASS", "").lower() == "null":
     from sqlalchemy.pool import NullPool
 

--- a/database/dependencies.py
+++ b/database/dependencies.py
@@ -12,7 +12,21 @@ load_dotenv()
 
 DATABASE_URL = os.getenv("AQUA_DB")
 
-engine = create_async_engine(DATABASE_URL, poolclass=NullPool)
+# Pytest's TestClient spawns a new event loop per request; asyncpg
+# connections can't migrate across loops, so test runs must use NullPool.
+# Production runs a single persistent loop per worker and benefits from
+# pooling — avoids re-running asyncpg+TLS handshake on every request.
+if os.getenv("AQUA_DB_POOLCLASS", "").lower() == "null":
+    engine = create_async_engine(DATABASE_URL, poolclass=NullPool)
+else:
+    engine = create_async_engine(
+        DATABASE_URL,
+        pool_size=int(os.getenv("AQUA_DB_POOL_SIZE", "5")),
+        max_overflow=int(os.getenv("AQUA_DB_MAX_OVERFLOW", "10")),
+        pool_timeout=int(os.getenv("AQUA_DB_POOL_TIMEOUT", "30")),
+        pool_recycle=int(os.getenv("AQUA_DB_POOL_RECYCLE", "1800")),
+        pool_pre_ping=True,
+    )
 AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,14 @@ services:
       - GRAPHQL_URL=${GRAPHQL_URL}
       - GRAPHQL_SECRET=${GRAPHQL_SECRET}
       - AQUA_DB=postgresql+asyncpg://dbuser:dbpassword@db:5432/dbname
+      # DB connection pool tuning (defaults: pool_size=2, max_overflow=3,
+      # timeout=10, recycle=1800). Set AQUA_DB_POOLCLASS=null to disable
+      # pooling entirely (one connection per request).
+      - AQUA_DB_POOLCLASS=${AQUA_DB_POOLCLASS:-}
+      - AQUA_DB_POOL_SIZE=${AQUA_DB_POOL_SIZE:-}
+      - AQUA_DB_MAX_OVERFLOW=${AQUA_DB_MAX_OVERFLOW:-}
+      - AQUA_DB_POOL_TIMEOUT=${AQUA_DB_POOL_TIMEOUT:-}
+      - AQUA_DB_POOL_RECYCLE=${AQUA_DB_POOL_RECYCLE:-}
       - TEST_KEY=${TEST_KEY}
       - FAIL_KEY=${FAIL_KEY}
       - KEY_VAULT=${KEY_VAULT}

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,22 +1,23 @@
 # version_id conftest.py
 import os
-from datetime import date
 
 # TestClient spawns a new event loop per request; asyncpg connections can't
 # migrate across loops. Force NullPool so the app-level engine opens a fresh
 # connection each time during tests. Must run before `from app import app`.
 os.environ.setdefault("AQUA_DB_POOLCLASS", "null")
 
-import bcrypt
-import pandas as pd
-import pytest
-from fastapi.testclient import TestClient
-from sqlalchemy import create_engine, select
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from sqlalchemy.orm import sessionmaker
+from datetime import date  # noqa: E402
 
-from app import app
-from database.models import (
+import bcrypt  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import create_engine, select  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine  # noqa: E402
+from sqlalchemy.orm import sessionmaker  # noqa: E402
+
+from app import app  # noqa: E402
+from database.models import (  # noqa: E402
     Assessment,
     Base,
     BibleRevision,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,8 +3,10 @@ import os
 
 # TestClient spawns a new event loop per request; asyncpg connections can't
 # migrate across loops. Force NullPool so the app-level engine opens a fresh
-# connection each time during tests. Must run before `from app import app`.
-os.environ.setdefault("AQUA_DB_POOLCLASS", "null")
+# connection each time during tests. Set unconditionally (not setdefault) so
+# the test process can never accidentally inherit a pooled engine — this must
+# run before `from app import app` regardless of pytest collection order.
+os.environ["AQUA_DB_POOLCLASS"] = "null"
 
 from datetime import date  # noqa: E402
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,11 @@
 # version_id conftest.py
+import os
 from datetime import date
+
+# TestClient spawns a new event loop per request; asyncpg connections can't
+# migrate across loops. Force NullPool so the app-level engine opens a fresh
+# connection each time during tests. Must run before `from app import app`.
+os.environ.setdefault("AQUA_DB_POOLCLASS", "null")
 
 import bcrypt
 import pandas as pd


### PR DESCRIPTION
## Summary
- `/latest/revision?version_id=...` is sitting at 6-7 s in prod despite the late-April/early-May fix to the route. The endpoint structurally only runs ~5 sequential indexed queries.
- Root cause we're addressing here: the app engine uses `NullPool`, so every request opens (and tears down) a fresh asyncpg+TLS connection to RDS. Within one request the connection is reused, but each new request pays the handshake cost again — and Postgres pays its per-connection auth/SSL cost server-side, which compounds under any concurrency.
- Switch to `AsyncAdaptedQueuePool` with env-tunable sizing and `pool_pre_ping=True` to drop dead connections.
- **Conservative defaults:** `pool_size=2`, `max_overflow=3`, `pool_timeout=10s`, `pool_recycle=1800s`. With 8 uvicorn workers/container, steady state is ~16 conns and the burst ceiling is ~40. RDS default `max_connections = LEAST({DBInstanceClassMemory/9531392}, 5000)` — roughly 170 on `db.t3.small`, 340 on `db.t3.medium`, 675 on `db.m5.large` — so 40/container leaves comfortable headroom even on small instance classes. Scale up via env (`AQUA_DB_POOL_SIZE`, `AQUA_DB_MAX_OVERFLOW`, `AQUA_DB_POOL_TIMEOUT`, `AQUA_DB_POOL_RECYCLE`) if you want a larger steady-state pool.

## Scope and what this PR does *not* claim
This removes the per-request connection-setup cost. It does **not** assume connection setup is the *entire* 6-7 s floor. The auth path (`get_current_user` + `is_user_authorized_for_bible_version`) does multiple sequential DB hits, and the network path to RDS adds its own latency — both could still dominate after this lands. Expected outcome: a measurable drop, not necessarily down to subsecond. Further profiling (per-phase `time.perf_counter()` in the route, or `pg_stat_statements`) is a follow-up, separate from this PR.

## Why the test-side change
Pytest's `TestClient` spawns a new event loop per request, and asyncpg connections can't migrate across event loops — `QueuePool` reuse blows up with *"Task ... got Future ... attached to a different loop"*. `NullPool` masked this because it always opens fresh connections. Production runs a single persistent loop per worker, so this is purely a test-harness concern. Fix: `test/conftest.py` unconditionally sets `AQUA_DB_POOLCLASS=null` before `from app import app`, forcing NullPool inside the test process.

## Review changes (post-feedback)
- Tightened defaults from `5/10/30s` to `2/3/10s` to keep total connection count comfortable across containers.
- Switched test override from `os.environ.setdefault` to unconditional set so collection order can't sneak a pooled engine into tests.
- Replaced raw `int(os.getenv(...))` with `_env_int()` that gives a clear error on bad input.
- Moved `from sqlalchemy.pool import NullPool` inside the null branch (no dead import in the hot path).
- Exposed the new env vars in `docker-compose.yml`.

## Test plan
- [x] `pytest test/test_bible_routes/` — 71 passed (including all 9 revision-route tests)
- [x] `pytest test/test_security_routes/` — 8 passed (auth path is on the same engine)
- [x] Lint: `black --check`, `isort --check`, `flake8` all clean
- [x] Verified engine swap manually (default → `AsyncAdaptedQueuePool`, size 2 / overflow 3 / timeout 10; `AQUA_DB_POOLCLASS=null` → `NullPool`; bad int env value raises a clear ValueError)
- [ ] After deploy: confirm `/latest/revision?version_id=…` p95 drops in Grafana
- [ ] After deploy: confirm RDS connection count stays well within `max_connections`; tune `AQUA_DB_POOL_SIZE` / `AQUA_DB_MAX_OVERFLOW` if more pool steady-state would help

## Follow-ups (out of scope)
- Profile the residual latency — auth N+1, network, middleware
- Pool-exhaustion observability (log on `sqlalchemy.exc.TimeoutError` from `get_db()`)
- Consider caching `get_current_user` for short TTL keyed on JWT subject

🤖 Generated with [Claude Code](https://claude.com/claude-code)