### PR TITLE
Mark stuck non-terminal assessments as failed after timeout (#655)

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,6 +16,7 @@ from assessment_routes.v3.search_routes import router as search_router_v3
 from assessment_routes.v3.tfidf_artifact_routes import (
     router as tfidf_artifact_router_v3,
 )
+from assessment_routes.v3.timeout_sweep_routes import router as timeout_sweep_router_v3
 from bible_routes.v3.language_routes import router as language_router_v3
 from bible_routes.v3.revision_routes import router as revision_router_v3
 from bible_routes.v3.verse_routes import router as verse_router_v3
@@ -114,6 +115,7 @@ def configure_routing(app):
     app.include_router(tfidf_artifact_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(results_write_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(predict_router_v3, prefix="/v3", tags=["Version 3"])
+    app.include_router(timeout_sweep_router_v3, prefix="/v3", tags=["Version 3"])
 
     app.include_router(
         language_router_v3, prefix="/latest", tags=["Version 3 / Latest"]
@@ -142,6 +144,9 @@ def configure_routing(app):
         results_write_router_v3, prefix="/latest", tags=["Version 3 / Latest"]
     )
     app.include_router(predict_router_v3, prefix="/latest", tags=["Version 3 / Latest"])
+    app.include_router(
+        timeout_sweep_router_v3, prefix="/latest", tags=["Version 3 / Latest"]
+    )
 
     app.include_router(security_router, prefix="/latest", tags=["Latest"])
     app.include_router(admin_router, prefix="/latest", tags=["Latest"])

--- a/assessment_routes/v3/timeout_sweep_routes.py
+++ b/assessment_routes/v3/timeout_sweep_routes.py
@@ -13,12 +13,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from database.dependencies import get_db
 from database.models import Assessment
 from database.models import UserDB as UserModel
+from models import ASSESSMENT_TERMINAL_STATUSES, AssessmentStatus
 from security_routes.admin_routes import get_current_admin
 from utils.logging_config import setup_logger
 
 DEFAULT_TIMEOUT_HOURS = 24
+MIN_TIMEOUT_HOURS = 2
+MAX_TIMEOUT_HOURS = 87600  # ten years; guard against timedelta overflow
+MAX_RETURNED_SWEPT_IDS = 1000
 TIMEOUT_STATUS_DETAIL = "Marked failed by upstream timeout sweep"
-NON_TERMINAL_STATUSES = ["queued", "running"]
+NON_TERMINAL_STATUS_VALUES = [
+    s.value for s in AssessmentStatus if s not in ASSESSMENT_TERMINAL_STATUSES
+]
 
 container_id = socket.gethostname()
 logger = setup_logger(__name__, container_id=container_id)
@@ -29,6 +35,7 @@ router = fastapi.APIRouter()
 class TimeoutSweepResult(BaseModel):
     swept_count: int
     swept_ids: List[int]
+    truncated: bool
     cutoff: datetime
     hours: int
 
@@ -36,17 +43,20 @@ class TimeoutSweepResult(BaseModel):
 async def sweep_stuck_assessments(
     db: AsyncSession, hours: int = DEFAULT_TIMEOUT_HOURS
 ) -> TimeoutSweepResult:
-    now = datetime.utcnow()
+    # Match the convention used elsewhere when writing requested_time
+    # (assessment_routes.v3.assessment_routes uses datetime.now()) so the
+    # cutoff comparison stays consistent regardless of server timezone.
+    now = datetime.now()
     cutoff = now - timedelta(hours=hours)
     stmt = (
         update(Assessment)
         .where(
-            Assessment.status.in_(NON_TERMINAL_STATUSES),
+            Assessment.status.in_(NON_TERMINAL_STATUS_VALUES),
             Assessment.deleted.is_not(True),
             Assessment.requested_time < cutoff,
         )
         .values(
-            status="failed",
+            status=AssessmentStatus.failed.value,
             status_detail=TIMEOUT_STATUS_DETAIL,
             end_time=now,
         )
@@ -57,20 +67,23 @@ async def sweep_stuck_assessments(
     swept_ids = [row[0] for row in result.all()]
     await db.commit()
 
-    if swept_ids:
-        logger.info(
-            "Timeout sweep marked stuck assessments as failed",
-            extra={
-                "swept_count": len(swept_ids),
-                "hours": hours,
-                "cutoff": cutoff.isoformat(),
-                "swept_ids_sample": swept_ids[:50],
-            },
-        )
+    truncated = len(swept_ids) > MAX_RETURNED_SWEPT_IDS
+    returned_ids = swept_ids[:MAX_RETURNED_SWEPT_IDS]
+
+    logger.info(
+        "Timeout sweep completed",
+        extra={
+            "swept_count": len(swept_ids),
+            "hours": hours,
+            "cutoff": cutoff.isoformat(),
+            "swept_ids_sample": swept_ids[:50],
+        },
+    )
 
     return TimeoutSweepResult(
         swept_count=len(swept_ids),
-        swept_ids=swept_ids,
+        swept_ids=returned_ids,
+        truncated=truncated,
         cutoff=cutoff,
         hours=hours,
     )
@@ -80,7 +93,8 @@ async def sweep_stuck_assessments(
 async def timeout_sweep(
     hours: int = Query(
         DEFAULT_TIMEOUT_HOURS,
-        ge=1,
+        ge=MIN_TIMEOUT_HOURS,
+        le=MAX_TIMEOUT_HOURS,
         description=(
             "Mark assessments as failed if they are still queued or running and "
             "their requested_time is older than this many hours."

--- a/assessment_routes/v3/timeout_sweep_routes.py
+++ b/assessment_routes/v3/timeout_sweep_routes.py
@@ -1,0 +1,99 @@
+__version__ = "v3"
+
+import socket
+from datetime import datetime, timedelta
+from typing import List
+
+import fastapi
+from fastapi import Depends, Query
+from pydantic import BaseModel
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.dependencies import get_db
+from database.models import Assessment
+from database.models import UserDB as UserModel
+from security_routes.admin_routes import get_current_admin
+from utils.logging_config import setup_logger
+
+DEFAULT_TIMEOUT_HOURS = 24
+TIMEOUT_STATUS_DETAIL = "Marked failed by upstream timeout sweep"
+NON_TERMINAL_STATUSES = ["queued", "running"]
+
+container_id = socket.gethostname()
+logger = setup_logger(__name__, container_id=container_id)
+
+router = fastapi.APIRouter()
+
+
+class TimeoutSweepResult(BaseModel):
+    swept_count: int
+    swept_ids: List[int]
+    cutoff: datetime
+    hours: int
+
+
+async def sweep_stuck_assessments(
+    db: AsyncSession, hours: int = DEFAULT_TIMEOUT_HOURS
+) -> TimeoutSweepResult:
+    now = datetime.utcnow()
+    cutoff = now - timedelta(hours=hours)
+    stmt = (
+        update(Assessment)
+        .where(
+            Assessment.status.in_(NON_TERMINAL_STATUSES),
+            Assessment.deleted.is_not(True),
+            Assessment.requested_time < cutoff,
+        )
+        .values(
+            status="failed",
+            status_detail=TIMEOUT_STATUS_DETAIL,
+            end_time=now,
+        )
+        .returning(Assessment.id)
+        .execution_options(synchronize_session=False)
+    )
+    result = await db.execute(stmt)
+    swept_ids = [row[0] for row in result.all()]
+    await db.commit()
+
+    if swept_ids:
+        logger.info(
+            "Timeout sweep marked stuck assessments as failed",
+            extra={
+                "swept_count": len(swept_ids),
+                "hours": hours,
+                "cutoff": cutoff.isoformat(),
+                "swept_ids_sample": swept_ids[:50],
+            },
+        )
+
+    return TimeoutSweepResult(
+        swept_count=len(swept_ids),
+        swept_ids=swept_ids,
+        cutoff=cutoff,
+        hours=hours,
+    )
+
+
+@router.post("/assessment/timeout-sweep", response_model=TimeoutSweepResult)
+async def timeout_sweep(
+    hours: int = Query(
+        DEFAULT_TIMEOUT_HOURS,
+        ge=1,
+        description=(
+            "Mark assessments as failed if they are still queued or running and "
+            "their requested_time is older than this many hours."
+        ),
+    ),
+    db: AsyncSession = Depends(get_db),
+    _: UserModel = Depends(get_current_admin),
+) -> TimeoutSweepResult:
+    """Admin-only sweep that marks stuck non-terminal assessments as failed.
+
+    Assessments accumulate in the database in non-terminal states (queued,
+    running) when an upstream runner is lost or never reports a final status.
+    Calling this endpoint transitions any such assessment older than `hours`
+    to `failed` with a traceable status_detail.
+    """
+    return await sweep_stuck_assessments(db, hours=hours)

--- a/test/test_assessment_routes/test_timeout_sweep_routes.py
+++ b/test/test_assessment_routes/test_timeout_sweep_routes.py
@@ -1,0 +1,196 @@
+from datetime import datetime, timedelta
+
+from database.models import Assessment
+
+prefix = "v3"
+
+
+def _create_assessment(
+    db_session,
+    revision_id,
+    reference_id,
+    *,
+    status,
+    requested_time,
+    deleted=False,
+):
+    assessment = Assessment(
+        revision_id=revision_id,
+        reference_id=reference_id,
+        type="word-alignment",
+        status=status,
+        requested_time=requested_time,
+        deleted=deleted,
+    )
+    db_session.add(assessment)
+    db_session.commit()
+    db_session.refresh(assessment)
+    return assessment
+
+
+def test_timeout_sweep_marks_old_running_and_queued_failed(
+    client, admin_token, db_session, test_db_session
+):
+    revision_id = test_db_session.test_revision_id_1
+    reference_id = test_db_session.test_revision_id_2
+
+    old = datetime.utcnow() - timedelta(hours=48)
+    recent = datetime.utcnow() - timedelta(minutes=5)
+
+    stuck_running = _create_assessment(
+        db_session, revision_id, reference_id, status="running", requested_time=old
+    )
+    stuck_queued = _create_assessment(
+        db_session, revision_id, reference_id, status="queued", requested_time=old
+    )
+    fresh_running = _create_assessment(
+        db_session, revision_id, reference_id, status="running", requested_time=recent
+    )
+    already_finished = _create_assessment(
+        db_session, revision_id, reference_id, status="finished", requested_time=old
+    )
+    already_failed = _create_assessment(
+        db_session, revision_id, reference_id, status="failed", requested_time=old
+    )
+    deleted_stuck = _create_assessment(
+        db_session,
+        revision_id,
+        reference_id,
+        status="running",
+        requested_time=old,
+        deleted=True,
+    )
+
+    response = client.post(
+        f"{prefix}/assessment/timeout-sweep",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    swept_ids = set(body["swept_ids"])
+    assert stuck_running.id in swept_ids
+    assert stuck_queued.id in swept_ids
+    assert fresh_running.id not in swept_ids
+    assert already_finished.id not in swept_ids
+    assert already_failed.id not in swept_ids
+    assert deleted_stuck.id not in swept_ids
+    assert body["swept_count"] == len(body["swept_ids"])
+    assert body["hours"] == 24
+
+    db_session.expire_all()
+    refreshed_running = (
+        db_session.query(Assessment).filter(Assessment.id == stuck_running.id).first()
+    )
+    assert refreshed_running.status == "failed"
+    assert refreshed_running.status_detail == (
+        "Marked failed by upstream timeout sweep"
+    )
+    assert refreshed_running.end_time is not None
+
+    refreshed_queued = (
+        db_session.query(Assessment).filter(Assessment.id == stuck_queued.id).first()
+    )
+    assert refreshed_queued.status == "failed"
+    assert refreshed_queued.end_time is not None
+
+    refreshed_fresh = (
+        db_session.query(Assessment).filter(Assessment.id == fresh_running.id).first()
+    )
+    assert refreshed_fresh.status == "running"
+
+    refreshed_finished = (
+        db_session.query(Assessment)
+        .filter(Assessment.id == already_finished.id)
+        .first()
+    )
+    assert refreshed_finished.status == "finished"
+
+    refreshed_deleted = (
+        db_session.query(Assessment).filter(Assessment.id == deleted_stuck.id).first()
+    )
+    assert refreshed_deleted.status == "running"
+
+    # cleanup
+    for a in [
+        stuck_running,
+        stuck_queued,
+        fresh_running,
+        already_finished,
+        already_failed,
+        deleted_stuck,
+    ]:
+        db_session.query(Assessment).filter(Assessment.id == a.id).delete()
+    db_session.commit()
+
+
+def test_timeout_sweep_respects_custom_hours(
+    client, admin_token, db_session, test_db_session
+):
+    revision_id = test_db_session.test_revision_id_1
+    reference_id = test_db_session.test_revision_id_2
+
+    three_hours_ago = datetime.utcnow() - timedelta(hours=3)
+    forty_minutes_ago = datetime.utcnow() - timedelta(minutes=40)
+
+    older_than_2h = _create_assessment(
+        db_session,
+        revision_id,
+        reference_id,
+        status="running",
+        requested_time=three_hours_ago,
+    )
+    younger_than_2h = _create_assessment(
+        db_session,
+        revision_id,
+        reference_id,
+        status="running",
+        requested_time=forty_minutes_ago,
+    )
+
+    response = client.post(
+        f"{prefix}/assessment/timeout-sweep?hours=2",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["hours"] == 2
+    swept_ids = set(body["swept_ids"])
+    assert older_than_2h.id in swept_ids
+    assert younger_than_2h.id not in swept_ids
+
+    # cleanup
+    for a in [older_than_2h, younger_than_2h]:
+        db_session.query(Assessment).filter(Assessment.id == a.id).delete()
+    db_session.commit()
+
+
+def test_timeout_sweep_requires_admin(
+    client, regular_token1, db_session, test_db_session
+):
+    revision_id = test_db_session.test_revision_id_1
+    reference_id = test_db_session.test_revision_id_2
+    old = datetime.utcnow() - timedelta(hours=48)
+    stuck = _create_assessment(
+        db_session, revision_id, reference_id, status="running", requested_time=old
+    )
+
+    response = client.post(
+        f"{prefix}/assessment/timeout-sweep",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 403
+
+    db_session.expire_all()
+    refreshed = db_session.query(Assessment).filter(Assessment.id == stuck.id).first()
+    assert refreshed.status == "running"
+
+    db_session.query(Assessment).filter(Assessment.id == stuck.id).delete()
+    db_session.commit()
+
+
+def test_timeout_sweep_rejects_invalid_hours(client, admin_token):
+    response = client.post(
+        f"{prefix}/assessment/timeout-sweep?hours=0",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert response.status_code == 422

--- a/test/test_assessment_routes/test_timeout_sweep_routes.py
+++ b/test/test_assessment_routes/test_timeout_sweep_routes.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 
+from assessment_routes.v3.timeout_sweep_routes import TIMEOUT_STATUS_DETAIL
 from database.models import Assessment
 
 prefix = "v3"
@@ -28,14 +29,20 @@ def _create_assessment(
     return assessment
 
 
+def _delete_assessments(db_session, assessments):
+    for a in assessments:
+        db_session.query(Assessment).filter(Assessment.id == a.id).delete()
+    db_session.commit()
+
+
 def test_timeout_sweep_marks_old_running_and_queued_failed(
     client, admin_token, db_session, test_db_session
 ):
     revision_id = test_db_session.test_revision_id_1
     reference_id = test_db_session.test_revision_id_2
 
-    old = datetime.utcnow() - timedelta(hours=48)
-    recent = datetime.utcnow() - timedelta(minutes=5)
+    old = datetime.now() - timedelta(hours=48)
+    recent = datetime.now() - timedelta(minutes=5)
 
     stuck_running = _create_assessment(
         db_session, revision_id, reference_id, status="running", requested_time=old
@@ -60,67 +67,73 @@ def test_timeout_sweep_marks_old_running_and_queued_failed(
         requested_time=old,
         deleted=True,
     )
-
-    response = client.post(
-        f"{prefix}/assessment/timeout-sweep",
-        headers={"Authorization": f"Bearer {admin_token}"},
-    )
-    assert response.status_code == 200, response.text
-    body = response.json()
-    swept_ids = set(body["swept_ids"])
-    assert stuck_running.id in swept_ids
-    assert stuck_queued.id in swept_ids
-    assert fresh_running.id not in swept_ids
-    assert already_finished.id not in swept_ids
-    assert already_failed.id not in swept_ids
-    assert deleted_stuck.id not in swept_ids
-    assert body["swept_count"] == len(body["swept_ids"])
-    assert body["hours"] == 24
-
-    db_session.expire_all()
-    refreshed_running = (
-        db_session.query(Assessment).filter(Assessment.id == stuck_running.id).first()
-    )
-    assert refreshed_running.status == "failed"
-    assert refreshed_running.status_detail == (
-        "Marked failed by upstream timeout sweep"
-    )
-    assert refreshed_running.end_time is not None
-
-    refreshed_queued = (
-        db_session.query(Assessment).filter(Assessment.id == stuck_queued.id).first()
-    )
-    assert refreshed_queued.status == "failed"
-    assert refreshed_queued.end_time is not None
-
-    refreshed_fresh = (
-        db_session.query(Assessment).filter(Assessment.id == fresh_running.id).first()
-    )
-    assert refreshed_fresh.status == "running"
-
-    refreshed_finished = (
-        db_session.query(Assessment)
-        .filter(Assessment.id == already_finished.id)
-        .first()
-    )
-    assert refreshed_finished.status == "finished"
-
-    refreshed_deleted = (
-        db_session.query(Assessment).filter(Assessment.id == deleted_stuck.id).first()
-    )
-    assert refreshed_deleted.status == "running"
-
-    # cleanup
-    for a in [
+    created = [
         stuck_running,
         stuck_queued,
         fresh_running,
         already_finished,
         already_failed,
         deleted_stuck,
-    ]:
-        db_session.query(Assessment).filter(Assessment.id == a.id).delete()
-    db_session.commit()
+    ]
+
+    try:
+        response = client.post(
+            f"{prefix}/assessment/timeout-sweep",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        swept_ids = set(body["swept_ids"])
+        assert stuck_running.id in swept_ids
+        assert stuck_queued.id in swept_ids
+        assert fresh_running.id not in swept_ids
+        assert already_finished.id not in swept_ids
+        assert already_failed.id not in swept_ids
+        assert deleted_stuck.id not in swept_ids
+        assert body["swept_count"] == len(body["swept_ids"])
+        assert body["truncated"] is False
+        assert body["hours"] == 24
+
+        db_session.expire_all()
+        refreshed_running = (
+            db_session.query(Assessment)
+            .filter(Assessment.id == stuck_running.id)
+            .first()
+        )
+        assert refreshed_running.status == "failed"
+        assert refreshed_running.status_detail == TIMEOUT_STATUS_DETAIL
+        assert refreshed_running.end_time is not None
+
+        refreshed_queued = (
+            db_session.query(Assessment)
+            .filter(Assessment.id == stuck_queued.id)
+            .first()
+        )
+        assert refreshed_queued.status == "failed"
+        assert refreshed_queued.end_time is not None
+
+        refreshed_fresh = (
+            db_session.query(Assessment)
+            .filter(Assessment.id == fresh_running.id)
+            .first()
+        )
+        assert refreshed_fresh.status == "running"
+
+        refreshed_finished = (
+            db_session.query(Assessment)
+            .filter(Assessment.id == already_finished.id)
+            .first()
+        )
+        assert refreshed_finished.status == "finished"
+
+        refreshed_deleted = (
+            db_session.query(Assessment)
+            .filter(Assessment.id == deleted_stuck.id)
+            .first()
+        )
+        assert refreshed_deleted.status == "running"
+    finally:
+        _delete_assessments(db_session, created)
 
 
 def test_timeout_sweep_respects_custom_hours(
@@ -129,39 +142,50 @@ def test_timeout_sweep_respects_custom_hours(
     revision_id = test_db_session.test_revision_id_1
     reference_id = test_db_session.test_revision_id_2
 
-    three_hours_ago = datetime.utcnow() - timedelta(hours=3)
-    forty_minutes_ago = datetime.utcnow() - timedelta(minutes=40)
+    five_hours_ago = datetime.now() - timedelta(hours=5)
+    one_hour_ago = datetime.now() - timedelta(hours=1)
 
-    older_than_2h = _create_assessment(
+    older_than_3h = _create_assessment(
         db_session,
         revision_id,
         reference_id,
         status="running",
-        requested_time=three_hours_ago,
+        requested_time=five_hours_ago,
     )
-    younger_than_2h = _create_assessment(
+    younger_than_3h = _create_assessment(
         db_session,
         revision_id,
         reference_id,
         status="running",
-        requested_time=forty_minutes_ago,
+        requested_time=one_hour_ago,
     )
+    created = [older_than_3h, younger_than_3h]
 
+    try:
+        response = client.post(
+            f"{prefix}/assessment/timeout-sweep?hours=3",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["hours"] == 3
+        swept_ids = set(body["swept_ids"])
+        assert older_than_3h.id in swept_ids
+        assert younger_than_3h.id not in swept_ids
+    finally:
+        _delete_assessments(db_session, created)
+
+
+def test_timeout_sweep_returns_zero_when_nothing_to_sweep(client, admin_token):
     response = client.post(
-        f"{prefix}/assessment/timeout-sweep?hours=2",
+        f"{prefix}/assessment/timeout-sweep?hours=87600",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 200, response.text
     body = response.json()
-    assert body["hours"] == 2
-    swept_ids = set(body["swept_ids"])
-    assert older_than_2h.id in swept_ids
-    assert younger_than_2h.id not in swept_ids
-
-    # cleanup
-    for a in [older_than_2h, younger_than_2h]:
-        db_session.query(Assessment).filter(Assessment.id == a.id).delete()
-    db_session.commit()
+    assert body["swept_count"] == 0
+    assert body["swept_ids"] == []
+    assert body["truncated"] is False
 
 
 def test_timeout_sweep_requires_admin(
@@ -169,28 +193,38 @@ def test_timeout_sweep_requires_admin(
 ):
     revision_id = test_db_session.test_revision_id_1
     reference_id = test_db_session.test_revision_id_2
-    old = datetime.utcnow() - timedelta(hours=48)
+    old = datetime.now() - timedelta(hours=48)
     stuck = _create_assessment(
         db_session, revision_id, reference_id, status="running", requested_time=old
     )
 
+    try:
+        response = client.post(
+            f"{prefix}/assessment/timeout-sweep",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 403
+
+        db_session.expire_all()
+        refreshed = (
+            db_session.query(Assessment).filter(Assessment.id == stuck.id).first()
+        )
+        assert refreshed.status == "running"
+    finally:
+        _delete_assessments(db_session, [stuck])
+
+
+def test_timeout_sweep_rejects_hours_below_floor(client, admin_token):
     response = client.post(
-        f"{prefix}/assessment/timeout-sweep",
-        headers={"Authorization": f"Bearer {regular_token1}"},
+        f"{prefix}/assessment/timeout-sweep?hours=1",
+        headers={"Authorization": f"Bearer {admin_token}"},
     )
-    assert response.status_code == 403
-
-    db_session.expire_all()
-    refreshed = db_session.query(Assessment).filter(Assessment.id == stuck.id).first()
-    assert refreshed.status == "running"
-
-    db_session.query(Assessment).filter(Assessment.id == stuck.id).delete()
-    db_session.commit()
+    assert response.status_code == 422
 
 
-def test_timeout_sweep_rejects_invalid_hours(client, admin_token):
+def test_timeout_sweep_rejects_hours_above_ceiling(client, admin_token):
     response = client.post(
-        f"{prefix}/assessment/timeout-sweep?hours=0",
+        f"{prefix}/assessment/timeout-sweep?hours=999999",
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 422


### PR DESCRIPTION
## Summary

- Adds admin-only `POST /assessment/timeout-sweep` exposed under both `/v3` and `/latest` (matches the convention used by every other v3 router in `app.py`).
- Bulk-marks queued/running assessments older than a threshold as `failed`.
- Default threshold is **24 hours**, override via `?hours=N` query parameter (validated `2 <= N <= 87600`; the lower bound prevents an admin from accidentally failing a legitimately running 1-hour-old job, the upper bound prevents `timedelta` overflow).
- Status transition sets `status="failed"`, `status_detail="Marked failed by upstream timeout sweep"`, and `end_time=now()` so swept rows are traceable apart from real worker-reported failures.
- Skips deleted rows and rows already in a terminal status.
- Returns the count and IDs of swept assessments (capped at 1000 IDs with a `truncated` bool flag).
- Uses `datetime.now()` for the cutoff to stay consistent with how `requested_time` is written in `assessment_routes.py:480` and how `STALE_ASSESSMENT_HOURS` is computed at line 416 — see inline comment.

This unsticks assessments whose runners were lost or never reported a final status. Per #655, these were accumulating in non-terminal state and bloating the Django app's `refresh_running_assessments` sync URL (152 ancient ids in a single GET).

## Test plan

- [x] `pytest test/test_assessment_routes/test_timeout_sweep_routes.py` — 6 tests cover stuck-running/stuck-queued sweep, recent rows untouched, terminal rows untouched, deleted rows untouched, status_detail and `end_time` set, custom hours param respected, zero-swept happy path, non-admin gets 403, and `hours` below floor / above ceiling rejected with 422.
- [x] Existing `test/test_assessment_routes/test_assessment_routes.py` still green (51 tests).
- [ ] After deploy: call `POST /latest/assessment/timeout-sweep` once as admin and verify the Django app's polling URL shrinks back to in-flight ids only.

Closes #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)