### PR TITLE
fix(affixes): 409 on duplicate (form, position); add PATCH endpoint

### DIFF
--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -94,6 +94,25 @@ async def commit_affixes(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
+    """Bulk upsert of language affixes, keyed on (iso, form, position).
+
+    Same gloss → idempotent upsert of examples/n_runs/source_model.
+    Different gloss for an existing (form, position) → **409** with body:
+
+        {"detail": {"message": ..., "conflicts": [
+            {"form", "position", "submitted_gloss",
+             "existing_id", "existing_gloss"}, ...
+        ]}}
+
+    A single conflict aborts the whole batch — there are no partial inserts.
+    Callers should PATCH /v3/affixes/{existing_id} to update the stored row.
+
+    The SELECT-then-INSERT pattern has a small race window: a concurrent
+    writer can land between the conflict check and the upsert. The
+    on_conflict_do_update clause omits `gloss` from set_, so a racing
+    same-key insert with a different gloss is silently dropped rather than
+    overwriting the stored gloss.
+    """
     request_start = time.perf_counter()
     iso = payload.iso_639_3
 
@@ -448,6 +467,16 @@ async def patch_affix(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
+    """Partial update of a single affix by id.
+
+    Only provided fields are updated; an empty body is a no-op that returns
+    the unchanged row. NFC normalization is applied to `form` and `gloss` by
+    Pydantic validators; both must be non-empty after strip.
+
+    Returns **409** with `{"detail": {"message", "existing_id"}}` if changing
+    `form` and/or `position` would collide with another row in the same
+    language.
+    """
     request_start = time.perf_counter()
 
     result = await db.execute(select(LanguageAffix).where(LanguageAffix.id == affix_id))
@@ -460,25 +489,9 @@ async def patch_affix(
 
     provided = patch.model_fields_set
 
-    new_form = affix.form
-    if "form" in provided:
-        new_form = _normalize(patch.form)
-        if not new_form:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="Affix form must not be empty",
-            )
-
+    new_form = patch.form if "form" in provided else affix.form
     new_position = patch.position if "position" in provided else affix.position
-
-    new_gloss = affix.gloss
-    if "gloss" in provided:
-        new_gloss = _normalize(patch.gloss)
-        if not new_gloss:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail="Affix gloss must not be empty",
-            )
+    new_gloss = patch.gloss if "gloss" in provided else affix.gloss
 
     if (new_form, new_position) != (affix.form, affix.position):
         dup_result = await db.execute(
@@ -508,7 +521,10 @@ async def patch_affix(
         affix.gloss = new_gloss
         if "examples" in provided:
             affix.examples = patch.examples
-        if "n_runs" in provided:
+        # n_runs is NOT NULL; a caller that sends `"n_runs": null` is
+        # asking to clear a non-clearable column — treat that the same
+        # as omitting the field.
+        if "n_runs" in provided and patch.n_runs is not None:
             affix.n_runs = patch.n_runs
         if "source_model" in provided:
             affix.source_model = patch.source_model

--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -25,6 +25,7 @@ from models import (
     AffixCommitResponse,
     AffixListOut,
     AffixOut,
+    AffixPatch,
     AffixReplaceResponse,
 )
 from security_routes.auth_routes import get_current_user
@@ -131,7 +132,7 @@ async def commit_affixes(
 
     try:
         if payload.affixes:
-            incoming: dict[tuple[str, str, str], dict] = {}
+            incoming: dict[tuple[str, str], dict] = {}
             for a in payload.affixes:
                 form = _normalize(a.form)
                 gloss = _normalize(a.gloss)
@@ -142,36 +143,37 @@ async def commit_affixes(
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                         detail="Affix form and gloss must not be empty",
                     )
-                key = (form, a.position, gloss)
+                key = (form, a.position)
                 if key in incoming:
                     raise HTTPException(
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                         detail=(
                             f"Duplicate affix in payload: "
-                            f"form={form!r}, position={a.position!r}, "
-                            f"gloss={gloss!r}"
+                            f"form={form!r}, position={a.position!r} "
+                            f"(each form+position pair may appear once)"
                         ),
                     )
                 incoming[key] = {
+                    "gloss": gloss,
                     "examples": a.examples,
                     "n_runs": a.n_runs,
                 }
 
-            # Look up existing rows for the exact (form, position, gloss)
-            # tuples in the payload. One OR-of-ANDs clause per tuple is
-            # fine at the ~10-30 affix scale the comment specifies.
-            existing_map: dict[tuple[str, str, str], dict] = {}
+            # Look up existing rows for the (form, position) tuples in the
+            # payload. One OR-of-ANDs clause per tuple is fine at the
+            # ~10-30 affix scale the comment specifies.
+            existing_map: dict[tuple[str, str], dict] = {}
             if incoming:
                 clauses = [
                     and_(
                         LanguageAffix.form == f,
                         LanguageAffix.position == p,
-                        LanguageAffix.gloss == g,
                     )
-                    for (f, p, g) in incoming.keys()
+                    for (f, p) in incoming.keys()
                 ]
                 existing_result = await db.execute(
                     select(
+                        LanguageAffix.id,
                         LanguageAffix.form,
                         LanguageAffix.position,
                         LanguageAffix.gloss,
@@ -184,17 +186,46 @@ async def commit_affixes(
                     )
                 )
                 for row in existing_result.all():
-                    existing_map[(row.form, row.position, row.gloss)] = {
+                    existing_map[(row.form, row.position)] = {
+                        "id": row.id,
+                        "gloss": row.gloss,
                         "examples": row.examples,
                         "n_runs": row.n_runs,
                         "source_model": row.source_model,
                     }
 
+            # Reject any (form, position) that already exists with a
+            # different gloss. Caller must PATCH the existing row instead.
+            conflicts = []
+            for (form, position), fields in incoming.items():
+                stored = existing_map.get((form, position))
+                if stored is not None and stored["gloss"] != fields["gloss"]:
+                    conflicts.append(
+                        {
+                            "form": form,
+                            "position": position,
+                            "submitted_gloss": fields["gloss"],
+                            "existing_id": stored["id"],
+                            "existing_gloss": stored["gloss"],
+                        }
+                    )
+            if conflicts:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "message": (
+                            "One or more affixes already exist for this language "
+                            "with a different gloss. PATCH /v3/affixes/{id} to "
+                            "update the existing rows."
+                        ),
+                        "conflicts": conflicts,
+                    },
+                )
+
             rows_to_write = []
-            for (form, position, gloss), fields in incoming.items():
-                key = (form, position, gloss)
-                if key in existing_map:
-                    stored = existing_map[key]
+            for (form, position), fields in incoming.items():
+                stored = existing_map.get((form, position))
+                if stored is not None:
                     if (
                         stored["examples"] == fields["examples"]
                         and stored["n_runs"] == fields["n_runs"]
@@ -213,7 +244,7 @@ async def commit_affixes(
                         "iso_639_3": iso,
                         "form": form,
                         "position": position,
-                        "gloss": gloss,
+                        "gloss": fields["gloss"],
                         "examples": fields["examples"],
                         "n_runs": fields["n_runs"],
                         "source_model": payload.source_model,
@@ -223,10 +254,12 @@ async def commit_affixes(
 
             if rows_to_write:
                 stmt = pg_insert(LanguageAffix).values(rows_to_write)
-                # updated_at is refreshed explicitly: raw pg_insert
-                # bypasses SQLAlchemy's ORM-level onupdate hook.
+                # gloss is intentionally omitted from set_ — we already
+                # rejected mismatched glosses above, so leaving the stored
+                # gloss in place is correct even if a concurrent writer
+                # raced in between the select and the insert.
                 stmt = stmt.on_conflict_do_update(
-                    index_elements=["iso_639_3", "form", "position", "gloss"],
+                    index_elements=["iso_639_3", "form", "position"],
                     set_={
                         "examples": stmt.excluded.examples,
                         "n_runs": stmt.excluded.n_runs,
@@ -321,7 +354,7 @@ async def replace_affixes(
 
         n_inserted = 0
         if payload.affixes:
-            incoming: dict[tuple[str, str, str], dict] = {}
+            incoming: dict[tuple[str, str], dict] = {}
             for a in payload.affixes:
                 form = _normalize(a.form)
                 gloss = _normalize(a.gloss)
@@ -330,17 +363,18 @@ async def replace_affixes(
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                         detail="Affix form and gloss must not be empty",
                     )
-                key = (form, a.position, gloss)
+                key = (form, a.position)
                 if key in incoming:
                     raise HTTPException(
                         status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                         detail=(
                             f"Duplicate affix in payload: "
-                            f"form={form!r}, position={a.position!r}, "
-                            f"gloss={gloss!r}"
+                            f"form={form!r}, position={a.position!r} "
+                            f"(each form+position pair may appear once)"
                         ),
                     )
                 incoming[key] = {
+                    "gloss": gloss,
                     "examples": a.examples,
                     "n_runs": a.n_runs,
                 }
@@ -350,18 +384,23 @@ async def replace_affixes(
                     "iso_639_3": iso,
                     "form": form,
                     "position": position,
-                    "gloss": gloss,
+                    "gloss": fields["gloss"],
                     "examples": fields["examples"],
                     "n_runs": fields["n_runs"],
                     "source_model": payload.source_model,
                     "first_seen_revision_id": payload.revision_id,
                 }
-                for (form, position, gloss), fields in incoming.items()
+                for (form, position), fields in incoming.items()
             ]
             stmt = pg_insert(LanguageAffix).values(rows)
+            # PUT is "replace": if the scoped delete left a row from another
+            # scope with the same (form, position), authoritatively overwrite
+            # gloss too. This is the one path that may change an existing
+            # row's gloss without an explicit PATCH.
             stmt = stmt.on_conflict_do_update(
-                index_elements=["iso_639_3", "form", "position", "gloss"],
+                index_elements=["iso_639_3", "form", "position"],
                 set_={
+                    "gloss": stmt.excluded.gloss,
                     "examples": stmt.excluded.examples,
                     "n_runs": stmt.excluded.n_runs,
                     "source_model": stmt.excluded.source_model,
@@ -400,3 +439,99 @@ async def replace_affixes(
         },
     )
     return AffixReplaceResponse(n_deleted=n_deleted, n_inserted=n_inserted)
+
+
+@router.patch("/affixes/{affix_id}", response_model=AffixOut)
+async def patch_affix(
+    affix_id: int,
+    patch: AffixPatch,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    request_start = time.perf_counter()
+
+    result = await db.execute(select(LanguageAffix).where(LanguageAffix.id == affix_id))
+    affix = result.scalar_one_or_none()
+    if affix is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Affix with id {affix_id} not found",
+        )
+
+    provided = patch.model_fields_set
+
+    new_form = affix.form
+    if "form" in provided:
+        new_form = _normalize(patch.form)
+        if not new_form:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Affix form must not be empty",
+            )
+
+    new_position = patch.position if "position" in provided else affix.position
+
+    new_gloss = affix.gloss
+    if "gloss" in provided:
+        new_gloss = _normalize(patch.gloss)
+        if not new_gloss:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Affix gloss must not be empty",
+            )
+
+    if (new_form, new_position) != (affix.form, affix.position):
+        dup_result = await db.execute(
+            select(LanguageAffix.id).where(
+                LanguageAffix.iso_639_3 == affix.iso_639_3,
+                LanguageAffix.form == new_form,
+                LanguageAffix.position == new_position,
+                LanguageAffix.id != affix.id,
+            )
+        )
+        existing_id = dup_result.scalar_one_or_none()
+        if existing_id is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "message": (
+                        "Another affix with this (form, position) already "
+                        "exists for this language."
+                    ),
+                    "existing_id": existing_id,
+                },
+            )
+
+    try:
+        affix.form = new_form
+        affix.position = new_position
+        affix.gloss = new_gloss
+        if "examples" in provided:
+            affix.examples = patch.examples
+        if "n_runs" in provided:
+            affix.n_runs = patch.n_runs
+        if "source_model" in provided:
+            affix.source_model = patch.source_model
+        affix.updated_at = func.now()
+
+        await db.commit()
+        await db.refresh(affix)
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error("Failed to patch affix", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {e}",
+        ) from e
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"patch_affix completed in {duration}s",
+        extra={
+            "method": "PATCH",
+            "path": "/affixes/{affix_id}",
+            "affix_id": affix_id,
+            "duration_s": duration,
+        },
+    )
+    return AffixOut.model_validate(affix)

--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -489,9 +489,22 @@ async def patch_affix(
 
     provided = patch.model_fields_set
 
-    new_form = patch.form if "form" in provided else affix.form
-    new_position = patch.position if "position" in provided else affix.position
-    new_gloss = patch.gloss if "gloss" in provided else affix.gloss
+    # form / position / gloss are NOT NULL on the table; if the caller sends
+    # explicit `null` for any of them, treat it the same as omission rather
+    # than letting the assignment try to write NULL and raise a 500.
+    new_form = (
+        patch.form if ("form" in provided and patch.form is not None) else affix.form
+    )
+    new_position = (
+        patch.position
+        if ("position" in provided and patch.position is not None)
+        else affix.position
+    )
+    new_gloss = (
+        patch.gloss
+        if ("gloss" in provided and patch.gloss is not None)
+        else affix.gloss
+    )
 
     if (new_form, new_position) != (affix.form, affix.position):
         dup_result = await db.execute(

--- a/alembic/migrations/versions/c4f2a8e9b1d7_language_affix_unique_form_position.py
+++ b/alembic/migrations/versions/c4f2a8e9b1d7_language_affix_unique_form_position.py
@@ -99,6 +99,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Lossy: rows merged in upgrade() cannot be restored. Restores the old
+    # 4-column unique index so the schema lines up, but any polysemy rows
+    # that existed before upgrade are permanently gone.
     op.drop_index(
         "ux_language_affixes_iso_form_position",
         table_name="language_affixes",

--- a/alembic/migrations/versions/c4f2a8e9b1d7_language_affix_unique_form_position.py
+++ b/alembic/migrations/versions/c4f2a8e9b1d7_language_affix_unique_form_position.py
@@ -46,13 +46,17 @@ def upgrade() -> None:
             SET examples = (
                     SELECT COALESCE(jsonb_agg(DISTINCT elem), '[]'::jsonb)
                     FROM (
-                        SELECT jsonb_array_elements(
-                            COALESCE(a2.examples, '[]'::jsonb)
-                        ) AS elem
+                        -- Filter to rows whose examples is an actual JSONB
+                        -- array. Skip SQL NULL, JSONB 'null' literals, and
+                        -- anything scalar that would make jsonb_array_elements
+                        -- raise "cannot extract elements from a scalar".
+                        SELECT jsonb_array_elements(a2.examples) AS elem
                         FROM language_affixes a2
                         WHERE a2.iso_639_3 = w.iso_639_3
                           AND a2.form = w.form
                           AND a2.position = w.position
+                          AND a2.examples IS NOT NULL
+                          AND jsonb_typeof(a2.examples) = 'array'
                     ) sub
                 ),
                 n_runs = LEAST(

--- a/alembic/migrations/versions/c4f2a8e9b1d7_language_affix_unique_form_position.py
+++ b/alembic/migrations/versions/c4f2a8e9b1d7_language_affix_unique_form_position.py
@@ -1,0 +1,111 @@
+"""tighten language_affixes unique key to (iso, form, position)
+
+Revision ID: c4f2a8e9b1d7
+Revises: a6c1e7d3b4f2
+Create Date: 2026-05-13 10:00:00.000000
+
+Collapses any existing rows that share (iso_639_3, form, position) into a single
+row, then replaces the (iso, form, position, gloss) unique index with one on
+(iso, form, position). Going forward, polysemy is rejected at the API layer
+with a 409, mirroring how lexeme card duplicates are handled.
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "c4f2a8e9b1d7"
+down_revision: Union[str, None] = "a6c1e7d3b4f2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Merge duplicate rows for the same (iso, form, position). Winner is the
+    # lowest-id row in each group: union its examples with the losers',
+    # sum n_runs (capped at the smallint ceiling), then drop the losers.
+    op.execute(
+        """
+        WITH duplicate_groups AS (
+            SELECT iso_639_3, form, position, MIN(id) AS winner_id
+            FROM language_affixes
+            GROUP BY iso_639_3, form, position
+            HAVING COUNT(*) > 1
+        ),
+        losers AS (
+            SELECT a.id AS loser_id, dg.winner_id
+            FROM language_affixes a
+            JOIN duplicate_groups dg
+              ON a.iso_639_3 = dg.iso_639_3
+             AND a.form = dg.form
+             AND a.position = dg.position
+            WHERE a.id != dg.winner_id
+        ),
+        merged AS (
+            UPDATE language_affixes w
+            SET examples = (
+                    SELECT COALESCE(jsonb_agg(DISTINCT elem), '[]'::jsonb)
+                    FROM (
+                        SELECT jsonb_array_elements(
+                            COALESCE(a2.examples, '[]'::jsonb)
+                        ) AS elem
+                        FROM language_affixes a2
+                        WHERE a2.iso_639_3 = w.iso_639_3
+                          AND a2.form = w.form
+                          AND a2.position = w.position
+                    ) sub
+                ),
+                n_runs = LEAST(
+                    32767,
+                    (
+                        SELECT SUM(a2.n_runs)::int
+                        FROM language_affixes a2
+                        WHERE a2.iso_639_3 = w.iso_639_3
+                          AND a2.form = w.form
+                          AND a2.position = w.position
+                    )
+                ),
+                updated_at = NOW()
+            FROM duplicate_groups dg
+            WHERE w.id = dg.winner_id
+        )
+        DELETE FROM language_affixes a
+        USING losers l
+        WHERE a.id = l.loser_id
+        """
+    )
+
+    # Examples may have ended up as an empty JSONB array '[]' for winners that
+    # had no examples and no losers had examples — normalise those back to NULL
+    # to match the prior on-insert convention.
+    op.execute(
+        """
+        UPDATE language_affixes
+        SET examples = NULL
+        WHERE examples = '[]'::jsonb
+        """
+    )
+
+    op.drop_index(
+        "ux_language_affixes_iso_form_position_gloss",
+        table_name="language_affixes",
+    )
+    op.create_index(
+        "ux_language_affixes_iso_form_position",
+        "language_affixes",
+        ["iso_639_3", "form", "position"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ux_language_affixes_iso_form_position",
+        table_name="language_affixes",
+    )
+    op.create_index(
+        "ux_language_affixes_iso_form_position_gloss",
+        "language_affixes",
+        ["iso_639_3", "form", "position", "gloss"],
+        unique=True,
+    )

--- a/database/models.py
+++ b/database/models.py
@@ -1155,11 +1155,10 @@ class LanguageAffix(Base):
         ),
         CheckConstraint("n_runs >= 1", name="ck_language_affixes_n_runs_min_1"),
         Index(
-            "ux_language_affixes_iso_form_position_gloss",
+            "ux_language_affixes_iso_form_position",
             "iso_639_3",
             "form",
             "position",
-            "gloss",
             unique=True,
         ),
         Index("ix_language_affixes_iso", "iso_639_3"),

--- a/models.py
+++ b/models.py
@@ -1777,6 +1777,16 @@ class AffixPatch(BaseModel):
     n_runs: Optional[int] = Field(default=None, ge=1, le=32767)
     source_model: Optional[str] = None
 
+    @field_validator("form", "gloss", mode="after")
+    @classmethod
+    def _nfc_strip(cls, v):
+        if v is None:
+            return v
+        v = unicodedata.normalize("NFC", v).strip()
+        if not v:
+            raise ValueError("must not be empty after NFC + strip")
+        return v
+
 
 class WordIndexRequest(BaseModel):
     iso_639_3: str = Field(..., min_length=3, max_length=3)

--- a/models.py
+++ b/models.py
@@ -1733,6 +1733,7 @@ class AffixIn(BaseModel):
 class AffixOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
+    id: int
     form: str
     position: AffixPosition
     gloss: str
@@ -1764,6 +1765,17 @@ class AffixCommitResponse(BaseModel):
 class AffixReplaceResponse(BaseModel):
     n_deleted: int
     n_inserted: int
+
+
+class AffixPatch(BaseModel):
+    """Partial update model for language affixes — all fields optional."""
+
+    form: Optional[str] = Field(default=None, min_length=1)
+    position: Optional[AffixPosition] = None
+    gloss: Optional[str] = Field(default=None, min_length=1)
+    examples: Optional[List[str]] = None
+    n_runs: Optional[int] = Field(default=None, ge=1, le=32767)
+    source_model: Optional[str] = None
 
 
 class WordIndexRequest(BaseModel):

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -1281,3 +1281,34 @@ def test_put_affixes_overwrites_gloss_on_cross_revision_collision(
     assert listing["affixes"][0]["gloss"] == "perfective"
     assert listing["affixes"][0]["first_seen_revision_id"] == test_revision_id
     _cleanup(db_session)
+
+
+def test_patch_affix_null_form_position_gloss_ignored(
+    client, regular_token1, db_session
+):
+    """Explicit JSON null for NOT NULL fields is treated as omission, not as
+    'clear the column' — avoids a 500 from a NOT NULL violation."""
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "akha-", "prefix", "past"
+    )
+    resp = client.patch(
+        f"/{prefix}/affixes/{affix_id}",
+        json={
+            "form": None,
+            "position": None,
+            "gloss": None,
+            "source_model": "gpt-5-pro",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["form"] == "akha-"
+    assert body["position"] == "prefix"
+    assert body["gloss"] == "past"
+    assert body["source_model"] == "gpt-5-pro"
+    _cleanup(db_session)

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -1151,3 +1151,133 @@ def test_patch_affix_position_change_with_no_collision(
     assert resp.status_code == 200
     assert resp.json()["position"] == "infix"
     _cleanup(db_session)
+
+
+def test_patch_affix_empty_body_is_noop(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client,
+        headers,
+        TEST_ISO,
+        "akha-",
+        "prefix",
+        "past",
+        examples=["akhatenda"],
+        n_runs=3,
+    )
+    before = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers).json()[
+        "affixes"
+    ][0]
+
+    resp = client.patch(f"/{prefix}/affixes/{affix_id}", json={}, headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["form"] == before["form"]
+    assert body["position"] == before["position"]
+    assert body["gloss"] == before["gloss"]
+    assert body["examples"] == before["examples"]
+    assert body["n_runs"] == before["n_runs"]
+    _cleanup(db_session)
+
+
+def test_patch_affix_idempotent(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "-ile", "suffix", "perfect"
+    )
+    payload = {"gloss": "perfect", "n_runs": 5}
+    first = client.patch(f"/{prefix}/affixes/{affix_id}", json=payload, headers=headers)
+    second = client.patch(
+        f"/{prefix}/affixes/{affix_id}", json=payload, headers=headers
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["gloss"] == second.json()["gloss"] == "perfect"
+    assert first.json()["n_runs"] == second.json()["n_runs"] == 5
+    _cleanup(db_session)
+
+
+def test_patch_affix_source_model_only(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "akha-", "prefix", "past"
+    )
+    resp = client.patch(
+        f"/{prefix}/affixes/{affix_id}",
+        json={"source_model": "gpt-5-pro"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["source_model"] == "gpt-5-pro"
+    _cleanup(db_session)
+
+
+def test_patch_affix_n_runs_null_ignored(client, regular_token1, db_session):
+    """`n_runs: null` is ignored — the NOT NULL column keeps its existing value."""
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "akha-", "prefix", "past", n_runs=4
+    )
+    resp = client.patch(
+        f"/{prefix}/affixes/{affix_id}",
+        json={"n_runs": None, "source_model": "gpt-5-pro"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["n_runs"] == 4
+    assert body["source_model"] == "gpt-5-pro"
+    _cleanup(db_session)
+
+
+def test_put_affixes_overwrites_gloss_on_cross_revision_collision(
+    client, regular_token1, test_revision_id, db_session
+):
+    """PUT scoped to rev2 overwrites the gloss of an unscoped row at the same
+    (form, position) — authoritative replace under the new
+    (iso, form, position) unique key."""
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "akha-", "position": "prefix", "gloss": "past"},
+            ],
+        },
+        headers=headers,
+    )
+
+    resp = client.put(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "revision_id": test_revision_id,
+            "affixes": [
+                {"form": "akha-", "position": "prefix", "gloss": "perfective"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    listing = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers).json()
+    assert listing["total"] == 1
+    assert listing["affixes"][0]["gloss"] == "perfective"
+    assert listing["affixes"][0]["first_seen_revision_id"] == test_revision_id
+    _cleanup(db_session)

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -76,7 +76,7 @@ def test_affixes_round_trip(client, regular_token1, db_session):
     _cleanup(db_session)
 
 
-def test_affixes_polysemy_same_form_position_different_gloss(
+def test_affixes_second_gloss_for_same_form_position_returns_409(
     client, regular_token1, db_session
 ):
     _cleanup(db_session)
@@ -89,20 +89,77 @@ def test_affixes_polysemy_same_form_position_different_gloss(
             "iso_639_3": TEST_ISO,
             "affixes": [
                 {"form": "-ile", "position": "suffix", "gloss": "perfective"},
-                {"form": "-ile", "position": "suffix", "gloss": "applicative"},
-                {"form": "-ile", "position": "suffix", "gloss": "locative"},
             ],
         },
         headers=headers,
     )
     assert resp.status_code == 200
-    assert resp.json()["n_affixes_new"] == 3
 
-    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
-    data = resp.json()
-    assert data["total"] == 3
-    glosses = {a["gloss"] for a in data["affixes"]}
-    assert glosses == {"perfective", "applicative", "locative"}
+    listing = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers).json()
+    existing_id = listing["affixes"][0]["id"]
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "-ile", "position": "suffix", "gloss": "applicative"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert "conflicts" in detail
+    assert len(detail["conflicts"]) == 1
+    conflict = detail["conflicts"][0]
+    assert conflict["form"] == "-ile"
+    assert conflict["position"] == "suffix"
+    assert conflict["submitted_gloss"] == "applicative"
+    assert conflict["existing_gloss"] == "perfective"
+    assert conflict["existing_id"] == existing_id
+
+    # The conflict aborts the whole batch — the existing row is unchanged.
+    listing = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers).json()
+    assert listing["total"] == 1
+    assert listing["affixes"][0]["gloss"] == "perfective"
+    _cleanup(db_session)
+
+
+def test_affixes_409_aborts_entire_batch(client, regular_token1, db_session):
+    """A single gloss conflict rejects the whole payload — no partial inserts."""
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "-ile", "position": "suffix", "gloss": "perfective"},
+            ],
+        },
+        headers=headers,
+    )
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "-ile", "position": "suffix", "gloss": "applicative"},
+                {"form": "ku-", "position": "prefix", "gloss": "infinitive"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 409
+
+    listing = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers).json()
+    forms = {a["form"] for a in listing["affixes"]}
+    # ku- must NOT have been inserted alongside the rejected -ile conflict.
+    assert forms == {"-ile"}
     _cleanup(db_session)
 
 
@@ -903,4 +960,194 @@ def test_put_affixes_scoped_delete_handles_conflict_with_other_revision(
     assert data["total"] == 1
     assert data["affixes"][0]["examples"] == ["akhatenda"]
     assert data["affixes"][0]["first_seen_revision_id"] == test_revision_id
+    _cleanup(db_session)
+
+
+# ── GET /affixes exposes id ─────────────────────────────────────────
+
+
+def test_get_affixes_includes_id(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": TEST_ISO,
+            "affixes": [
+                {"form": "akha-", "position": "prefix", "gloss": "past"},
+            ],
+        },
+        headers=headers,
+    )
+    listing = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers).json()
+    assert listing["total"] == 1
+    affix = listing["affixes"][0]
+    assert isinstance(affix["id"], int)
+    assert affix["id"] > 0
+    _cleanup(db_session)
+
+
+# ── PATCH /affixes/{id} ─────────────────────────────────────────────
+
+
+def _post_one_and_get_id(client, headers, iso, form, position, gloss, **extra):
+    payload = {
+        "iso_639_3": iso,
+        "affixes": [
+            {"form": form, "position": position, "gloss": gloss, **extra},
+        ],
+    }
+    client.post(f"/{prefix}/affixes", json=payload, headers=headers)
+    listing = client.get(f"/{prefix}/affixes?iso={iso}", headers=headers).json()
+    for a in listing["affixes"]:
+        if a["form"] == form and a["position"] == position:
+            return a["id"]
+    raise AssertionError(f"no affix posted for ({form}, {position})")
+
+
+def test_patch_affix_updates_gloss(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "-ile", "suffix", "perfective"
+    )
+
+    resp = client.patch(
+        f"/{prefix}/affixes/{affix_id}",
+        json={"gloss": "perfect/past"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == affix_id
+    assert body["form"] == "-ile"
+    assert body["position"] == "suffix"
+    assert body["gloss"] == "perfect/past"
+
+    listing = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers).json()
+    assert listing["total"] == 1
+    assert listing["affixes"][0]["gloss"] == "perfect/past"
+    _cleanup(db_session)
+
+
+def test_patch_affix_updates_examples_and_n_runs(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "-ile", "suffix", "perfect"
+    )
+
+    resp = client.patch(
+        f"/{prefix}/affixes/{affix_id}",
+        json={"examples": ["tendile", "lalile"], "n_runs": 7},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["examples"] == ["tendile", "lalile"]
+    assert body["n_runs"] == 7
+    # Untouched fields remain.
+    assert body["gloss"] == "perfect"
+    _cleanup(db_session)
+
+
+def test_patch_affix_404_when_not_found(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    resp = client.patch(
+        f"/{prefix}/affixes/999999999",
+        json={"gloss": "anything"},
+        headers=headers,
+    )
+    assert resp.status_code == 404
+    _cleanup(db_session)
+
+
+def test_patch_affix_409_on_form_position_collision(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    a_id = _post_one_and_get_id(client, headers, TEST_ISO, "-ile", "suffix", "perfect")
+    b_id = _post_one_and_get_id(client, headers, TEST_ISO, "-aka", "suffix", "habitual")
+
+    # Try to rename b to -ile/suffix, which collides with a.
+    resp = client.patch(
+        f"/{prefix}/affixes/{b_id}",
+        json={"form": "-ile"},
+        headers=headers,
+    )
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["existing_id"] == a_id
+    _cleanup(db_session)
+
+
+def test_patch_affix_nfc_normalizes_form(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "akha-", "prefix", "past"
+    )
+
+    decomposed = "  é-  "
+    composed = "é-"
+    resp = client.patch(
+        f"/{prefix}/affixes/{affix_id}",
+        json={"form": decomposed},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["form"] == composed
+    _cleanup(db_session)
+
+
+def test_patch_affix_empty_form_rejected(client, regular_token1, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "akha-", "prefix", "past"
+    )
+    resp = client.patch(
+        f"/{prefix}/affixes/{affix_id}",
+        json={"form": "   "},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    _cleanup(db_session)
+
+
+def test_patch_affix_without_token(client, db_session):
+    resp = client.patch(f"/{prefix}/affixes/1", json={"gloss": "x"})
+    assert resp.status_code == 401
+
+
+def test_patch_affix_position_change_with_no_collision(
+    client, regular_token1, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    affix_id = _post_one_and_get_id(
+        client, headers, TEST_ISO, "akha-", "prefix", "past"
+    )
+    resp = client.patch(
+        f"/{prefix}/affixes/{affix_id}",
+        json={"position": "infix"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["position"] == "infix"
     _cleanup(db_session)


### PR DESCRIPTION
## Summary
- Tighten the `language_affixes` unique key from `(iso, form, position, gloss)` to `(iso, form, position)` so polysemy duplicates can't accumulate.
- `POST /v3/affixes` returns **409** with `detail.conflicts: [{form, position, submitted_gloss, existing_id, existing_gloss}]` when the payload would re-define a stored gloss. Same-gloss re-posts remain idempotent. A single conflict aborts the whole batch.
- Add `PATCH /v3/affixes/{id}` for partial updates (form/position/gloss/examples/n_runs/source_model), with 409 on `(form, position)` collisions, NFC normalization, and empty-after-strip rejection.
- Expose `id` on `AffixOut` so callers can address an existing row.
- Migration `c4f2a8e9b1d7` merges any existing duplicate rows (winner = lowest id; examples are unioned, n_runs summed and capped at 32767) before swapping the unique index. Chained off `a6c1e7d3b4f2`.

Mirrors the lexeme-card duplicate contract.

## Test plan
- [x] `pytest test/test_agent_routes/test_affix_routes.py` — 44/44 pass (incl. new 409, batch-abort, PATCH update/404/collision/NFC/empty/position-change tests)
- [x] `pytest test/test_agent_routes/test_tokenizer_routes.py test/test_assessment_routes/test_search_routes.py` — 97/97 pass (adjacent suites untouched)
- [x] `alembic upgrade head` clean against a fresh DB
- [ ] Manual: confirm Bantu polysemy on `-ile` now requires PATCH per gloss rather than silently producing parallel rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)