### PR TITLE
Add model parameter to PredictInput

### DIFF
--- a/models.py
+++ b/models.py
@@ -403,7 +403,7 @@ class PredictInput(BaseModel):
                 "reference_id": 2,
                 "source_version_id": 1,
                 "target_version_id": 2,
-                "apps": ["ngrams", "tfidf"],
+                "apps": ["ngrams", "tfidf", "agent"],
                 "include_translation": False,
                 "include_critique": False,
                 "model": "claude-opus-4-7",

--- a/models.py
+++ b/models.py
@@ -383,12 +383,11 @@ class PredictInput(BaseModel):
     apps: Optional[List[str]] = None
     include_translation: bool = False
     include_critique: bool = False
-    # Agent-only: friendly name of a caller-selectable model defined in
-    # the agent's models.selectable_models config. Forwarded as-is to
-    # the agent Modal function, which rejects unknown names. Ignored
-    # by other apps. When omitted (default), agent uses the deploy-time
-    # default model.
-    model: Optional[str] = None
+    # Agent-only override for the LLM the agent should use. The allowlist
+    # lives in the agent's separate Modal repo (models.selectable_models in
+    # its config.yaml), so we can't validate the name here — agent rejects
+    # unknown names server-side. max_length caps abuse at this boundary.
+    model: Optional[str] = Field(default=None, max_length=200)
 
     model_config = {
         "json_schema_extra": {
@@ -407,6 +406,7 @@ class PredictInput(BaseModel):
                 "apps": ["ngrams", "tfidf"],
                 "include_translation": False,
                 "include_critique": False,
+                "model": "claude-opus-4-7",
             }
         }
     }

--- a/models.py
+++ b/models.py
@@ -383,6 +383,12 @@ class PredictInput(BaseModel):
     apps: Optional[List[str]] = None
     include_translation: bool = False
     include_critique: bool = False
+    # Agent-only: friendly name of a caller-selectable model defined in
+    # the agent's models.selectable_models config. Forwarded as-is to
+    # the agent Modal function, which rejects unknown names. Ignored
+    # by other apps. When omitted (default), agent uses the deploy-time
+    # default model.
+    model: Optional[str] = None
 
     model_config = {
         "json_schema_extra": {

--- a/predict_routes/v3/predict_routes.py
+++ b/predict_routes/v3/predict_routes.py
@@ -170,21 +170,25 @@ async def predict(
         body.include_translation or body.include_critique
     )
     if spawn_slow_agent:
-        sync_payload = dict(input_payload)
-        sync_payload["include_translation"] = False
-        sync_payload["include_critique"] = False
+        sync_agent_payload = dict(input_payload)
+        sync_agent_payload["include_translation"] = False
+        sync_agent_payload["include_critique"] = False
     else:
-        sync_payload = input_payload
+        sync_agent_payload = input_payload
+
+    # `model` is an agent-only knob; other apps' Pydantic models may not
+    # accept it, so strip it from their fan-out payload. They otherwise
+    # see the same payload as the agent (including any flag suppression).
+    non_agent_payload = {k: v for k, v in sync_agent_payload.items() if k != "model"}
 
     async def call_one(name: str) -> tuple[str, PredictAppResult]:
         started = time.perf_counter()
         modal_app = PREDICT_APPS[name]
         timeout_s = PER_APP_TIMEOUT_S.get(name, DEFAULT_PER_APP_TIMEOUT_S)
+        payload = sync_agent_payload if name == "agent" else non_agent_payload
         try:
             fn = _get_predict_fn(modal_app, modal_env)
-            data = await asyncio.wait_for(
-                fn.remote.aio(sync_payload), timeout=timeout_s
-            )
+            data = await asyncio.wait_for(fn.remote.aio(payload), timeout=timeout_s)
             duration_ms = int((time.perf_counter() - started) * 1000)
             return name, PredictAppResult(
                 status="ok", data=data, duration_ms=duration_ms
@@ -231,6 +235,7 @@ async def predict(
             "assessment_id": body.assessment_id,
             "modal_env": modal_env,
             "spawn_slow_agent": spawn_slow_agent,
+            "model": body.model,
         },
     )
 

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -346,6 +346,71 @@ def test_predict_forwards_include_flags_to_modal(
     assert captured["payload"][field] is expected
 
 
+def test_predict_forwards_model_override_to_agent_only(client, regular_token1):
+    """`model` is an agent-only knob — it must reach the agent's payload and
+    must NOT appear in non-agent app payloads (which may not accept the
+    field on their input model).
+    """
+    captured: dict[str, dict] = {}
+
+    def from_name(app_name, fn_name, environment_name=None):
+        mock_fn = AsyncMock()
+
+        async def capture(payload):
+            captured[app_name] = payload
+            return {"ok": True}
+
+        mock_fn.remote.aio = AsyncMock(side_effect=capture)
+        return mock_fn
+
+    mock_cls = AsyncMock()
+    mock_cls.from_name = from_name
+    with patch("predict_routes.v3.predict_routes.modal.Function", mock_cls):
+        response = client.post(
+            f"/{prefix}/predict",
+            json=_body(apps=["agent", "ngrams"], model="claude-opus-4-7"),
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200, response.text
+    # The agent app receives the field; ngrams does not.
+    agent_payloads = [v for k, v in captured.items() if "agent" in k]
+    assert agent_payloads, captured
+    assert all(p.get("model") == "claude-opus-4-7" for p in agent_payloads)
+    assert "model" not in captured["ngrams"]
+
+
+def test_predict_omitted_model_round_trips_as_none(client, regular_token1):
+    """When the caller omits `model`, the agent payload still carries
+    `model: None` (round-trip default), letting the agent fall back to its
+    deploy-time PREDICT_MODEL without a presence check."""
+    captured: dict[str, dict] = {}
+
+    def from_name(app_name, fn_name, environment_name=None):
+        mock_fn = AsyncMock()
+
+        async def capture(payload):
+            captured[app_name] = payload
+            return {"ok": True}
+
+        mock_fn.remote.aio = AsyncMock(side_effect=capture)
+        return mock_fn
+
+    mock_cls = AsyncMock()
+    mock_cls.from_name = from_name
+    with patch("predict_routes.v3.predict_routes.modal.Function", mock_cls):
+        response = client.post(
+            f"/{prefix}/predict",
+            json=_body(apps=["agent"]),
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200, response.text
+    agent_payloads = [v for k, v in captured.items() if "agent" in k]
+    assert agent_payloads, captured
+    assert all(p.get("model") is None for p in agent_payloads)
+
+
 def test_predict_rejects_critique_without_translation(client, regular_token1):
     """`include_critique=True` requires `include_translation=True` —
     aqua-api mirrors the agent-side validator so the caller gets a clean


### PR DESCRIPTION
## Summary

Adds an optional `model` field to `PredictInput` so callers can select which LLM the agent should use for a request. The field is forwarded as-is to the agent Modal function, which validates it against its `models.selectable_models` allowlist (declared in the agent's `config.yaml`). Other apps in the fan-out ignore the field. When omitted (default), the agent uses its deploy-time `PREDICT_MODEL`.

Intended as a short-term hook for benchmarking against premium models without changing the default for everyone.

## Test plan

- [ ] POST /v3/predict with `model: "<allowlisted name>"` → agent picks up the override.
- [ ] POST /v3/predict with `model: "garbage"` → agent rejects against allowlist.
- [ ] POST /v3/predict with no `model` field → behaves exactly as today (deploy-time default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)