### PR TITLE
Phase 1: version-key tokenizer training artifacts (#687)

### DIFF
--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -135,11 +135,15 @@ async def commit_affixes(
             ),
         )
 
+    target_version_id: Optional[int] = None
     if payload.revision_id is not None:
-        revision_exists = await db.execute(
-            select(BibleRevision.id).where(BibleRevision.id == payload.revision_id)
+        revision_lookup = await db.execute(
+            select(BibleRevision.bible_version_id).where(
+                BibleRevision.id == payload.revision_id
+            )
         )
-        if revision_exists.scalar_one_or_none() is None:
+        target_version_id = revision_lookup.scalar_one_or_none()
+        if target_version_id is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=f"Unknown revision_id {payload.revision_id}",
@@ -268,6 +272,7 @@ async def commit_affixes(
                         "n_runs": fields["n_runs"],
                         "source_model": payload.source_model,
                         "first_seen_revision_id": payload.revision_id,
+                        "target_version_id": target_version_id,
                     }
                 )
 
@@ -277,14 +282,21 @@ async def commit_affixes(
                 # rejected mismatched glosses above, so leaving the stored
                 # gloss in place is correct even if a concurrent writer
                 # raced in between the select and the insert.
+                set_values = {
+                    "examples": stmt.excluded.examples,
+                    "n_runs": stmt.excluded.n_runs,
+                    "source_model": stmt.excluded.source_model,
+                    "updated_at": func.now(),
+                }
+                # First-writer-wins for target_version_id: only stamp it on
+                # rows where it's currently NULL (Phase 1 backfill semantics).
+                if target_version_id is not None:
+                    set_values["target_version_id"] = func.coalesce(
+                        LanguageAffix.target_version_id, stmt.excluded.target_version_id
+                    )
                 stmt = stmt.on_conflict_do_update(
                     index_elements=["iso_639_3", "form", "position"],
-                    set_={
-                        "examples": stmt.excluded.examples,
-                        "n_runs": stmt.excluded.n_runs,
-                        "source_model": stmt.excluded.source_model,
-                        "updated_at": func.now(),
-                    },
+                    set_=set_values,
                 )
                 await db.execute(stmt)
 
@@ -351,11 +363,15 @@ async def replace_affixes(
             ),
         )
 
+    target_version_id: Optional[int] = None
     if payload.revision_id is not None:
-        revision_exists = await db.execute(
-            select(BibleRevision.id).where(BibleRevision.id == payload.revision_id)
+        revision_lookup = await db.execute(
+            select(BibleRevision.bible_version_id).where(
+                BibleRevision.id == payload.revision_id
+            )
         )
-        if revision_exists.scalar_one_or_none() is None:
+        target_version_id = revision_lookup.scalar_one_or_none()
+        if target_version_id is None:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
                 detail=f"Unknown revision_id {payload.revision_id}",
@@ -408,6 +424,7 @@ async def replace_affixes(
                     "n_runs": fields["n_runs"],
                     "source_model": payload.source_model,
                     "first_seen_revision_id": payload.revision_id,
+                    "target_version_id": target_version_id,
                 }
                 for (form, position), fields in incoming.items()
             ]
@@ -416,16 +433,21 @@ async def replace_affixes(
             # scope with the same (form, position), authoritatively overwrite
             # gloss too. This is the one path that may change an existing
             # row's gloss without an explicit PATCH.
+            replace_set = {
+                "gloss": stmt.excluded.gloss,
+                "examples": stmt.excluded.examples,
+                "n_runs": stmt.excluded.n_runs,
+                "source_model": stmt.excluded.source_model,
+                "first_seen_revision_id": stmt.excluded.first_seen_revision_id,
+                "updated_at": func.now(),
+            }
+            # PUT overwrites target_version_id authoritatively when caller
+            # supplies a revision; otherwise preserve any prior stamp.
+            if target_version_id is not None:
+                replace_set["target_version_id"] = stmt.excluded.target_version_id
             stmt = stmt.on_conflict_do_update(
                 index_elements=["iso_639_3", "form", "position"],
-                set_={
-                    "gloss": stmt.excluded.gloss,
-                    "examples": stmt.excluded.examples,
-                    "n_runs": stmt.excluded.n_runs,
-                    "source_model": stmt.excluded.source_model,
-                    "first_seen_revision_id": stmt.excluded.first_seen_revision_id,
-                    "updated_at": func.now(),
-                },
+                set_=replace_set,
             )
             await db.execute(stmt)
             n_inserted = len(rows)

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -22,6 +22,7 @@ from database.models import (
     LanguageMorpheme,
     LanguageProfile,
     TokenizerRun,
+    TrainingArtifacts,
 )
 from database.models import UserDB as UserModel
 from database.models import (
@@ -133,6 +134,28 @@ async def upsert_language_profile(
         },
     )
     return LanguageProfileOut.model_validate(profile)
+
+
+async def _upsert_training_artifacts(
+    db: AsyncSession,
+    target_version_id: int,
+    grammar_sketch: str,
+    source_model: Optional[str],
+) -> None:
+    stmt = pg_insert(TrainingArtifacts).values(
+        target_version_id=target_version_id,
+        grammar_sketch=grammar_sketch,
+        source_model=source_model,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["target_version_id"],
+        set_={
+            "grammar_sketch": stmt.excluded.grammar_sketch,
+            "source_model": stmt.excluded.source_model,
+            "updated_at": datetime.datetime.utcnow(),
+        },
+    )
+    await db.execute(stmt)
 
 
 async def _upsert_profile(
@@ -272,10 +295,13 @@ async def commit_tokenizer_run(
             detail=f"Unknown ISO 639-3 code '{iso}'",
         )
 
-    revision_exists = await db.execute(
-        select(BibleRevision.id).where(BibleRevision.id == payload.revision_id)
+    revision_lookup = await db.execute(
+        select(BibleRevision.bible_version_id).where(
+            BibleRevision.id == payload.revision_id
+        )
     )
-    if revision_exists.scalar_one_or_none() is None:
+    target_version_id = revision_lookup.scalar_one_or_none()
+    if target_version_id is None:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"Unknown revision_id {payload.revision_id}",
@@ -284,6 +310,13 @@ async def commit_tokenizer_run(
     try:
         if payload.profile is not None:
             await _upsert_profile(db, iso, payload.profile)
+            if payload.profile.grammar_sketch is not None:
+                await _upsert_training_artifacts(
+                    db,
+                    target_version_id=target_version_id,
+                    grammar_sketch=payload.profile.grammar_sketch,
+                    source_model=payload.source_model,
+                )
         else:
             existing = await db.execute(
                 select(LanguageProfile.iso_639_3).where(
@@ -354,6 +387,7 @@ async def commit_tokenizer_run(
                             "morpheme": morpheme,
                             "morpheme_class": cls,
                             "first_seen_revision_id": payload.revision_id,
+                            "target_version_id": target_version_id,
                         }
                     )
 

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -9,7 +9,7 @@ from typing import Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import delete, select
+from sqlalchemy import delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -22,7 +22,7 @@ from database.models import (
     LanguageMorpheme,
     LanguageProfile,
     TokenizerRun,
-    TrainingArtifacts,
+    TrainingArtifact,
 )
 from database.models import UserDB as UserModel
 from database.models import (
@@ -142,7 +142,7 @@ async def _upsert_training_artifacts(
     grammar_sketch: str,
     source_model: Optional[str],
 ) -> None:
-    stmt = pg_insert(TrainingArtifacts).values(
+    stmt = pg_insert(TrainingArtifact).values(
         target_version_id=target_version_id,
         grammar_sketch=grammar_sketch,
         source_model=source_model,
@@ -152,7 +152,7 @@ async def _upsert_training_artifacts(
         set_={
             "grammar_sketch": stmt.excluded.grammar_sketch,
             "source_model": stmt.excluded.source_model,
-            "updated_at": datetime.datetime.utcnow(),
+            "updated_at": func.now(),
         },
     )
     await db.execute(stmt)
@@ -356,26 +356,32 @@ async def commit_tokenizer_run(
 
             existing_result = await db.execute(
                 select(
-                    LanguageMorpheme.morpheme, LanguageMorpheme.morpheme_class
+                    LanguageMorpheme.morpheme,
+                    LanguageMorpheme.morpheme_class,
+                    LanguageMorpheme.target_version_id,
                 ).where(
                     LanguageMorpheme.iso_639_3 == iso,
                     LanguageMorpheme.morpheme.in_(incoming.keys()),
                 )
             )
-            existing_map = {row[0]: row[1] for row in existing_result.all()}
+            existing_map = {row[0]: (row[1], row[2]) for row in existing_result.all()}
 
             new_rows = []
+            unstamped_existing: list[str] = []
             for morpheme, cls in incoming.items():
                 if morpheme in existing_map:
                     n_existing += 1
-                    if existing_map[morpheme] != cls:
+                    stored_class, stored_version_id = existing_map[morpheme]
+                    if stored_version_id is None:
+                        unstamped_existing.append(morpheme)
+                    if stored_class != cls:
                         n_conflicts += 1
                         logger.warning(
                             "Morpheme class conflict ignored",
                             extra={
                                 "iso": iso,
                                 "morpheme": morpheme,
-                                "stored_class": existing_map[morpheme],
+                                "stored_class": stored_class,
                                 "incoming_class": cls,
                             },
                         )
@@ -397,6 +403,23 @@ async def commit_tokenizer_run(
                     index_elements=["iso_639_3", "morpheme"]
                 )
                 await db.execute(stmt)
+
+            # Backfill target_version_id for legacy rows that pre-date Phase 1.
+            # Stamp only when currently NULL to preserve first-writer-wins
+            # semantics — once a version owns the row, later runs from other
+            # versions don't overwrite it. Properly per-version morpheme rows
+            # arrive in Phase 5 when the (iso_639_3, morpheme) unique constraint
+            # is dropped.
+            if unstamped_existing:
+                await db.execute(
+                    update(LanguageMorpheme)
+                    .where(
+                        LanguageMorpheme.iso_639_3 == iso,
+                        LanguageMorpheme.morpheme.in_(unstamped_existing),
+                        LanguageMorpheme.target_version_id.is_(None),
+                    )
+                    .values(target_version_id=target_version_id)
+                )
 
         merged_stats = dict(payload.stats or {})
         merged_stats["n_morphemes_new"] = n_new

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -151,7 +151,12 @@ async def _upsert_training_artifacts(
         index_elements=["target_version_id"],
         set_={
             "grammar_sketch": stmt.excluded.grammar_sketch,
-            "source_model": stmt.excluded.source_model,
+            # Preserve prior provenance: only update source_model when the
+            # incoming run carries one. NULL incoming values must not wipe
+            # the stored value from an earlier run.
+            "source_model": func.coalesce(
+                stmt.excluded.source_model, TrainingArtifact.source_model
+            ),
             "updated_at": func.now(),
         },
     )

--- a/alembic/migrations/versions/a3c1e7b9d4f0_add_training_artifacts_table.py
+++ b/alembic/migrations/versions/a3c1e7b9d4f0_add_training_artifacts_table.py
@@ -18,6 +18,7 @@ This migration:
    fan-out to every non-deleted `bible_version` of that ISO, so reads in
    Phase 2 see no functional change.
 """
+
 from typing import Sequence, Union
 
 import sqlalchemy as sa

--- a/alembic/migrations/versions/a3c1e7b9d4f0_add_training_artifacts_table.py
+++ b/alembic/migrations/versions/a3c1e7b9d4f0_add_training_artifacts_table.py
@@ -1,0 +1,141 @@
+"""add training_artifacts table and version-scoped keys for affixes/morphemes
+
+Revision ID: a3c1e7b9d4f0
+Revises: f9b8a1d2c4e6
+Create Date: 2026-05-18 23:30:00.000000
+
+Phase 1 of issue #687: move agent-discovered tokenizer artifacts off the
+language-keyed `language_profiles` row and onto a per-`bible_version` key.
+
+This migration:
+1. Creates `training_artifacts` (one row per bible_version) holding
+   grammar_sketch + source_model. Future phases also move per-affix /
+   per-morpheme rows fully under this version key.
+2. Adds nullable `target_version_id` columns to `language_affixes` and
+   `language_morphemes` plus version-scoped unique indexes, so dual-writes
+   can populate them going forward.
+3. Backfills `training_artifacts` from existing `language_profiles` rows by
+   fan-out to every non-deleted `bible_version` of that ISO, so reads in
+   Phase 2 see no functional change.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a3c1e7b9d4f0"
+down_revision: Union[str, None] = "f9b8a1d2c4e6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "training_artifacts",
+        sa.Column("target_version_id", sa.Integer(), nullable=False),
+        sa.Column("grammar_sketch", sa.Text(), nullable=True),
+        sa.Column("source_model", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=True
+        ),
+        sa.Column(
+            "updated_at", sa.TIMESTAMP(), server_default=sa.func.now(), nullable=True
+        ),
+        sa.ForeignKeyConstraint(
+            ["target_version_id"], ["bible_version.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("target_version_id"),
+    )
+
+    op.add_column(
+        "language_affixes",
+        sa.Column("target_version_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_language_affixes_target_version_id",
+        "language_affixes",
+        "bible_version",
+        ["target_version_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "ix_language_affixes_target_version_id",
+        "language_affixes",
+        ["target_version_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ux_language_affixes_version_form_position_gloss",
+        "language_affixes",
+        ["target_version_id", "form", "position", "gloss"],
+        unique=True,
+    )
+
+    op.add_column(
+        "language_morphemes",
+        sa.Column("target_version_id", sa.Integer(), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_language_morphemes_target_version_id",
+        "language_morphemes",
+        "bible_version",
+        ["target_version_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "ix_language_morphemes_target_version_id",
+        "language_morphemes",
+        ["target_version_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ux_language_morphemes_version_morpheme",
+        "language_morphemes",
+        ["target_version_id", "morpheme"],
+        unique=True,
+    )
+
+    op.execute(
+        """
+        INSERT INTO training_artifacts (target_version_id, grammar_sketch)
+        SELECT bv.id, lp.grammar_sketch
+        FROM language_profiles lp
+        JOIN bible_version bv ON bv.iso_language = lp.iso_639_3
+        WHERE bv.deleted IS NOT TRUE
+          AND lp.grammar_sketch IS NOT NULL
+        ON CONFLICT (target_version_id) DO NOTHING
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ux_language_morphemes_version_morpheme", table_name="language_morphemes"
+    )
+    op.drop_index(
+        "ix_language_morphemes_target_version_id", table_name="language_morphemes"
+    )
+    op.drop_constraint(
+        "fk_language_morphemes_target_version_id",
+        "language_morphemes",
+        type_="foreignkey",
+    )
+    op.drop_column("language_morphemes", "target_version_id")
+
+    op.drop_index(
+        "ux_language_affixes_version_form_position_gloss", table_name="language_affixes"
+    )
+    op.drop_index(
+        "ix_language_affixes_target_version_id", table_name="language_affixes"
+    )
+    op.drop_constraint(
+        "fk_language_affixes_target_version_id",
+        "language_affixes",
+        type_="foreignkey",
+    )
+    op.drop_column("language_affixes", "target_version_id")
+
+    op.drop_table("training_artifacts")

--- a/database/models.py
+++ b/database/models.py
@@ -1192,7 +1192,7 @@ class LanguageAffix(Base):
     )
 
 
-class TrainingArtifacts(Base):
+class TrainingArtifact(Base):
     __tablename__ = "training_artifacts"
 
     target_version_id = Column(

--- a/database/models.py
+++ b/database/models.py
@@ -1112,6 +1112,11 @@ class LanguageMorpheme(Base):
         nullable=True,
     )
     first_seen_at = Column(TIMESTAMP, server_default=func.now())
+    target_version_id = Column(
+        Integer,
+        ForeignKey("bible_version.id", ondelete="CASCADE"),
+        nullable=True,
+    )
 
     __table_args__ = (
         Index(
@@ -1120,8 +1125,15 @@ class LanguageMorpheme(Base):
             "morpheme",
             unique=True,
         ),
+        Index(
+            "ux_language_morphemes_version_morpheme",
+            "target_version_id",
+            "morpheme",
+            unique=True,
+        ),
         Index("ix_language_morphemes_iso", "iso_639_3"),
         Index("ix_language_morphemes_iso_class", "iso_639_3", "morpheme_class"),
+        Index("ix_language_morphemes_target_version_id", "target_version_id"),
     )
 
 
@@ -1147,6 +1159,11 @@ class LanguageAffix(Base):
     )
     first_seen_at = Column(TIMESTAMP, server_default=func.now())
     updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
+    target_version_id = Column(
+        Integer,
+        ForeignKey("bible_version.id", ondelete="CASCADE"),
+        nullable=True,
+    )
 
     __table_args__ = (
         CheckConstraint(
@@ -1161,9 +1178,32 @@ class LanguageAffix(Base):
             "position",
             unique=True,
         ),
+        Index(
+            "ux_language_affixes_version_form_position_gloss",
+            "target_version_id",
+            "form",
+            "position",
+            "gloss",
+            unique=True,
+        ),
         Index("ix_language_affixes_iso", "iso_639_3"),
         Index("ix_language_affixes_iso_position", "iso_639_3", "position"),
+        Index("ix_language_affixes_target_version_id", "target_version_id"),
     )
+
+
+class TrainingArtifacts(Base):
+    __tablename__ = "training_artifacts"
+
+    target_version_id = Column(
+        Integer,
+        ForeignKey("bible_version.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    grammar_sketch = Column(Text, nullable=True)
+    source_model = Column(Text, nullable=True)
+    created_at = Column(TIMESTAMP, server_default=func.now())
+    updated_at = Column(TIMESTAMP, server_default=func.now(), onupdate=func.now())
 
 
 class TokenizerRun(Base):

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -7,7 +7,7 @@ from database.models import (
     LanguageMorpheme,
     LanguageProfile,
     TokenizerRun,
-    TrainingArtifacts,
+    TrainingArtifact,
     VerseMorphemeIndex,
     VerseText,
     WordMorphemeIndex,
@@ -43,15 +43,6 @@ def _cleanup(db_session):
         db_session.query(LanguageProfile).filter(
             LanguageProfile.iso_639_3 == iso
         ).delete()
-    db_session.commit()
-
-
-def _cleanup_training_artifacts(db_session, version_ids):
-    if not version_ids:
-        return
-    db_session.query(TrainingArtifacts).filter(
-        TrainingArtifacts.target_version_id.in_(version_ids)
-    ).delete(synchronize_session="fetch")
     db_session.commit()
 
 
@@ -1216,6 +1207,82 @@ def test_tokenizer_run_populates_target_version_id(
     _cleanup(db_session)
 
 
+def test_tokenizer_run_backfills_target_version_id_on_existing_morpheme(
+    client, regular_token1, test_revision_id, db_session
+):
+    """When a later run resubmits an existing iso+morpheme row whose
+    target_version_id is NULL (e.g. created before Phase 1), the dual-write
+    stamps it. Once stamped, a subsequent run doesn't overwrite it
+    (first-writer-wins)."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    expected_version_id = _resolve_version_id(db_session, test_revision_id)
+
+    # Simulate a legacy row with target_version_id=NULL by inserting directly.
+    db_session.add(
+        LanguageProfile(iso_639_3=TEST_ISO, name="Swahili"),
+    )
+    db_session.flush()
+    db_session.add(
+        LanguageMorpheme(
+            iso_639_3=TEST_ISO,
+            morpheme="legacy",
+            morpheme_class="LEXICAL",
+            target_version_id=None,
+        ),
+    )
+    db_session.commit()
+
+    # Resubmit the same morpheme — the existing-path should stamp version_id.
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "legacy", "morpheme_class": "LEXICAL"}],
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["n_morphemes_new"] == 0
+    assert resp.json()["n_morphemes_existing"] == 1
+
+    db_session.expire_all()
+    row = (
+        db_session.query(LanguageMorpheme)
+        .filter(
+            LanguageMorpheme.iso_639_3 == TEST_ISO,
+            LanguageMorpheme.morpheme == "legacy",
+        )
+        .one()
+    )
+    assert row.target_version_id == expected_version_id
+
+    # A second run also reporting the same morpheme must not change the stamp.
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "legacy", "morpheme_class": "LEXICAL"}],
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200
+
+    db_session.expire_all()
+    row = (
+        db_session.query(LanguageMorpheme)
+        .filter(
+            LanguageMorpheme.iso_639_3 == TEST_ISO,
+            LanguageMorpheme.morpheme == "legacy",
+        )
+        .one()
+    )
+    assert row.target_version_id == expected_version_id
+
+    _cleanup(db_session)
+
+
 def test_tokenizer_run_dual_writes_training_artifacts(
     client, regular_token1, test_revision_id, db_session
 ):
@@ -1225,8 +1292,8 @@ def test_tokenizer_run_dual_writes_training_artifacts(
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     version_id = _resolve_version_id(db_session, test_revision_id)
-    db_session.query(TrainingArtifacts).filter(
-        TrainingArtifacts.target_version_id == version_id
+    db_session.query(TrainingArtifact).filter(
+        TrainingArtifact.target_version_id == version_id
     ).delete()
     db_session.commit()
 
@@ -1243,8 +1310,8 @@ def test_tokenizer_run_dual_writes_training_artifacts(
     assert resp.status_code == 200, resp.text
 
     artifact = (
-        db_session.query(TrainingArtifacts)
-        .filter(TrainingArtifacts.target_version_id == version_id)
+        db_session.query(TrainingArtifact)
+        .filter(TrainingArtifact.target_version_id == version_id)
         .one()
     )
     assert artifact.grammar_sketch == "draft v1"
@@ -1265,14 +1332,14 @@ def test_tokenizer_run_dual_writes_training_artifacts(
 
     db_session.expire_all()
     refreshed = (
-        db_session.query(TrainingArtifacts)
-        .filter(TrainingArtifacts.target_version_id == version_id)
+        db_session.query(TrainingArtifact)
+        .filter(TrainingArtifact.target_version_id == version_id)
         .one()
     )
     assert refreshed.grammar_sketch == "draft v2"
 
-    db_session.query(TrainingArtifacts).filter(
-        TrainingArtifacts.target_version_id == version_id
+    db_session.query(TrainingArtifact).filter(
+        TrainingArtifact.target_version_id == version_id
     ).delete()
     db_session.commit()
     _cleanup(db_session)
@@ -1287,8 +1354,8 @@ def test_tokenizer_run_no_grammar_sketch_skips_training_artifacts(
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     version_id = _resolve_version_id(db_session, test_revision_id)
-    db_session.query(TrainingArtifacts).filter(
-        TrainingArtifacts.target_version_id == version_id
+    db_session.query(TrainingArtifact).filter(
+        TrainingArtifact.target_version_id == version_id
     ).delete()
     db_session.commit()
 
@@ -1304,8 +1371,8 @@ def test_tokenizer_run_no_grammar_sketch_skips_training_artifacts(
     assert resp.status_code == 200, resp.text
 
     assert (
-        db_session.query(TrainingArtifacts)
-        .filter(TrainingArtifacts.target_version_id == version_id)
+        db_session.query(TrainingArtifact)
+        .filter(TrainingArtifact.target_version_id == version_id)
         .one_or_none()
         is None
     )

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -4,6 +4,7 @@ import unicodedata
 
 from database.models import (
     BibleRevision,
+    BibleVersion,
     LanguageMorpheme,
     LanguageProfile,
     TokenizerRun,
@@ -43,6 +44,18 @@ def _cleanup(db_session):
         db_session.query(LanguageProfile).filter(
             LanguageProfile.iso_639_3 == iso
         ).delete()
+        # Drop training_artifacts for any bible_version under this ISO so
+        # tests that submit a grammar_sketch don't leak rows into siblings.
+        version_ids = [
+            row.id
+            for row in db_session.query(BibleVersion.id)
+            .filter(BibleVersion.iso_language == iso)
+            .all()
+        ]
+        if version_ids:
+            db_session.query(TrainingArtifact).filter(
+                TrainingArtifact.target_version_id.in_(version_ids)
+            ).delete(synchronize_session="fetch")
     db_session.commit()
 
 
@@ -1292,10 +1305,6 @@ def test_tokenizer_run_dual_writes_training_artifacts(
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     version_id = _resolve_version_id(db_session, test_revision_id)
-    db_session.query(TrainingArtifact).filter(
-        TrainingArtifact.target_version_id == version_id
-    ).delete()
-    db_session.commit()
 
     profile = {"name": "Swahili", "grammar_sketch": "draft v1"}
     resp = client.post(
@@ -1338,10 +1347,51 @@ def test_tokenizer_run_dual_writes_training_artifacts(
     )
     assert refreshed.grammar_sketch == "draft v2"
 
-    db_session.query(TrainingArtifact).filter(
-        TrainingArtifact.target_version_id == version_id
-    ).delete()
-    db_session.commit()
+    _cleanup(db_session)
+
+
+def test_training_artifacts_upsert_preserves_source_model(
+    client, regular_token1, test_revision_id, db_session
+):
+    """A subsequent run without source_model must not wipe the source_model
+    written by an earlier run (preserves provenance)."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    version_id = _resolve_version_id(db_session, test_revision_id)
+
+    # First run records source_model = gpt-5-mini.
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "first", "morpheme_class": "LEXICAL"}],
+            profile={"name": "Swahili", "grammar_sketch": "v1"},
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Second run omits source_model entirely.
+    body = {
+        "iso_639_3": TEST_ISO,
+        "revision_id": test_revision_id,
+        "morphemes": [{"morpheme": "second", "morpheme_class": "LEXICAL"}],
+        "profile": {"name": "Swahili", "grammar_sketch": "v2"},
+        "stats": {},
+    }
+    resp = client.post(f"/{prefix}/tokenizer/runs", json=body, headers=headers)
+    assert resp.status_code == 200, resp.text
+
+    db_session.expire_all()
+    artifact = (
+        db_session.query(TrainingArtifact)
+        .filter(TrainingArtifact.target_version_id == version_id)
+        .one()
+    )
+    assert artifact.grammar_sketch == "v2"
+    assert artifact.source_model == "gpt-5-mini"
+
     _cleanup(db_session)
 
 
@@ -1354,10 +1404,6 @@ def test_tokenizer_run_no_grammar_sketch_skips_training_artifacts(
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     version_id = _resolve_version_id(db_session, test_revision_id)
-    db_session.query(TrainingArtifact).filter(
-        TrainingArtifact.target_version_id == version_id
-    ).delete()
-    db_session.commit()
 
     resp = client.post(
         f"/{prefix}/tokenizer/runs",

--- a/test/test_agent_routes/test_tokenizer_routes.py
+++ b/test/test_agent_routes/test_tokenizer_routes.py
@@ -3,9 +3,11 @@
 import unicodedata
 
 from database.models import (
+    BibleRevision,
     LanguageMorpheme,
     LanguageProfile,
     TokenizerRun,
+    TrainingArtifacts,
     VerseMorphemeIndex,
     VerseText,
     WordMorphemeIndex,
@@ -41,6 +43,15 @@ def _cleanup(db_session):
         db_session.query(LanguageProfile).filter(
             LanguageProfile.iso_639_3 == iso
         ).delete()
+    db_session.commit()
+
+
+def _cleanup_training_artifacts(db_session, version_ids):
+    if not version_ids:
+        return
+    db_session.query(TrainingArtifacts).filter(
+        TrainingArtifacts.target_version_id.in_(version_ids)
+    ).delete(synchronize_session="fetch")
     db_session.commit()
 
 
@@ -1159,4 +1170,144 @@ def test_word_index_idempotency(client, regular_token1, test_revision_id, db_ses
     assert resp2.json() == data1
 
     _cleanup_verses(db_session, vt_objs)
+    _cleanup(db_session)
+
+
+def _resolve_version_id(db_session, revision_id):
+    return (
+        db_session.query(BibleRevision.bible_version_id)
+        .filter(BibleRevision.id == revision_id)
+        .scalar()
+    )
+
+
+def test_tokenizer_run_populates_target_version_id(
+    client, regular_token1, test_revision_id, db_session
+):
+    """commit_tokenizer_run dual-writes target_version_id on new morpheme rows
+    (Phase 1 of issue #687)."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    expected_version_id = _resolve_version_id(db_session, test_revision_id)
+    assert expected_version_id is not None
+
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "alpha", "morpheme_class": "LEXICAL"}],
+            profile={"name": "Swahili"},
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    row = (
+        db_session.query(LanguageMorpheme)
+        .filter(
+            LanguageMorpheme.iso_639_3 == TEST_ISO,
+            LanguageMorpheme.morpheme == "alpha",
+        )
+        .one()
+    )
+    assert row.target_version_id == expected_version_id
+
+    _cleanup(db_session)
+
+
+def test_tokenizer_run_dual_writes_training_artifacts(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Posting a tokenizer run with a grammar_sketch upserts a training_artifacts
+    row keyed on the bible_version of the revision."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    version_id = _resolve_version_id(db_session, test_revision_id)
+    db_session.query(TrainingArtifacts).filter(
+        TrainingArtifacts.target_version_id == version_id
+    ).delete()
+    db_session.commit()
+
+    profile = {"name": "Swahili", "grammar_sketch": "draft v1"}
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "beta", "morpheme_class": "LEXICAL"}],
+            profile=profile,
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    artifact = (
+        db_session.query(TrainingArtifacts)
+        .filter(TrainingArtifacts.target_version_id == version_id)
+        .one()
+    )
+    assert artifact.grammar_sketch == "draft v1"
+    assert artifact.source_model == "gpt-5-mini"
+
+    # A second run with a refreshed sketch upserts in place.
+    profile2 = {"name": "Swahili", "grammar_sketch": "draft v2"}
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "gamma", "morpheme_class": "LEXICAL"}],
+            profile=profile2,
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    db_session.expire_all()
+    refreshed = (
+        db_session.query(TrainingArtifacts)
+        .filter(TrainingArtifacts.target_version_id == version_id)
+        .one()
+    )
+    assert refreshed.grammar_sketch == "draft v2"
+
+    db_session.query(TrainingArtifacts).filter(
+        TrainingArtifacts.target_version_id == version_id
+    ).delete()
+    db_session.commit()
+    _cleanup(db_session)
+
+
+def test_tokenizer_run_no_grammar_sketch_skips_training_artifacts(
+    client, regular_token1, test_revision_id, db_session
+):
+    """When the run's profile has no grammar_sketch, no training_artifacts row
+    is created — the dual-write is opt-in on grammar_sketch."""
+    _cleanup(db_session)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    version_id = _resolve_version_id(db_session, test_revision_id)
+    db_session.query(TrainingArtifacts).filter(
+        TrainingArtifacts.target_version_id == version_id
+    ).delete()
+    db_session.commit()
+
+    resp = client.post(
+        f"/{prefix}/tokenizer/runs",
+        json=_run_payload(
+            test_revision_id,
+            [{"morpheme": "delta", "morpheme_class": "LEXICAL"}],
+            profile={"name": "Swahili"},
+        ),
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    assert (
+        db_session.query(TrainingArtifacts)
+        .filter(TrainingArtifacts.target_version_id == version_id)
+        .one_or_none()
+        is None
+    )
+
     _cleanup(db_session)


### PR DESCRIPTION
## Summary

First step toward issue #687. Adds a per-`bible_version` `training_artifacts` table and dual-write plumbing so agent-discovered tokenizer artifacts stop being keyed on `iso_language`. This is the schema + write-path slice; reads still come from the legacy language-keyed rows (Phase 2).

- New table `training_artifacts(target_version_id PK → bible_version.id, grammar_sketch, source_model, …)`
- Nullable `target_version_id` FK columns + version-scoped unique indexes added to `language_affixes` and `language_morphemes`
- Inline backfill: fan out each non-null `language_profiles.grammar_sketch` to every non-deleted `bible_version` of that ISO so Phase 2 reads see no functional change
- `POST /v3/tokenizer/runs` now resolves `bible_version_id` from `revision_id` and (a) stamps `target_version_id` on new morpheme rows and (b) upserts a `training_artifacts` row when the payload carries a `grammar_sketch`. `PUT /v3/tokenizer/profile/{iso}` is intentionally unchanged — it has no version context

This closes the cross-group affix/grammar permission leak path for new writes; Phase 2+ flip reads and cut aqua-assessments over.

Fixes part of #687

## Test plan

- [x] `pytest test/test_agent_routes/test_tokenizer_routes.py` (29 passed, including 3 new tests for the dual-write)
- [x] `pytest test/test_agent_routes/` full suite (361 passed)
- [x] Migration applies and downgrades cleanly (`alembic upgrade head` → `alembic downgrade -1` → `alembic upgrade head`)
- [ ] Backfill verified on a snapshot of prod data before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)