### PR TITLE
textsearch: disable bitmap scan to bypass pg_trgm cost mis-estimate

### DIFF
--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -7,7 +7,7 @@ import unicodedata
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func, true
+from sqlalchemy import func, text, true
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import select
@@ -406,7 +406,22 @@ async def search_revision_text(
         )
 
     try:
-        # Execute the query
+        # The trgm GIN index on NORMALIZE(text, NFC) has very poor real
+        # selectivity for common-trigram phrases (e.g. "mu kwata" returns
+        # ~1.4M candidate rows per scan), but the planner's selectivity
+        # estimate is ~80x optimistic. Combined with the nested loop over
+        # multi-revision versions, that picks a plan that re-runs the trgm
+        # bitmap scan once per revision (~6s × N revisions).
+        #
+        # The plain ix_verse_text_revision_id scan with a per-row
+        # NORMALIZE+ILIKE recheck is ~76x faster on the slow case (1.2s vs
+        # 91s in production EXPLAIN ANALYZE) and only marginally slower on
+        # the selective-phrase case where both plans are sub-second. Force
+        # it on for this query; SET LOCAL scopes the change to this
+        # transaction, so the pooled connection isn't poisoned for other
+        # callers.
+        await db.execute(text("SET LOCAL enable_bitmapscan = off"))
+
         result = await db.execute(search_query)
         rows = result.all()
 

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -419,9 +419,9 @@ async def search_revision_text(
         # the selective-phrase case where both plans are sub-second. Disable
         # bitmap scan so the planner picks that path. SET LOCAL scopes the
         # change to this transaction, so the pooled connection isn't
-        # poisoned for other callers — but note this relies on session-mode
-        # pooling: in pgbouncer transaction-mode the setting would only
-        # cover the SET statement itself and silently no-op for the search.
+        # poisoned for other callers — relies on the SET and the search
+        # query running in the same transaction, which AsyncSession does by
+        # default; would silently no-op under autocommit-style execution.
         await db.execute(text("SET LOCAL enable_bitmapscan = off"))
 
         result = await db.execute(search_query)

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -416,10 +416,12 @@ async def search_revision_text(
         # The plain ix_verse_text_revision_id scan with a per-row
         # NORMALIZE+ILIKE recheck is ~76x faster on the slow case (1.2s vs
         # 91s in production EXPLAIN ANALYZE) and only marginally slower on
-        # the selective-phrase case where both plans are sub-second. Force
-        # it on for this query; SET LOCAL scopes the change to this
-        # transaction, so the pooled connection isn't poisoned for other
-        # callers.
+        # the selective-phrase case where both plans are sub-second. Disable
+        # bitmap scan so the planner picks that path. SET LOCAL scopes the
+        # change to this transaction, so the pooled connection isn't
+        # poisoned for other callers — but note this relies on session-mode
+        # pooling: in pgbouncer transaction-mode the setting would only
+        # cover the SET statement itself and silently no-op for the search.
         await db.execute(text("SET LOCAL enable_bitmapscan = off"))
 
         result = await db.execute(search_query)


### PR DESCRIPTION
## Summary

Follow-up to #658. The lateral comp lookup eliminated the comparison-side blowup, but production EXPLAIN ANALYZE on `?term=mu+kwata&version_id=54&comparison_version_id=1036` still ran in 91s. Root cause is on the main side and unrelated to the lateral fix.

The pg_trgm GIN index on `NORMALIZE(text, NFC)` reports an 80x optimistic selectivity estimate for common-trigram phrases:

```
Bitmap Index Scan on ix_verse_text_nfc_trgm
  est rows=17,661   actual rows=1,389,297   loops=15   total ≈ 91s
```

The planner picks `BitmapAnd(trgm, revision_id)` as the inner of a nested loop over a multi-revision version. Bitmap leaves don't cache across loops, so the trgm scan is re-executed once per revision (15 × ~6s).

Forcing `enable_bitmapscan = off` on the same query in the same transaction makes the planner pick a plain `Index Scan using ix_verse_text_revision_id` with a per-row NORMALIZE+ILIKE recheck:

```
Execution Time: 1192.406 ms     (vs 91 s with bitmap on — ~76x faster)
```

`ANALYZE verse_text` was tried first and made no difference — the cost-vs-actual gap survives fresh statistics.

## What this changes

One `SET LOCAL enable_bitmapscan = off` issued just before the search query in the same transaction. Sanity-checked that:

- The setting takes effect within the transaction (`SHOW enable_bitmapscan` returns `off` after).
- It reverts cleanly on commit, so the pooled connection isn't poisoned for other callers (`SHOW` returns `on` in a fresh session).
- All 58 tests in `test_search_routes.py` still pass.

## Tradeoff

For very selective phrases (rare long words), bitmap was faster than the index-scan path — but both were sub-second, so the absolute difference is small. For common phrases like `mu kwata`, bitmap is 76x slower. Disabling bitmap trades a tiny worst-case slowdown on selective queries for a massive win on common ones.

## Test plan

- [x] All 58 search tests pass locally
- [x] `SHOW enable_bitmapscan` confirms scoping (off-during, on-after)
- [x] black / isort / flake8 clean
- [ ] After merge, re-run EXPLAIN ANALYZE on prod with the same URL — expect ~1–2s total (vs 91s)
- [ ] Watch p95 of `/v3/textsearch` after deploy — should drop into the seconds range

🤖 Generated with [Claude Code](https://claude.com/claude-code)