### PR TITLE
Include example_id in lexeme-card responses

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -744,7 +744,7 @@ async def add_lexeme_card(
                 examples_result = await db.execute(examples_query)
                 examples_objs = examples_result.scalars().all()
                 examples_list = [
-                    {"source": ex.source_text, "target": ex.target_text}
+                    {"id": ex.id, "source": ex.source_text, "target": ex.target_text}
                     for ex in examples_objs
                 ]
 
@@ -835,7 +835,7 @@ async def add_lexeme_card(
                 examples_result = await db.execute(examples_query)
                 examples_objs = examples_result.scalars().all()
                 examples_list = [
-                    {"source": ex.source_text, "target": ex.target_text}
+                    {"id": ex.id, "source": ex.source_text, "target": ex.target_text}
                     for ex in examples_objs
                 ]
 
@@ -1102,7 +1102,7 @@ async def _apply_lexeme_card_patch(
         )
     examples_result = await db.execute(examples_query)
     examples_list = [
-        {"source": ex.source_text, "target": ex.target_text}
+        {"id": ex.id, "source": ex.source_text, "target": ex.target_text}
         for ex in examples_result.scalars().all()
     ]
 
@@ -1944,6 +1944,7 @@ async def get_lexeme_cards(
 
             examples_out = [
                 {
+                    "id": ex["id"],
                     "source": override_map.get(ex["id"], ex["source"])
                     if requires_merge
                     else ex["source"],
@@ -2385,6 +2386,7 @@ async def get_lexeme_card_by_id(
 
         examples = [
             {
+                "id": row.id,
                 "source": translated_source_by_example_id.get(row.id, row.source_text),
                 "target": row.target_text,
             }

--- a/models.py
+++ b/models.py
@@ -827,7 +827,9 @@ class LexemeCardOut(BaseModel):
     surface_forms: Optional[list] = None
     source_surface_forms: Optional[list] = None  # Source language surface forms
     senses: Optional[list] = None
-    examples: Optional[list] = None  # Filtered list for the requested revision_id
+    # Each example dict has shape {"id": int, "source": str, "target": str};
+    # filtered to the requested revision_id when set.
+    examples: Optional[list] = None
     confidence: Optional[float] = None
     english_lemma: Optional[str] = None
     alignment_scores: Optional[Dict[str, float]] = None

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6978,10 +6978,11 @@ def test_get_lexeme_cards_bulk_no_lang_back_compat(
     assert response.status_code == 200
     cards = response.json()
     card = next(c for c in cards if c["id"] == card_id)
-    # Examples should be the canonical {source, target} shape (no extra keys).
-    assert card["examples"] == [
-        {"source": "back compat src", "target": "back compat tgt"}
-    ]
+    # Examples should be the canonical {id, source, target} shape.
+    assert len(card["examples"]) == 1
+    assert card["examples"][0]["source"] == "back compat src"
+    assert card["examples"][0]["target"] == "back compat tgt"
+    assert isinstance(card["examples"][0]["id"], int)
 
 
 def test_get_lexeme_cards_bulk_lang_matches_canonical(

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6752,7 +6752,10 @@ def test_get_lexeme_card_by_id_canonical(
     assert data["id"] == card_id
     assert data["source_lemma"] == "single_canon_src"
     assert data["target_lemma"] == "single_canon_lemma"
-    assert data["examples"] == [{"source": "canon source", "target": "canon target"}]
+    assert len(data["examples"]) == 1
+    assert data["examples"][0]["source"] == "canon source"
+    assert data["examples"][0]["target"] == "canon target"
+    assert isinstance(data["examples"][0]["id"], int)
 
 
 def test_get_lexeme_card_by_id_lang_matches_canonical(
@@ -7007,7 +7010,10 @@ def test_get_lexeme_cards_bulk_lang_matches_canonical(
     assert response.status_code == 200
     card = next(c for c in response.json() if c["id"] == card_id)
     assert card["source_lemma"] == "bulk_canon_src"
-    assert card["examples"] == [{"source": "canon en src", "target": "canon tgt"}]
+    assert len(card["examples"]) == 1
+    assert card["examples"][0]["source"] == "canon en src"
+    assert card["examples"][0]["target"] == "canon tgt"
+    assert isinstance(card["examples"][0]["id"], int)
 
 
 def test_card_translation_cascade_delete(


### PR DESCRIPTION
## Summary

The five sites that serialize example rows for `LexemeCardOut` were dropping the row's primary key. This makes API-only consumers unable to construct downstream payloads that reference specific examples — most notably the `card_translator.derive_missing_translations` orchestrator in aqua-assessments, which has to fall back to direct DB reads just to recover `example_id` for constructing translation POST bodies.

Adds `"id"` to each example dict in:

- `POST /v3/agent/lexeme-card` (create)
- `POST /v3/agent/lexeme-card` upsert path
- `PATCH /v3/agent/lexeme-card/{card_id}`
- `GET /v3/agent/lexeme-card` (list, including joined-view `lang=` overlay)
- `GET /v3/agent/lexeme-card/{card_id}`

`LexemeCardOut.examples` remains an untyped list (each item is a dict with `id` + `source` + `target`) — comment updated to reflect the new contract.

## Why now

Phase 1 of the pivot-card-translation work merged the new write/read endpoints (#669/#670) and the orchestrator wired through end-to-end. The DB-fallback in the orchestrator was always intended as a stopgap pending this small response-shape fix.

## Test plan

- [ ] Existing two tests that asserted exact example-dict shape are updated to check `source`/`target` individually plus `isinstance(id, int)`. All other tests touch fields by key (`ex["source"]`) and remain unaffected.
- [ ] Once deployed to dev, the aqua-assessments orchestrator will be simplified to drop the DB lookup and source `example_id` from the API response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)