### PR TITLE
Add pivot-language routing endpoints (#673)

### DIFF
--- a/agent_routes/v3/pivot_routes.py
+++ b/agent_routes/v3/pivot_routes.py
@@ -1,0 +1,358 @@
+__version__ = "v3"
+
+import socket
+import time
+from typing import Optional
+
+import fastapi
+from fastapi import Depends, HTTPException, Query, status
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.dependencies import get_db
+from database.models import (
+    BibleVersion,
+    IsoLanguage,
+    LanguagePivot,
+    LanguageProfile,
+    PivotCandidate,
+)
+from database.models import UserDB as UserModel
+from models import (
+    LanguagePivotIn,
+    LanguagePivotListOut,
+    LanguagePivotMissOut,
+    LanguagePivotOut,
+    LanguageProfileOut,
+    PivotCandidateIn,
+    PivotCandidateListOut,
+    PivotCandidateOut,
+)
+from security_routes.auth_routes import get_current_user
+from utils.logging_config import setup_logger
+
+container_id = socket.gethostname()
+logger = setup_logger(__name__, container_id=container_id)
+
+router = fastapi.APIRouter()
+
+
+CANDIDATE_HINT = (
+    "No mapping for this target. Choose the best pivot from the candidates "
+    "by family/typology and POST your decision."
+)
+
+
+def _require_admin(user: UserModel) -> None:
+    if not user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Admin privileges required",
+        )
+
+
+async def _candidate_with_profile(
+    db: AsyncSession, candidate: PivotCandidate
+) -> Optional[PivotCandidateOut]:
+    """Build a PivotCandidateOut, returning None if no language_profile exists.
+
+    We skip candidates with no profile so the auto-decision flow only sees
+    pivots it can actually compare against.
+    """
+    profile_result = await db.execute(
+        select(LanguageProfile).where(LanguageProfile.iso_639_3 == candidate.pivot_iso)
+    )
+    profile = profile_result.scalar_one_or_none()
+    if profile is None:
+        return None
+    return PivotCandidateOut(
+        pivot_iso=candidate.pivot_iso,
+        pivot_version_id=candidate.pivot_version_id,
+        notes=candidate.notes,
+        language_profile=LanguageProfileOut.model_validate(profile),
+        created_at=candidate.created_at,
+        updated_at=candidate.updated_at,
+    )
+
+
+async def _list_candidates(db: AsyncSession) -> list[PivotCandidateOut]:
+    result = await db.execute(select(PivotCandidate).order_by(PivotCandidate.pivot_iso))
+    out: list[PivotCandidateOut] = []
+    for candidate in result.scalars().all():
+        item = await _candidate_with_profile(db, candidate)
+        if item is not None:
+            out.append(item)
+    return out
+
+
+async def _build_pivot_out(
+    db: AsyncSession, mapping: LanguagePivot
+) -> LanguagePivotOut:
+    candidate_result = await db.execute(
+        select(PivotCandidate).where(PivotCandidate.pivot_iso == mapping.pivot_iso)
+    )
+    candidate = candidate_result.scalar_one()
+    profile_result = await db.execute(
+        select(LanguageProfile).where(LanguageProfile.iso_639_3 == mapping.pivot_iso)
+    )
+    profile = profile_result.scalar_one_or_none()
+    return LanguagePivotOut(
+        target_iso=mapping.target_iso,
+        pivot_iso=mapping.pivot_iso,
+        pivot_version_id=candidate.pivot_version_id,
+        notes=mapping.notes,
+        language_profile=(
+            LanguageProfileOut.model_validate(profile) if profile is not None else None
+        ),
+        created_at=mapping.created_at,
+        updated_at=mapping.updated_at,
+    )
+
+
+@router.get("/pivot-candidate", response_model=PivotCandidateListOut)
+async def list_pivot_candidates(
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    request_start = time.perf_counter()
+    candidates = await _list_candidates(db)
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"list_pivot_candidates completed in {duration}s",
+        extra={
+            "method": "GET",
+            "path": "/pivot-candidate",
+            "count": len(candidates),
+            "duration_s": duration,
+        },
+    )
+    return PivotCandidateListOut(candidates=candidates)
+
+
+@router.post("/pivot-candidate", response_model=PivotCandidateOut)
+async def upsert_pivot_candidate(
+    payload: PivotCandidateIn,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Create or update a pivot candidate. Admin-only.
+
+    Adding a pivot is a curated decision tied to licensing/quality, so it
+    should not be done autonomously by the agent.
+    """
+    _require_admin(current_user)
+    request_start = time.perf_counter()
+
+    iso_exists = await db.execute(
+        select(IsoLanguage).where(IsoLanguage.iso639 == payload.pivot_iso)
+    )
+    if iso_exists.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown ISO 639-3 code '{payload.pivot_iso}'",
+        )
+
+    version_exists = await db.execute(
+        select(BibleVersion.id).where(BibleVersion.id == payload.pivot_version_id)
+    )
+    if version_exists.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown bible_version id {payload.pivot_version_id}",
+        )
+
+    try:
+        existing_result = await db.execute(
+            select(PivotCandidate).where(PivotCandidate.pivot_iso == payload.pivot_iso)
+        )
+        candidate = existing_result.scalar_one_or_none()
+        if candidate is None:
+            candidate = PivotCandidate(
+                pivot_iso=payload.pivot_iso,
+                pivot_version_id=payload.pivot_version_id,
+                notes=payload.notes,
+            )
+            db.add(candidate)
+        else:
+            candidate.pivot_version_id = payload.pivot_version_id
+            candidate.notes = payload.notes
+        await db.commit()
+        await db.refresh(candidate)
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error("Failed to upsert pivot candidate", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {e}",
+        ) from e
+
+    profile_result = await db.execute(
+        select(LanguageProfile).where(LanguageProfile.iso_639_3 == candidate.pivot_iso)
+    )
+    profile = profile_result.scalar_one_or_none()
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"upsert_pivot_candidate completed in {duration}s",
+        extra={
+            "method": "POST",
+            "path": "/pivot-candidate",
+            "pivot_iso": payload.pivot_iso,
+            "duration_s": duration,
+        },
+    )
+    return PivotCandidateOut(
+        pivot_iso=candidate.pivot_iso,
+        pivot_version_id=candidate.pivot_version_id,
+        notes=candidate.notes,
+        language_profile=(
+            LanguageProfileOut.model_validate(profile) if profile is not None else None
+        ),
+        created_at=candidate.created_at,
+        updated_at=candidate.updated_at,
+    )
+
+
+@router.get("/language-pivot")
+async def get_language_pivot(
+    response: fastapi.Response,
+    target_iso: Optional[str] = Query(None, min_length=3, max_length=3),
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Resolve a target_iso to its pivot, or list all mappings.
+
+    With ``target_iso``: returns the resolved mapping on hit (200) or a
+    candidate list on miss (404 body). Without ``target_iso``: lists all
+    mappings.
+    """
+    request_start = time.perf_counter()
+
+    if target_iso is None:
+        result = await db.execute(
+            select(LanguagePivot).order_by(LanguagePivot.target_iso)
+        )
+        mappings = result.scalars().all()
+        out_list = [await _build_pivot_out(db, m) for m in mappings]
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"list_language_pivot completed in {duration}s",
+            extra={
+                "method": "GET",
+                "path": "/language-pivot",
+                "count": len(out_list),
+                "duration_s": duration,
+            },
+        )
+        return LanguagePivotListOut(mappings=out_list)
+
+    mapping_result = await db.execute(
+        select(LanguagePivot).where(LanguagePivot.target_iso == target_iso)
+    )
+    mapping = mapping_result.scalar_one_or_none()
+
+    if mapping is not None:
+        out = await _build_pivot_out(db, mapping)
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"get_language_pivot hit in {duration}s",
+            extra={
+                "method": "GET",
+                "path": "/language-pivot",
+                "target_iso": target_iso,
+                "pivot_iso": mapping.pivot_iso,
+                "duration_s": duration,
+            },
+        )
+        return out
+
+    candidates = await _list_candidates(db)
+    miss = LanguagePivotMissOut(
+        target_iso=target_iso,
+        candidates=candidates,
+        hint=CANDIDATE_HINT,
+    )
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"get_language_pivot miss in {duration}s",
+        extra={
+            "method": "GET",
+            "path": "/language-pivot",
+            "target_iso": target_iso,
+            "n_candidates": len(candidates),
+            "duration_s": duration,
+        },
+    )
+    response.status_code = status.HTTP_404_NOT_FOUND
+    return miss
+
+
+@router.post("/language-pivot", response_model=LanguagePivotOut)
+async def upsert_language_pivot(
+    payload: LanguagePivotIn,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Upsert a target -> pivot mapping. Re-POST replaces the pivot for that target."""
+    request_start = time.perf_counter()
+
+    iso_exists = await db.execute(
+        select(IsoLanguage).where(IsoLanguage.iso639 == payload.target_iso)
+    )
+    if iso_exists.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown ISO 639-3 code '{payload.target_iso}'",
+        )
+
+    candidate_result = await db.execute(
+        select(PivotCandidate).where(PivotCandidate.pivot_iso == payload.pivot_iso)
+    )
+    if candidate_result.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"pivot_iso '{payload.pivot_iso}' is not a registered pivot "
+                "candidate. POST it to /pivot-candidate first."
+            ),
+        )
+
+    try:
+        existing_result = await db.execute(
+            select(LanguagePivot).where(LanguagePivot.target_iso == payload.target_iso)
+        )
+        mapping = existing_result.scalar_one_or_none()
+        if mapping is None:
+            mapping = LanguagePivot(
+                target_iso=payload.target_iso,
+                pivot_iso=payload.pivot_iso,
+                notes=payload.notes,
+            )
+            db.add(mapping)
+        else:
+            mapping.pivot_iso = payload.pivot_iso
+            mapping.notes = payload.notes
+        await db.commit()
+        await db.refresh(mapping)
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error("Failed to upsert language pivot", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {e}",
+        ) from e
+
+    out = await _build_pivot_out(db, mapping)
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"upsert_language_pivot completed in {duration}s",
+        extra={
+            "method": "POST",
+            "path": "/language-pivot",
+            "target_iso": payload.target_iso,
+            "pivot_iso": payload.pivot_iso,
+            "duration_s": duration,
+        },
+    )
+    return out

--- a/agent_routes/v3/pivot_routes.py
+++ b/agent_routes/v3/pivot_routes.py
@@ -2,11 +2,13 @@ __version__ = "v3"
 
 import socket
 import time
-from typing import Optional
+from typing import Optional, Union
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import select
+from fastapi.responses import JSONResponse
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -52,51 +54,38 @@ def _require_admin(user: UserModel) -> None:
         )
 
 
-async def _candidate_with_profile(
-    db: AsyncSession, candidate: PivotCandidate
-) -> Optional[PivotCandidateOut]:
-    """Build a PivotCandidateOut, returning None if no language_profile exists.
-
-    We skip candidates with no profile so the auto-decision flow only sees
-    pivots it can actually compare against.
-    """
-    profile_result = await db.execute(
-        select(LanguageProfile).where(LanguageProfile.iso_639_3 == candidate.pivot_iso)
+async def _profiles_by_iso(
+    db: AsyncSession, isos: list[str]
+) -> dict[str, LanguageProfile]:
+    if not isos:
+        return {}
+    result = await db.execute(
+        select(LanguageProfile).where(LanguageProfile.iso_639_3.in_(isos))
     )
-    profile = profile_result.scalar_one_or_none()
-    if profile is None:
-        return None
+    return {p.iso_639_3: p for p in result.scalars().all()}
+
+
+def _candidate_to_out(
+    candidate: PivotCandidate,
+    profile: Optional[LanguageProfile],
+) -> PivotCandidateOut:
     return PivotCandidateOut(
         pivot_iso=candidate.pivot_iso,
         pivot_version_id=candidate.pivot_version_id,
         notes=candidate.notes,
-        language_profile=LanguageProfileOut.model_validate(profile),
+        language_profile=(
+            LanguageProfileOut.model_validate(profile) if profile is not None else None
+        ),
         created_at=candidate.created_at,
         updated_at=candidate.updated_at,
     )
 
 
-async def _list_candidates(db: AsyncSession) -> list[PivotCandidateOut]:
-    result = await db.execute(select(PivotCandidate).order_by(PivotCandidate.pivot_iso))
-    out: list[PivotCandidateOut] = []
-    for candidate in result.scalars().all():
-        item = await _candidate_with_profile(db, candidate)
-        if item is not None:
-            out.append(item)
-    return out
-
-
-async def _build_pivot_out(
-    db: AsyncSession, mapping: LanguagePivot
+def _mapping_to_out(
+    mapping: LanguagePivot,
+    candidate: PivotCandidate,
+    profile: Optional[LanguageProfile],
 ) -> LanguagePivotOut:
-    candidate_result = await db.execute(
-        select(PivotCandidate).where(PivotCandidate.pivot_iso == mapping.pivot_iso)
-    )
-    candidate = candidate_result.scalar_one()
-    profile_result = await db.execute(
-        select(LanguageProfile).where(LanguageProfile.iso_639_3 == mapping.pivot_iso)
-    )
-    profile = profile_result.scalar_one_or_none()
     return LanguagePivotOut(
         target_iso=mapping.target_iso,
         pivot_iso=mapping.pivot_iso,
@@ -110,13 +99,35 @@ async def _build_pivot_out(
     )
 
 
+async def _list_candidates_with_profiles(
+    db: AsyncSession,
+) -> list[PivotCandidateOut]:
+    """Return candidate list, omitting any whose pivot_iso lacks a language_profile.
+
+    The agent's auto-decision flow compares language profiles, so a candidate
+    without one isn't useful in that flow.
+    """
+    result = await db.execute(select(PivotCandidate).order_by(PivotCandidate.pivot_iso))
+    candidates = result.scalars().all()
+    if not candidates:
+        return []
+    profiles = await _profiles_by_iso(db, [c.pivot_iso for c in candidates])
+    out: list[PivotCandidateOut] = []
+    for candidate in candidates:
+        profile = profiles.get(candidate.pivot_iso)
+        if profile is None:
+            continue
+        out.append(_candidate_to_out(candidate, profile))
+    return out
+
+
 @router.get("/pivot-candidate", response_model=PivotCandidateListOut)
 async def list_pivot_candidates(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
     request_start = time.perf_counter()
-    candidates = await _list_candidates(db)
+    candidates = await _list_candidates_with_profiles(db)
     duration = round(time.perf_counter() - request_start, 2)
     logger.info(
         f"list_pivot_candidates completed in {duration}s",
@@ -139,46 +150,55 @@ async def upsert_pivot_candidate(
     """Create or update a pivot candidate. Admin-only.
 
     Adding a pivot is a curated decision tied to licensing/quality, so it
-    should not be done autonomously by the agent.
+    should not be done autonomously by the agent. Fields omitted from the
+    payload (e.g. ``notes``) preserve their existing value on update.
     """
     _require_admin(current_user)
     request_start = time.perf_counter()
 
-    iso_exists = await db.execute(
-        select(IsoLanguage).where(IsoLanguage.iso639 == payload.pivot_iso)
-    )
-    if iso_exists.scalar_one_or_none() is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Unknown ISO 639-3 code '{payload.pivot_iso}'",
-        )
-
-    version_exists = await db.execute(
-        select(BibleVersion.id).where(BibleVersion.id == payload.pivot_version_id)
-    )
-    if version_exists.scalar_one_or_none() is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Unknown bible_version id {payload.pivot_version_id}",
-        )
-
     try:
-        existing_result = await db.execute(
+        iso_exists = await db.execute(
+            select(IsoLanguage).where(IsoLanguage.iso639 == payload.pivot_iso)
+        )
+        if iso_exists.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown ISO 639-3 code '{payload.pivot_iso}'",
+            )
+
+        version_exists = await db.execute(
+            select(BibleVersion.id).where(BibleVersion.id == payload.pivot_version_id)
+        )
+        if version_exists.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown bible_version id {payload.pivot_version_id}",
+            )
+
+        sent = payload.model_dump(exclude_unset=True)
+        sent["pivot_iso"] = payload.pivot_iso  # always identifies the row
+        update_cols = {k: v for k, v in sent.items() if k != "pivot_iso"}
+
+        stmt = pg_insert(PivotCandidate).values(**sent)
+        if update_cols:
+            on_conflict_set = {col: stmt.excluded[col] for col in update_cols}
+            on_conflict_set["updated_at"] = func.now()
+            stmt = stmt.on_conflict_do_update(
+                index_elements=["pivot_iso"], set_=on_conflict_set
+            )
+        else:
+            stmt = stmt.on_conflict_do_nothing(index_elements=["pivot_iso"])
+        await db.execute(stmt)
+        await db.commit()
+
+        result = await db.execute(
             select(PivotCandidate).where(PivotCandidate.pivot_iso == payload.pivot_iso)
         )
-        candidate = existing_result.scalar_one_or_none()
-        if candidate is None:
-            candidate = PivotCandidate(
-                pivot_iso=payload.pivot_iso,
-                pivot_version_id=payload.pivot_version_id,
-                notes=payload.notes,
-            )
-            db.add(candidate)
-        else:
-            candidate.pivot_version_id = payload.pivot_version_id
-            candidate.notes = payload.notes
-        await db.commit()
-        await db.refresh(candidate)
+        candidate = result.scalar_one()
+        profiles = await _profiles_by_iso(db, [candidate.pivot_iso])
+    except HTTPException:
+        await db.rollback()
+        raise
     except SQLAlchemyError as e:
         await db.rollback()
         logger.error("Failed to upsert pivot candidate", exc_info=True)
@@ -186,11 +206,6 @@ async def upsert_pivot_candidate(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Database error: {e}",
         ) from e
-
-    profile_result = await db.execute(
-        select(LanguageProfile).where(LanguageProfile.iso_639_3 == candidate.pivot_iso)
-    )
-    profile = profile_result.scalar_one_or_none()
 
     duration = round(time.perf_counter() - request_start, 2)
     logger.info(
@@ -202,21 +217,15 @@ async def upsert_pivot_candidate(
             "duration_s": duration,
         },
     )
-    return PivotCandidateOut(
-        pivot_iso=candidate.pivot_iso,
-        pivot_version_id=candidate.pivot_version_id,
-        notes=candidate.notes,
-        language_profile=(
-            LanguageProfileOut.model_validate(profile) if profile is not None else None
-        ),
-        created_at=candidate.created_at,
-        updated_at=candidate.updated_at,
-    )
+    return _candidate_to_out(candidate, profiles.get(candidate.pivot_iso))
 
 
-@router.get("/language-pivot")
+@router.get(
+    "/language-pivot",
+    response_model=Union[LanguagePivotOut, LanguagePivotListOut],
+    responses={404: {"model": LanguagePivotMissOut}},
+)
 async def get_language_pivot(
-    response: fastapi.Response,
     target_iso: Optional[str] = Query(None, min_length=3, max_length=3),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
@@ -224,8 +233,8 @@ async def get_language_pivot(
     """Resolve a target_iso to its pivot, or list all mappings.
 
     With ``target_iso``: returns the resolved mapping on hit (200) or a
-    candidate list on miss (404 body). Without ``target_iso``: lists all
-    mappings.
+    structured candidate list on miss (404 body). Without ``target_iso``:
+    lists all mappings.
     """
     request_start = time.perf_counter()
 
@@ -234,7 +243,20 @@ async def get_language_pivot(
             select(LanguagePivot).order_by(LanguagePivot.target_iso)
         )
         mappings = result.scalars().all()
-        out_list = [await _build_pivot_out(db, m) for m in mappings]
+        if mappings:
+            pivot_isos = list({m.pivot_iso for m in mappings})
+            candidates = await db.execute(
+                select(PivotCandidate).where(PivotCandidate.pivot_iso.in_(pivot_isos))
+            )
+            candidate_by_iso = {c.pivot_iso: c for c in candidates.scalars().all()}
+            profiles = await _profiles_by_iso(db, pivot_isos)
+        else:
+            candidate_by_iso = {}
+            profiles = {}
+        out_list = [
+            _mapping_to_out(m, candidate_by_iso[m.pivot_iso], profiles.get(m.pivot_iso))
+            for m in mappings
+        ]
         duration = round(time.perf_counter() - request_start, 2)
         logger.info(
             f"list_language_pivot completed in {duration}s",
@@ -253,7 +275,22 @@ async def get_language_pivot(
     mapping = mapping_result.scalar_one_or_none()
 
     if mapping is not None:
-        out = await _build_pivot_out(db, mapping)
+        candidate_result = await db.execute(
+            select(PivotCandidate).where(PivotCandidate.pivot_iso == mapping.pivot_iso)
+        )
+        candidate = candidate_result.scalar_one_or_none()
+        profiles = await _profiles_by_iso(db, [mapping.pivot_iso])
+        if candidate is None:
+            # FK should prevent this; defensively surface as 500.
+            logger.error(
+                "language_pivot row references missing pivot_candidate",
+                extra={"target_iso": target_iso, "pivot_iso": mapping.pivot_iso},
+            )
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Pivot mapping references missing candidate",
+            )
+        out = _mapping_to_out(mapping, candidate, profiles.get(mapping.pivot_iso))
         duration = round(time.perf_counter() - request_start, 2)
         logger.info(
             f"get_language_pivot hit in {duration}s",
@@ -267,7 +304,7 @@ async def get_language_pivot(
         )
         return out
 
-    candidates = await _list_candidates(db)
+    candidates = await _list_candidates_with_profiles(db)
     miss = LanguagePivotMissOut(
         target_iso=target_iso,
         candidates=candidates,
@@ -284,8 +321,10 @@ async def get_language_pivot(
             "duration_s": duration,
         },
     )
-    response.status_code = status.HTTP_404_NOT_FOUND
-    return miss
+    return JSONResponse(
+        status_code=status.HTTP_404_NOT_FOUND,
+        content=miss.model_dump(mode="json"),
+    )
 
 
 @router.post("/language-pivot", response_model=LanguagePivotOut)
@@ -294,47 +333,59 @@ async def upsert_language_pivot(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
-    """Upsert a target -> pivot mapping. Re-POST replaces the pivot for that target."""
+    """Upsert a target -> pivot mapping. Re-POST replaces the pivot for that target.
+
+    Standard authenticated access (not admin-only): the agent's self-bootstrap
+    flow needs to POST decisions for unknown targets. Fields omitted from the
+    payload (e.g. ``notes``) preserve their existing value on update.
+    """
     request_start = time.perf_counter()
 
-    iso_exists = await db.execute(
-        select(IsoLanguage).where(IsoLanguage.iso639 == payload.target_iso)
-    )
-    if iso_exists.scalar_one_or_none() is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=f"Unknown ISO 639-3 code '{payload.target_iso}'",
-        )
-
-    candidate_result = await db.execute(
-        select(PivotCandidate).where(PivotCandidate.pivot_iso == payload.pivot_iso)
-    )
-    if candidate_result.scalar_one_or_none() is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=(
-                f"pivot_iso '{payload.pivot_iso}' is not a registered pivot "
-                "candidate. POST it to /pivot-candidate first."
-            ),
-        )
-
     try:
-        existing_result = await db.execute(
+        iso_exists = await db.execute(
+            select(IsoLanguage).where(IsoLanguage.iso639 == payload.target_iso)
+        )
+        if iso_exists.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"Unknown ISO 639-3 code '{payload.target_iso}'",
+            )
+
+        candidate_result = await db.execute(
+            select(PivotCandidate).where(PivotCandidate.pivot_iso == payload.pivot_iso)
+        )
+        candidate = candidate_result.scalar_one_or_none()
+        if candidate is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    f"pivot_iso '{payload.pivot_iso}' is not a registered pivot "
+                    "candidate. POST it to /pivot-candidate first."
+                ),
+            )
+
+        sent = payload.model_dump(exclude_unset=True)
+        sent["target_iso"] = payload.target_iso
+        sent["pivot_iso"] = payload.pivot_iso
+        update_cols = {k: v for k, v in sent.items() if k != "target_iso"}
+
+        stmt = pg_insert(LanguagePivot).values(**sent)
+        on_conflict_set = {col: stmt.excluded[col] for col in update_cols}
+        on_conflict_set["updated_at"] = func.now()
+        stmt = stmt.on_conflict_do_update(
+            index_elements=["target_iso"], set_=on_conflict_set
+        )
+        await db.execute(stmt)
+        await db.commit()
+
+        mapping_result = await db.execute(
             select(LanguagePivot).where(LanguagePivot.target_iso == payload.target_iso)
         )
-        mapping = existing_result.scalar_one_or_none()
-        if mapping is None:
-            mapping = LanguagePivot(
-                target_iso=payload.target_iso,
-                pivot_iso=payload.pivot_iso,
-                notes=payload.notes,
-            )
-            db.add(mapping)
-        else:
-            mapping.pivot_iso = payload.pivot_iso
-            mapping.notes = payload.notes
-        await db.commit()
-        await db.refresh(mapping)
+        mapping = mapping_result.scalar_one()
+        profiles = await _profiles_by_iso(db, [mapping.pivot_iso])
+    except HTTPException:
+        await db.rollback()
+        raise
     except SQLAlchemyError as e:
         await db.rollback()
         logger.error("Failed to upsert language pivot", exc_info=True)
@@ -343,7 +394,7 @@ async def upsert_language_pivot(
             detail=f"Database error: {e}",
         ) from e
 
-    out = await _build_pivot_out(db, mapping)
+    out = _mapping_to_out(mapping, candidate, profiles.get(mapping.pivot_iso))
     duration = round(time.perf_counter() - request_start, 2)
     logger.info(
         f"upsert_language_pivot completed in {duration}s",

--- a/agent_routes/v3/pivot_routes.py
+++ b/agent_routes/v3/pivot_routes.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.dependencies import get_db
 from database.models import (
-    BibleVersion,
+    BibleRevision,
     IsoLanguage,
     LanguagePivot,
     LanguageProfile,
@@ -65,13 +65,29 @@ async def _profiles_by_iso(
     return {p.iso_639_3: p for p in result.scalars().all()}
 
 
+async def _version_ids_by_revision(
+    db: AsyncSession, revision_ids: list[int]
+) -> dict[int, int]:
+    """Map revision_id -> bible_version_id for the given revisions."""
+    if not revision_ids:
+        return {}
+    result = await db.execute(
+        select(BibleRevision.id, BibleRevision.bible_version_id).where(
+            BibleRevision.id.in_(revision_ids)
+        )
+    )
+    return {row.id: row.bible_version_id for row in result.all()}
+
+
 def _candidate_to_out(
     candidate: PivotCandidate,
+    pivot_version_id: int,
     profile: Optional[LanguageProfile],
 ) -> PivotCandidateOut:
     return PivotCandidateOut(
         pivot_iso=candidate.pivot_iso,
-        pivot_version_id=candidate.pivot_version_id,
+        pivot_revision_id=candidate.pivot_revision_id,
+        pivot_version_id=pivot_version_id,
         notes=candidate.notes,
         language_profile=(
             LanguageProfileOut.model_validate(profile) if profile is not None else None
@@ -84,12 +100,14 @@ def _candidate_to_out(
 def _mapping_to_out(
     mapping: LanguagePivot,
     candidate: PivotCandidate,
+    pivot_version_id: int,
     profile: Optional[LanguageProfile],
 ) -> LanguagePivotOut:
     return LanguagePivotOut(
         target_iso=mapping.target_iso,
         pivot_iso=mapping.pivot_iso,
-        pivot_version_id=candidate.pivot_version_id,
+        pivot_revision_id=candidate.pivot_revision_id,
+        pivot_version_id=pivot_version_id,
         notes=mapping.notes,
         language_profile=(
             LanguageProfileOut.model_validate(profile) if profile is not None else None
@@ -112,12 +130,19 @@ async def _list_candidates_with_profiles(
     if not candidates:
         return []
     profiles = await _profiles_by_iso(db, [c.pivot_iso for c in candidates])
+    version_ids = await _version_ids_by_revision(
+        db, [c.pivot_revision_id for c in candidates]
+    )
     out: list[PivotCandidateOut] = []
     for candidate in candidates:
         profile = profiles.get(candidate.pivot_iso)
         if profile is None:
             continue
-        out.append(_candidate_to_out(candidate, profile))
+        out.append(
+            _candidate_to_out(
+                candidate, version_ids[candidate.pivot_revision_id], profile
+            )
+        )
     return out
 
 
@@ -166,13 +191,16 @@ async def upsert_pivot_candidate(
                 detail=f"Unknown ISO 639-3 code '{payload.pivot_iso}'",
             )
 
-        version_exists = await db.execute(
-            select(BibleVersion.id).where(BibleVersion.id == payload.pivot_version_id)
+        revision_result = await db.execute(
+            select(BibleRevision.bible_version_id).where(
+                BibleRevision.id == payload.pivot_revision_id
+            )
         )
-        if version_exists.scalar_one_or_none() is None:
+        pivot_version_id = revision_result.scalar_one_or_none()
+        if pivot_version_id is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Unknown bible_version id {payload.pivot_version_id}",
+                detail=f"Unknown bible_revision id {payload.pivot_revision_id}",
             )
 
         sent = payload.model_dump(exclude_unset=True)
@@ -217,7 +245,9 @@ async def upsert_pivot_candidate(
             "duration_s": duration,
         },
     )
-    return _candidate_to_out(candidate, profiles.get(candidate.pivot_iso))
+    return _candidate_to_out(
+        candidate, pivot_version_id, profiles.get(candidate.pivot_iso)
+    )
 
 
 @router.get(
@@ -250,11 +280,20 @@ async def get_language_pivot(
             )
             candidate_by_iso = {c.pivot_iso: c for c in candidates.scalars().all()}
             profiles = await _profiles_by_iso(db, pivot_isos)
+            version_ids = await _version_ids_by_revision(
+                db, [c.pivot_revision_id for c in candidate_by_iso.values()]
+            )
         else:
             candidate_by_iso = {}
             profiles = {}
+            version_ids = {}
         out_list = [
-            _mapping_to_out(m, candidate_by_iso[m.pivot_iso], profiles.get(m.pivot_iso))
+            _mapping_to_out(
+                m,
+                candidate_by_iso[m.pivot_iso],
+                version_ids[candidate_by_iso[m.pivot_iso].pivot_revision_id],
+                profiles.get(m.pivot_iso),
+            )
             for m in mappings
         ]
         duration = round(time.perf_counter() - request_start, 2)
@@ -290,7 +329,13 @@ async def get_language_pivot(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Pivot mapping references missing candidate",
             )
-        out = _mapping_to_out(mapping, candidate, profiles.get(mapping.pivot_iso))
+        version_ids = await _version_ids_by_revision(db, [candidate.pivot_revision_id])
+        out = _mapping_to_out(
+            mapping,
+            candidate,
+            version_ids[candidate.pivot_revision_id],
+            profiles.get(mapping.pivot_iso),
+        )
         duration = round(time.perf_counter() - request_start, 2)
         logger.info(
             f"get_language_pivot hit in {duration}s",
@@ -383,6 +428,7 @@ async def upsert_language_pivot(
         )
         mapping = mapping_result.scalar_one()
         profiles = await _profiles_by_iso(db, [mapping.pivot_iso])
+        version_ids = await _version_ids_by_revision(db, [candidate.pivot_revision_id])
     except HTTPException:
         await db.rollback()
         raise
@@ -394,7 +440,12 @@ async def upsert_language_pivot(
             detail=f"Database error: {e}",
         ) from e
 
-    out = _mapping_to_out(mapping, candidate, profiles.get(mapping.pivot_iso))
+    out = _mapping_to_out(
+        mapping,
+        candidate,
+        version_ids[candidate.pivot_revision_id],
+        profiles.get(mapping.pivot_iso),
+    )
     duration = round(time.perf_counter() - request_start, 2)
     logger.info(
         f"upsert_language_pivot completed in {duration}s",

--- a/alembic/migrations/versions/d7a3f9b1c5e2_add_pivot_language_tables.py
+++ b/alembic/migrations/versions/d7a3f9b1c5e2_add_pivot_language_tables.py
@@ -26,7 +26,7 @@ def upgrade() -> None:
     op.create_table(
         "pivot_candidate",
         sa.Column("pivot_iso", sa.String(length=3), nullable=False),
-        sa.Column("pivot_version_id", sa.Integer(), nullable=False),
+        sa.Column("pivot_revision_id", sa.Integer(), nullable=False),
         sa.Column("notes", sa.Text(), nullable=True),
         sa.Column(
             "created_at",
@@ -41,7 +41,7 @@ def upgrade() -> None:
             nullable=False,
         ),
         sa.ForeignKeyConstraint(["pivot_iso"], ["iso_language.iso639"]),
-        sa.ForeignKeyConstraint(["pivot_version_id"], ["bible_version.id"]),
+        sa.ForeignKeyConstraint(["pivot_revision_id"], ["bible_revision.id"]),
         sa.PrimaryKeyConstraint("pivot_iso"),
     )
 

--- a/alembic/migrations/versions/d7a3f9b1c5e2_add_pivot_language_tables.py
+++ b/alembic/migrations/versions/d7a3f9b1c5e2_add_pivot_language_tables.py
@@ -1,0 +1,80 @@
+"""add pivot_candidate and language_pivot tables
+
+Revision ID: d7a3f9b1c5e2
+Revises: c4f2a8e9b1d7
+Create Date: 2026-05-15 12:00:00.000000
+
+Pivot-language routing tables. ``pivot_candidate`` is the curated whitelist of
+languages we route through (typically Biblica-published versions). ``language_pivot``
+records resolved ``target_iso -> pivot_iso`` mappings, populated either by curator
+seed or by the agent's self-bootstrap flow.
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "d7a3f9b1c5e2"
+down_revision: Union[str, None] = "c4f2a8e9b1d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pivot_candidate",
+        sa.Column("pivot_iso", sa.String(length=3), nullable=False),
+        sa.Column("pivot_version_id", sa.Integer(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["pivot_iso"], ["iso_language.iso639"]),
+        sa.ForeignKeyConstraint(["pivot_version_id"], ["bible_version.id"]),
+        sa.PrimaryKeyConstraint("pivot_iso"),
+    )
+
+    op.create_table(
+        "language_pivot",
+        sa.Column("target_iso", sa.String(length=3), nullable=False),
+        sa.Column("pivot_iso", sa.String(length=3), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["target_iso"], ["iso_language.iso639"]),
+        sa.ForeignKeyConstraint(["pivot_iso"], ["pivot_candidate.pivot_iso"]),
+        sa.PrimaryKeyConstraint("target_iso"),
+    )
+    op.create_index(
+        "ix_language_pivot_pivot_iso",
+        "language_pivot",
+        ["pivot_iso"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_language_pivot_pivot_iso", table_name="language_pivot")
+    op.drop_table("language_pivot")
+    op.drop_table("pivot_candidate")

--- a/app.py
+++ b/app.py
@@ -7,6 +7,7 @@ from fastapi.openapi.utils import get_openapi
 
 from agent_routes.v3.affix_routes import router as affix_router_v3
 from agent_routes.v3.agent_routes import router as agent_router_v3
+from agent_routes.v3.pivot_routes import router as pivot_router_v3
 from agent_routes.v3.tokenizer_routes import router as tokenizer_router_v3
 from assessment_routes.v3.assessment_routes import router as assessment_router_v3
 from assessment_routes.v3.eflomal_routes import router as eflomal_router_v3
@@ -110,6 +111,7 @@ def configure_routing(app):
     app.include_router(agent_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(tokenizer_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(affix_router_v3, prefix="/v3", tags=["Version 3"])
+    app.include_router(pivot_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(train_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(eflomal_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(tfidf_artifact_router_v3, prefix="/v3", tags=["Version 3"])
@@ -135,6 +137,7 @@ def configure_routing(app):
         tokenizer_router_v3, prefix="/latest", tags=["Version 3 / Latest"]
     )
     app.include_router(affix_router_v3, prefix="/latest", tags=["Version 3 / Latest"])
+    app.include_router(pivot_router_v3, prefix="/latest", tags=["Version 3 / Latest"])
     app.include_router(train_router_v3, prefix="/latest", tags=["Version 3 / Latest"])
     app.include_router(eflomal_router_v3, prefix="/latest", tags=["Version 3 / Latest"])
     app.include_router(

--- a/database/models.py
+++ b/database/models.py
@@ -1422,7 +1422,9 @@ class PivotCandidate(Base):
     __tablename__ = "pivot_candidate"
 
     pivot_iso = Column(String(3), ForeignKey("iso_language.iso639"), primary_key=True)
-    pivot_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
+    pivot_revision_id = Column(
+        Integer, ForeignKey("bible_revision.id"), nullable=False
+    )
     notes = Column(Text, nullable=True)
     created_at = Column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False

--- a/database/models.py
+++ b/database/models.py
@@ -1409,3 +1409,56 @@ class PredictJob(Base):
         ),
         Index("ix_predict_jobs_owner_created", "owner_id", "created_at"),
     )
+
+
+class PivotCandidate(Base):
+    """Curated whitelist of pivot languages used for routing translations.
+
+    The pivot is the well-resourced language we route a target through. Choice
+    matters: Malila A/B (swh vs eng pivot) showed ~44% fewer back-translation
+    placeholders for the closer-family swh pivot.
+    """
+
+    __tablename__ = "pivot_candidate"
+
+    pivot_iso = Column(String(3), ForeignKey("iso_language.iso639"), primary_key=True)
+    pivot_version_id = Column(Integer, ForeignKey("bible_version.id"), nullable=False)
+    notes = Column(Text, nullable=True)
+    created_at = Column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+
+class LanguagePivot(Base):
+    """Resolved target_iso -> pivot_iso routing decisions.
+
+    Populated by curator seed for known targets and by the agent's self-bootstrap
+    flow for unknown targets. Keyed on target_iso only: each target has one pivot.
+    """
+
+    __tablename__ = "language_pivot"
+
+    target_iso = Column(String(3), ForeignKey("iso_language.iso639"), primary_key=True)
+    pivot_iso = Column(
+        String(3),
+        ForeignKey("pivot_candidate.pivot_iso"),
+        nullable=False,
+    )
+    notes = Column(Text, nullable=True)
+    created_at = Column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (Index("ix_language_pivot_pivot_iso", "pivot_iso"),)

--- a/database/models.py
+++ b/database/models.py
@@ -1422,9 +1422,7 @@ class PivotCandidate(Base):
     __tablename__ = "pivot_candidate"
 
     pivot_iso = Column(String(3), ForeignKey("iso_language.iso639"), primary_key=True)
-    pivot_revision_id = Column(
-        Integer, ForeignKey("bible_revision.id"), nullable=False
-    )
+    pivot_revision_id = Column(Integer, ForeignKey("bible_revision.id"), nullable=False)
     notes = Column(Text, nullable=True)
     created_at = Column(
         TIMESTAMP(timezone=True), server_default=func.now(), nullable=False

--- a/models.py
+++ b/models.py
@@ -1922,7 +1922,7 @@ class MorphemeSearchResponse(BaseModel):
 
 class PivotCandidateIn(BaseModel):
     pivot_iso: str = Field(..., min_length=3, max_length=3)
-    pivot_version_id: int
+    pivot_revision_id: int
     notes: Optional[str] = None
 
 
@@ -1930,7 +1930,8 @@ class PivotCandidateOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     pivot_iso: str
-    pivot_version_id: int
+    pivot_revision_id: int
+    pivot_version_id: int  # derived via bible_revision.bible_version_id
     notes: Optional[str] = None
     language_profile: Optional[LanguageProfileOut] = None
     created_at: Optional[datetime.datetime] = None
@@ -1952,7 +1953,8 @@ class LanguagePivotOut(BaseModel):
 
     target_iso: str
     pivot_iso: str
-    pivot_version_id: int
+    pivot_revision_id: int
+    pivot_version_id: int  # derived via bible_revision.bible_version_id
     notes: Optional[str] = None
     language_profile: Optional[LanguageProfileOut] = None
     created_at: Optional[datetime.datetime] = None

--- a/models.py
+++ b/models.py
@@ -1918,3 +1918,52 @@ class MorphemeSearchResponse(BaseModel):
     iso_639_3: str
     result_count: int
     results: List[MorphemeSearchResult]
+
+
+class PivotCandidateIn(BaseModel):
+    pivot_iso: str = Field(..., min_length=3, max_length=3)
+    pivot_version_id: int
+    notes: Optional[str] = None
+
+
+class PivotCandidateOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    pivot_iso: str
+    pivot_version_id: int
+    notes: Optional[str] = None
+    language_profile: Optional[LanguageProfileOut] = None
+    created_at: Optional[datetime.datetime] = None
+    updated_at: Optional[datetime.datetime] = None
+
+
+class PivotCandidateListOut(BaseModel):
+    candidates: List[PivotCandidateOut]
+
+
+class LanguagePivotIn(BaseModel):
+    target_iso: str = Field(..., min_length=3, max_length=3)
+    pivot_iso: str = Field(..., min_length=3, max_length=3)
+    notes: Optional[str] = None
+
+
+class LanguagePivotOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    target_iso: str
+    pivot_iso: str
+    pivot_version_id: int
+    notes: Optional[str] = None
+    language_profile: Optional[LanguageProfileOut] = None
+    created_at: Optional[datetime.datetime] = None
+    updated_at: Optional[datetime.datetime] = None
+
+
+class LanguagePivotListOut(BaseModel):
+    mappings: List[LanguagePivotOut]
+
+
+class LanguagePivotMissOut(BaseModel):
+    target_iso: str
+    candidates: List[PivotCandidateOut]
+    hint: str

--- a/test/test_agent_routes/test_pivot_routes.py
+++ b/test/test_agent_routes/test_pivot_routes.py
@@ -1,0 +1,305 @@
+"""Tests for pivot-language routing endpoints."""
+
+from database.models import LanguagePivot, LanguageProfile, PivotCandidate
+
+prefix = "v3"
+
+PIVOT_ISO = "swh"
+TARGET_ISO = "eng"
+
+
+def _cleanup(db_session):
+    db_session.query(LanguagePivot).filter(
+        LanguagePivot.target_iso.in_([TARGET_ISO, PIVOT_ISO])
+    ).delete(synchronize_session="fetch")
+    db_session.query(PivotCandidate).filter(
+        PivotCandidate.pivot_iso.in_([PIVOT_ISO, TARGET_ISO])
+    ).delete(synchronize_session="fetch")
+    db_session.query(LanguageProfile).filter(
+        LanguageProfile.iso_639_3.in_([PIVOT_ISO, TARGET_ISO])
+    ).delete(synchronize_session="fetch")
+    db_session.commit()
+
+
+def _seed_profile(db_session, iso, name):
+    db_session.add(LanguageProfile(iso_639_3=iso, name=name))
+    db_session.commit()
+
+
+def test_pivot_candidate_admin_create_and_list(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    payload = {
+        "pivot_iso": PIVOT_ISO,
+        "pivot_version_id": test_version_id,
+        "notes": "Bantu pivot",
+    }
+    resp = client.post(
+        f"/{prefix}/pivot-candidate", json=payload, headers=admin_headers
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["pivot_iso"] == PIVOT_ISO
+    assert body["pivot_version_id"] == test_version_id
+    assert body["notes"] == "Bantu pivot"
+    assert body["language_profile"]["name"] == "Swahili"
+
+    resp = client.get(f"/{prefix}/pivot-candidate", headers=user_headers)
+    assert resp.status_code == 200
+    candidates = resp.json()["candidates"]
+    assert any(c["pivot_iso"] == PIVOT_ISO for c in candidates)
+    _cleanup(db_session)
+
+
+def test_pivot_candidate_post_requires_admin(
+    client, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        headers=headers,
+    )
+    assert resp.status_code == 403
+    _cleanup(db_session)
+
+
+def test_pivot_candidate_rejects_unknown_version(client, admin_token, db_session):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    resp = client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": 999_999_999},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    _cleanup(db_session)
+
+
+def test_pivot_candidate_upsert_replaces_notes(
+    client, admin_token, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    headers = {"Authorization": f"Bearer {admin_token}"}
+
+    client.post(
+        f"/{prefix}/pivot-candidate",
+        json={
+            "pivot_iso": PIVOT_ISO,
+            "pivot_version_id": test_version_id,
+            "notes": "first",
+        },
+        headers=headers,
+    )
+    resp = client.post(
+        f"/{prefix}/pivot-candidate",
+        json={
+            "pivot_iso": PIVOT_ISO,
+            "pivot_version_id": test_version_id,
+            "notes": "second",
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["notes"] == "second"
+    _cleanup(db_session)
+
+
+def test_pivot_candidate_without_profile_is_omitted_from_list(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    # No LanguageProfile seeded for PIVOT_ISO
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    # POST response includes the row even without profile (language_profile is None)
+    assert resp.json()["language_profile"] is None
+
+    resp = client.get(f"/{prefix}/pivot-candidate", headers=user_headers)
+    assert resp.status_code == 200
+    pivot_isos = [c["pivot_iso"] for c in resp.json()["candidates"]]
+    assert PIVOT_ISO not in pivot_isos
+    _cleanup(db_session)
+
+
+def test_language_pivot_hit(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        headers=admin_headers,
+    )
+    resp = client.post(
+        f"/{prefix}/language-pivot",
+        json={
+            "target_iso": TARGET_ISO,
+            "pivot_iso": PIVOT_ISO,
+            "notes": "Bantu pivot",
+        },
+        headers=user_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["target_iso"] == TARGET_ISO
+    assert body["pivot_iso"] == PIVOT_ISO
+    assert body["pivot_version_id"] == test_version_id
+    assert body["language_profile"]["name"] == "Swahili"
+    assert body["notes"] == "Bantu pivot"
+
+    resp = client.get(
+        f"/{prefix}/language-pivot?target_iso={TARGET_ISO}", headers=user_headers
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["pivot_iso"] == PIVOT_ISO
+    assert body["pivot_version_id"] == test_version_id
+    _cleanup(db_session)
+
+
+def test_language_pivot_miss_returns_candidate_list(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        headers=admin_headers,
+    )
+
+    resp = client.get(
+        f"/{prefix}/language-pivot?target_iso={TARGET_ISO}", headers=user_headers
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["target_iso"] == TARGET_ISO
+    assert "hint" in body
+    pivot_isos = [c["pivot_iso"] for c in body["candidates"]]
+    assert PIVOT_ISO in pivot_isos
+    _cleanup(db_session)
+
+
+def test_language_pivot_rejects_unknown_pivot_candidate(
+    client, regular_token1, db_session
+):
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.post(
+        f"/{prefix}/language-pivot",
+        json={"target_iso": TARGET_ISO, "pivot_iso": PIVOT_ISO},
+        headers=headers,
+    )
+    assert resp.status_code == 422
+    _cleanup(db_session)
+
+
+def test_language_pivot_upsert_replaces_pivot(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    _seed_profile(db_session, TARGET_ISO, "English")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Register two pivot candidates: swh and eng (using TARGET_ISO as a second
+    # candidate for upsert symmetry).
+    for iso in (PIVOT_ISO, TARGET_ISO):
+        client.post(
+            f"/{prefix}/pivot-candidate",
+            json={"pivot_iso": iso, "pivot_version_id": test_version_id},
+            headers=admin_headers,
+        )
+
+    # First mapping: target=eng -> pivot=swh. Then replace with pivot=eng.
+    # We use TARGET_ISO/PIVOT_ISO names loosely here — both ISOs are valid
+    # iso_language rows in the test fixture, and the upsert needs a distinct
+    # target/pivot pair to flip between.
+    target = "eng"
+    client.post(
+        f"/{prefix}/language-pivot",
+        json={"target_iso": target, "pivot_iso": PIVOT_ISO},
+        headers=user_headers,
+    )
+    resp = client.post(
+        f"/{prefix}/language-pivot",
+        json={"target_iso": target, "pivot_iso": target, "notes": "self"},
+        headers=user_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["pivot_iso"] == target
+    assert resp.json()["notes"] == "self"
+
+    resp = client.get(
+        f"/{prefix}/language-pivot?target_iso={target}", headers=user_headers
+    )
+    assert resp.status_code == 200
+    assert resp.json()["pivot_iso"] == target
+    _cleanup(db_session)
+
+
+def test_language_pivot_list_all(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        headers=admin_headers,
+    )
+    client.post(
+        f"/{prefix}/language-pivot",
+        json={"target_iso": TARGET_ISO, "pivot_iso": PIVOT_ISO},
+        headers=user_headers,
+    )
+
+    resp = client.get(f"/{prefix}/language-pivot", headers=user_headers)
+    assert resp.status_code == 200
+    mappings = resp.json()["mappings"]
+    assert any(
+        m["target_iso"] == TARGET_ISO and m["pivot_iso"] == PIVOT_ISO for m in mappings
+    )
+    _cleanup(db_session)
+
+
+def test_language_pivot_requires_auth(client, db_session):
+    _cleanup(db_session)
+    resp = client.get(f"/{prefix}/language-pivot?target_iso={TARGET_ISO}")
+    assert resp.status_code == 401
+    resp = client.post(
+        f"/{prefix}/language-pivot",
+        json={"target_iso": TARGET_ISO, "pivot_iso": PIVOT_ISO},
+    )
+    assert resp.status_code == 401

--- a/test/test_agent_routes/test_pivot_routes.py
+++ b/test/test_agent_routes/test_pivot_routes.py
@@ -5,18 +5,21 @@ from database.models import LanguagePivot, LanguageProfile, PivotCandidate
 prefix = "v3"
 
 PIVOT_ISO = "swh"
-TARGET_ISO = "eng"
+SECOND_PIVOT_ISO = "ngq"
+TARGET_ISO = "zga"
+
+_ALL_TEST_ISOS = [PIVOT_ISO, SECOND_PIVOT_ISO, TARGET_ISO]
 
 
 def _cleanup(db_session):
     db_session.query(LanguagePivot).filter(
-        LanguagePivot.target_iso.in_([TARGET_ISO, PIVOT_ISO])
+        LanguagePivot.target_iso.in_(_ALL_TEST_ISOS)
     ).delete(synchronize_session="fetch")
     db_session.query(PivotCandidate).filter(
-        PivotCandidate.pivot_iso.in_([PIVOT_ISO, TARGET_ISO])
+        PivotCandidate.pivot_iso.in_(_ALL_TEST_ISOS)
     ).delete(synchronize_session="fetch")
     db_session.query(LanguageProfile).filter(
-        LanguageProfile.iso_639_3.in_([PIVOT_ISO, TARGET_ISO])
+        LanguageProfile.iso_639_3.in_(_ALL_TEST_ISOS)
     ).delete(synchronize_session="fetch")
     db_session.commit()
 
@@ -226,43 +229,110 @@ def test_language_pivot_upsert_replaces_pivot(
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
-    _seed_profile(db_session, TARGET_ISO, "English")
+    _seed_profile(db_session, SECOND_PIVOT_ISO, "Ngq")
     admin_headers = {"Authorization": f"Bearer {admin_token}"}
     user_headers = {"Authorization": f"Bearer {regular_token1}"}
 
-    # Register two pivot candidates: swh and eng (using TARGET_ISO as a second
-    # candidate for upsert symmetry).
-    for iso in (PIVOT_ISO, TARGET_ISO):
+    for iso in (PIVOT_ISO, SECOND_PIVOT_ISO):
         client.post(
             f"/{prefix}/pivot-candidate",
             json={"pivot_iso": iso, "pivot_version_id": test_version_id},
             headers=admin_headers,
         )
 
-    # First mapping: target=eng -> pivot=swh. Then replace with pivot=eng.
-    # We use TARGET_ISO/PIVOT_ISO names loosely here — both ISOs are valid
-    # iso_language rows in the test fixture, and the upsert needs a distinct
-    # target/pivot pair to flip between.
-    target = "eng"
     client.post(
         f"/{prefix}/language-pivot",
-        json={"target_iso": target, "pivot_iso": PIVOT_ISO},
+        json={"target_iso": TARGET_ISO, "pivot_iso": PIVOT_ISO, "notes": "v1"},
         headers=user_headers,
     )
     resp = client.post(
         f"/{prefix}/language-pivot",
-        json={"target_iso": target, "pivot_iso": target, "notes": "self"},
+        json={
+            "target_iso": TARGET_ISO,
+            "pivot_iso": SECOND_PIVOT_ISO,
+            "notes": "v2",
+        },
         headers=user_headers,
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["pivot_iso"] == target
-    assert resp.json()["notes"] == "self"
+    assert resp.json()["pivot_iso"] == SECOND_PIVOT_ISO
+    assert resp.json()["notes"] == "v2"
 
     resp = client.get(
-        f"/{prefix}/language-pivot?target_iso={target}", headers=user_headers
+        f"/{prefix}/language-pivot?target_iso={TARGET_ISO}", headers=user_headers
     )
     assert resp.status_code == 200
-    assert resp.json()["pivot_iso"] == target
+    assert resp.json()["pivot_iso"] == SECOND_PIVOT_ISO
+    _cleanup(db_session)
+
+
+def test_language_pivot_upsert_preserves_notes_when_omitted(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    """Re-POST without notes must not clear an existing curator rationale."""
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/pivot-candidate",
+        json={
+            "pivot_iso": PIVOT_ISO,
+            "pivot_version_id": test_version_id,
+            "notes": "Biblica swh",
+        },
+        headers=admin_headers,
+    )
+    client.post(
+        f"/{prefix}/language-pivot",
+        json={
+            "target_iso": TARGET_ISO,
+            "pivot_iso": PIVOT_ISO,
+            "notes": "curator rationale",
+        },
+        headers=user_headers,
+    )
+
+    # Re-POST without notes — should keep "curator rationale".
+    resp = client.post(
+        f"/{prefix}/language-pivot",
+        json={"target_iso": TARGET_ISO, "pivot_iso": PIVOT_ISO},
+        headers=user_headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["notes"] == "curator rationale"
+
+    # Same for pivot_candidate.
+    resp = client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        headers=admin_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["notes"] == "Biblica swh"
+    _cleanup(db_session)
+
+
+def test_language_pivot_rejects_unknown_target_iso(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        headers=admin_headers,
+    )
+    resp = client.post(
+        f"/{prefix}/language-pivot",
+        json={"target_iso": "xxx", "pivot_iso": PIVOT_ISO},
+        headers=user_headers,
+    )
+    assert resp.status_code == 422
     _cleanup(db_session)
 
 
@@ -288,9 +358,37 @@ def test_language_pivot_list_all(
     resp = client.get(f"/{prefix}/language-pivot", headers=user_headers)
     assert resp.status_code == 200
     mappings = resp.json()["mappings"]
-    assert any(
-        m["target_iso"] == TARGET_ISO and m["pivot_iso"] == PIVOT_ISO for m in mappings
+    match = next((m for m in mappings if m["target_iso"] == TARGET_ISO), None)
+    assert match is not None
+    assert match["pivot_iso"] == PIVOT_ISO
+    assert match["pivot_version_id"] == test_version_id
+    _cleanup(db_session)
+
+
+def test_language_pivot_miss_hint_is_populated(
+    client, admin_token, regular_token1, test_version_id, db_session
+):
+    _cleanup(db_session)
+    _seed_profile(db_session, PIVOT_ISO, "Swahili")
+    admin_headers = {"Authorization": f"Bearer {admin_token}"}
+    user_headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        headers=admin_headers,
     )
+    resp = client.get(
+        f"/{prefix}/language-pivot?target_iso={TARGET_ISO}", headers=user_headers
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert isinstance(body.get("hint"), str) and body["hint"]
+    candidate = next(
+        (c for c in body["candidates"] if c["pivot_iso"] == PIVOT_ISO), None
+    )
+    assert candidate is not None
+    assert candidate["pivot_version_id"] == test_version_id
     _cleanup(db_session)
 
 
@@ -301,5 +399,12 @@ def test_language_pivot_requires_auth(client, db_session):
     resp = client.post(
         f"/{prefix}/language-pivot",
         json={"target_iso": TARGET_ISO, "pivot_iso": PIVOT_ISO},
+    )
+    assert resp.status_code == 401
+    resp = client.get(f"/{prefix}/pivot-candidate")
+    assert resp.status_code == 401
+    resp = client.post(
+        f"/{prefix}/pivot-candidate",
+        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": 1},
     )
     assert resp.status_code == 401

--- a/test/test_agent_routes/test_pivot_routes.py
+++ b/test/test_agent_routes/test_pivot_routes.py
@@ -30,7 +30,7 @@ def _seed_profile(db_session, iso, name):
 
 
 def test_pivot_candidate_admin_create_and_list(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -39,7 +39,7 @@ def test_pivot_candidate_admin_create_and_list(
 
     payload = {
         "pivot_iso": PIVOT_ISO,
-        "pivot_version_id": test_version_id,
+        "pivot_revision_id": test_revision_id,
         "notes": "Bantu pivot",
     }
     resp = client.post(
@@ -48,6 +48,7 @@ def test_pivot_candidate_admin_create_and_list(
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["pivot_iso"] == PIVOT_ISO
+    assert body["pivot_revision_id"] == test_revision_id
     assert body["pivot_version_id"] == test_version_id
     assert body["notes"] == "Bantu pivot"
     assert body["language_profile"]["name"] == "Swahili"
@@ -60,7 +61,7 @@ def test_pivot_candidate_admin_create_and_list(
 
 
 def test_pivot_candidate_post_requires_admin(
-    client, regular_token1, test_version_id, db_session
+    client, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -68,21 +69,21 @@ def test_pivot_candidate_post_requires_admin(
 
     resp = client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": test_revision_id},
         headers=headers,
     )
     assert resp.status_code == 403
     _cleanup(db_session)
 
 
-def test_pivot_candidate_rejects_unknown_version(client, admin_token, db_session):
+def test_pivot_candidate_rejects_unknown_revision(client, admin_token, db_session):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
     headers = {"Authorization": f"Bearer {admin_token}"}
 
     resp = client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": 999_999_999},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": 999_999_999},
         headers=headers,
     )
     assert resp.status_code == 422
@@ -90,7 +91,7 @@ def test_pivot_candidate_rejects_unknown_version(client, admin_token, db_session
 
 
 def test_pivot_candidate_upsert_replaces_notes(
-    client, admin_token, test_version_id, db_session
+    client, admin_token, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -100,7 +101,7 @@ def test_pivot_candidate_upsert_replaces_notes(
         f"/{prefix}/pivot-candidate",
         json={
             "pivot_iso": PIVOT_ISO,
-            "pivot_version_id": test_version_id,
+            "pivot_revision_id": test_revision_id,
             "notes": "first",
         },
         headers=headers,
@@ -109,7 +110,7 @@ def test_pivot_candidate_upsert_replaces_notes(
         f"/{prefix}/pivot-candidate",
         json={
             "pivot_iso": PIVOT_ISO,
-            "pivot_version_id": test_version_id,
+            "pivot_revision_id": test_revision_id,
             "notes": "second",
         },
         headers=headers,
@@ -120,7 +121,7 @@ def test_pivot_candidate_upsert_replaces_notes(
 
 
 def test_pivot_candidate_without_profile_is_omitted_from_list(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     # No LanguageProfile seeded for PIVOT_ISO
@@ -129,7 +130,7 @@ def test_pivot_candidate_without_profile_is_omitted_from_list(
 
     resp = client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": test_revision_id},
         headers=admin_headers,
     )
     assert resp.status_code == 200
@@ -144,7 +145,7 @@ def test_pivot_candidate_without_profile_is_omitted_from_list(
 
 
 def test_language_pivot_hit(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -153,7 +154,7 @@ def test_language_pivot_hit(
 
     client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": test_revision_id},
         headers=admin_headers,
     )
     resp = client.post(
@@ -169,6 +170,7 @@ def test_language_pivot_hit(
     body = resp.json()
     assert body["target_iso"] == TARGET_ISO
     assert body["pivot_iso"] == PIVOT_ISO
+    assert body["pivot_revision_id"] == test_revision_id
     assert body["pivot_version_id"] == test_version_id
     assert body["language_profile"]["name"] == "Swahili"
     assert body["notes"] == "Bantu pivot"
@@ -179,12 +181,13 @@ def test_language_pivot_hit(
     assert resp.status_code == 200
     body = resp.json()
     assert body["pivot_iso"] == PIVOT_ISO
+    assert body["pivot_revision_id"] == test_revision_id
     assert body["pivot_version_id"] == test_version_id
     _cleanup(db_session)
 
 
 def test_language_pivot_miss_returns_candidate_list(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -193,7 +196,7 @@ def test_language_pivot_miss_returns_candidate_list(
 
     client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": test_revision_id},
         headers=admin_headers,
     )
 
@@ -225,7 +228,7 @@ def test_language_pivot_rejects_unknown_pivot_candidate(
 
 
 def test_language_pivot_upsert_replaces_pivot(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -236,7 +239,7 @@ def test_language_pivot_upsert_replaces_pivot(
     for iso in (PIVOT_ISO, SECOND_PIVOT_ISO):
         client.post(
             f"/{prefix}/pivot-candidate",
-            json={"pivot_iso": iso, "pivot_version_id": test_version_id},
+            json={"pivot_iso": iso, "pivot_revision_id": test_revision_id},
             headers=admin_headers,
         )
 
@@ -267,7 +270,7 @@ def test_language_pivot_upsert_replaces_pivot(
 
 
 def test_language_pivot_upsert_preserves_notes_when_omitted(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     """Re-POST without notes must not clear an existing curator rationale."""
     _cleanup(db_session)
@@ -279,7 +282,7 @@ def test_language_pivot_upsert_preserves_notes_when_omitted(
         f"/{prefix}/pivot-candidate",
         json={
             "pivot_iso": PIVOT_ISO,
-            "pivot_version_id": test_version_id,
+            "pivot_revision_id": test_revision_id,
             "notes": "Biblica swh",
         },
         headers=admin_headers,
@@ -306,7 +309,7 @@ def test_language_pivot_upsert_preserves_notes_when_omitted(
     # Same for pivot_candidate.
     resp = client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": test_revision_id},
         headers=admin_headers,
     )
     assert resp.status_code == 200
@@ -315,7 +318,7 @@ def test_language_pivot_upsert_preserves_notes_when_omitted(
 
 
 def test_language_pivot_rejects_unknown_target_iso(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -324,7 +327,7 @@ def test_language_pivot_rejects_unknown_target_iso(
 
     client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": test_revision_id},
         headers=admin_headers,
     )
     resp = client.post(
@@ -337,7 +340,7 @@ def test_language_pivot_rejects_unknown_target_iso(
 
 
 def test_language_pivot_list_all(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -346,7 +349,7 @@ def test_language_pivot_list_all(
 
     client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": test_revision_id},
         headers=admin_headers,
     )
     client.post(
@@ -361,12 +364,13 @@ def test_language_pivot_list_all(
     match = next((m for m in mappings if m["target_iso"] == TARGET_ISO), None)
     assert match is not None
     assert match["pivot_iso"] == PIVOT_ISO
+    assert match["pivot_revision_id"] == test_revision_id
     assert match["pivot_version_id"] == test_version_id
     _cleanup(db_session)
 
 
 def test_language_pivot_miss_hint_is_populated(
-    client, admin_token, regular_token1, test_version_id, db_session
+    client, admin_token, regular_token1, test_revision_id, test_version_id, db_session
 ):
     _cleanup(db_session)
     _seed_profile(db_session, PIVOT_ISO, "Swahili")
@@ -375,7 +379,7 @@ def test_language_pivot_miss_hint_is_populated(
 
     client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": test_version_id},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": test_revision_id},
         headers=admin_headers,
     )
     resp = client.get(
@@ -388,6 +392,7 @@ def test_language_pivot_miss_hint_is_populated(
         (c for c in body["candidates"] if c["pivot_iso"] == PIVOT_ISO), None
     )
     assert candidate is not None
+    assert candidate["pivot_revision_id"] == test_revision_id
     assert candidate["pivot_version_id"] == test_version_id
     _cleanup(db_session)
 
@@ -405,6 +410,6 @@ def test_language_pivot_requires_auth(client, db_session):
     assert resp.status_code == 401
     resp = client.post(
         f"/{prefix}/pivot-candidate",
-        json={"pivot_iso": PIVOT_ISO, "pivot_version_id": 1},
+        json={"pivot_iso": PIVOT_ISO, "pivot_revision_id": 1},
     )
     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- Add `pivot_candidate` (curated pivot whitelist, admin-only writes) and `language_pivot` (resolved `target_iso → pivot_iso` mappings) tables, plus a new `agent_routes/v3/pivot_routes.py` router mounted at `/v3` and `/latest`.
- Persisted FK is `pivot_revision_id` (FK to `bible_revision.id`). The derived `pivot_version_id` is surfaced in every GET/POST response via a JOIN through `bible_revision.bible_version_id`, so callers see both without duplicating storage.
- `GET /language-pivot?target_iso=…` returns the resolved mapping (with `pivot_revision_id`, `pivot_version_id`, and the pivot's `language_profile`) on hit (200), or the full candidate list with profiles and a hint on miss (404). `GET /language-pivot` with no params lists all mappings.
- `POST /language-pivot` upserts on `target_iso` and FK-validates `pivot_iso` against `pivot_candidate`. `POST /pivot-candidate` is admin-only and validates `pivot_revision_id`.
- Candidates without a `language_profiles` row are omitted from candidate lists so the agent's auto-decision flow only sees pivots it can compare against.

Fixes #673

## Test plan
- [x] Migration applies cleanly (`alembic upgrade head` on a fresh local DB)
- [x] New tests in `test/test_agent_routes/test_pivot_routes.py` pass (14/14)
- [x] Full `test/test_agent_routes/` suite passes (339/339)

🤖 Generated with [Claude Code](https://claude.com/claude-code)