### PR TITLE
Expose lexeme card build_version through the API

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -632,9 +632,8 @@ async def add_lexeme_card(
             existing_card.confidence = card.confidence
             existing_card.english_lemma = card.english_lemma
             existing_card.alignment_scores = sorted_alignment_scores
+            existing_card.build_version = card.build_version
             existing_card.last_updated = func.now()
-            if card.build_version is not None:
-                existing_card.build_version = card.build_version
             if is_user_edit:
                 existing_card.last_user_edit = func.now()
 

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -633,6 +633,8 @@ async def add_lexeme_card(
             existing_card.english_lemma = card.english_lemma
             existing_card.alignment_scores = sorted_alignment_scores
             existing_card.last_updated = func.now()
+            if card.build_version is not None:
+                existing_card.build_version = card.build_version
             if is_user_edit:
                 existing_card.last_user_edit = func.now()
 
@@ -763,6 +765,7 @@ async def add_lexeme_card(
                 "confidence": existing_card.confidence,
                 "english_lemma": existing_card.english_lemma,
                 "alignment_scores": sorted_alignment_scores,
+                "build_version": existing_card.build_version,
                 "created_at": existing_card.created_at,
                 "last_updated": existing_card.last_updated,
                 "last_user_edit": existing_card.last_user_edit,
@@ -792,6 +795,7 @@ async def add_lexeme_card(
                 confidence=card.confidence,
                 english_lemma=card.english_lemma,
                 alignment_scores=sorted_alignment_scores,
+                build_version=card.build_version,
                 last_user_edit=func.now() if is_user_edit else None,
             )
 
@@ -854,6 +858,7 @@ async def add_lexeme_card(
                 "confidence": lexeme_card.confidence,
                 "english_lemma": lexeme_card.english_lemma,
                 "alignment_scores": sorted_alignment_scores,
+                "build_version": lexeme_card.build_version,
                 "created_at": lexeme_card.created_at,
                 "last_updated": lexeme_card.last_updated,
                 "last_user_edit": lexeme_card.last_user_edit,
@@ -960,6 +965,8 @@ async def _apply_lexeme_card_patch(
         card.confidence = patch_data.confidence
     if "english_lemma" in provided_fields:
         card.english_lemma = patch_data.english_lemma
+    if "build_version" in provided_fields:
+        card.build_version = patch_data.build_version
 
     # Handle alignment_scores (dict) - merge keys, null value removes key
     if "alignment_scores" in provided_fields:
@@ -1121,6 +1128,7 @@ async def _apply_lexeme_card_patch(
         "confidence": card.confidence,
         "english_lemma": card.english_lemma,
         "alignment_scores": card.alignment_scores,
+        "build_version": card.build_version,
         "created_at": card.created_at,
         "last_updated": card.last_updated,
         "last_user_edit": card.last_user_edit,
@@ -1965,6 +1973,7 @@ async def get_lexeme_cards(
                 "confidence": card.confidence,
                 "english_lemma": card.english_lemma,
                 "alignment_scores": card.alignment_scores,
+                "build_version": card.build_version,
                 "created_at": card.created_at,
                 "last_updated": card.last_updated,
                 "last_user_edit": card.last_user_edit,
@@ -2413,6 +2422,7 @@ async def get_lexeme_card_by_id(
             "confidence": card.confidence,
             "english_lemma": card.english_lemma,
             "alignment_scores": card.alignment_scores,
+            "build_version": card.build_version,
             "created_at": card.created_at,
             "last_updated": card.last_updated,
             "last_user_edit": card.last_user_edit,

--- a/models.py
+++ b/models.py
@@ -761,6 +761,10 @@ class LexemeCardIn(BaseModel):
     confidence: Optional[float] = None
     english_lemma: Optional[str] = None
     alignment_scores: Optional[Dict[str, float]] = None
+    # Opaque token bumped when the canonical card-builder rebuilds the card.
+    # Derived translations record this in parent_build_version so cache
+    # invalidation can detect when the canonical has moved on.
+    build_version: Optional[str] = None
 
     @field_validator("surface_forms")
     @classmethod
@@ -812,6 +816,7 @@ class LexemeCardIn(BaseModel):
                 "confidence": 0.95,
                 "english_lemma": "love",
                 "alignment_scores": {"love": 0.92, "you": 0.88},
+                "build_version": "agent-20260514T123000Z",
             }
         }
     }
@@ -831,6 +836,7 @@ class LexemeCardOut(BaseModel):
     confidence: Optional[float] = None
     english_lemma: Optional[str] = None
     alignment_scores: Optional[Dict[str, float]] = None
+    build_version: Optional[str] = None
     created_at: Optional[datetime.datetime] = None
     last_updated: Optional[datetime.datetime] = None
     last_user_edit: Optional[datetime.datetime] = None
@@ -869,6 +875,7 @@ class LexemeCardPatch(BaseModel):
     examples: Optional[List[dict]] = None  # Each dict has: source, target, revision_id
     # Dict values can be float or None (None means remove that key)
     alignment_scores: Optional[Dict[str, Optional[float]]] = None
+    build_version: Optional[str] = None
 
     @field_validator("surface_forms")
     @classmethod

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -4027,6 +4027,31 @@ def test_lexeme_card_build_version_roundtrip(
     )
     assert final.json()["build_version"] == "agent-v2"
 
+    # POST upsert with build_version set overwrites the existing value
+    # (matches the convention for other scalar fields like pos/confidence).
+    upsert = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "build_ver_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+            "build_version": "agent-v3",
+        },
+    )
+    assert upsert.status_code == 200
+    assert upsert.json()["build_version"] == "agent-v3"
+
+    # PATCH with explicit null clears the field
+    cleared = client.patch(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"build_version": None},
+    )
+    assert cleared.status_code == 200
+    assert cleared.json()["build_version"] is None
+
 
 # Lexeme Card PATCH Tests
 

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -3963,6 +3963,71 @@ def test_patch_lexeme_card_can_keep_same_target_lemma(
     assert patch_response.json()["confidence"] == 0.9
 
 
+def test_lexeme_card_build_version_roundtrip(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """POST + GET + PATCH preserve and update build_version end-to-end.
+
+    Canonical build_version is set by the agent's word-memory builder and read
+    back by the derivation orchestrator as parent_build_version when persisting
+    derived translations. This test exercises the full round-trip.
+    """
+    # POST with build_version set
+    create = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "build_ver_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+            "build_version": "agent-v1",
+        },
+    )
+    assert create.status_code == 200
+    assert create.json()["build_version"] == "agent-v1"
+    card_id = create.json()["id"]
+
+    # GET single by id returns the stored build_version
+    single = client.get(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert single.status_code == 200
+    assert single.json()["build_version"] == "agent-v1"
+
+    # GET list also includes build_version
+    listing = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert listing.status_code == 200
+    in_list = next(c for c in listing.json() if c["id"] == card_id)
+    assert in_list["build_version"] == "agent-v1"
+
+    # PATCH bumps build_version
+    patch = client.patch(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"build_version": "agent-v2"},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["build_version"] == "agent-v2"
+
+    # Confirm the new value persisted
+    final = client.get(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert final.json()["build_version"] == "agent-v2"
+
+
 # Lexeme Card PATCH Tests
 
 


### PR DESCRIPTION
## Summary

The `agent_lexeme_cards.build_version` column was added in Phase 0 (#666) but the API never accepted or returned it. This PR propagates the field through:

- **`LexemeCardIn`** — POST/upsert accepts it
- **`LexemeCardOut`** — GET/POST/PATCH responses include it
- **`LexemeCardPatch`** — PATCH can update it
- All five card serialization sites (create, upsert, patch, list-with-overlay, single read)

## Why

The canonical card-builder in aqua-assessments uses `build_version` as the "version of the canonical that produced these cards" stamp (e.g., `agent-{timestamp}` or `agent-{commit}-{timestamp}`). The derivation orchestrator (`card_translator.derive_missing_translations`) reads it back as `parent_build_version` when persisting a derived translation overlay — so cache-invalidation can detect when the canonical has rolled forward and the derived translations are stale.

Today the orchestrator records `parent_build_version=None` because `card.build_version` always comes back null from the API. After this PR, the agent will start populating it and stale-detection becomes meaningful.

## Test plan

- [x] New `test_lexeme_card_build_version_roundtrip` exercises POST + GET (single + list) + PATCH + GET to confirm the field flows cleanly end-to-end.
- [ ] After deploy, the aqua-assessments builder will start setting `build_version` on canonical card writes (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)