### PR TITLE
Phase 0 schema for pivot-language card architecture (#665)

### DIFF
--- a/alembic/migrations/versions/a6c1e7d3b4f2_pivot_card_schema.py
+++ b/alembic/migrations/versions/a6c1e7d3b4f2_pivot_card_schema.py
@@ -119,9 +119,16 @@ def upgrade() -> None:
         )
 
     # 2. Add the new columns (nullable for now so we can backfill).
+    # FK to iso_language matches the convention used by
+    # bible_version.iso_language and other ISO language columns.
     op.add_column(
         "agent_lexeme_cards",
-        sa.Column("source_language_iso", sa.String(3), nullable=True),
+        sa.Column(
+            "source_language_iso",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=True,
+        ),
     )
     op.add_column(
         "agent_lexeme_cards",
@@ -196,7 +203,12 @@ def upgrade() -> None:
             sa.ForeignKey("agent_lexeme_cards.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("language_iso", sa.String(3), nullable=False),
+        sa.Column(
+            "language_iso",
+            sa.String(3),
+            sa.ForeignKey("iso_language.iso639"),
+            nullable=False,
+        ),
         sa.Column("source_lemma", sa.Text(), nullable=True),
         sa.Column(
             "source_surface_forms",

--- a/alembic/migrations/versions/a6c1e7d3b4f2_pivot_card_schema.py
+++ b/alembic/migrations/versions/a6c1e7d3b4f2_pivot_card_schema.py
@@ -1,0 +1,305 @@
+"""Phase 0 schema for pivot-language card architecture
+
+Revision ID: a6c1e7d3b4f2
+Revises: 1d460bf9ea55
+Create Date: 2026-05-13
+
+Additive schema work that unblocks the pivot-language card architecture
+being developed in aqua-assessments (see aqua-api#665):
+
+  * Card identity shifts from "built against this specific Bible version"
+    to "built against this language" — the source-side reading pool is a
+    curated set of openly-licensed Bibles, so version-specificity doesn't
+    apply on that side. Target-side identity stays revision-keyed.
+  * Cards become a per-target-revision artifact built once against a
+    system-chosen canonical pivot language; cheap MT-derived translations
+    for other languages will be layered on top in subsequent issues via
+    the new `card_translations` / `card_translation_examples` tables.
+
+Concrete changes in this revision:
+
+  1. Add ``source_language_iso`` (NOT NULL after backfill) and
+     ``build_version`` (nullable) to ``agent_lexeme_cards``.
+  2. Backfill ``source_language_iso`` from ``bible_version.iso_language``
+     via ``source_version_id``. Embedded pre-check refuses to proceed if
+     any orphaned rows exist (empirically zero today).
+  3. Swap the unique constraint from version-keyed
+     ``(LOWER(target_lemma), source_version_id, target_version_id)`` to
+     language-keyed
+     ``(LOWER(target_lemma), source_language_iso, target_version_id)``.
+     Embedded pre-check refuses to proceed if the new constraint would
+     create collisions.
+  4. Install a BEFORE INSERT/UPDATE trigger that auto-fills
+     ``source_language_iso`` from the row's ``source_version_id`` when
+     callers don't supply it. This is what lets existing writers — which
+     don't know about the new column yet — keep working unchanged
+     against the NOT NULL constraint. Writers will be updated in a
+     follow-up issue to set it explicitly.
+  5. Create ``card_translations`` and ``card_translation_examples``
+     tables. No readers/writers yet; this revision is purely structural.
+
+Everything runs in a single upgrade transaction so a partially-applied
+state is impossible. (Index ops are plain CREATE/DROP INDEX rather than
+CONCURRENTLY for that reason; the table is small enough — TRUNCATE'd in
+e3a9f5d2c8b1 and only repopulated by new agent-critique runs — that the
+brief ACCESS EXCLUSIVE lock is acceptable.)
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a6c1e7d3b4f2"
+down_revision: Union[str, None] = "1d460bf9ea55"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Trigger keeps existing writers working: pre-pivot code paths insert
+# rows without source_language_iso. The trigger derives it from the
+# row's source_version_id so the NOT NULL constraint holds without app
+# changes. Mirrored in database/models.py via DDL events so test DBs
+# (which use Base.metadata.create_all, not migrations) get it too.
+_TRIGGER_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION fill_lexeme_card_source_language_iso()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.source_language_iso IS NULL AND NEW.source_version_id IS NOT NULL THEN
+        SELECT iso_language INTO NEW.source_language_iso
+        FROM bible_version WHERE id = NEW.source_version_id;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+_TRIGGER_CREATE_SQL = """
+CREATE TRIGGER trg_fill_lexeme_card_source_language_iso
+BEFORE INSERT OR UPDATE OF source_version_id ON agent_lexeme_cards
+FOR EACH ROW
+EXECUTE FUNCTION fill_lexeme_card_source_language_iso();
+"""
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # 1. Empirical pre-check: every row must resolve to a bible_version
+    # with a populated iso_language, otherwise the backfill leaves rows
+    # with NULL source_language_iso and the NOT NULL flip below fails.
+    # Empirically zero today; abort if anything has crept in.
+    orphans = bind.exec_driver_sql(
+        """
+        SELECT COUNT(*) FROM agent_lexeme_cards c
+        WHERE c.source_version_id NOT IN (SELECT id FROM bible_version)
+           OR (SELECT iso_language FROM bible_version
+               WHERE id = c.source_version_id) IS NULL
+        """
+    ).scalar()
+    if orphans:
+        raise RuntimeError(
+            f"agent_lexeme_cards: {orphans} row(s) have a source_version_id "
+            "that does not resolve to a bible_version with iso_language set. "
+            "Resolve these by hand before re-running the migration."
+        )
+
+    # 2. Add the new columns (nullable for now so we can backfill).
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column("source_language_iso", sa.CHAR(3), nullable=True),
+    )
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column("build_version", sa.Text(), nullable=True),
+    )
+
+    # 3. Backfill source_language_iso from bible_version.iso_language.
+    op.execute(
+        """
+        UPDATE agent_lexeme_cards c
+        SET source_language_iso = bv.iso_language
+        FROM bible_version bv
+        WHERE c.source_version_id = bv.id
+        """
+    )
+
+    # 4. Now that every row has a value, lock the NOT NULL in.
+    op.alter_column("agent_lexeme_cards", "source_language_iso", nullable=False)
+
+    # 5. Install the auto-fill trigger so existing writers (which don't
+    # set source_language_iso) keep working. Must come before any later
+    # writes — including ones from concurrent rolling-deploy code paths.
+    op.execute(_TRIGGER_FUNCTION_SQL)
+    op.execute(_TRIGGER_CREATE_SQL)
+
+    # 6. Empirical pre-check for the constraint swap: would the
+    # language-keyed unique index create collisions? Empirically returns
+    # zero rows today; abort with a clear error if anything has changed.
+    duplicates = bind.exec_driver_sql(
+        """
+        SELECT bv.iso_language, c.target_version_id, LOWER(c.target_lemma),
+               COUNT(*) AS n
+        FROM agent_lexeme_cards c
+        JOIN bible_version bv ON c.source_version_id = bv.id
+        GROUP BY bv.iso_language, c.target_version_id, LOWER(c.target_lemma)
+        HAVING COUNT(*) > 1
+        """
+    ).fetchall()
+    if duplicates:
+        sample = ", ".join(
+            f"({lang!r}, target_version_id={tvid}, lemma={lemma!r}, count={n})"
+            for lang, tvid, lemma, n in duplicates[:5]
+        )
+        raise RuntimeError(
+            f"agent_lexeme_cards: {len(duplicates)} collision group(s) would "
+            f"violate the new language-keyed unique constraint. Examples: "
+            f"{sample}. Reconcile by hand before re-running the migration."
+        )
+
+    # 7. Swap the unique index from version-keyed (v4) to language-keyed (v5).
+    op.drop_index("ix_agent_lexeme_cards_unique_v4", table_name="agent_lexeme_cards")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX ix_agent_lexeme_cards_unique_v5
+        ON agent_lexeme_cards
+            (LOWER(target_lemma), source_language_iso, target_version_id)
+        """
+    )
+
+    # 8. Holder for cheap MT-derived translations of canonical cards.
+    # Canonical content stays in agent_lexeme_cards directly — the
+    # U-shaped model rejected by the issue would make canonical "just
+    # another row" here at the cost of more invasive reader changes.
+    op.create_table(
+        "card_translations",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "card_id",
+            sa.Integer(),
+            sa.ForeignKey("agent_lexeme_cards.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("language_iso", sa.CHAR(3), nullable=False),
+        sa.Column("source_lemma", sa.Text(), nullable=True),
+        sa.Column(
+            "source_surface_forms",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column(
+            "senses",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+        sa.Column("parent_build_version", sa.Text(), nullable=True),
+        sa.Column("build_version", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "last_updated",
+            sa.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_card_translations_unique",
+        "card_translations",
+        ["card_id", "language_iso"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_card_translations_card_id",
+        "card_translations",
+        ["card_id"],
+    )
+
+    # 9. Per-example translation rows. The target-language text lives on
+    # the canonical example via the example_id FK; this table stores
+    # only the MT'd source-side text. That avoids duplicating low-
+    # resource target text and lets corrections to a canonical example
+    # flow through translation consumers automatically.
+    op.create_table(
+        "card_translation_examples",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "card_translation_id",
+            sa.Integer(),
+            sa.ForeignKey("card_translations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "example_id",
+            sa.Integer(),
+            sa.ForeignKey("agent_lexeme_card_examples.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("source_text", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_card_translation_examples_unique",
+        "card_translation_examples",
+        ["card_translation_id", "example_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_card_translation_examples_translation",
+        "card_translation_examples",
+        ["card_translation_id"],
+    )
+
+
+def downgrade() -> None:
+    # 1. Drop the new translation tables (cascade FKs handled by op.drop_table).
+    op.drop_index(
+        "ix_card_translation_examples_translation",
+        table_name="card_translation_examples",
+    )
+    op.drop_index(
+        "ix_card_translation_examples_unique",
+        table_name="card_translation_examples",
+    )
+    op.drop_table("card_translation_examples")
+
+    op.drop_index("ix_card_translations_card_id", table_name="card_translations")
+    op.drop_index("ix_card_translations_unique", table_name="card_translations")
+    op.drop_table("card_translations")
+
+    # 2. Reverse the unique-index swap. Both directions use the same
+    # row data because v4's (source_version_id, target_version_id)
+    # tuple is one-to-one with v5's (source_language_iso,
+    # target_version_id) for any row that's actually in the table
+    # (source_version_id determines source_language_iso by FK).
+    op.execute("DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v5")
+    op.execute(
+        """
+        CREATE UNIQUE INDEX ix_agent_lexeme_cards_unique_v4
+        ON agent_lexeme_cards
+            (LOWER(target_lemma), source_version_id, target_version_id)
+        """
+    )
+
+    # 3. Drop the auto-fill trigger before its target column goes away.
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_fill_lexeme_card_source_language_iso "
+        "ON agent_lexeme_cards"
+    )
+    op.execute("DROP FUNCTION IF EXISTS fill_lexeme_card_source_language_iso()")
+
+    # 4. Drop the new columns. Backfilled data is lost on downgrade but
+    # is recoverable from bible_version.iso_language if needed.
+    op.drop_column("agent_lexeme_cards", "build_version")
+    op.drop_column("agent_lexeme_cards", "source_language_iso")

--- a/alembic/migrations/versions/a6c1e7d3b4f2_pivot_card_schema.py
+++ b/alembic/migrations/versions/a6c1e7d3b4f2_pivot_card_schema.py
@@ -61,8 +61,11 @@ depends_on: Union[str, Sequence[str], None] = None
 # Trigger keeps existing writers working: pre-pivot code paths insert
 # rows without source_language_iso. The trigger derives it from the
 # row's source_version_id so the NOT NULL constraint holds without app
-# changes. Mirrored in database/models.py via DDL events so test DBs
-# (which use Base.metadata.create_all, not migrations) get it too.
+# changes. The IS NULL guard means a follow-up UPDATE that swaps
+# source_version_id to a different language without also clearing
+# source_language_iso will leave the column out of sync — callers
+# updating source_version_id should set source_language_iso = NULL to
+# trigger the re-derive, or set both explicitly.
 _TRIGGER_FUNCTION_SQL = """
 CREATE OR REPLACE FUNCTION fill_lexeme_card_source_language_iso()
 RETURNS TRIGGER AS $$
@@ -76,6 +79,11 @@ END;
 $$ LANGUAGE plpgsql;
 """
 
+_TRIGGER_DROP_SQL = (
+    "DROP TRIGGER IF EXISTS trg_fill_lexeme_card_source_language_iso "
+    "ON agent_lexeme_cards"
+)
+
 _TRIGGER_CREATE_SQL = """
 CREATE TRIGGER trg_fill_lexeme_card_source_language_iso
 BEFORE INSERT OR UPDATE OF source_version_id ON agent_lexeme_cards
@@ -87,10 +95,14 @@ EXECUTE FUNCTION fill_lexeme_card_source_language_iso();
 def upgrade() -> None:
     bind = op.get_bind()
 
-    # 1. Empirical pre-check: every row must resolve to a bible_version
-    # with a populated iso_language, otherwise the backfill leaves rows
-    # with NULL source_language_iso and the NOT NULL flip below fails.
-    # Empirically zero today; abort if anything has crept in.
+    # Fail fast rather than queue behind a long-running concurrent
+    # transaction on RDS — the alter_column SET NOT NULL below takes
+    # ACCESS EXCLUSIVE and would otherwise wait indefinitely.
+    op.execute("SET LOCAL lock_timeout = '5s'")
+
+    # 1. Pre-check: every row must resolve to a bible_version with a
+    # populated iso_language, otherwise the backfill leaves rows with
+    # NULL source_language_iso and the NOT NULL flip below fails.
     orphans = bind.exec_driver_sql(
         """
         SELECT COUNT(*) FROM agent_lexeme_cards c
@@ -109,7 +121,7 @@ def upgrade() -> None:
     # 2. Add the new columns (nullable for now so we can backfill).
     op.add_column(
         "agent_lexeme_cards",
-        sa.Column("source_language_iso", sa.CHAR(3), nullable=True),
+        sa.Column("source_language_iso", sa.String(3), nullable=True),
     )
     op.add_column(
         "agent_lexeme_cards",
@@ -133,18 +145,19 @@ def upgrade() -> None:
     # set source_language_iso) keep working. Must come before any later
     # writes — including ones from concurrent rolling-deploy code paths.
     op.execute(_TRIGGER_FUNCTION_SQL)
+    op.execute(_TRIGGER_DROP_SQL)
     op.execute(_TRIGGER_CREATE_SQL)
 
-    # 6. Empirical pre-check for the constraint swap: would the
-    # language-keyed unique index create collisions? Empirically returns
-    # zero rows today; abort with a clear error if anything has changed.
+    # 6. Pre-check for the constraint swap: would the language-keyed
+    # unique index create collisions? Uses the freshly-backfilled
+    # column rather than re-joining bible_version.
     duplicates = bind.exec_driver_sql(
         """
-        SELECT bv.iso_language, c.target_version_id, LOWER(c.target_lemma),
-               COUNT(*) AS n
+        SELECT c.source_language_iso, c.target_version_id,
+               LOWER(c.target_lemma), COUNT(*) AS n
         FROM agent_lexeme_cards c
-        JOIN bible_version bv ON c.source_version_id = bv.id
-        GROUP BY bv.iso_language, c.target_version_id, LOWER(c.target_lemma)
+        GROUP BY c.source_language_iso, c.target_version_id,
+                 LOWER(c.target_lemma)
         HAVING COUNT(*) > 1
         """
     ).fetchall()
@@ -160,7 +173,9 @@ def upgrade() -> None:
         )
 
     # 7. Swap the unique index from version-keyed (v4) to language-keyed (v5).
-    op.drop_index("ix_agent_lexeme_cards_unique_v4", table_name="agent_lexeme_cards")
+    # IF EXISTS on the drop mirrors the downgrade's defensive form so the
+    # migration tolerates partial-state recoveries from prior runs.
+    op.execute("DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v4")
     op.execute(
         """
         CREATE UNIQUE INDEX ix_agent_lexeme_cards_unique_v5
@@ -169,10 +184,9 @@ def upgrade() -> None:
         """
     )
 
-    # 8. Holder for cheap MT-derived translations of canonical cards.
-    # Canonical content stays in agent_lexeme_cards directly — the
-    # U-shaped model rejected by the issue would make canonical "just
-    # another row" here at the cost of more invasive reader changes.
+    # 8. Canonical card content stays on agent_lexeme_cards; the
+    # U-shaped alternative (canonical as just another row here) was
+    # rejected as more invasive without enough payoff.
     op.create_table(
         "card_translations",
         sa.Column("id", sa.Integer(), primary_key=True),
@@ -182,7 +196,7 @@ def upgrade() -> None:
             sa.ForeignKey("agent_lexeme_cards.id", ondelete="CASCADE"),
             nullable=False,
         ),
-        sa.Column("language_iso", sa.CHAR(3), nullable=False),
+        sa.Column("language_iso", sa.String(3), nullable=False),
         sa.Column("source_lemma", sa.Text(), nullable=True),
         sa.Column(
             "source_surface_forms",

--- a/database/models.py
+++ b/database/models.py
@@ -1,5 +1,7 @@
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
+    CHAR,
+    DDL,
     TIMESTAMP,
     Boolean,
     CheckConstraint,
@@ -15,6 +17,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    event,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.declarative import declarative_base
@@ -458,6 +461,13 @@ class AgentLexemeCard(Base):
     target_lemma = Column(Text, nullable=False)
     source_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
     target_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
+    # Pivot-language card identity: the ISO 639-3 code of the source language
+    # the canonical card was built against. Auto-filled from source_version_id
+    # by a BEFORE INSERT/UPDATE trigger if callers omit it.
+    source_language_iso = Column(CHAR(3), nullable=False)
+    # Opaque token bumped when the canonical card-builder rebuilds the card.
+    # Nullable forever; only the most recent build sets it.
+    build_version = Column(Text, nullable=True)
     pos = Column(Text)
     surface_forms = Column(JSONB)  # JSON array of target language surface forms
     source_surface_forms = Column(JSONB)  # JSON array of source language surface forms
@@ -471,12 +481,13 @@ class AgentLexemeCard(Base):
     last_user_edit = Column(TIMESTAMP, nullable=True)
 
     __table_args__ = (
-        # Case-insensitive unique constraint to prevent duplicate cards
-        # Each LOWER(target_lemma) can only have one card per version pair
+        # Case-insensitive language-keyed unique constraint (pivot-language
+        # architecture): one canonical card per (lemma, source language,
+        # target revision's version). Replaces the older version-keyed v4.
         Index(
-            "ix_agent_lexeme_cards_unique_v4",
+            "ix_agent_lexeme_cards_unique_v5",
             func.lower(target_lemma),
-            "source_version_id",
+            "source_language_iso",
             "target_version_id",
             unique=True,
         ),
@@ -557,6 +568,126 @@ class AgentLexemeCardExample(Base):
     # Relationships
     lexeme_card = relationship("AgentLexemeCard", back_populates="examples_rel")
     revision = relationship("BibleRevision")
+
+
+class CardTranslation(Base):
+    """Cheap MT-derived translation of a canonical lexeme card.
+
+    Canonical card content stays on AgentLexemeCard; this table only
+    carries the per-output-language overlay (source-side lemma, surface
+    forms, senses) plus build-version provenance so consumers can detect
+    when a translation is stale relative to its parent card.
+    """
+
+    __tablename__ = "card_translations"
+
+    id = Column(Integer, primary_key=True)
+    card_id = Column(
+        Integer,
+        ForeignKey("agent_lexeme_cards.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    language_iso = Column(CHAR(3), nullable=False)
+    source_lemma = Column(Text, nullable=True)
+    source_surface_forms = Column(JSONB, nullable=True)
+    senses = Column(JSONB, nullable=True)
+    parent_build_version = Column(Text, nullable=True)
+    build_version = Column(Text, nullable=True)
+    created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+    last_updated = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+
+    __table_args__ = (
+        Index(
+            "ix_card_translations_unique",
+            "card_id",
+            "language_iso",
+            unique=True,
+        ),
+        Index("ix_card_translations_card_id", "card_id"),
+    )
+
+    card = relationship("AgentLexemeCard")
+    examples = relationship(
+        "CardTranslationExample",
+        back_populates="card_translation",
+        cascade="all, delete-orphan",
+    )
+
+
+class CardTranslationExample(Base):
+    """Per-example translation of a card example.
+
+    The canonical AgentLexemeCardExample owns the target-language text;
+    this row stores only the MT'd source-side text. Reading the full
+    translated example means joining example_id back to
+    agent_lexeme_card_examples for the target text.
+    """
+
+    __tablename__ = "card_translation_examples"
+
+    id = Column(Integer, primary_key=True)
+    card_translation_id = Column(
+        Integer,
+        ForeignKey("card_translations.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    example_id = Column(
+        Integer,
+        ForeignKey("agent_lexeme_card_examples.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source_text = Column(Text, nullable=False)
+    created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+
+    __table_args__ = (
+        Index(
+            "ix_card_translation_examples_unique",
+            "card_translation_id",
+            "example_id",
+            unique=True,
+        ),
+        Index(
+            "ix_card_translation_examples_translation",
+            "card_translation_id",
+        ),
+    )
+
+    card_translation = relationship("CardTranslation", back_populates="examples")
+    example = relationship("AgentLexemeCardExample")
+
+
+# Auto-fill trigger for agent_lexeme_cards.source_language_iso.
+# Defined here as well as in the alembic migration so test DBs (which
+# bootstrap via Base.metadata.create_all rather than alembic) get it on
+# table creation. Production picks it up from the migration.
+_LEXEME_CARD_FILL_LANG_FN = DDL(
+    """
+    CREATE OR REPLACE FUNCTION fill_lexeme_card_source_language_iso()
+    RETURNS TRIGGER AS $$
+    BEGIN
+        IF NEW.source_language_iso IS NULL AND NEW.source_version_id IS NOT NULL THEN
+            SELECT iso_language INTO NEW.source_language_iso
+            FROM bible_version WHERE id = NEW.source_version_id;
+        END IF;
+        RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    """
+)
+
+_LEXEME_CARD_FILL_LANG_TRIGGER = DDL(
+    """
+    DROP TRIGGER IF EXISTS trg_fill_lexeme_card_source_language_iso
+        ON agent_lexeme_cards;
+    CREATE TRIGGER trg_fill_lexeme_card_source_language_iso
+    BEFORE INSERT OR UPDATE OF source_version_id ON agent_lexeme_cards
+    FOR EACH ROW
+    EXECUTE FUNCTION fill_lexeme_card_source_language_iso();
+    """
+)
+
+event.listen(AgentLexemeCard.__table__, "after_create", _LEXEME_CARD_FILL_LANG_FN)
+event.listen(AgentLexemeCard.__table__, "after_create", _LEXEME_CARD_FILL_LANG_TRIGGER)
 
 
 class AgentWordAlignment(Base):

--- a/database/models.py
+++ b/database/models.py
@@ -463,7 +463,9 @@ class AgentLexemeCard(Base):
     # Pivot-language card identity: the ISO 639-3 code of the source language
     # the canonical card was built against. Auto-filled from source_version_id
     # by a BEFORE INSERT/UPDATE trigger if callers omit it.
-    source_language_iso = Column(String(3), nullable=False)
+    source_language_iso = Column(
+        String(3), ForeignKey("iso_language.iso639"), nullable=False
+    )
     # Opaque token bumped when the canonical card-builder rebuilds the card.
     # Nullable forever; only the most recent build sets it.
     build_version = Column(Text, nullable=True)
@@ -586,7 +588,7 @@ class CardTranslation(Base):
         ForeignKey("agent_lexeme_cards.id", ondelete="CASCADE"),
         nullable=False,
     )
-    language_iso = Column(String(3), nullable=False)
+    language_iso = Column(String(3), ForeignKey("iso_language.iso639"), nullable=False)
     source_lemma = Column(Text, nullable=True)
     source_surface_forms = Column(JSONB, nullable=True)
     senses = Column(JSONB, nullable=True)

--- a/database/models.py
+++ b/database/models.py
@@ -674,10 +674,16 @@ _LEXEME_CARD_FILL_LANG_FN = DDL(
     """
 )
 
-_LEXEME_CARD_FILL_LANG_TRIGGER = DDL(
+# Split into separate DROP and CREATE so each DDL string is a single
+# statement — asyncpg rejects multi-statement prepared queries, which
+# matters if a test path bootstraps via an async engine.
+_LEXEME_CARD_FILL_LANG_TRIGGER_DROP = DDL(
+    "DROP TRIGGER IF EXISTS trg_fill_lexeme_card_source_language_iso "
+    "ON agent_lexeme_cards"
+)
+
+_LEXEME_CARD_FILL_LANG_TRIGGER_CREATE = DDL(
     """
-    DROP TRIGGER IF EXISTS trg_fill_lexeme_card_source_language_iso
-        ON agent_lexeme_cards;
     CREATE TRIGGER trg_fill_lexeme_card_source_language_iso
     BEFORE INSERT OR UPDATE OF source_version_id ON agent_lexeme_cards
     FOR EACH ROW
@@ -685,8 +691,18 @@ _LEXEME_CARD_FILL_LANG_TRIGGER = DDL(
     """
 )
 
+# Listener order matters: function first, then trigger drop, then trigger create.
 event.listen(AgentLexemeCard.__table__, "after_create", _LEXEME_CARD_FILL_LANG_FN)
-event.listen(AgentLexemeCard.__table__, "after_create", _LEXEME_CARD_FILL_LANG_TRIGGER)
+event.listen(
+    AgentLexemeCard.__table__,
+    "after_create",
+    _LEXEME_CARD_FILL_LANG_TRIGGER_DROP,
+)
+event.listen(
+    AgentLexemeCard.__table__,
+    "after_create",
+    _LEXEME_CARD_FILL_LANG_TRIGGER_CREATE,
+)
 
 
 class AgentWordAlignment(Base):

--- a/database/models.py
+++ b/database/models.py
@@ -1,6 +1,5 @@
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
-    CHAR,
     DDL,
     TIMESTAMP,
     Boolean,
@@ -464,7 +463,7 @@ class AgentLexemeCard(Base):
     # Pivot-language card identity: the ISO 639-3 code of the source language
     # the canonical card was built against. Auto-filled from source_version_id
     # by a BEFORE INSERT/UPDATE trigger if callers omit it.
-    source_language_iso = Column(CHAR(3), nullable=False)
+    source_language_iso = Column(String(3), nullable=False)
     # Opaque token bumped when the canonical card-builder rebuilds the card.
     # Nullable forever; only the most recent build sets it.
     build_version = Column(Text, nullable=True)
@@ -587,7 +586,7 @@ class CardTranslation(Base):
         ForeignKey("agent_lexeme_cards.id", ondelete="CASCADE"),
         nullable=False,
     )
-    language_iso = Column(CHAR(3), nullable=False)
+    language_iso = Column(String(3), nullable=False)
     source_lemma = Column(Text, nullable=True)
     source_surface_forms = Column(JSONB, nullable=True)
     senses = Column(JSONB, nullable=True)

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6058,7 +6058,7 @@ def test_deduplicate_lexeme_cards_dry_run(
     # Drop unique index, insert case-variant duplicates
     _raw_psycopg2(
         [
-            "DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v4",
+            "DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v5",
             "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_version_id, target_version_id, confidence, created_at, last_updated) "
             f"VALUES ('go', 'enda_dedup_dry', {test_version_id}, {test_version_id_2}, 0.5, now(), now())",
             "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_version_id, target_version_id, confidence, created_at, last_updated) "
@@ -6099,8 +6099,8 @@ def test_deduplicate_lexeme_cards_dry_run(
                 "WHERE LOWER(target_lemma) = 'enda_dedup_dry' "
                 f"AND source_version_id = {test_version_id} "
                 f"AND target_version_id = {test_version_id_2}",
-                "CREATE UNIQUE INDEX IF NOT EXISTS ix_agent_lexeme_cards_unique_v4 "
-                "ON agent_lexeme_cards (LOWER(target_lemma), source_version_id, target_version_id)",
+                "CREATE UNIQUE INDEX IF NOT EXISTS ix_agent_lexeme_cards_unique_v5 "
+                "ON agent_lexeme_cards (LOWER(target_lemma), source_language_iso, target_version_id)",
             ]
         )
 
@@ -6112,7 +6112,7 @@ def test_deduplicate_lexeme_cards_merge(
     # Drop unique index, insert case-variant duplicates
     _raw_psycopg2(
         [
-            "DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v4",
+            "DROP INDEX IF EXISTS ix_agent_lexeme_cards_unique_v5",
             "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_version_id, target_version_id, confidence, surface_forms, created_at, last_updated) "
             f"VALUES ('come', 'kuja_dedup_merge', {test_version_id}, {test_version_id_2}, 0.5, '[\"kuja\", \"anakuja\"]'::jsonb, now(), now())",
             "INSERT INTO agent_lexeme_cards (source_lemma, target_lemma, source_version_id, target_version_id, confidence, surface_forms, created_at, last_updated) "
@@ -6156,8 +6156,8 @@ def test_deduplicate_lexeme_cards_merge(
                 "WHERE LOWER(target_lemma) = 'kuja_dedup_merge' "
                 f"AND source_version_id = {test_version_id} "
                 f"AND target_version_id = {test_version_id_2}",
-                "CREATE UNIQUE INDEX IF NOT EXISTS ix_agent_lexeme_cards_unique_v4 "
-                "ON agent_lexeme_cards (LOWER(target_lemma), source_version_id, target_version_id)",
+                "CREATE UNIQUE INDEX IF NOT EXISTS ix_agent_lexeme_cards_unique_v5 "
+                "ON agent_lexeme_cards (LOWER(target_lemma), source_language_iso, target_version_id)",
             ]
         )
 


### PR DESCRIPTION
## Summary

Closes #665. Single additive alembic revision that unblocks the pivot-language card architecture being developed in `aqua-assessments`. No reader/writer changes — existing code on every branch continues to work unchanged.

- `agent_lexeme_cards`: adds NOT NULL `source_language_iso` (backfilled from `bible_version.iso_language` via `source_version_id`) and nullable `build_version`. Unique identity swaps from version-keyed (v4) to language-keyed (v5): `(LOWER(target_lemma), source_language_iso, target_version_id)`.
- A `BEFORE INSERT/UPDATE` trigger auto-fills `source_language_iso` from `source_version_id` when callers omit it. That's what lets existing writers (which don't know about the new column) keep working against the NOT NULL constraint. Mirrored as a SQLAlchemy DDL event so test DBs (which bootstrap via `Base.metadata.create_all`, not alembic) pick it up too.
- New `card_translations` and `card_translation_examples` tables hold cheap MT-derived translations of canonical cards. `card_translation_examples.example_id` FKs back to `agent_lexeme_card_examples` so the canonical target-language text isn't duplicated and corrections flow through automatically.
- Migration embeds the issue's empirical orphan + duplicate pre-checks and aborts with a clear error if either fires. Single upgrade transaction; downgrade reverses cleanly.

The only test fixture change is `test_deduplicate_lexeme_cards_*` updating its raw-SQL drop/create-index references from `_v4` to `_v5` to track the new constraint name.

## Test plan

- [x] `alembic upgrade head` on a fresh local DB succeeds; new schema matches spec (`\d agent_lexeme_cards`, `\d card_translations`, `\d card_translation_examples`)
- [x] Trigger verified manually: `INSERT INTO agent_lexeme_cards (target_lemma, source_version_id, target_version_id) VALUES (...)` (no `source_language_iso`) auto-populates the column from the FK'd `bible_version.iso_language`
- [x] Duplicate pre-check verified manually: deliberately seeding two cards that collide under the new key causes upgrade to abort with the expected `RuntimeError` listing the offending group
- [x] `alembic downgrade -1` then `alembic upgrade head` round-trips cleanly with no schema drift
- [x] `pytest test/test_agent_routes/` — 279 passed (including the 106 lexeme-card tests and the dedupe tests that needed the v4→v5 rename)
- [x] `pre-commit run` on touched files: clean