### PR TITLE
textsearch: lateral comp lookup to drop p95 from minutes to ms

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -7,7 +7,7 @@ import unicodedata
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func
+from sqlalchemy import func, true
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import select
@@ -75,24 +75,27 @@ def _authorized_revisions_select(
     return q
 
 
-def _side_subquery(
+def _main_subquery(
     user: UserModel,
     version_id: Optional[int],
     revision_id: Optional[int],
-    ilike_pattern: Optional[str],
+    ilike_pattern: str,
 ):
-    """Build a subquery yielding one verse_text row per (book, chapter, verse).
+    """Build the main-side subquery: one verse_text row per (book, chapter, verse)
+    matching the search term.
 
     For ``version_id``, applies ``DISTINCT ON (book, chapter, verse)`` ordered
-    by ``bible_revision.date DESC`` so the latest non-empty revision wins per
-    vref, with older revisions filling gaps where the latest revision lacks
-    the verse (empty text or no row).
+    by ``bible_revision.date DESC`` so the latest non-empty matching revision
+    wins per vref, with older revisions filling gaps where the latest revision
+    lacks the verse (empty text or no term match).
 
     For ``revision_id``, simply filters by revision id (one row per vref by
     construction). Empty-text rows are excluded in both modes.
 
     Authorization is enforced inline via :func:`_authorized_revisions_select`,
-    so unauthorized callers get an empty subquery (zero rows).
+    so unauthorized callers get an empty subquery (zero rows). Includes
+    ``verse_reference`` so callers can join the comparison side via the
+    indexed column.
     """
     auth_revs = _authorized_revisions_select(
         user, version_id=version_id, revision_id=revision_id
@@ -104,6 +107,7 @@ def _side_subquery(
         vt.book.label("book"),
         vt.chapter.label("chapter"),
         vt.verse.label("verse"),
+        vt.verse_reference.label("verse_reference"),
         vt.text.label("text"),
     ]
 
@@ -115,10 +119,9 @@ def _side_subquery(
             .where(
                 vt.revision_id.in_(auth_revs),
                 vt.text != "",
+                _nfc_sql(vt.text).ilike(ilike_pattern),
             )
         )
-        if ilike_pattern is not None:
-            q = q.where(_nfc_sql(vt.text).ilike(ilike_pattern))
         # br.id.desc() is a stable tie-breaker so the per-vref pick is
         # deterministic when two revisions share the same date.
         q = q.distinct(vt.book, vt.chapter, vt.verse).order_by(
@@ -128,11 +131,61 @@ def _side_subquery(
         q = select(*select_cols).where(
             vt.revision_id.in_(auth_revs),
             vt.text != "",
+            _nfc_sql(vt.text).ilike(ilike_pattern),
         )
-        if ilike_pattern is not None:
-            q = q.where(_nfc_sql(vt.text).ilike(ilike_pattern))
 
     return q.subquery()
+
+
+def _comp_lateral(
+    user: UserModel,
+    version_id: Optional[int],
+    revision_id: Optional[int],
+    main_vref_col,
+):
+    """LATERAL subquery yielding the comparison text for the current main row.
+
+    For ``revision_id`` mode, returns the single row matching the vref
+    (zero rows if the comp revision lacks the verse). For ``version_id``
+    mode, performs the per-vref date-DESC pick of the latest non-empty
+    revision text.
+
+    Correlates to ``main_vref_col`` (the main row's ``verse_reference``)
+    so each main row triggers an indexed lookup against
+    ``ix_verse_text_verse_reference_revision`` instead of materializing the
+    full Bible for the comparison version up-front.
+    """
+    auth_revs = _authorized_revisions_select(
+        user, version_id=version_id, revision_id=revision_id
+    )
+
+    vt = aliased(VerseText)
+
+    if version_id is not None:
+        br = aliased(BibleRevision)
+        q = (
+            select(vt.text.label("text"))
+            .join(br, br.id == vt.revision_id)
+            .where(
+                vt.revision_id.in_(auth_revs),
+                vt.text != "",
+                vt.verse_reference == main_vref_col,
+            )
+            .order_by(br.date.desc(), br.id.desc())
+            .limit(1)
+        )
+    else:
+        q = (
+            select(vt.text.label("text"))
+            .where(
+                vt.revision_id.in_(auth_revs),
+                vt.text != "",
+                vt.verse_reference == main_vref_col,
+            )
+            .limit(1)
+        )
+
+    return q.lateral("comp")
 
 
 @router.get("/textsearch")
@@ -268,10 +321,10 @@ async def search_revision_text(
     ]
     like_pattern = "%" + "%".join(escaped_pieces) + "%"
 
-    # Build per-side subqueries. Each subquery produces one row per
-    # (book, chapter, verse): a single revision pick for revision_id mode
-    # or the date-DESC latest non-empty pick for version_id mode.
-    main_sub = _side_subquery(
+    # Build the main-side subquery (one row per vref matching the term),
+    # then look up the comparison side per-row via LATERAL so we never
+    # materialize the full Bible for the comparison version.
+    main_sub = _main_subquery(
         current_user,
         version_id=version_id,
         revision_id=revision_id,
@@ -281,11 +334,11 @@ async def search_revision_text(
         comparison_revision_id is not None or comparison_version_id is not None
     )
     if use_comparison:
-        comp_sub = _side_subquery(
+        comp_lat = _comp_lateral(
             current_user,
             version_id=comparison_version_id,
             revision_id=comparison_revision_id,
-            ilike_pattern=None,
+            main_vref_col=main_sub.c.verse_reference,
         )
         search_query = select(
             main_sub.c.id.label("id"),
@@ -293,15 +346,8 @@ async def search_revision_text(
             main_sub.c.chapter.label("chapter"),
             main_sub.c.verse.label("verse"),
             main_sub.c.text.label("main_text"),
-            comp_sub.c.text.label("comparison_text"),
-        ).select_from(
-            main_sub.join(
-                comp_sub,
-                (comp_sub.c.book == main_sub.c.book)
-                & (comp_sub.c.chapter == main_sub.c.chapter)
-                & (comp_sub.c.verse == main_sub.c.verse),
-            )
-        )
+            comp_lat.c.text.label("comparison_text"),
+        ).select_from(main_sub.join(comp_lat, true()))
     else:
         search_query = select(
             main_sub.c.id.label("id"),

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -145,7 +145,7 @@ def _comp_lateral(
 ):
     """LATERAL subquery yielding the comparison text for the current main row.
 
-    For ``revision_id`` mode, returns the single row matching the vref
+    For ``revision_id`` mode, returns at most one row matching the vref
     (zero rows if the comp revision lacks the verse). For ``version_id``
     mode, performs the per-vref date-DESC pick of the latest non-empty
     revision text.
@@ -154,10 +154,15 @@ def _comp_lateral(
     so each main row triggers an indexed lookup against
     ``ix_verse_text_verse_reference_revision`` instead of materializing the
     full Bible for the comparison version up-front.
+
+    The auth subquery is materialized as a CTE so Postgres evaluates it
+    once for the entire statement instead of risking re-evaluation per
+    lateral invocation, which would cost more for non-admin users whose
+    auth involves additional joins.
     """
     auth_revs = _authorized_revisions_select(
         user, version_id=version_id, revision_id=revision_id
-    )
+    ).cte("comp_auth_revs")
 
     vt = aliased(VerseText)
 
@@ -167,21 +172,29 @@ def _comp_lateral(
             select(vt.text.label("text"))
             .join(br, br.id == vt.revision_id)
             .where(
-                vt.revision_id.in_(auth_revs),
+                vt.revision_id.in_(select(auth_revs)),
                 vt.text != "",
+                vt.verse_reference.is_not(None),
                 vt.verse_reference == main_vref_col,
             )
+            # br.id.desc() is a stable tie-breaker so the per-vref pick is
+            # deterministic when two revisions share the same date.
             .order_by(br.date.desc(), br.id.desc())
             .limit(1)
         )
     else:
+        # The (verse_reference, revision_id) index is non-unique; in case
+        # duplicate rows ever exist for a (vref, revision_id) pair, pick the
+        # newest by id so the result is deterministic.
         q = (
             select(vt.text.label("text"))
             .where(
-                vt.revision_id.in_(auth_revs),
+                vt.revision_id.in_(select(auth_revs)),
                 vt.text != "",
+                vt.verse_reference.is_not(None),
                 vt.verse_reference == main_vref_col,
             )
+            .order_by(vt.id.desc())
             .limit(1)
         )
 
@@ -371,8 +384,9 @@ async def search_revision_text(
     search_query = search_query.limit(sql_limit)
 
     # Apply ordering on the outer query. Per-side dedup is already handled
-    # inside main_sub / comp_sub, so the outer query is free to randomize
-    # without violating DISTINCT ON's leading-column rule.
+    # inside main_sub (and the comp lateral picks at most one row per main
+    # row), so the outer query is free to randomize without violating
+    # DISTINCT ON's leading-column rule.
     if random:
         search_query = search_query.order_by(func.random())
     else:

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1388,6 +1388,114 @@ def test_search_by_version_id_with_comparison_version_id(
     )
 
 
+def test_search_comparison_drops_main_rows_with_no_comp_coverage(
+    client, regular_token1, test_db_session
+):
+    """When comp has no row at all for a vref the main matches, that main
+    row is dropped from results (INNER JOIN LATERAL semantics)."""
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+    if (
+        test_db_session.query(IsoLanguage).filter(IsoLanguage.iso639 == "swh").first()
+        is None
+    ):
+        test_db_session.add(IsoLanguage(iso639="swh", name="Swahili"))
+        test_db_session.commit()
+
+    eng_version = BibleVersion(
+        name="Drop Coverage Eng",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="DCE",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    swh_version = BibleVersion(
+        name="Drop Coverage Swh",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="DCS",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add_all([eng_version, swh_version])
+    test_db_session.commit()
+    test_db_session.refresh(eng_version)
+    test_db_session.refresh(swh_version)
+
+    eng_rev = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=eng_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    swh_rev = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=swh_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add_all([eng_rev, swh_rev])
+    test_db_session.commit()
+    test_db_session.refresh(eng_rev)
+    test_db_session.refresh(swh_rev)
+
+    # Main matches at GEN 1:1 and GEN 1:2
+    for verse, text in [
+        (1, "God created the heavens."),
+        (2, "God said let there be light."),
+    ]:
+        test_db_session.add(
+            VerseText(
+                text=text,
+                revision_id=eng_rev.id,
+                verse_reference=f"GEN 1:{verse}",
+                book="GEN",
+                chapter=1,
+                verse=verse,
+            )
+        )
+    # Comp covers GEN 1:1 only — GEN 1:2 has no row at all on the comp side.
+    test_db_session.add(
+        VerseText(
+            text="Mwanzoni Mungu aliumba mbingu.",
+            revision_id=swh_rev.id,
+            verse_reference="GEN 1:1",
+            book="GEN",
+            chapter=1,
+            verse=1,
+        )
+    )
+    for version in (eng_version, swh_version):
+        test_db_session.add(
+            BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+        )
+    test_db_session.commit()
+
+    response = client.get(
+        "/v3/textsearch",
+        params={
+            "version_id": eng_version.id,
+            "comparison_version_id": swh_version.id,
+            "term": "God",
+            "limit": 10,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    refs = {(r["book"], r["chapter"], r["verse"]) for r in data["results"]}
+    # GEN 1:2 must be absent because comp lacks coverage there.
+    assert ("GEN", 1, 1) in refs
+    assert (
+        "GEN",
+        1,
+        2,
+    ) not in refs, (
+        f"Expected GEN 1:2 dropped from results when comp has no row for it; got {refs}"
+    )
+
+
 def test_search_by_version_id_with_comparison_revision_id(
     client, regular_token1, test_db_session
 ):


### PR DESCRIPTION
## Summary

The /v3/textsearch endpoint with both `version_id` and `comparison_version_id` had p95s of 50+ minutes in production (top-10 slowest endpoints). Root cause: the comparison side materialized the full per-vref dedup of the comparison version up front, then joined it with the term-filtered main side. With `random=true`, `ORDER BY random() LIMIT N` ran over that join, so the user-facing `limit` didn't bound the inner work.

This PR replaces the materialized comp subquery with a `JOIN LATERAL` correlated on `verse_reference`. Per main row, comp becomes an indexed point lookup against `ix_verse_text_verse_reference_revision` — total comp work scales with the trgm-filtered match count instead of the size of the comparison Bible.

- `_side_subquery` split into `_main_subquery` (kept DISTINCT ON + trgm filter, now exposes `verse_reference`) and `_comp_lateral` (correlated lateral, returns the per-vref date-DESC pick or single revision row).
- INNER `JOIN LATERAL ... ON true` preserves prior behavior of dropping main rows where comp lacks coverage.
- Random sampling fix is implicit: the outer `ORDER BY random() LIMIT` now sorts a set bounded by main_sub size.

## Expected impact

For `?term=mu+kwata&version_id=54&comparison_version_id=1036`:
- **Before:** materialize ~30k–150k comp rows for v1036, sort, dedup, join, sort by random
- **After:** trgm prefilter on main (small set) → per-row indexed lookup on comp → small sort

Compiled SQL inspected to confirm `JOIN LATERAL (... WHERE verse_text_2.verse_reference = anon_1.verse_reference ... LIMIT 1) ON true`.

## Test plan

- [x] All 57 tests in `test/test_assessment_routes/test_search_routes.py` pass
- [x] black / isort / flake8 clean
- [ ] After merge, run `EXPLAIN (ANALYZE, BUFFERS)` on the slow URL in prod to confirm trgm bitmap scan + verse_reference index lookup
- [ ] Watch p95 on the textsearch endpoint after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)