### PR TITLE
Fix #686: make lexeme-card source_lemma case-insensitive

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -644,8 +644,7 @@ async def add_lexeme_card(
         existing_card = result.scalar_one_or_none()
 
         if existing_card:
-            # Compare lowercased forms so legacy mixed-case rows don't 409 against
-            # a validator-normalized incoming value.
+            # Legacy rows may predate the source_lemma backfill.
             existing_source_lc = (
                 existing_card.source_lemma.lower()
                 if existing_card.source_lemma
@@ -1549,9 +1548,10 @@ async def deduplicate_lexeme_cards(
                     if not winner.english_lemma and loser.english_lemma:
                         winner.english_lemma = loser.english_lemma
 
-                    # source_lemma: prefer winner's
+                    # source_lemma: prefer winner's. Lowercase on adopt so a
+                    # pre-backfill mixed-case loser doesn't re-introduce uppercase.
                     if not winner.source_lemma and loser.source_lemma:
-                        winner.source_lemma = loser.source_lemma
+                        winner.source_lemma = loser.source_lemma.lower()
 
                     # Timestamps: keep earliest created_at, latest last_updated, latest last_user_edit
                     if loser.created_at and (

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -644,8 +644,17 @@ async def add_lexeme_card(
         existing_card = result.scalar_one_or_none()
 
         if existing_card:
-            # If source_lemma differs, reject with 409 and tell them to use PATCH
-            if existing_card.source_lemma != card.source_lemma:
+            # Compare lowercased forms so legacy mixed-case rows don't 409 against
+            # a validator-normalized incoming value.
+            existing_source_lc = (
+                existing_card.source_lemma.lower()
+                if existing_card.source_lemma
+                else None
+            )
+            incoming_source_lc = (
+                card.source_lemma.lower() if card.source_lemma else None
+            )
+            if existing_source_lc != incoming_source_lc:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail={
@@ -1302,7 +1311,9 @@ async def patch_lexeme_card_by_lemma(
 
         # Only filter by source_lemma if explicitly provided
         if source_lemma is not None:
-            query = query.where(AgentLexemeCard.source_lemma == source_lemma)
+            query = query.where(
+                sql_func.lower(AgentLexemeCard.source_lemma) == source_lemma.lower()
+            )
 
         result = await db.execute(query)
         cards = result.scalars().all()

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -647,11 +647,11 @@ async def add_lexeme_card(
             # Legacy rows may predate the source_lemma backfill.
             existing_source_lc = (
                 existing_card.source_lemma.lower()
-                if existing_card.source_lemma
+                if existing_card.source_lemma is not None
                 else None
             )
             incoming_source_lc = (
-                card.source_lemma.lower() if card.source_lemma else None
+                card.source_lemma.lower() if card.source_lemma is not None else None
             )
             if existing_source_lc != incoming_source_lc:
                 raise HTTPException(
@@ -664,7 +664,8 @@ async def add_lexeme_card(
                         "existing_source_lemma": existing_card.source_lemma,
                     },
                 )
-            # Otherwise, update the existing card (same source_lemma)
+            # Migrate any pre-backfill mixed-case value to the validator-normalized form.
+            existing_card.source_lemma = card.source_lemma
             # Update existing card
             existing_card.pos = card.pos
             existing_card.confidence = card.confidence

--- a/alembic/migrations/versions/f9b8a1d2c4e6_lowercase_lexeme_card_source_lemma.py
+++ b/alembic/migrations/versions/f9b8a1d2c4e6_lowercase_lexeme_card_source_lemma.py
@@ -1,0 +1,34 @@
+"""Lowercase agent_lexeme_cards.source_lemma to align with target_lemma
+
+Revision ID: f9b8a1d2c4e6
+Revises: d7a3f9b1c5e2
+Create Date: 2026-05-18
+
+target_lemma was already normalized to lowercase by e5f6a7b8c9d0; source_lemma
+was left untouched, which made the POST/PATCH endpoints reject case-only
+variants like "God"/"god" inconsistently. There is no uniqueness constraint
+involving source_lemma, so this is a straight backfill with no merge logic.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f9b8a1d2c4e6"
+down_revision = "d7a3f9b1c5e2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE agent_lexeme_cards "
+        "SET source_lemma = LOWER(source_lemma) "
+        "WHERE source_lemma IS NOT NULL "
+        "  AND source_lemma <> LOWER(source_lemma)"
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError(
+        "Original case of source_lemma values is not recoverable."
+    )

--- a/alembic/migrations/versions/f9b8a1d2c4e6_lowercase_lexeme_card_source_lemma.py
+++ b/alembic/migrations/versions/f9b8a1d2c4e6_lowercase_lexeme_card_source_lemma.py
@@ -10,13 +10,15 @@ variants like "God"/"god" inconsistently. There is no uniqueness constraint
 involving source_lemma, so this is a straight backfill with no merge logic.
 """
 
+from typing import Sequence, Union
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "f9b8a1d2c4e6"
-down_revision = "d7a3f9b1c5e2"
-branch_labels = None
-depends_on = None
+revision: str = "f9b8a1d2c4e6"
+down_revision: Union[str, None] = "d7a3f9b1c5e2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:

--- a/models.py
+++ b/models.py
@@ -757,7 +757,7 @@ class LexemeCardIn(BaseModel):
     @field_validator("source_lemma")
     @classmethod
     def normalize_source_lemma(cls, v):
-        return unicodedata.normalize("NFC", v) if v else v
+        return unicodedata.normalize("NFC", v).lower() if v else v
 
     pos: Optional[str] = None
     surface_forms: Optional[list] = None
@@ -872,7 +872,7 @@ class LexemeCardPatch(BaseModel):
     @field_validator("source_lemma")
     @classmethod
     def normalize_source_lemma(cls, v):
-        return unicodedata.normalize("NFC", v) if v else v
+        return unicodedata.normalize("NFC", v).lower() if v else v
 
     pos: Optional[str] = None
     confidence: Optional[float] = None

--- a/models.py
+++ b/models.py
@@ -941,6 +941,9 @@ class CardTranslationIn(BaseModel):
     def normalize_language_iso(cls, v):
         return v.lower() if v else v
 
+    # Unlike LexemeCardIn.source_lemma (lowercased to match target_lemma's
+    # case-insensitive uniqueness), card_translations.source_lemma has no
+    # lookup-key role, so casing is preserved.
     @field_validator("source_lemma")
     @classmethod
     def normalize_source_lemma(cls, v):

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6123,6 +6123,122 @@ def test_patch_lexeme_card_case_insensitive_duplicate_check(
     assert resp.status_code == 409
 
 
+def test_post_lexeme_card_normalizes_source_lemma_to_lowercase(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """POST should store source_lemma as lowercase regardless of input case."""
+    resp = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "God_SrcCase",
+            "target_lemma": "mungu_srccase",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["source_lemma"] == "god_srccase"
+
+
+def test_post_lexeme_card_case_only_source_lemma_diff_is_upsert(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """POST with same target_lemma and case-only-different source_lemma should
+    upsert, not 409. Regression test for the case-sensitivity asymmetry where
+    'God' (existing) vs 'god' (incoming) silently 409'd proper nouns."""
+    resp1 = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "Lord_SrcUpsert",
+            "target_lemma": "bwana_srcupsert",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+        },
+    )
+    assert resp1.status_code == 200
+    card_id = resp1.json()["id"]
+
+    resp2 = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "lord_srcupsert",
+            "target_lemma": "bwana_srcupsert",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.9,
+        },
+    )
+    assert resp2.status_code == 200
+    assert resp2.json()["id"] == card_id
+    assert resp2.json()["confidence"] == 0.9
+
+
+def test_patch_lexeme_card_by_lemma_source_lemma_case_insensitive(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """PATCH by lemma should match source_lemma case-insensitively when the
+    stored value is mixed case (e.g. legacy rows that predate the backfill)."""
+    # Insert a legacy-style mixed-case source_lemma directly, bypassing the
+    # Pydantic validator that now lowercases on the way in.
+    import psycopg2
+
+    conn = psycopg2.connect(
+        "dbname=dbname user=dbuser password=dbpassword host=localhost"
+    )
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "INSERT INTO agent_lexeme_cards "
+            "(source_lemma, target_lemma, source_version_id, target_version_id, "
+            " confidence, created_at, last_updated) "
+            "VALUES (%s, %s, %s, %s, %s, now(), now()) RETURNING id",
+            (
+                "Jesus_LegacyCase",
+                "yesu_legacycase",
+                test_version_id,
+                test_version_id_2,
+                0.5,
+            ),
+        )
+        legacy_id = cur.fetchone()[0]
+    finally:
+        cur.close()
+        conn.close()
+
+    # PATCH using lowercased source_lemma — must still find the mixed-case row
+    resp = client.patch(
+        f"/v3/agent/lexeme-card?target_lemma=yesu_legacycase"
+        f"&source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}"
+        f"&source_lemma=jesus_legacycase",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"confidence": 0.95},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == legacy_id
+    assert resp.json()["confidence"] == 0.95
+
+
 # ── Deduplicate endpoint tests ──────────────────────────────────
 
 

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6259,6 +6259,46 @@ def test_patch_lexeme_card_by_lemma_without_source_lemma_param(
     assert resp.json()["confidence"] == 0.88
 
 
+def test_post_lexeme_card_upsert_normalizes_legacy_mixed_case_source_lemma(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """When a legacy mixed-case source_lemma row exists and a POST comes in with
+    the lowercased form, the upsert should rewrite the stored value to lowercase
+    so clients never see pre-backfill casing leaking back out."""
+    legacy_id = _raw_psycopg2_fetchone(
+        "INSERT INTO agent_lexeme_cards "
+        "(source_lemma, target_lemma, source_version_id, target_version_id, "
+        " confidence, created_at, last_updated) "
+        "VALUES (%s, %s, %s, %s, %s, now(), now()) RETURNING id",
+        (
+            "Spirit_LegacyUpsert",
+            "roho_legacyupsert",
+            test_version_id,
+            test_version_id_2,
+            0.3,
+        ),
+    )[0]
+
+    resp = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "spirit_legacyupsert",
+            "target_lemma": "roho_legacyupsert",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.95,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["id"] == legacy_id
+    assert resp.json()["source_lemma"] == "spirit_legacyupsert"
+
+
 def test_post_lexeme_card_both_source_lemmas_none_is_upsert(
     client,
     regular_token1,

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6190,7 +6190,6 @@ def test_post_lexeme_card_case_only_source_lemma_diff_is_upsert(
 def test_patch_lexeme_card_by_lemma_source_lemma_case_insensitive(
     client,
     regular_token1,
-    db_session,
     test_revision_id,
     test_version_id,
     test_version_id_2,
@@ -6199,31 +6198,19 @@ def test_patch_lexeme_card_by_lemma_source_lemma_case_insensitive(
     stored value is mixed case (e.g. legacy rows that predate the backfill)."""
     # Insert a legacy-style mixed-case source_lemma directly, bypassing the
     # Pydantic validator that now lowercases on the way in.
-    import psycopg2
-
-    conn = psycopg2.connect(
-        "dbname=dbname user=dbuser password=dbpassword host=localhost"
-    )
-    conn.autocommit = True
-    cur = conn.cursor()
-    try:
-        cur.execute(
-            "INSERT INTO agent_lexeme_cards "
-            "(source_lemma, target_lemma, source_version_id, target_version_id, "
-            " confidence, created_at, last_updated) "
-            "VALUES (%s, %s, %s, %s, %s, now(), now()) RETURNING id",
-            (
-                "Jesus_LegacyCase",
-                "yesu_legacycase",
-                test_version_id,
-                test_version_id_2,
-                0.5,
-            ),
-        )
-        legacy_id = cur.fetchone()[0]
-    finally:
-        cur.close()
-        conn.close()
+    legacy_id = _raw_psycopg2_fetchone(
+        "INSERT INTO agent_lexeme_cards "
+        "(source_lemma, target_lemma, source_version_id, target_version_id, "
+        " confidence, created_at, last_updated) "
+        "VALUES (%s, %s, %s, %s, %s, now(), now()) RETURNING id",
+        (
+            "Jesus_LegacyCase",
+            "yesu_legacycase",
+            test_version_id,
+            test_version_id_2,
+            0.5,
+        ),
+    )[0]
 
     # PATCH using lowercased source_lemma — must still find the mixed-case row
     resp = client.patch(
@@ -6237,6 +6224,77 @@ def test_patch_lexeme_card_by_lemma_source_lemma_case_insensitive(
     assert resp.status_code == 200
     assert resp.json()["id"] == legacy_id
     assert resp.json()["confidence"] == 0.95
+
+
+def test_patch_lexeme_card_by_lemma_without_source_lemma_param(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """PATCH by lemma must not crash when source_lemma is omitted (None path).
+    Regression guard for the `if source_lemma is not None:` filter — without
+    that guard, sql_func.lower(None) would explode."""
+    client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "sleep_noparam",
+            "target_lemma": "lala_noparam",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+        },
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card?target_lemma=lala_noparam"
+        f"&source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"confidence": 0.88},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["confidence"] == 0.88
+
+
+def test_post_lexeme_card_both_source_lemmas_none_is_upsert(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """POST should upsert (not 409) when both existing and incoming source_lemma
+    are None. Pins down the None×None branch in the case-insensitive comparison."""
+    resp1 = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "nullsrc_upsert",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.4,
+        },
+    )
+    assert resp1.status_code == 200
+    card_id = resp1.json()["id"]
+    assert resp1.json()["source_lemma"] is None
+
+    resp2 = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "nullsrc_upsert",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.99,
+        },
+    )
+    assert resp2.status_code == 200
+    assert resp2.json()["id"] == card_id
+    assert resp2.json()["confidence"] == 0.99
 
 
 # ── Deduplicate endpoint tests ──────────────────────────────────
@@ -6254,6 +6312,23 @@ def _raw_psycopg2(statements):
     try:
         for sql in statements:
             cur.execute(sql)
+    finally:
+        cur.close()
+        conn.close()
+
+
+def _raw_psycopg2_fetchone(sql, params=None):
+    """Execute a single parameterised SQL statement and return one row."""
+    import psycopg2
+
+    conn = psycopg2.connect(
+        "dbname=dbname user=dbuser password=dbpassword host=localhost"
+    )
+    conn.autocommit = True
+    cur = conn.cursor()
+    try:
+        cur.execute(sql, params)
+        return cur.fetchone()
     finally:
         cur.close()
         conn.close()


### PR DESCRIPTION
## Summary

Resolves the case-sensitivity asymmetry between `target_lemma` (case-insensitive) and `source_lemma` (case-exact) on `/v3/agent/lexeme-card` POST/PATCH endpoints, reported in #686.

- Lowercase `source_lemma` in the `LexemeCardIn` and `LexemeCardPatch` validators (mirrors `normalize_target_lemma`).
- Compare `source_lemma` case-insensitively at the two query/branch sites flagged in the issue (`agent_routes.py:648` POST 409 check, `agent_routes.py:1305` PATCH-by-lemma filter). Belt-and-suspenders so legacy mixed-case rows still match during the rollout window before the backfill lands in prod.
- Migration `f9b8a1d2c4e6` backfills `agent_lexeme_cards.source_lemma` to lowercase. No uniqueness constraint involves `source_lemma`, so it's a straight `UPDATE` with no merge logic.

This lets the aqua-django-app proxy lowercasing workaround ([sil-ai/aqua-django-app#374](https://github.com/sil-ai/aqua-django-app/pull/374)) be reverted.

`CardTranslationIn.source_lemma` (writes to a separate `card_translations` table) is left case-preserving for now — that table has no uniqueness on `source_lemma` and isn't named in the issue. Worth a follow-up if we want strict consistency.

## Test plan

- [x] `test_post_lexeme_card_normalizes_source_lemma_to_lowercase` — POST stores lowercase regardless of input case
- [x] `test_post_lexeme_card_case_only_source_lemma_diff_is_upsert` — "God" then "god" upserts (was 409 before)
- [x] `test_patch_lexeme_card_by_lemma_source_lemma_case_insensitive` — PATCH finds legacy mixed-case row when queried with lowercase form (raw-SQL insert bypasses the validator to simulate pre-backfill data)
- [x] All 9 existing case-related lexeme tests still pass
- [x] Full `test_agent_routes.py` (214 tests) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)