### PR TITLE
Default lang to source_version_id ISO when pivot routes

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1919,12 +1919,10 @@ async def get_lexeme_cards(
                     }
                 )
 
-        # Apply non-canonical language overlay when requested. If the caller
-        # did not specify lang AND pivot routing redirected the source, default
-        # to the caller's source_version_id ISO so the pivot stays invisible:
-        # the caller asked for cards "from their reference" and should see
-        # source-side fields in their reference's language, not the pivot's.
+        # Apply non-canonical language overlay when requested.
         requested_lang = lang.lower() if lang else None
+        # When pivot routing rewrote the source, default lang to the caller's
+        # source ISO so the pivot stays invisible.
         if (
             requested_lang is None
             and cards

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1919,8 +1919,25 @@ async def get_lexeme_cards(
                     }
                 )
 
-        # Apply non-canonical language overlay when requested.
+        # Apply non-canonical language overlay when requested. If the caller
+        # did not specify lang AND pivot routing redirected the source, default
+        # to the caller's source_version_id ISO so the pivot stays invisible:
+        # the caller asked for cards "from their reference" and should see
+        # source-side fields in their reference's language, not the pivot's.
         requested_lang = lang.lower() if lang else None
+        if (
+            requested_lang is None
+            and cards
+            and cards[0].source_version_id != source_version_id
+        ):
+            source_iso_result = await db.execute(
+                select(BibleVersion.iso_language).where(
+                    BibleVersion.id == source_version_id
+                )
+            )
+            source_iso = source_iso_result.scalar_one_or_none()
+            if source_iso is not None:
+                requested_lang = source_iso.lower()
         # Per-card translation row (only loaded when needed)
         translation_by_card: dict[int, CardTranslation] = {}
         # Per-card map of example_id -> translated source_text

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -7884,3 +7884,227 @@ def test_check_word_in_lexeme_cards_pivot_routing(
             PivotCandidate.pivot_iso == "eng"
         ).delete()
         db_session.commit()
+
+
+def test_get_lexeme_cards_pivot_routing_defaults_lang_to_source_iso(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+):
+    """When pivot routing kicks in and the caller omits `lang`, default it to
+    the caller's source_version_id ISO so the response is overlaid in the
+    caller's reference language rather than the pivot's.
+
+    Scenario from #681: caller is reading an English reference, target has a
+    Tagalog pivot. Without this behavior the caller would see Tagalog
+    source-side fields by default; with it, they see English.
+    """
+    from database.models import (
+        BibleVersion,
+        LanguagePivot,
+        PivotCandidate,
+        UserDB,
+    )
+
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    target = BibleVersion(
+        name="default_lang_target",
+        iso_language="zga",
+        iso_script="Latn",
+        abbreviation="DLT",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    # Caller's reference has iso=swh — distinct from the pivot's iso (eng) so
+    # defaulting to source iso must trigger an overlay rather than no-op.
+    caller_reference = BibleVersion(
+        name="default_lang_caller",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="DLC",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    db_session.add_all([target, caller_reference])
+    db_session.commit()
+
+    db_session.merge(
+        PivotCandidate(pivot_iso="eng", pivot_revision_id=test_revision_id)
+    )
+    db_session.commit()
+    db_session.merge(LanguagePivot(target_iso="zga", pivot_iso="eng"))
+    db_session.commit()
+
+    try:
+        card_id = _create_card_with_examples(
+            client,
+            regular_token1,
+            target_lemma="default_lang_tgt",
+            source_lemma="default_lang_eng_src",
+            revision_id=test_revision_id,
+            source_version_id=test_version_id,  # pivot version (eng)
+            target_version_id=target.id,
+            examples=[{"source": "default lang en src", "target": "default lang tgt"}],
+        )
+        ex_id = (
+            db_session.query(AgentLexemeCardExample)
+            .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+            .first()
+            .id
+        )
+        trans = client.post(
+            f"/v3/agent/lexeme-card/{card_id}/translation",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+            json={
+                "language_iso": "swh",
+                "source_lemma": "default_lang_swh_src",
+                "examples": [
+                    {"example_id": ex_id, "source_text": "default lang swh src"}
+                ],
+            },
+        )
+        assert trans.status_code == 200, trans.text
+
+        # No `lang` query param — the endpoint should default to the caller's
+        # source iso (swh) because pivot routing was applied.
+        response = client.get(
+            f"/v3/agent/lexeme-card?source_version_id={caller_reference.id}"
+            f"&target_version_id={target.id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        returned = next(c for c in response.json() if c["id"] == card_id)
+        assert returned["source_lemma"] == "default_lang_swh_src"
+        assert returned["examples"][0]["source"] == "default lang swh src"
+        assert returned["examples"][0]["target"] == "default lang tgt"
+    finally:
+        db_session.query(LanguagePivot).filter(
+            LanguagePivot.target_iso == "zga"
+        ).delete()
+        db_session.query(PivotCandidate).filter(
+            PivotCandidate.pivot_iso == "eng"
+        ).delete()
+        db_session.commit()
+
+
+def test_get_lexeme_cards_no_pivot_no_lang_returns_canonical(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Without pivot routing AND without lang, the response is canonical (no
+    overlay). Guards against the new defaulting accidentally firing on the
+    non-pivot path."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="no_default_lang_tgt",
+        source_lemma="no_default_lang_eng_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "canonical en src", "target": "canonical tgt"}],
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    returned = next(c for c in response.json() if c["id"] == card_id)
+    assert returned["source_lemma"] == "no_default_lang_eng_src"
+    assert returned["examples"][0]["source"] == "canonical en src"
+
+
+def test_get_lexeme_cards_explicit_lang_overrides_default(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+):
+    """Caller's explicit `lang` wins even when pivot routing would otherwise
+    default to the source iso."""
+    from database.models import (
+        BibleVersion,
+        LanguagePivot,
+        PivotCandidate,
+        UserDB,
+    )
+
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    target = BibleVersion(
+        name="explicit_lang_target",
+        iso_language="ngq",
+        iso_script="Latn",
+        abbreviation="ELT",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    caller_reference = BibleVersion(
+        name="explicit_lang_caller",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="ELC",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    db_session.add_all([target, caller_reference])
+    db_session.commit()
+
+    db_session.merge(
+        PivotCandidate(pivot_iso="eng", pivot_revision_id=test_revision_id)
+    )
+    db_session.commit()
+    db_session.merge(LanguagePivot(target_iso="ngq", pivot_iso="eng"))
+    db_session.commit()
+
+    try:
+        card_id = _create_card_with_examples(
+            client,
+            regular_token1,
+            target_lemma="explicit_lang_tgt",
+            source_lemma="explicit_lang_eng_src",
+            revision_id=test_revision_id,
+            source_version_id=test_version_id,
+            target_version_id=target.id,
+            examples=[{"source": "explicit en src", "target": "explicit tgt"}],
+        )
+        ex_id = (
+            db_session.query(AgentLexemeCardExample)
+            .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+            .first()
+            .id
+        )
+        # Caller iso is swh, but they explicitly ask for zga — zga should win.
+        trans = client.post(
+            f"/v3/agent/lexeme-card/{card_id}/translation",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+            json={
+                "language_iso": "zga",
+                "source_lemma": "explicit_lang_zga_src",
+                "examples": [{"example_id": ex_id, "source_text": "explicit zga src"}],
+            },
+        )
+        assert trans.status_code == 200, trans.text
+
+        response = client.get(
+            f"/v3/agent/lexeme-card?source_version_id={caller_reference.id}"
+            f"&target_version_id={target.id}&lang=zga",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        returned = next(c for c in response.json() if c["id"] == card_id)
+        assert returned["source_lemma"] == "explicit_lang_zga_src"
+    finally:
+        db_session.query(LanguagePivot).filter(
+            LanguagePivot.target_iso == "ngq"
+        ).delete()
+        db_session.query(PivotCandidate).filter(
+            PivotCandidate.pivot_iso == "eng"
+        ).delete()
+        db_session.commit()

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -7937,6 +7937,7 @@ def test_get_lexeme_cards_pivot_routing_defaults_lang_to_source_iso(
     db_session.merge(LanguagePivot(target_iso="zga", pivot_iso="eng"))
     db_session.commit()
 
+    card_id = None
     try:
         card_id = _create_card_with_examples(
             client,
@@ -7980,18 +7981,114 @@ def test_get_lexeme_cards_pivot_routing_defaults_lang_to_source_iso(
         assert returned["examples"][0]["source"] == "default lang swh src"
         assert returned["examples"][0]["target"] == "default lang tgt"
     finally:
+        if card_id is not None:
+            client.delete(
+                f"/v3/agent/lexeme-card/{card_id}",
+                headers={"Authorization": f"Bearer {regular_token1}"},
+            )
         db_session.query(LanguagePivot).filter(
             LanguagePivot.target_iso == "zga"
         ).delete()
         db_session.query(PivotCandidate).filter(
             PivotCandidate.pivot_iso == "eng"
         ).delete()
+        db_session.delete(target)
+        db_session.delete(caller_reference)
+        db_session.commit()
+
+
+def test_get_lexeme_cards_pivot_routing_no_default_when_caller_iso_matches_pivot(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+):
+    """Pivot routing fires but caller's source iso equals the pivot's iso —
+    defaulting computes lang == canonical source_language_iso, which is a
+    no-op overlay (canonical fields returned). Guards against accidentally
+    swapping in a `CardTranslation` row when none is needed.
+    """
+    from database.models import (
+        BibleVersion,
+        LanguagePivot,
+        PivotCandidate,
+        UserDB,
+    )
+
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    target = BibleVersion(
+        name="noop_default_lang_target",
+        iso_language="zga",
+        iso_script="Latn",
+        abbreviation="NDLT",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    # Caller iso also "eng" — same as the pivot's iso. Defaulting still fires
+    # (different version), but the resulting overlay is a no-op.
+    caller_reference = BibleVersion(
+        name="noop_default_lang_caller",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="NDLC",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    db_session.add_all([target, caller_reference])
+    db_session.commit()
+
+    db_session.merge(
+        PivotCandidate(pivot_iso="eng", pivot_revision_id=test_revision_id)
+    )
+    db_session.commit()
+    db_session.merge(LanguagePivot(target_iso="zga", pivot_iso="eng"))
+    db_session.commit()
+
+    card_id = None
+    try:
+        card_id = _create_card_with_examples(
+            client,
+            regular_token1,
+            target_lemma="noop_default_tgt",
+            source_lemma="noop_default_eng_src",
+            revision_id=test_revision_id,
+            source_version_id=test_version_id,
+            target_version_id=target.id,
+            examples=[{"source": "noop en src", "target": "noop tgt"}],
+        )
+
+        response = client.get(
+            f"/v3/agent/lexeme-card?source_version_id={caller_reference.id}"
+            f"&target_version_id={target.id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        returned = next(c for c in response.json() if c["id"] == card_id)
+        # Canonical eng fields are returned — no translation was needed.
+        assert returned["source_lemma"] == "noop_default_eng_src"
+        assert returned["examples"][0]["source"] == "noop en src"
+    finally:
+        if card_id is not None:
+            client.delete(
+                f"/v3/agent/lexeme-card/{card_id}",
+                headers={"Authorization": f"Bearer {regular_token1}"},
+            )
+        db_session.query(LanguagePivot).filter(
+            LanguagePivot.target_iso == "zga"
+        ).delete()
+        db_session.query(PivotCandidate).filter(
+            PivotCandidate.pivot_iso == "eng"
+        ).delete()
+        db_session.delete(target)
+        db_session.delete(caller_reference)
         db_session.commit()
 
 
 def test_get_lexeme_cards_no_pivot_no_lang_returns_canonical(
     client,
     regular_token1,
+    db_session,
     test_revision_id,
     test_version_id,
     test_version_id_2,
@@ -7999,25 +8096,35 @@ def test_get_lexeme_cards_no_pivot_no_lang_returns_canonical(
     """Without pivot routing AND without lang, the response is canonical (no
     overlay). Guards against the new defaulting accidentally firing on the
     non-pivot path."""
-    card_id = _create_card_with_examples(
-        client,
-        regular_token1,
-        target_lemma="no_default_lang_tgt",
-        source_lemma="no_default_lang_eng_src",
-        revision_id=test_revision_id,
-        source_version_id=test_version_id,
-        target_version_id=test_version_id_2,
-        examples=[{"source": "canonical en src", "target": "canonical tgt"}],
-    )
-    response = client.get(
-        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
-        f"&target_version_id={test_version_id_2}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-    )
-    assert response.status_code == 200
-    returned = next(c for c in response.json() if c["id"] == card_id)
-    assert returned["source_lemma"] == "no_default_lang_eng_src"
-    assert returned["examples"][0]["source"] == "canonical en src"
+    card_id = None
+    try:
+        card_id = _create_card_with_examples(
+            client,
+            regular_token1,
+            target_lemma="no_default_lang_tgt",
+            source_lemma="no_default_lang_eng_src",
+            revision_id=test_revision_id,
+            source_version_id=test_version_id,
+            target_version_id=test_version_id_2,
+            examples=[{"source": "canonical en src", "target": "canonical tgt"}],
+        )
+        response = client.get(
+            f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+            f"&target_version_id={test_version_id_2}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200
+        matching = [c for c in response.json() if c["id"] == card_id]
+        assert len(matching) == 1
+        returned = matching[0]
+        assert returned["source_lemma"] == "no_default_lang_eng_src"
+        assert returned["examples"][0]["source"] == "canonical en src"
+    finally:
+        if card_id is not None:
+            client.delete(
+                f"/v3/agent/lexeme-card/{card_id}",
+                headers={"Authorization": f"Bearer {regular_token1}"},
+            )
 
 
 def test_get_lexeme_cards_explicit_lang_overrides_default(
@@ -8063,6 +8170,7 @@ def test_get_lexeme_cards_explicit_lang_overrides_default(
     db_session.merge(LanguagePivot(target_iso="ngq", pivot_iso="eng"))
     db_session.commit()
 
+    card_id = None
     try:
         card_id = _create_card_with_examples(
             client,
@@ -8080,17 +8188,22 @@ def test_get_lexeme_cards_explicit_lang_overrides_default(
             .first()
             .id
         )
-        # Caller iso is swh, but they explicitly ask for zga — zga should win.
-        trans = client.post(
-            f"/v3/agent/lexeme-card/{card_id}/translation",
-            headers={"Authorization": f"Bearer {regular_token1}"},
-            json={
-                "language_iso": "zga",
-                "source_lemma": "explicit_lang_zga_src",
-                "examples": [{"example_id": ex_id, "source_text": "explicit zga src"}],
-            },
-        )
-        assert trans.status_code == 200, trans.text
+        # Add both a swh translation (the would-be default) and a zga
+        # translation (the explicit ask) so we can prove the explicit one wins.
+        for iso, src_lemma, ex_source in [
+            ("swh", "explicit_lang_swh_src", "explicit swh src"),
+            ("zga", "explicit_lang_zga_src", "explicit zga src"),
+        ]:
+            trans = client.post(
+                f"/v3/agent/lexeme-card/{card_id}/translation",
+                headers={"Authorization": f"Bearer {regular_token1}"},
+                json={
+                    "language_iso": iso,
+                    "source_lemma": src_lemma,
+                    "examples": [{"example_id": ex_id, "source_text": ex_source}],
+                },
+            )
+            assert trans.status_code == 200, trans.text
 
         response = client.get(
             f"/v3/agent/lexeme-card?source_version_id={caller_reference.id}"
@@ -8100,11 +8213,19 @@ def test_get_lexeme_cards_explicit_lang_overrides_default(
         assert response.status_code == 200, response.text
         returned = next(c for c in response.json() if c["id"] == card_id)
         assert returned["source_lemma"] == "explicit_lang_zga_src"
+        assert returned["source_lemma"] != "explicit_lang_swh_src"
     finally:
+        if card_id is not None:
+            client.delete(
+                f"/v3/agent/lexeme-card/{card_id}",
+                headers={"Authorization": f"Bearer {regular_token1}"},
+            )
         db_session.query(LanguagePivot).filter(
             LanguagePivot.target_iso == "ngq"
         ).delete()
         db_session.query(PivotCandidate).filter(
             PivotCandidate.pivot_iso == "eng"
         ).delete()
+        db_session.delete(target)
+        db_session.delete(caller_reference)
         db_session.commit()


### PR DESCRIPTION
## Summary

Follow-up to #678. When `/v3/agent/lexeme-card` transparently pivots to a different `bible_version` than the caller asked for, and the caller did not pass an explicit `lang`, default `lang` to the ISO of the caller's `source_version_id`. The response is then overlaid in the reference language the caller is reading in — pivots stay invisible regardless of which reference language was chosen.

- Defaulting only fires on the pivot path (`cards[0].source_version_id != source_version_id`); the non-pivot path is unchanged.
- Caller's explicit `lang` continues to win.

Fixes #681

## Test plan

- [x] `test_get_lexeme_cards_pivot_routing_defaults_lang_to_source_iso` — pivot-routed call without `lang` returns cards overlaid in the caller's source ISO.
- [x] `test_get_lexeme_cards_no_pivot_no_lang_returns_canonical` — no-pivot path without `lang` keeps canonical fields (no accidental overlay).
- [x] `test_get_lexeme_cards_explicit_lang_overrides_default` — caller's explicit `lang` wins over the defaulting.
- [x] All 127 lexeme-card tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)