### PR TITLE
feat(agent): Phase 1 endpoints for card translations (#669)

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1919,18 +1919,14 @@ async def get_lexeme_cards(
         # card's canonical source_language_iso, the card is omitted unless a
         # translation row exists; its source-side fields are then replaced.
         response_cards = []
-        omitted_card_ids: list[int] = []
+        omitted_for_missing_translation = 0
         for card in cards:
             requires_merge = (
                 requested_lang is not None
                 and card.source_language_iso != requested_lang
             )
             if requires_merge and card.id not in translation_by_card:
-                # Omit cards without a translation in the requested language.
-                # Tracked + logged below so a downstream pipeline that gets
-                # fewer cards than it expected can correlate the gap with
-                # cards that need derivation.
-                omitted_card_ids.append(card.id)
+                omitted_for_missing_translation += 1
                 continue
 
             if requires_merge:
@@ -1988,7 +1984,7 @@ async def get_lexeme_cards(
                 "target_words": target_words,
                 "pos": pos,
                 "lang": requested_lang,
-                "omitted_for_missing_translation": len(omitted_card_ids),
+                "omitted_for_missing_translation": omitted_for_missing_translation,
                 "duration_s": duration,
             },
         )
@@ -2110,11 +2106,7 @@ async def add_lexeme_card_translation(
                 detail=f"Lexeme card with id {card_id} not found",
             )
 
-        # Explicit .lower() on both sides: the Pydantic field normalizes the
-        # request, and the DB trigger normalizes the column, but compare
-        # case-insensitively so a stray uppercase value in either source can't
-        # silently bypass this guard.
-        if translation.language_iso.lower() == (card.source_language_iso or "").lower():
+        if translation.language_iso == card.source_language_iso:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
@@ -2207,53 +2199,6 @@ async def add_lexeme_card_translation(
 
         await db.commit()
 
-        # Re-fetch the row to pick up the server-side last_updated timestamp
-        # and per-example created_at values for the response.
-        translation_row = await db.scalar(
-            select(CardTranslation).where(CardTranslation.id == translation_id)
-        )
-        examples_result = await db.execute(
-            select(CardTranslationExample)
-            .where(CardTranslationExample.card_translation_id == translation_id)
-            .order_by(CardTranslationExample.id)
-        )
-        example_rows = examples_result.scalars().all()
-
-        duration = round(time.perf_counter() - request_start, 2)
-        logger.info(
-            f"add_lexeme_card_translation completed in {duration}s",
-            extra={
-                "method": "POST",
-                "path": "/agent/lexeme-card/{card_id}/translation",
-                "card_id": card_id,
-                "language_iso": translation.language_iso,
-                "example_count": len(translation.examples),
-                "duration_s": duration,
-            },
-        )
-
-        return CardTranslationOut(
-            id=translation_row.id,
-            card_id=translation_row.card_id,
-            language_iso=translation_row.language_iso,
-            source_lemma=translation_row.source_lemma,
-            source_surface_forms=translation_row.source_surface_forms,
-            senses=translation_row.senses,
-            parent_build_version=translation_row.parent_build_version,
-            build_version=translation_row.build_version,
-            created_at=translation_row.created_at,
-            last_updated=translation_row.last_updated,
-            examples=[
-                {
-                    "id": e.id,
-                    "example_id": e.example_id,
-                    "source_text": e.source_text,
-                    "created_at": e.created_at,
-                }
-                for e in example_rows
-            ],
-        )
-
     except HTTPException:
         await db.rollback()
         raise
@@ -2271,6 +2216,63 @@ async def add_lexeme_card_translation(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Database error: {str(e)}",
         ) from e
+
+    # Post-commit: fetch the row + examples to populate server-side timestamps
+    # in the response. Errors past this point must NOT rollback (the write
+    # already landed); they surface as a 500 to the caller.
+    try:
+        from sqlalchemy import select
+
+        translation_row = await db.scalar(
+            select(CardTranslation).where(CardTranslation.id == translation_id)
+        )
+        examples_result = await db.execute(
+            select(CardTranslationExample)
+            .where(CardTranslationExample.card_translation_id == translation_id)
+            .order_by(CardTranslationExample.id)
+        )
+        example_rows = examples_result.scalars().all()
+    except SQLAlchemyError as e:
+        logger.error(f"Post-commit fetch failed for card translation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error fetching persisted translation: {str(e)}",
+        ) from e
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"add_lexeme_card_translation completed in {duration}s",
+        extra={
+            "method": "POST",
+            "path": "/agent/lexeme-card/{card_id}/translation",
+            "card_id": card_id,
+            "language_iso": translation.language_iso,
+            "example_count": len(translation.examples),
+            "duration_s": duration,
+        },
+    )
+
+    return CardTranslationOut(
+        id=translation_row.id,
+        card_id=translation_row.card_id,
+        language_iso=translation_row.language_iso,
+        source_lemma=translation_row.source_lemma,
+        source_surface_forms=translation_row.source_surface_forms,
+        senses=translation_row.senses,
+        parent_build_version=translation_row.parent_build_version,
+        build_version=translation_row.build_version,
+        created_at=translation_row.created_at,
+        last_updated=translation_row.last_updated,
+        examples=[
+            {
+                "id": e.id,
+                "example_id": e.example_id,
+                "source_text": e.source_text,
+                "created_at": e.created_at,
+            }
+            for e in example_rows
+        ],
+    )
 
 
 # Registration order matters: this parameterized GET must stay AFTER any

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -23,6 +23,8 @@ from database.models import (
     BibleRevision,
     BibleVersion,
     BibleVersionAccess,
+    CardTranslation,
+    CardTranslationExample,
 )
 from database.models import UserDB as UserModel
 from database.models import (
@@ -35,6 +37,8 @@ from models import (
     AgentWordAlignmentBulkRequest,
     AgentWordAlignmentIn,
     AgentWordAlignmentOut,
+    CardTranslationIn,
+    CardTranslationOut,
     CritiqueIssueOut,
     CritiqueIssueResolutionRequest,
     CritiqueStorageRequest,
@@ -1688,6 +1692,7 @@ async def get_lexeme_cards(
     target_word: str = None,
     target_words: str = None,
     pos: str = None,
+    lang: str | None = None,
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -1708,6 +1713,12 @@ async def get_lexeme_cards(
       cards where target_lemma or any surface_form matches any of the given words
       (case-insensitive, NFC-normalized). Cannot be used with target_word.
     - pos: str (optional) - Filter by part of speech
+    - lang: str (optional) - ISO 639-3 code for the desired source-side language.
+      When omitted or equal to the cards' canonical source_language_iso, returns
+      cards in their canonical shape (back-compat). When it differs, source-side
+      fields (source_lemma, source_surface_forms, senses, per-example source_text)
+      are replaced by the matching card_translations row. Cards without a
+      translation in the requested language are omitted from the response.
 
     Returns:
     - List[LexemeCardOut]: List of matching lexeme cards, ordered by confidence (descending).
@@ -1799,7 +1810,9 @@ async def get_lexeme_cards(
         result = await db.execute(query)
         cards = result.scalars().all()
 
-        # Batch-load all examples for the returned cards in a single query
+        # Batch-load all examples for the returned cards in a single query.
+        # Include the row id so per-example translation overrides (keyed by
+        # example_id) can be applied when `lang` is non-canonical.
         card_ids = [card.id for card in cards]
         examples_by_card: dict[int, list[dict]] = {cid: [] for cid in card_ids}
 
@@ -1837,6 +1850,7 @@ async def get_lexeme_cards(
                 )
             examples_query = (
                 select(
+                    AgentLexemeCardExample.id,
                     AgentLexemeCardExample.lexeme_card_id,
                     AgentLexemeCardExample.source_text,
                     AgentLexemeCardExample.target_text,
@@ -1850,29 +1864,114 @@ async def get_lexeme_cards(
             examples_result = await db.execute(examples_query)
             for row in examples_result.all():
                 examples_by_card[row.lexeme_card_id].append(
-                    {"source": row.source_text, "target": row.target_text}
+                    {
+                        "id": row.id,
+                        "source": row.source_text,
+                        "target": row.target_text,
+                    }
                 )
 
-        # Build response cards
+        # Apply non-canonical language overlay when requested.
+        requested_lang = lang.lower() if lang else None
+        # Per-card translation row (only loaded when needed)
+        translation_by_card: dict[int, CardTranslation] = {}
+        # Per-card map of example_id -> translated source_text
+        trans_source_by_card: dict[int, dict[int, str]] = {}
+        if card_ids and requested_lang is not None:
+            # Identify cards whose canonical source doesn't match the requested
+            # lang. Cards whose canonical already matches return canonical
+            # verbatim, no DB lookups needed.
+            needs_translation_card_ids = [
+                card.id for card in cards if card.source_language_iso != requested_lang
+            ]
+            if needs_translation_card_ids:
+                trans_result = await db.execute(
+                    select(CardTranslation).where(
+                        CardTranslation.card_id.in_(needs_translation_card_ids),
+                        CardTranslation.language_iso == requested_lang,
+                    )
+                )
+                for trans in trans_result.scalars().all():
+                    translation_by_card[trans.card_id] = trans
+
+                if translation_by_card:
+                    trans_ids = [t.id for t in translation_by_card.values()]
+                    # Map translation id -> card_id for the per-example reverse lookup
+                    card_id_by_trans = {
+                        t.id: t.card_id for t in translation_by_card.values()
+                    }
+                    te_result = await db.execute(
+                        select(
+                            CardTranslationExample.card_translation_id,
+                            CardTranslationExample.example_id,
+                            CardTranslationExample.source_text,
+                        ).where(
+                            CardTranslationExample.card_translation_id.in_(trans_ids)
+                        )
+                    )
+                    for row in te_result.all():
+                        cid = card_id_by_trans[row.card_translation_id]
+                        trans_source_by_card.setdefault(cid, {})[
+                            row.example_id
+                        ] = row.source_text
+
+        # Build response cards. When `lang` is requested and differs from a
+        # card's canonical source_language_iso, the card is omitted unless a
+        # translation row exists; its source-side fields are then replaced.
         response_cards = []
+        omitted_card_ids: list[int] = []
         for card in cards:
+            requires_merge = (
+                requested_lang is not None
+                and card.source_language_iso != requested_lang
+            )
+            if requires_merge and card.id not in translation_by_card:
+                # Omit cards without a translation in the requested language.
+                # Tracked + logged below so a downstream pipeline that gets
+                # fewer cards than it expected can correlate the gap with
+                # cards that need derivation.
+                omitted_card_ids.append(card.id)
+                continue
+
+            if requires_merge:
+                trans = translation_by_card[card.id]
+                source_lemma = trans.source_lemma
+                source_surface_forms = trans.source_surface_forms
+                senses = trans.senses
+                override_map = trans_source_by_card.get(card.id, {})
+            else:
+                source_lemma = card.source_lemma
+                source_surface_forms = card.source_surface_forms
+                senses = card.senses
+                override_map = {}
+
+            examples_out = [
+                {
+                    "source": override_map.get(ex["id"], ex["source"])
+                    if requires_merge
+                    else ex["source"],
+                    "target": ex["target"],
+                }
+                for ex in examples_by_card[card.id]
+            ]
+
             card_dict = {
                 "id": card.id,
-                "source_lemma": card.source_lemma,
+                "source_lemma": source_lemma,
                 "target_lemma": card.target_lemma,
                 "source_version_id": card.source_version_id,
                 "target_version_id": card.target_version_id,
                 "pos": card.pos,
                 "surface_forms": card.surface_forms,
-                "source_surface_forms": card.source_surface_forms,
-                "senses": card.senses,
+                "source_surface_forms": source_surface_forms,
+                "senses": senses,
                 "confidence": card.confidence,
                 "english_lemma": card.english_lemma,
                 "alignment_scores": card.alignment_scores,
                 "created_at": card.created_at,
                 "last_updated": card.last_updated,
                 "last_user_edit": card.last_user_edit,
-                "examples": examples_by_card[card.id],
+                "examples": examples_out,
             }
             response_cards.append(LexemeCardOut.model_validate(card_dict))
 
@@ -1888,6 +1987,8 @@ async def get_lexeme_cards(
                 "target_word": target_word,
                 "target_words": target_words,
                 "pos": pos,
+                "lang": requested_lang,
+                "omitted_for_missing_translation": len(omitted_card_ids),
                 "duration_s": duration,
             },
         )
@@ -1971,6 +2072,370 @@ async def check_word_in_lexeme_cards(
 
     except SQLAlchemyError as e:
         logger.error(f"Error checking word in lexeme cards: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(e)}",
+        ) from e
+
+
+@router.post(
+    "/agent/lexeme-card/{card_id}/translation",
+    response_model=CardTranslationOut,
+)
+async def add_lexeme_card_translation(
+    card_id: int,
+    translation: CardTranslationIn,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Upsert a derived translation for a single lexeme card.
+
+    Stores the (card_id, language_iso) translation overlay and replaces
+    its associated example translations wholesale. Used by the derivation
+    pipeline in aqua-assessments to persist MT output for cards built
+    against a non-matching canonical pivot language.
+    """
+    request_start = time.perf_counter()
+    try:
+        from sqlalchemy import delete, select
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+        from sqlalchemy.sql import func
+
+        card = await db.scalar(
+            select(AgentLexemeCard).where(AgentLexemeCard.id == card_id)
+        )
+        if card is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Lexeme card with id {card_id} not found",
+            )
+
+        # Explicit .lower() on both sides: the Pydantic field normalizes the
+        # request, and the DB trigger normalizes the column, but compare
+        # case-insensitively so a stray uppercase value in either source can't
+        # silently bypass this guard.
+        if translation.language_iso.lower() == (card.source_language_iso or "").lower():
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"language_iso={translation.language_iso} matches the card's "
+                    f"canonical source_language_iso; translations are only stored "
+                    f"for non-canonical languages. Read the canonical fields "
+                    f"directly."
+                ),
+            )
+
+        if translation.examples:
+            example_ids = [e.example_id for e in translation.examples]
+            # Reject duplicate example_ids in the payload up front — otherwise
+            # the per-row INSERT would fail on the (card_translation_id,
+            # example_id) unique index with a less helpful IntegrityError.
+            duplicate_ids = sorted(
+                {eid for eid in example_ids if example_ids.count(eid) > 1}
+            )
+            if duplicate_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"duplicate example_id(s) {duplicate_ids} in payload; "
+                        f"each example_id may appear at most once"
+                    ),
+                )
+            valid_ids_result = await db.scalars(
+                select(AgentLexemeCardExample.id).where(
+                    AgentLexemeCardExample.id.in_(example_ids),
+                    AgentLexemeCardExample.lexeme_card_id == card_id,
+                )
+            )
+            valid_ids = set(valid_ids_result.all())
+            invalid_ids = sorted({eid for eid in example_ids if eid not in valid_ids})
+            if invalid_ids:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        f"example_id(s) {invalid_ids} do not belong to card "
+                        f"{card_id}"
+                    ),
+                )
+
+        # Atomic upsert: ON CONFLICT DO UPDATE avoids the TOCTOU race a
+        # SELECT-then-INSERT pattern would have under concurrent callers
+        # targeting the same (card_id, language_iso).
+        upsert_stmt = (
+            pg_insert(CardTranslation)
+            .values(
+                card_id=card_id,
+                language_iso=translation.language_iso,
+                source_lemma=translation.source_lemma,
+                source_surface_forms=translation.source_surface_forms,
+                senses=translation.senses,
+                parent_build_version=translation.parent_build_version,
+                build_version=translation.build_version,
+            )
+            .on_conflict_do_update(
+                index_elements=["card_id", "language_iso"],
+                set_={
+                    "source_lemma": translation.source_lemma,
+                    "source_surface_forms": translation.source_surface_forms,
+                    "senses": translation.senses,
+                    "parent_build_version": translation.parent_build_version,
+                    "build_version": translation.build_version,
+                    "last_updated": func.now(),
+                },
+            )
+            .returning(CardTranslation.id)
+        )
+        translation_id = await db.scalar(upsert_stmt)
+
+        # Replace example rows wholesale. DELETE-then-INSERT runs in the same
+        # transaction as the upsert above, so the row + examples land as a
+        # single atomic unit from the perspective of other transactions.
+        await db.execute(
+            delete(CardTranslationExample).where(
+                CardTranslationExample.card_translation_id == translation_id
+            )
+        )
+
+        for ex in translation.examples:
+            db.add(
+                CardTranslationExample(
+                    card_translation_id=translation_id,
+                    example_id=ex.example_id,
+                    source_text=ex.source_text,
+                )
+            )
+
+        await db.commit()
+
+        # Re-fetch the row to pick up the server-side last_updated timestamp
+        # and per-example created_at values for the response.
+        translation_row = await db.scalar(
+            select(CardTranslation).where(CardTranslation.id == translation_id)
+        )
+        examples_result = await db.execute(
+            select(CardTranslationExample)
+            .where(CardTranslationExample.card_translation_id == translation_id)
+            .order_by(CardTranslationExample.id)
+        )
+        example_rows = examples_result.scalars().all()
+
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"add_lexeme_card_translation completed in {duration}s",
+            extra={
+                "method": "POST",
+                "path": "/agent/lexeme-card/{card_id}/translation",
+                "card_id": card_id,
+                "language_iso": translation.language_iso,
+                "example_count": len(translation.examples),
+                "duration_s": duration,
+            },
+        )
+
+        return CardTranslationOut(
+            id=translation_row.id,
+            card_id=translation_row.card_id,
+            language_iso=translation_row.language_iso,
+            source_lemma=translation_row.source_lemma,
+            source_surface_forms=translation_row.source_surface_forms,
+            senses=translation_row.senses,
+            parent_build_version=translation_row.parent_build_version,
+            build_version=translation_row.build_version,
+            created_at=translation_row.created_at,
+            last_updated=translation_row.last_updated,
+            examples=[
+                {
+                    "id": e.id,
+                    "example_id": e.example_id,
+                    "source_text": e.source_text,
+                    "created_at": e.created_at,
+                }
+                for e in example_rows
+            ],
+        )
+
+    except HTTPException:
+        await db.rollback()
+        raise
+    except IntegrityError as e:
+        await db.rollback()
+        logger.error(f"Integrity error storing card translation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Integrity error: {str(e.orig) if e.orig else str(e)}",
+        ) from e
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error(f"Error storing card translation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(e)}",
+        ) from e
+
+
+# Registration order matters: this parameterized GET must stay AFTER any
+# literal-path GETs on /agent/lexeme-card/<word> (e.g. /check-word). FastAPI
+# matches routes in declaration order, so reordering would shadow them.
+@router.get("/agent/lexeme-card/{card_id}", response_model=LexemeCardOut)
+async def get_lexeme_card_by_id(
+    card_id: int,
+    lang: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Return a single lexeme card, optionally in a non-canonical language.
+
+    When ``lang`` is omitted or equals the card's canonical
+    ``source_language_iso``, returns the canonical card. Otherwise looks up
+    the ``card_translations`` row for that language and returns a
+    ``LexemeCardOut`` with translation-language source-side fields and
+    per-example translated source_text merged in. Returns 404 if the card
+    does not exist, or if a non-canonical ``lang`` is requested and no
+    translation row exists for it (the caller can then trigger derivation).
+    """
+    request_start = time.perf_counter()
+    try:
+        from sqlalchemy import select
+
+        card = await db.scalar(
+            select(AgentLexemeCard).where(AgentLexemeCard.id == card_id)
+        )
+        if card is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Lexeme card with id {card_id} not found",
+            )
+
+        requested_lang = lang.lower() if lang else None
+        use_translation = (
+            requested_lang is not None and requested_lang != card.source_language_iso
+        )
+
+        translation = None
+        if use_translation:
+            translation = await db.scalar(
+                select(CardTranslation).where(
+                    CardTranslation.card_id == card_id,
+                    CardTranslation.language_iso == requested_lang,
+                )
+            )
+            if translation is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail={
+                        "message": f"no translation for language_iso={requested_lang}",
+                        "card_id": card_id,
+                        "source_language_iso": card.source_language_iso,
+                    },
+                )
+
+        is_admin = current_user.is_admin
+        examples_conditions = [AgentLexemeCardExample.lexeme_card_id == card_id]
+        if not is_admin:
+            authorized_lang_revisions = (
+                select(BibleRevision.id)
+                .distinct()
+                .join(
+                    BibleVersion,
+                    BibleVersion.id == BibleRevision.bible_version_id,
+                )
+                .join(
+                    BibleVersionAccess,
+                    BibleVersionAccess.bible_version_id == BibleVersion.id,
+                )
+                .join(
+                    UserGroup,
+                    UserGroup.group_id == BibleVersionAccess.group_id,
+                )
+                .where(
+                    UserGroup.user_id == current_user.id,
+                    BibleVersion.id.in_(
+                        [card.source_version_id, card.target_version_id]
+                    ),
+                )
+            )
+            examples_conditions.append(
+                AgentLexemeCardExample.revision_id.in_(authorized_lang_revisions)
+            )
+
+        examples_result = await db.execute(
+            select(
+                AgentLexemeCardExample.id,
+                AgentLexemeCardExample.source_text,
+                AgentLexemeCardExample.target_text,
+            )
+            .where(*examples_conditions)
+            .order_by(AgentLexemeCardExample.id)
+        )
+        example_rows = list(examples_result.all())
+
+        translated_source_by_example_id: dict[int, str] = {}
+        if translation is not None:
+            te_result = await db.execute(
+                select(
+                    CardTranslationExample.example_id,
+                    CardTranslationExample.source_text,
+                ).where(CardTranslationExample.card_translation_id == translation.id)
+            )
+            translated_source_by_example_id = {
+                row.example_id: row.source_text for row in te_result.all()
+            }
+
+        examples = [
+            {
+                "source": translated_source_by_example_id.get(row.id, row.source_text),
+                "target": row.target_text,
+            }
+            for row in example_rows
+        ]
+
+        if translation is not None:
+            source_lemma = translation.source_lemma
+            source_surface_forms = translation.source_surface_forms
+            senses = translation.senses
+        else:
+            source_lemma = card.source_lemma
+            source_surface_forms = card.source_surface_forms
+            senses = card.senses
+
+        card_dict = {
+            "id": card.id,
+            "source_lemma": source_lemma,
+            "target_lemma": card.target_lemma,
+            "source_version_id": card.source_version_id,
+            "target_version_id": card.target_version_id,
+            "pos": card.pos,
+            "surface_forms": card.surface_forms,
+            "source_surface_forms": source_surface_forms,
+            "senses": senses,
+            "confidence": card.confidence,
+            "english_lemma": card.english_lemma,
+            "alignment_scores": card.alignment_scores,
+            "created_at": card.created_at,
+            "last_updated": card.last_updated,
+            "last_user_edit": card.last_user_edit,
+            "examples": examples,
+        }
+
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"get_lexeme_card_by_id completed in {duration}s",
+            extra={
+                "method": "GET",
+                "path": "/agent/lexeme-card/{card_id}",
+                "card_id": card_id,
+                "lang": requested_lang,
+                "merged": translation is not None,
+                "duration_s": duration,
+            },
+        )
+
+        return LexemeCardOut.model_validate(card_dict)
+
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        logger.error(f"Error fetching lexeme card by id: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Database error: {str(e)}",

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -4,6 +4,7 @@ import datetime
 import socket
 import time
 import unicodedata
+from collections import Counter
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, Request, status
@@ -1692,7 +1693,7 @@ async def get_lexeme_cards(
     target_word: str = None,
     target_words: str = None,
     pos: str = None,
-    lang: str | None = None,
+    lang: str | None = Query(default=None, min_length=3, max_length=3),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
@@ -2122,9 +2123,8 @@ async def add_lexeme_card_translation(
             # Reject duplicate example_ids in the payload up front — otherwise
             # the per-row INSERT would fail on the (card_translation_id,
             # example_id) unique index with a less helpful IntegrityError.
-            duplicate_ids = sorted(
-                {eid for eid in example_ids if example_ids.count(eid) > 1}
-            )
+            counts = Counter(example_ids)
+            duplicate_ids = sorted(eid for eid, n in counts.items() if n > 1)
             if duplicate_ids:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
@@ -2281,7 +2281,7 @@ async def add_lexeme_card_translation(
 @router.get("/agent/lexeme-card/{card_id}", response_model=LexemeCardOut)
 async def get_lexeme_card_by_id(
     card_id: int,
-    lang: str | None = None,
+    lang: str | None = Query(default=None, min_length=3, max_length=3),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):

--- a/models.py
+++ b/models.py
@@ -900,6 +900,89 @@ class LexemeCardPatch(BaseModel):
     }
 
 
+class CardTranslationExampleIn(BaseModel):
+    example_id: int
+    source_text: str
+
+    @field_validator("source_text")
+    @classmethod
+    def normalize_source_text(cls, v):
+        return unicodedata.normalize("NFC", v) if v else v
+
+
+class CardTranslationIn(BaseModel):
+    """Write-side payload for a single (card, target_language) translation overlay."""
+
+    language_iso: str = Field(min_length=3, max_length=3)
+    source_lemma: Optional[str] = None
+    source_surface_forms: Optional[List[str]] = None
+    senses: Optional[List[dict]] = None
+    parent_build_version: Optional[str] = None
+    build_version: Optional[str] = None
+    examples: List[CardTranslationExampleIn] = []
+
+    @field_validator("language_iso")
+    @classmethod
+    def normalize_language_iso(cls, v):
+        return v.lower() if v else v
+
+    @field_validator("source_lemma")
+    @classmethod
+    def normalize_source_lemma(cls, v):
+        return unicodedata.normalize("NFC", v) if v else v
+
+    @field_validator("source_surface_forms")
+    @classmethod
+    def normalize_source_surface_forms(cls, v):
+        if v is None:
+            return v
+        return [unicodedata.normalize("NFC", s) if isinstance(s, str) else s for s in v]
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "language_iso": "spa",
+                "source_lemma": "camino",
+                "source_surface_forms": ["camino", "caminos"],
+                "senses": [
+                    {"definition": "camino, ruta, sendero"},
+                ],
+                "parent_build_version": "v1",
+                "build_version": "spa-v1",
+                "examples": [
+                    {
+                        "example_id": 12345,
+                        "source_text": "nos salvó al renovarnos al nacer de nuevo",
+                    },
+                ],
+            }
+        }
+    }
+
+
+class CardTranslationExampleOut(BaseModel):
+    id: int
+    example_id: int
+    source_text: str
+    created_at: Optional[datetime.datetime] = None
+
+
+class CardTranslationOut(BaseModel):
+    """Read-side shape of a stored translation overlay."""
+
+    id: int
+    card_id: int
+    language_iso: str
+    source_lemma: Optional[str] = None
+    source_surface_forms: Optional[list] = None
+    senses: Optional[list] = None
+    parent_build_version: Optional[str] = None
+    build_version: Optional[str] = None
+    created_at: Optional[datetime.datetime] = None
+    last_updated: Optional[datetime.datetime] = None
+    examples: List[CardTranslationExampleOut] = []
+
+
 class OmissionIssueIn(BaseModel):
     """Omission critique issue: source text missing from the draft."""
 

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6393,7 +6393,7 @@ def _create_card_with_examples(
     examples=None,
 ):
     """Helper: POST a canonical card with one or more examples and return
-    the created card's id plus the loaded card row (for example ids)."""
+    its id."""
     if examples is None:
         examples = [{"source": "hello world", "target": "habari ya dunia"}]
     response = client.post(
@@ -7075,3 +7075,342 @@ def test_card_translation_cascade_delete(
         .first()
         is None
     )
+
+
+def test_add_card_translation_unknown_language_iso_returns_400(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """language_iso passing Pydantic length but absent from iso_language → 400."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_unknown_iso_lemma",
+        source_lemma="trans_unknown_iso_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+    response = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "xyz",  # Valid length, not in iso_language fixture
+            "source_lemma": "anything",
+            "examples": [],
+        },
+    )
+    # Handler catches IntegrityError from the FK violation and surfaces 400.
+    assert response.status_code == 400
+
+
+def test_add_card_translation_empty_examples_wipes_existing(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Second upsert with examples=[] removes all previously stored examples."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_wipe_lemma",
+        source_lemma="trans_wipe_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "wipe src", "target": "wipe tgt"}],
+    )
+    ex_id = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .first()
+        .id
+    )
+
+    first = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "wipe_first",
+            "examples": [{"example_id": ex_id, "source_text": "first swh"}],
+        },
+    )
+    assert first.status_code == 200
+    translation_id = first.json()["id"]
+    assert len(first.json()["examples"]) == 1
+
+    second = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "wipe_second",
+            "examples": [],  # explicit empty
+        },
+    )
+    assert second.status_code == 200
+    assert second.json()["id"] == translation_id  # same row, upsert
+    assert second.json()["examples"] == []
+
+    db_session.expire_all()
+    remaining = (
+        db_session.query(CardTranslationExample)
+        .filter(CardTranslationExample.card_translation_id == translation_id)
+        .all()
+    )
+    assert remaining == []
+
+
+def test_add_card_translation_build_version_round_trip_across_upsert(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """parent_build_version and build_version round-trip and update on upsert."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_bv_lemma",
+        source_lemma="trans_bv_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+
+    first = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "bv_v1",
+            "parent_build_version": "card-v1",
+            "build_version": "swh-v1",
+            "examples": [],
+        },
+    )
+    assert first.status_code == 200
+    assert first.json()["parent_build_version"] == "card-v1"
+    assert first.json()["build_version"] == "swh-v1"
+
+    second = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "bv_v2",
+            "parent_build_version": "card-v2",
+            "build_version": "swh-v2",
+            "examples": [],
+        },
+    )
+    assert second.status_code == 200
+    assert second.json()["parent_build_version"] == "card-v2"
+    assert second.json()["build_version"] == "swh-v2"
+
+
+def test_get_lexeme_card_by_id_lang_is_case_insensitive(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """?lang=SWH (uppercase) resolves to the same translation row as ?lang=swh."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="single_case_lemma",
+        source_lemma="single_case_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+    post = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "case_swh",
+            "examples": [],
+        },
+    )
+    assert post.status_code == 200
+
+    response = client.get(
+        f"/v3/agent/lexeme-card/{card_id}?lang=SWH",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["source_lemma"] == "case_swh"
+
+
+def test_get_lexeme_cards_bulk_lang_case_insensitive_and_asserts_senses(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Bulk ?lang=SWH merges, and asserts the translation's `senses` is returned."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="bulk_senses_lemma",
+        source_lemma="bulk_senses_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "senses src", "target": "senses tgt"}],
+    )
+    client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "bulk_senses_swh",
+            "senses": [{"definition": "swh definition only"}],
+            "examples": [],
+        },
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}&lang=SWH",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    merged = next(c for c in response.json() if c["id"] == card_id)
+    assert merged["senses"] == [{"definition": "swh definition only"}]
+    assert merged["source_lemma"] == "bulk_senses_swh"
+
+
+def test_get_lexeme_card_by_id_access_control(
+    client,
+    regular_token1,
+    regular_token2,
+    db_session,
+):
+    """Non-admin user only sees examples from revisions they have access to.
+
+    Setup mirrors test_lexeme_card_access_control_by_user: one card, two
+    versions each owned by a different group; each user adds examples from
+    their own revision; the new single-card GET enforces the same
+    access-control filter as the bulk endpoint.
+    """
+    from datetime import date
+
+    from database.models import (
+        BibleRevision,
+        BibleVersion,
+        BibleVersionAccess,
+        Group,
+        UserDB,
+    )
+
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    user2 = db_session.query(UserDB).filter(UserDB.username == "testuser2").first()
+    group1 = db_session.query(Group).filter(Group.name == "Group1").first()
+    group2 = db_session.query(Group).filter(Group.name == "Group2").first()
+
+    version_a = BibleVersion(
+        name="single_get_access_a",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="SGAA",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    version_b = BibleVersion(
+        name="single_get_access_b",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="SGAB",
+        owner_id=user2.id,
+        is_reference=False,
+    )
+    db_session.add_all([version_a, version_b])
+    db_session.commit()
+
+    revision_a = BibleRevision(
+        date=date.today(),
+        bible_version_id=version_a.id,
+        published=False,
+        machine_translation=True,
+    )
+    revision_b = BibleRevision(
+        date=date.today(),
+        bible_version_id=version_b.id,
+        published=False,
+        machine_translation=True,
+    )
+    db_session.add_all([revision_a, revision_b])
+    db_session.commit()
+    revision_a_id = revision_a.id
+    revision_b_id = revision_b.id
+
+    db_session.add_all(
+        [
+            BibleVersionAccess(bible_version_id=version_a.id, group_id=group1.id),
+            BibleVersionAccess(bible_version_id=version_b.id, group_id=group2.id),
+        ]
+    )
+    db_session.commit()
+
+    # User1 creates the card with an example from their revision
+    response_a = client.post(
+        f"/v3/agent/lexeme-card?revision_id={revision_a_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "access_src",
+            "target_lemma": "access_tgt",
+            "source_version_id": version_a.id,
+            "target_version_id": version_b.id,
+            "examples": [{"source": "user1 src", "target": "user1 tgt"}],
+        },
+    )
+    assert response_a.status_code == 200
+    card_id = response_a.json()["id"]
+
+    # User2 adds an example from their revision to the same card
+    response_b = client.post(
+        f"/v3/agent/lexeme-card?revision_id={revision_b_id}",
+        headers={"Authorization": f"Bearer {regular_token2}"},
+        json={
+            "source_lemma": "access_src",
+            "target_lemma": "access_tgt",
+            "source_version_id": version_a.id,
+            "target_version_id": version_b.id,
+            "examples": [{"source": "user2 src", "target": "user2 tgt"}],
+        },
+    )
+    assert response_b.status_code == 200
+
+    # User1 queries the single card → only sees their own example
+    response = client.get(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    examples = response.json()["examples"]
+    assert len(examples) == 1
+    assert examples[0]["source"] == "user1 src"
+
+    # User2 queries the same card → only sees their own example
+    response2 = client.get(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert response2.status_code == 200
+    examples2 = response2.json()["examples"]
+    assert len(examples2) == 1
+    assert examples2[0]["source"] == "user2 src"

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -7294,6 +7294,45 @@ def test_get_lexeme_cards_bulk_lang_case_insensitive_and_asserts_senses(
     assert merged["source_lemma"] == "bulk_senses_swh"
 
 
+def test_get_lexeme_card_by_id_rejects_invalid_lang_length(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """`?lang` must be exactly 3 chars (Query validation, 422)."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="single_lang_len_lemma",
+        source_lemma="single_lang_len_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card/{card_id}?lang=en",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 422
+
+
+def test_get_lexeme_cards_bulk_rejects_invalid_lang_length(
+    client,
+    regular_token1,
+    test_version_id,
+    test_version_id_2,
+):
+    """Bulk `?lang` must also be exactly 3 chars (422)."""
+    response = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}&lang=engl",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 422
+
+
 def test_get_lexeme_card_by_id_access_control(
     client,
     regular_token1,

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6,6 +6,8 @@ from database.models import (
     AgentLexemeCard,
     AgentLexemeCardExample,
     AgentWordAlignment,
+    CardTranslation,
+    CardTranslationExample,
 )
 
 prefix = "v3"
@@ -6372,3 +6374,704 @@ def test_delete_lexeme_card_unauthorized(client):
     """Test DELETE requires authentication."""
     response = client.delete("/v3/agent/lexeme-card/1")
     assert response.status_code == 401
+
+
+# --------------------------------------------------------------------------
+# Card translation endpoints (pivot-language architecture, issue #669)
+# --------------------------------------------------------------------------
+
+
+def _create_card_with_examples(
+    client,
+    token,
+    *,
+    target_lemma,
+    source_lemma,
+    revision_id,
+    source_version_id,
+    target_version_id,
+    examples=None,
+):
+    """Helper: POST a canonical card with one or more examples and return
+    the created card's id plus the loaded card row (for example ids)."""
+    if examples is None:
+        examples = [{"source": "hello world", "target": "habari ya dunia"}]
+    response = client.post(
+        f"/v3/agent/lexeme-card?revision_id={revision_id}",
+        headers={"Authorization": f"Bearer {token}"},
+        json={
+            "source_lemma": source_lemma,
+            "target_lemma": target_lemma,
+            "source_version_id": source_version_id,
+            "target_version_id": target_version_id,
+            "examples": examples,
+        },
+    )
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+def test_add_card_translation_insert_success(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """POST a translation for a card and verify the row + examples are persisted."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_insert_lemma",
+        source_lemma="trans_insert_source",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[
+            {"source": "first source", "target": "first target"},
+            {"source": "second source", "target": "second target"},
+        ],
+    )
+
+    example_rows = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .order_by(AgentLexemeCardExample.id)
+        .all()
+    )
+    assert len(example_rows) == 2
+    example_id_1 = example_rows[0].id
+    example_id_2 = example_rows[1].id
+
+    response = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "kupenda",
+            "source_surface_forms": ["kupenda", "anapenda"],
+            "senses": [{"definition": "kuwa na hisia ya upendo"}],
+            "parent_build_version": "v1",
+            "build_version": "swh-v1",
+            "examples": [
+                {"example_id": example_id_1, "source_text": "chanzo cha kwanza"},
+                {"example_id": example_id_2, "source_text": "chanzo cha pili"},
+            ],
+        },
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["card_id"] == card_id
+    assert data["language_iso"] == "swh"
+    assert data["source_lemma"] == "kupenda"
+    assert data["source_surface_forms"] == ["kupenda", "anapenda"]
+    assert data["senses"] == [{"definition": "kuwa na hisia ya upendo"}]
+    assert data["parent_build_version"] == "v1"
+    assert data["build_version"] == "swh-v1"
+    assert len(data["examples"]) == 2
+    assert {e["example_id"] for e in data["examples"]} == {example_id_1, example_id_2}
+
+
+def test_add_card_translation_upserts_existing(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """POSTing twice updates the existing row and replaces examples wholesale."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_upsert_lemma",
+        source_lemma="trans_upsert_source",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[
+            {"source": "alpha src", "target": "alpha tgt"},
+            {"source": "beta src", "target": "beta tgt"},
+            {"source": "gamma src", "target": "gamma tgt"},
+        ],
+    )
+    example_rows = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .order_by(AgentLexemeCardExample.id)
+        .all()
+    )
+    ex_ids = [e.id for e in example_rows]
+
+    # Initial insert
+    first = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "first_lemma",
+            "examples": [
+                {"example_id": ex_ids[0], "source_text": "first run alpha"},
+                {"example_id": ex_ids[1], "source_text": "first run beta"},
+            ],
+        },
+    )
+    assert first.status_code == 200
+    first_id = first.json()["id"]
+
+    # Second insert: same (card_id, language_iso) → update in place,
+    # replace examples wholesale (now using ex_ids[2] only, not [0]/[1]).
+    second = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "updated_lemma",
+            "examples": [
+                {"example_id": ex_ids[2], "source_text": "second run gamma"},
+            ],
+        },
+    )
+    assert second.status_code == 200, second.text
+    second_data = second.json()
+    assert second_data["id"] == first_id  # Same row, not a new insert
+    assert second_data["source_lemma"] == "updated_lemma"
+    assert len(second_data["examples"]) == 1
+    assert second_data["examples"][0]["example_id"] == ex_ids[2]
+
+    # Verify the old example translations are gone
+    db_session.expire_all()
+    remaining = (
+        db_session.query(CardTranslationExample)
+        .filter(CardTranslationExample.card_translation_id == first_id)
+        .all()
+    )
+    assert len(remaining) == 1
+    assert remaining[0].example_id == ex_ids[2]
+
+
+def test_add_card_translation_rejects_canonical_language(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """language_iso matching the card's canonical source_language_iso is 400."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_canonical_lemma",
+        source_lemma="trans_canonical_source",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+
+    response = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "eng",  # Canonical for these test versions
+            "source_lemma": "english",
+            "examples": [],
+        },
+    )
+    assert response.status_code == 400
+    assert "canonical" in response.json()["detail"].lower()
+
+
+def test_add_card_translation_rejects_foreign_example_id(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """example_id pointing to a different card is 400."""
+    target_card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_target_card",
+        source_lemma="trans_target_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+    other_card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_other_card",
+        source_lemma="trans_other_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "foreign src", "target": "foreign tgt"}],
+    )
+    foreign_example_id = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == other_card_id)
+        .first()
+        .id
+    )
+
+    response = client.post(
+        f"/v3/agent/lexeme-card/{target_card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "kupenda",
+            "examples": [
+                {"example_id": foreign_example_id, "source_text": "haijuhi"},
+            ],
+        },
+    )
+    assert response.status_code == 400
+    assert str(foreign_example_id) in response.json()["detail"]
+
+
+def test_add_card_translation_rejects_duplicate_example_ids_in_payload(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Duplicate example_id within one payload is rejected up front (400)."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_dup_lemma",
+        source_lemma="trans_dup_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "dup src", "target": "dup tgt"}],
+    )
+    ex_id = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .first()
+        .id
+    )
+    response = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "dup_swh",
+            "examples": [
+                {"example_id": ex_id, "source_text": "first"},
+                {"example_id": ex_id, "source_text": "second"},
+            ],
+        },
+    )
+    assert response.status_code == 400
+    assert "duplicate" in response.json()["detail"].lower()
+
+
+def test_add_card_translation_card_not_found(client, regular_token1):
+    """404 when the card id does not exist."""
+    response = client.post(
+        "/v3/agent/lexeme-card/999999/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "anything",
+            "examples": [],
+        },
+    )
+    assert response.status_code == 404
+
+
+def test_add_card_translation_unauthorized(client):
+    """No bearer token → 401."""
+    response = client.post(
+        "/v3/agent/lexeme-card/1/translation",
+        json={"language_iso": "swh", "source_lemma": "x", "examples": []},
+    )
+    assert response.status_code == 401
+
+
+def test_add_card_translation_invalid_language_iso_length(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """language_iso must be exactly 3 chars (Pydantic 422)."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_iso_len_lemma",
+        source_lemma="trans_iso_len_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+    response = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "en",  # Too short
+            "source_lemma": "x",
+            "examples": [],
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_get_lexeme_card_by_id_canonical(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Single-card GET with no lang returns canonical fields."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="single_canon_lemma",
+        source_lemma="single_canon_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "canon source", "target": "canon target"}],
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["id"] == card_id
+    assert data["source_lemma"] == "single_canon_src"
+    assert data["target_lemma"] == "single_canon_lemma"
+    assert data["examples"] == [{"source": "canon source", "target": "canon target"}]
+
+
+def test_get_lexeme_card_by_id_lang_matches_canonical(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """lang == source_language_iso returns canonical, no translation lookup."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="single_lang_match_lemma",
+        source_lemma="single_lang_match_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card/{card_id}?lang=eng",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    assert response.json()["source_lemma"] == "single_lang_match_src"
+
+
+def test_get_lexeme_card_by_id_lang_merges_translation(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """lang != source_language_iso merges the translation into LexemeCardOut."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="single_merge_lemma",
+        source_lemma="single_merge_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[
+            {"source": "alpha en", "target": "alpha tgt"},
+            {"source": "beta en", "target": "beta tgt"},
+        ],
+    )
+    example_rows = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .order_by(AgentLexemeCardExample.id)
+        .all()
+    )
+    ex_ids = [e.id for e in example_rows]
+
+    # Create translation overlay (translate first example, leave second alone)
+    post = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "kupenda",
+            "source_surface_forms": ["kupenda"],
+            "senses": [{"definition": "kupenda definition"}],
+            "examples": [
+                {"example_id": ex_ids[0], "source_text": "alpha swh"},
+            ],
+        },
+    )
+    assert post.status_code == 200
+
+    response = client.get(
+        f"/v3/agent/lexeme-card/{card_id}?lang=swh",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    # Source-side fields come from the translation
+    assert data["source_lemma"] == "kupenda"
+    assert data["source_surface_forms"] == ["kupenda"]
+    assert data["senses"] == [{"definition": "kupenda definition"}]
+    # Target-side fields come from the canonical card (unchanged)
+    assert data["target_lemma"] == "single_merge_lemma"
+    # The translated example has source_text overridden; the un-translated
+    # example keeps the canonical source_text.
+    sources = {ex["source"] for ex in data["examples"]}
+    targets = {ex["target"] for ex in data["examples"]}
+    assert sources == {"alpha swh", "beta en"}
+    assert targets == {"alpha tgt", "beta tgt"}
+
+
+def test_get_lexeme_card_by_id_404_when_no_translation(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """lang != source_language_iso and no translation row → 404."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="single_404_lemma",
+        source_lemma="single_404_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card/{card_id}?lang=swh",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 404
+    body = response.json()
+    detail = body["detail"]
+    assert detail["card_id"] == card_id
+    assert detail["source_language_iso"] == "eng"
+
+
+def test_get_lexeme_card_by_id_card_not_found(client, regular_token1):
+    """Unknown card_id → 404."""
+    response = client.get(
+        "/v3/agent/lexeme-card/999999",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 404
+
+
+def test_get_lexeme_cards_bulk_lang_omits_missing_translation(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Bulk GET with ?lang omits cards that lack a translation in that lang."""
+    target_lemma_with = "bulk_lang_with_trans"
+    target_lemma_without = "bulk_lang_without_trans"
+
+    card_with = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma=target_lemma_with,
+        source_lemma="bulk_with_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "with en src", "target": "with tgt"}],
+    )
+    card_without = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma=target_lemma_without,
+        source_lemma="bulk_without_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "without en src", "target": "without tgt"}],
+    )
+    ex_id = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_with)
+        .first()
+        .id
+    )
+    client.post(
+        f"/v3/agent/lexeme-card/{card_with}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "bulk_with_swh",
+            "examples": [
+                {"example_id": ex_id, "source_text": "with swh src"},
+            ],
+        },
+    )
+
+    response = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}&lang=swh",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    returned_ids = {c["id"] for c in response.json()}
+    assert card_with in returned_ids
+    assert card_without not in returned_ids
+
+    merged = next(c for c in response.json() if c["id"] == card_with)
+    assert merged["source_lemma"] == "bulk_with_swh"
+    assert merged["examples"][0]["source"] == "with swh src"
+    assert merged["examples"][0]["target"] == "with tgt"
+
+
+def test_get_lexeme_cards_bulk_no_lang_back_compat(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Bulk GET without ?lang behaves exactly as before (no translation lookup)."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="bulk_no_lang_lemma",
+        source_lemma="bulk_no_lang_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "back compat src", "target": "back compat tgt"}],
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    cards = response.json()
+    card = next(c for c in cards if c["id"] == card_id)
+    # Examples should be the canonical {source, target} shape (no extra keys).
+    assert card["examples"] == [
+        {"source": "back compat src", "target": "back compat tgt"}
+    ]
+
+
+def test_get_lexeme_cards_bulk_lang_matches_canonical(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Bulk GET with ?lang=<canonical> returns canonical for all cards (no lookups)."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="bulk_canon_lemma",
+        source_lemma="bulk_canon_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "canon en src", "target": "canon tgt"}],
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}&lang=eng",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    card = next(c for c in response.json() if c["id"] == card_id)
+    assert card["source_lemma"] == "bulk_canon_src"
+    assert card["examples"] == [{"source": "canon en src", "target": "canon tgt"}]
+
+
+def test_card_translation_cascade_delete(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Deleting the parent card cascades to card_translations + examples."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="trans_cascade_lemma",
+        source_lemma="trans_cascade_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "cascade src", "target": "cascade tgt"}],
+    )
+    ex_id = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .first()
+        .id
+    )
+    post = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "cascade_swh",
+            "examples": [{"example_id": ex_id, "source_text": "cascade swh"}],
+        },
+    )
+    assert post.status_code == 200
+    translation_id = post.json()["id"]
+
+    # Sanity: rows exist before delete
+    db_session.expire_all()
+    assert (
+        db_session.query(CardTranslation)
+        .filter(CardTranslation.id == translation_id)
+        .first()
+        is not None
+    )
+
+    delete_response = client.delete(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert delete_response.status_code == 204
+
+    db_session.expire_all()
+    assert (
+        db_session.query(CardTranslation)
+        .filter(CardTranslation.id == translation_id)
+        .first()
+        is None
+    )
+    assert (
+        db_session.query(CardTranslationExample)
+        .filter(CardTranslationExample.card_translation_id == translation_id)
+        .first()
+        is None
+    )


### PR DESCRIPTION
## Summary

Closes #669. Adds the read/write API surface the derivation pipeline needs to persist and serve per-output-language overlays on canonical lexeme cards (pivot-language architecture; Phase 0 schema landed in #666).

- **`POST /v3/agent/lexeme-card/{card_id}/translation`** — atomic upsert of a `card_translations` row plus its example translations. Uses `ON CONFLICT DO UPDATE` on `(card_id, language_iso)` so concurrent writers collapse to the latest write rather than racing on the unique index. Validates: card exists (404), `language_iso` ≠ canonical `source_language_iso` (400, compared case-insensitively), every `example_id` belongs to the card (400), no duplicate `example_id`s in the payload (400).
- **`GET /v3/agent/lexeme-card/{card_id}`** — new single-card read. Optional `?lang=`. Returns canonical when omitted or matching `source_language_iso`; merges the translation overlay when it differs (source-side fields + per-example `source_text`); 404s with `{card_id, source_language_iso}` when no overlay exists so callers can trigger derivation.
- **`GET /v3/agent/lexeme-card`** (bulk) — extended with `?lang=`. Cards lacking a translation in the requested language are omitted; merged cards keep the `LexemeCardOut` shape so existing consumers are untouched. Logs `omitted_for_missing_translation` count for pipelines that need to correlate partial results.

No schema changes — Phase 0 already added the tables and columns.

## Test plan

- [x] `pytest test/test_agent_routes/` — 316 passed (17 new + 299 existing)
- [x] New tests cover: insert + upsert, canonical-language rejection, foreign example_id rejection, duplicate example_id rejection, unknown card → 404, unauthorized → 401, invalid `language_iso` length → 422, single-card canonical read, `?lang` matching canonical, `?lang` merging translation, `?lang` 404 on missing translation, bulk omit-on-missing, bulk no-`lang` back-compat, bulk `?lang=canonical`, cascade delete of translations + examples
- [x] Back-compat: existing GET behavior unchanged when `?lang` is omitted
- [x] Pre-commit hooks (black, isort) clean