### PR TITLE
Make source_version_id optional on GET /v3/agent/lexeme-card

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1736,8 +1736,8 @@ async def get_word_alignments(
 
 @router.get("/agent/lexeme-card", response_model=list[LexemeCardOut])
 async def get_lexeme_cards(
-    source_version_id: int,
     target_version_id: int,
+    source_version_id: int | None = None,
     source_word: str = None,
     target_word: str = None,
     target_words: str = None,
@@ -1753,8 +1753,14 @@ async def get_lexeme_cards(
     the current user has access to.
 
     Query Parameters:
-    - source_version_id: int (required) - Bible version ID for source
     - target_version_id: int (required) - Bible version ID for target
+    - source_version_id: int (optional) - Bible version ID for source. When
+      provided, the canonical source is resolved via pivot routing (the SQL
+      filter rewrites to the pivot bible_version registered for the target's
+      iso, falling back to the given value). Internal callers that target a
+      specific canonical pair (pivot picker, derive, consolidation) should
+      keep passing this. When omitted, cards are matched on target_version_id
+      alone, which is what a UI showing "cards for this revision" wants.
     - source_word: str (optional) - Filter by source_lemma or source_surface_forms
       (case-insensitive exact match)
     - target_word: str (optional) - Filter by target_lemma or surface_forms
@@ -1790,19 +1796,23 @@ async def get_lexeme_cards(
 
         is_admin = current_user.is_admin
 
-        # Cards are persisted at the pivot bible_version for any target_iso
-        # registered in language_pivot. The caller's source_version_id is a
-        # hint; the SQL expression below resolves to the pivot version when a
-        # mapping exists, else the caller's source_version_id.
-        effective_source_version = _effective_source_version_expr(
-            source_version_id, target_version_id
-        )
-
-        # Base conditions: language pair filter
+        # Base conditions: target version is always pinned. When the caller
+        # passes source_version_id, we additionally pin the source side via
+        # pivot routing (caller's value, rewritten to the pivot bible_version
+        # if one is registered for the target's iso). When it's omitted, we
+        # match on target_version_id alone — a target revision is typically
+        # built against a single pivot, so this returns the canonicals the UI
+        # wants. If a target_version_id ever accumulates canonicals from
+        # multiple pivots, the omitted-source query will return both sets
+        # rather than deduping; callers can pass source_version_id to pick.
         conditions = [
-            AgentLexemeCard.source_version_id == effective_source_version,
             AgentLexemeCard.target_version_id == target_version_id,
         ]
+        if source_version_id is not None:
+            conditions.append(
+                AgentLexemeCard.source_version_id
+                == _effective_source_version_expr(source_version_id, target_version_id)
+            )
 
         # Add POS filter if provided
         if pos:
@@ -1883,6 +1893,14 @@ async def get_lexeme_cards(
             # are always created from revisions in the card's language pair
             # (the POST endpoint requires a revision_id for the language).
             if not is_admin:
+                # Authorize examples against the actual canonical source
+                # versions of the loaded cards plus the target. When the
+                # caller passed source_version_id, all returned cards share
+                # the same (pivot-resolved) source, so this is a single id;
+                # when omitted, multi-pivot result sets fall out naturally.
+                source_versions_for_auth = sorted(
+                    {card.source_version_id for card in cards}
+                )
                 authorized_lang_revisions = (
                     select(BibleRevision.id)
                     .distinct()
@@ -1901,7 +1919,7 @@ async def get_lexeme_cards(
                     .where(
                         UserGroup.user_id == current_user.id,
                         BibleVersion.id.in_(
-                            [effective_source_version, target_version_id]
+                            source_versions_for_auth + [target_version_id]
                         ),
                     )
                 )
@@ -1934,9 +1952,11 @@ async def get_lexeme_cards(
         # Apply non-canonical language overlay when requested.
         requested_lang = lang.lower() if lang else None
         # When pivot routing rewrote the source, default lang to the caller's
-        # source ISO so the pivot stays invisible.
+        # source ISO so the pivot stays invisible. Only meaningful when the
+        # caller supplied a source_version_id to compare against.
         if (
             requested_lang is None
+            and source_version_id is not None
             and cards
             and cards[0].source_version_id != source_version_id
         ):
@@ -2064,7 +2084,8 @@ async def get_lexeme_cards(
                 "target_version_id": target_version_id,
                 "effective_source_version_id": effective_source_version_id,
                 "pivot_routed": (
-                    effective_source_version_id is not None
+                    source_version_id is not None
+                    and effective_source_version_id is not None
                     and effective_source_version_id != source_version_id
                 ),
                 "source_word": source_word,

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -1696,14 +1696,14 @@ def test_get_lexeme_cards_empty_results(
     assert len(nonexistent_cards) == 0
 
 
-def test_get_lexeme_cards_missing_languages(client, regular_token1, db_session):
-    """Test that getting lexeme cards requires language parameters."""
+def test_get_lexeme_cards_missing_target_version_id(client, regular_token1, db_session):
+    """target_version_id is the only mandatory language parameter; omitting it 422s."""
     response = client.get(
         "/v3/agent/lexeme-card?target_word=test",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
-    assert response.status_code == 422  # Validation error for missing required params
+    assert response.status_code == 422  # Validation error for missing target_version_id
 
 
 def test_get_lexeme_cards_unauthorized(client, test_version_id, test_version_id_2):
@@ -7336,6 +7336,147 @@ def test_get_lexeme_cards_bulk_lang_matches_canonical(
     assert card["examples"][0]["source"] == "canon en src"
     assert card["examples"][0]["target"] == "canon tgt"
     assert isinstance(card["examples"][0]["id"], int)
+
+
+def test_get_lexeme_cards_bulk_no_source_version_id_filters_by_target_only(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Omitting source_version_id matches cards by target_version_id alone."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="bulk_no_src_lemma",
+        source_lemma="bulk_no_src_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "no-src en", "target": "no-src tgt"}],
+    )
+
+    response = client.get(
+        f"/v3/agent/lexeme-card?target_version_id={test_version_id_2}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    returned = response.json()
+    assert any(c["id"] == card_id for c in returned)
+
+    card = next(c for c in returned if c["id"] == card_id)
+    assert card["source_lemma"] == "bulk_no_src_src"
+    assert len(card["examples"]) == 1
+    assert card["examples"][0]["source"] == "no-src en"
+    assert card["examples"][0]["target"] == "no-src tgt"
+
+
+def test_get_lexeme_cards_bulk_no_source_version_id_with_lang_overlays(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """UI case: target_version_id + lang resolves overlays without knowing the pivot."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="ui_overlay_lemma",
+        source_lemma="ui_overlay_canon_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "canon en", "target": "canon tgt"}],
+    )
+    ex_id = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_id)
+        .first()
+        .id
+    )
+    post = client.post(
+        f"/v3/agent/lexeme-card/{card_id}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "ui_overlay_swh_src",
+            "examples": [{"example_id": ex_id, "source_text": "overlay swh"}],
+        },
+    )
+    assert post.status_code == 200, post.text
+
+    response = client.get(
+        f"/v3/agent/lexeme-card?target_version_id={test_version_id_2}&lang=swh",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    card = next(c for c in response.json() if c["id"] == card_id)
+    # Source-side fields swapped in from the translation overlay
+    assert card["source_lemma"] == "ui_overlay_swh_src"
+    assert card["examples"][0]["source"] == "overlay swh"
+    # Target-side fields untouched
+    assert card["target_lemma"] == "ui_overlay_lemma"
+    assert card["examples"][0]["target"] == "canon tgt"
+
+
+def test_get_lexeme_cards_bulk_no_source_version_id_with_lang_omits_missing(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Without source_version_id, ?lang still omits cards lacking that translation."""
+    card_without = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="ui_no_overlay_lemma",
+        source_lemma="ui_no_overlay_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "no overlay en", "target": "no overlay tgt"}],
+    )
+
+    response = client.get(
+        f"/v3/agent/lexeme-card?target_version_id={test_version_id_2}&lang=swh",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    returned_ids = {c["id"] for c in response.json()}
+    assert card_without not in returned_ids
+
+
+def test_get_lexeme_cards_bulk_source_version_id_still_pinned(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """When source_version_id is supplied, mismatched pairs return no rows
+    (back-compat for agent-internal callers that probe specific pairs)."""
+    _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="pinned_lemma",
+        source_lemma="pinned_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+
+    # Swap the pair: legacy filter must exclude this card.
+    response = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id_2}"
+        f"&target_version_id={test_version_id}&target_word=pinned_lemma",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 def test_card_translation_cascade_delete(


### PR DESCRIPTION
## Summary

- Drops `source_version_id` from the required query params on `GET /v3/agent/lexeme-card`. The UI only knows the user's reference version and the target revision — it doesn't (and shouldn't) know which pivot a given target language uses. Requiring `source_version_id` meant an English-side reference returned zero cards even when canonicals lived at the pivot version.
- When `source_version_id` is omitted, the filter is now `target_version_id` alone (plus any `lang`, `pos`, `target_word(s)`, `source_word` filters). When supplied, behavior is unchanged: pivot routing rewrites the source side to the pivot bible_version registered for the target's iso, falling back to the caller's value.
- Per-card example authorization for non-admins now derives the source-side `bible_version` from the loaded cards instead of the caller's input, which keeps access checks consistent across both query shapes (and behaves correctly if a `target_version_id` ever accumulates canonicals from more than one pivot).

Fixes #690

## Test plan

- [x] `pytest -k "test_get_lexeme_cards_bulk_no_source_version_id or test_get_lexeme_cards_bulk_source_version_id_still_pinned or test_get_lexeme_cards_missing_target_version_id or test_get_lexeme_cards_bulk_lang or test_get_lexeme_cards_by_language_pair"` — 9 passed
- [x] `pytest -k "lexeme_card or check_word or card_translation"` — 158 passed
- [x] `black --check` + `isort --check-only` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)