### PR TITLE
fix(lexeme-card): return cards with null overlay instead of omitting

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1774,7 +1774,9 @@ async def get_lexeme_cards(
       cards in their canonical shape (back-compat). When it differs, source-side
       fields (source_lemma, source_surface_forms, senses, per-example source_text)
       are replaced by the matching card_translations row. Cards without a
-      translation in the requested language are omitted from the response.
+      translation in the requested language are still returned, with the
+      source-side overlay fields set to null and example source_text omitted,
+      so the UI can render the target side and indicate the overlay is missing.
 
     Returns:
     - List[LexemeCardOut]: List of matching lexeme cards, ordered by confidence (descending).
@@ -2011,21 +2013,26 @@ async def get_lexeme_cards(
                         ] = row.source_text
 
         # Build response cards. When `lang` is requested and differs from a
-        # card's canonical source_language_iso, the card is omitted unless a
-        # translation row exists; its source-side fields are then replaced.
+        # card's canonical source_language_iso, source-side fields are replaced
+        # by the card_translations row. If no translation row exists for the
+        # requested lang, the card is still returned with overlay fields null
+        # so the UI can render the target side and signal a missing overlay.
         response_cards = []
-        omitted_for_missing_translation = 0
+        missing_translation_overlay = 0
         for card in cards:
             requires_merge = (
                 requested_lang is not None
                 and card.source_language_iso != requested_lang
             )
-            if requires_merge and card.id not in translation_by_card:
-                omitted_for_missing_translation += 1
-                continue
+            trans = translation_by_card.get(card.id) if requires_merge else None
 
-            if requires_merge:
-                trans = translation_by_card[card.id]
+            if requires_merge and trans is None:
+                missing_translation_overlay += 1
+                source_lemma = None
+                source_surface_forms = None
+                senses = None
+                override_map: dict[int, str | None] = {}
+            elif requires_merge:
                 source_lemma = trans.source_lemma
                 source_surface_forms = trans.source_surface_forms
                 senses = trans.senses
@@ -2036,18 +2043,26 @@ async def get_lexeme_cards(
                 senses = card.senses
                 override_map = {}
 
-            examples_out = [
-                {
-                    "id": ex["id"],
-                    "source": (
-                        override_map.get(ex["id"], ex["source"])
-                        if requires_merge
-                        else ex["source"]
-                    ),
-                    "target": ex["target"],
-                }
-                for ex in examples_by_card[card.id]
-            ]
+            if requires_merge and trans is None:
+                # No overlay: don't leak the canonical (pivot-language) source
+                # text through examples. Target side stays intact.
+                examples_out = [
+                    {"id": ex["id"], "source": None, "target": ex["target"]}
+                    for ex in examples_by_card[card.id]
+                ]
+            else:
+                examples_out = [
+                    {
+                        "id": ex["id"],
+                        "source": (
+                            override_map.get(ex["id"], ex["source"])
+                            if requires_merge
+                            else ex["source"]
+                        ),
+                        "target": ex["target"],
+                    }
+                    for ex in examples_by_card[card.id]
+                ]
 
             card_dict = {
                 "id": card.id,
@@ -2093,7 +2108,7 @@ async def get_lexeme_cards(
                 "target_words": target_words,
                 "pos": pos,
                 "lang": requested_lang,
-                "omitted_for_missing_translation": omitted_for_missing_translation,
+                "missing_translation_overlay": missing_translation_overlay,
                 "duration_s": duration,
             },
         )

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1772,15 +1772,22 @@ async def get_lexeme_cards(
     - lang: str (optional) - ISO 639-3 code for the desired source-side language.
       When omitted or equal to the cards' canonical source_language_iso, returns
       cards in their canonical shape (back-compat). When it differs, source-side
-      fields (source_lemma, source_surface_forms, senses, per-example source_text)
+      fields (source_lemma, source_surface_forms, senses, examples[].source)
       are replaced by the matching card_translations row. Cards without a
       translation in the requested language are still returned, with the
-      source-side overlay fields set to null, example source_text omitted, and
-      ``has_translation_overlay=False``, so the UI can render the target side
-      and indicate the overlay is missing. (Note: the single-card by-id
+      source-side overlay fields set to null, examples[].source set to null,
+      and ``has_translation_overlay=False``, so the UI can render the target
+      side and indicate the overlay is missing. (Note: the single-card by-id
       endpoint returns 404 in that same situation — it's the derivation
       trigger. Callers iterating the bulk list should check
       ``has_translation_overlay`` before clicking through to by-id.)
+
+      When ``lang`` is omitted but a ``source_version_id`` is also provided and
+      pivot routing rewrites the source, ``lang`` is auto-derived from the
+      caller's ``source_version_id`` ISO so the pivot stays invisible. In that
+      case the overlay logic above applies as if ``lang`` had been passed
+      explicitly; the structured log payload includes ``lang_auto_derived=True``
+      so dashboards can distinguish UI-driven misses from pivot-driven ones.
 
     Returns:
     - List[LexemeCardOut]: List of matching lexeme cards, ordered by confidence (descending).

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1775,8 +1775,12 @@ async def get_lexeme_cards(
       fields (source_lemma, source_surface_forms, senses, per-example source_text)
       are replaced by the matching card_translations row. Cards without a
       translation in the requested language are still returned, with the
-      source-side overlay fields set to null and example source_text omitted,
-      so the UI can render the target side and indicate the overlay is missing.
+      source-side overlay fields set to null, example source_text omitted, and
+      ``has_translation_overlay=False``, so the UI can render the target side
+      and indicate the overlay is missing. (Note: the single-card by-id
+      endpoint returns 404 in that same situation — it's the derivation
+      trigger. Callers iterating the bulk list should check
+      ``has_translation_overlay`` before clicking through to by-id.)
 
     Returns:
     - List[LexemeCardOut]: List of matching lexeme cards, ordered by confidence (descending).
@@ -1953,6 +1957,7 @@ async def get_lexeme_cards(
 
         # Apply non-canonical language overlay when requested.
         requested_lang = lang.lower() if lang else None
+        lang_auto_derived = False
         # When pivot routing rewrote the source, default lang to the caller's
         # source ISO so the pivot stays invisible. Only meaningful when the
         # caller supplied a source_version_id to compare against.
@@ -1970,6 +1975,7 @@ async def get_lexeme_cards(
             source_iso = source_iso_result.scalar_one_or_none()
             if source_iso is not None:
                 requested_lang = source_iso.lower()
+                lang_auto_derived = True
         # Per-card translation row (only loaded when needed)
         translation_by_card: dict[int, CardTranslation] = {}
         # Per-card map of example_id -> translated source_text
@@ -2016,7 +2022,10 @@ async def get_lexeme_cards(
         # card's canonical source_language_iso, source-side fields are replaced
         # by the card_translations row. If no translation row exists for the
         # requested lang, the card is still returned with overlay fields null
-        # so the UI can render the target side and signal a missing overlay.
+        # (and has_translation_overlay=False) so the UI can render the target
+        # side, signal the missing overlay, and suppress click-through to the
+        # by-id endpoint (which still 404s — that path is the derivation
+        # trigger).
         response_cards = []
         missing_translation_overlay = 0
         for card in cards:
@@ -2025,42 +2034,39 @@ async def get_lexeme_cards(
                 and card.source_language_iso != requested_lang
             )
             trans = translation_by_card.get(card.id) if requires_merge else None
+            has_translation_overlay = not requires_merge or trans is not None
 
             if requires_merge and trans is None:
+                # No overlay: null source-side fields and mask example source
+                # so we don't leak canonical (pivot-language) text into a
+                # response that asked for a different language.
                 missing_translation_overlay += 1
                 source_lemma = None
                 source_surface_forms = None
                 senses = None
-                override_map: dict[int, str | None] = {}
+                examples_out = [
+                    {"id": ex["id"], "source": None, "target": ex["target"]}
+                    for ex in examples_by_card[card.id]
+                ]
             elif requires_merge:
                 source_lemma = trans.source_lemma
                 source_surface_forms = trans.source_surface_forms
                 senses = trans.senses
                 override_map = trans_source_by_card.get(card.id, {})
+                examples_out = [
+                    {
+                        "id": ex["id"],
+                        "source": override_map.get(ex["id"], ex["source"]),
+                        "target": ex["target"],
+                    }
+                    for ex in examples_by_card[card.id]
+                ]
             else:
                 source_lemma = card.source_lemma
                 source_surface_forms = card.source_surface_forms
                 senses = card.senses
-                override_map = {}
-
-            if requires_merge and trans is None:
-                # No overlay: don't leak the canonical (pivot-language) source
-                # text through examples. Target side stays intact.
                 examples_out = [
-                    {"id": ex["id"], "source": None, "target": ex["target"]}
-                    for ex in examples_by_card[card.id]
-                ]
-            else:
-                examples_out = [
-                    {
-                        "id": ex["id"],
-                        "source": (
-                            override_map.get(ex["id"], ex["source"])
-                            if requires_merge
-                            else ex["source"]
-                        ),
-                        "target": ex["target"],
-                    }
+                    {"id": ex["id"], "source": ex["source"], "target": ex["target"]}
                     for ex in examples_by_card[card.id]
                 ]
 
@@ -2082,6 +2088,7 @@ async def get_lexeme_cards(
                 "last_updated": card.last_updated,
                 "last_user_edit": card.last_user_edit,
                 "examples": examples_out,
+                "has_translation_overlay": has_translation_overlay,
             }
             response_cards.append(LexemeCardOut.model_validate(card_dict))
 
@@ -2108,6 +2115,7 @@ async def get_lexeme_cards(
                 "target_words": target_words,
                 "pos": pos,
                 "lang": requested_lang,
+                "lang_auto_derived": lang_auto_derived,
                 "missing_translation_overlay": missing_translation_overlay,
                 "duration_s": duration,
             },

--- a/models.py
+++ b/models.py
@@ -838,8 +838,9 @@ class LexemeCardOut(BaseModel):
     surface_forms: Optional[list] = None
     source_surface_forms: Optional[list] = None  # Source language surface forms
     senses: Optional[list] = None
-    # Each example dict has shape {"id": int, "source": str, "target": str};
-    # filtered to the requested revision_id when set.
+    # Each example dict has shape {"id": int, "source": str | None, "target": str};
+    # source is None when ?lang requested a translation overlay that doesn't
+    # exist for this card. Filtered to the requested revision_id when set.
     examples: Optional[list] = None
     confidence: Optional[float] = None
     english_lemma: Optional[str] = None

--- a/models.py
+++ b/models.py
@@ -849,6 +849,12 @@ class LexemeCardOut(BaseModel):
     created_at: Optional[datetime.datetime] = None
     last_updated: Optional[datetime.datetime] = None
     last_user_edit: Optional[datetime.datetime] = None
+    # True when the response reflects the requested language: either canonical
+    # source matched ?lang, or a card_translations overlay was applied. False
+    # only on the bulk endpoint when ?lang was requested but no overlay
+    # existed — in that case source-side fields above are null. The by-id
+    # endpoint never returns False (it 404s instead, to trigger derivation).
+    has_translation_overlay: bool = True
 
 
 class ListMode(str, Enum):

--- a/models.py
+++ b/models.py
@@ -839,8 +839,9 @@ class LexemeCardOut(BaseModel):
     source_surface_forms: Optional[list] = None  # Source language surface forms
     senses: Optional[list] = None
     # Each example dict has shape {"id": int, "source": str | None, "target": str};
-    # source is None when ?lang requested a translation overlay that doesn't
-    # exist for this card. Filtered to the requested revision_id when set.
+    # source is None when a translation overlay was requested (either via
+    # ?lang= or auto-derived by pivot routing) but no card_translations row
+    # exists for this card. Filtered to the requested revision_id when set.
     examples: Optional[list] = None
     confidence: Optional[float] = None
     english_lemma: Optional[str] = None

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -8519,15 +8519,35 @@ def test_get_lexeme_cards_bulk_missing_overlay_logs_counter(
     ]
     assert completion_calls, "expected get_lexeme_cards completion log"
     extra = completion_calls[-1].kwargs.get("extra", {})
-    assert (
-        extra.get("missing_translation_overlay", 0) >= 2
-    ), f"counter should reflect ≥2 cards without an overlay, got extra={extra!r}"
+    # The test_version_id pair is shared with other tests in this module, so
+    # the response may include cards beyond the three created here. Compare
+    # the log counter against the response itself: every card with
+    # has_translation_overlay=False must be counted, and the counter must
+    # match the response exactly (no under- or over-count).
+    response_cards = response.json()
+    response_missing = sum(
+        1 for c in response_cards if c.get("has_translation_overlay") is False
+    )
+    assert response_missing >= 2, (
+        "expected at least 2 cards in response without an overlay "
+        f"(our own card_without_a and card_without_b), got {response_missing}"
+    )
+    assert extra.get("missing_translation_overlay") == response_missing, (
+        f"log counter ({extra.get('missing_translation_overlay')}) must match "
+        f"the count of has_translation_overlay=False cards in the response "
+        f"({response_missing}); extra={extra!r}"
+    )
     assert extra.get("lang") == "swh"
     assert extra.get("lang_auto_derived") is False
 
     # Sanity: the response contains all three of our cards.
-    returned_ids = {c["id"] for c in response.json()}
+    returned_ids = {c["id"] for c in response_cards}
     assert {card_with, card_without_a, card_without_b}.issubset(returned_ids)
+    # And our specific without-overlay cards are flagged.
+    by_id = {c["id"]: c for c in response_cards}
+    assert by_id[card_with]["has_translation_overlay"] is True
+    assert by_id[card_without_a]["has_translation_overlay"] is False
+    assert by_id[card_without_b]["has_translation_overlay"] is False
 
 
 def test_get_lexeme_card_by_id_lang_matches_canonical_iso_returns_200(

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -7207,7 +7207,7 @@ def test_get_lexeme_card_by_id_card_not_found(client, regular_token1):
     assert response.status_code == 404
 
 
-def test_get_lexeme_cards_bulk_lang_omits_missing_translation(
+def test_get_lexeme_cards_bulk_lang_returns_missing_translation_with_null_overlay(
     client,
     regular_token1,
     db_session,
@@ -7215,7 +7215,8 @@ def test_get_lexeme_cards_bulk_lang_omits_missing_translation(
     test_version_id,
     test_version_id_2,
 ):
-    """Bulk GET with ?lang omits cards that lack a translation in that lang."""
+    """Bulk GET with ?lang returns cards without a translation, with null
+    source-side overlay fields, so the UI can still render the target side."""
     target_lemma_with = "bulk_lang_with_trans"
     target_lemma_without = "bulk_lang_without_trans"
 
@@ -7263,14 +7264,24 @@ def test_get_lexeme_cards_bulk_lang_omits_missing_translation(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200
-    returned_ids = {c["id"] for c in response.json()}
-    assert card_with in returned_ids
-    assert card_without not in returned_ids
+    by_id = {c["id"]: c for c in response.json()}
+    assert card_with in by_id
+    assert card_without in by_id
 
-    merged = next(c for c in response.json() if c["id"] == card_with)
+    merged = by_id[card_with]
     assert merged["source_lemma"] == "bulk_with_swh"
     assert merged["examples"][0]["source"] == "with swh src"
     assert merged["examples"][0]["target"] == "with tgt"
+
+    # Card lacking a swh translation row is returned with the overlay fields
+    # set to None and example source masked (target side stays intact).
+    missing = by_id[card_without]
+    assert missing["target_lemma"] == target_lemma_without
+    assert missing["source_lemma"] is None
+    assert missing["source_surface_forms"] is None
+    assert missing["senses"] is None
+    assert missing["examples"][0]["source"] is None
+    assert missing["examples"][0]["target"] == "without tgt"
 
 
 def test_get_lexeme_cards_bulk_no_lang_back_compat(
@@ -7422,14 +7433,16 @@ def test_get_lexeme_cards_bulk_no_source_version_id_with_lang_overlays(
     assert card["examples"][0]["target"] == "canon tgt"
 
 
-def test_get_lexeme_cards_bulk_no_source_version_id_with_lang_omits_missing(
+def test_get_lexeme_cards_bulk_no_source_version_id_with_lang_returns_null_overlay(
     client,
     regular_token1,
     test_revision_id,
     test_version_id,
     test_version_id_2,
 ):
-    """Without source_version_id, ?lang still omits cards lacking that translation."""
+    """Without source_version_id, ?lang returns cards lacking a translation
+    with overlay fields nulled out (UI's main case when no translations exist
+    yet for the requested lang)."""
     card_without = _create_card_with_examples(
         client,
         regular_token1,
@@ -7446,8 +7459,15 @@ def test_get_lexeme_cards_bulk_no_source_version_id_with_lang_omits_missing(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert response.status_code == 200, response.text
-    returned_ids = {c["id"] for c in response.json()}
-    assert card_without not in returned_ids
+    by_id = {c["id"]: c for c in response.json()}
+    assert card_without in by_id
+    missing = by_id[card_without]
+    assert missing["target_lemma"] == "ui_no_overlay_lemma"
+    assert missing["source_lemma"] is None
+    assert missing["source_surface_forms"] is None
+    assert missing["senses"] is None
+    assert missing["examples"][0]["source"] is None
+    assert missing["examples"][0]["target"] == "no overlay tgt"
 
 
 def test_get_lexeme_cards_bulk_no_source_version_id_returns_multi_pivot_canonicals(

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -7163,11 +7163,13 @@ def test_get_lexeme_card_by_id_lang_merges_translation(
     # Target-side fields come from the canonical card (unchanged)
     assert data["target_lemma"] == "single_merge_lemma"
     # The translated example has source_text overridden; the un-translated
-    # example keeps the canonical source_text.
-    sources = {ex["source"] for ex in data["examples"]}
-    targets = {ex["target"] for ex in data["examples"]}
-    assert sources == {"alpha swh", "beta en"}
-    assert targets == {"alpha tgt", "beta tgt"}
+    # example keeps the canonical source_text. Assert per-id so a swap (both
+    # examples returning the same translated text on different ids) fails.
+    by_ex_id = {ex["id"]: ex for ex in data["examples"]}
+    assert by_ex_id[ex_ids[0]]["source"] == "alpha swh"
+    assert by_ex_id[ex_ids[0]]["target"] == "alpha tgt"
+    assert by_ex_id[ex_ids[1]]["source"] == "beta en"
+    assert by_ex_id[ex_ids[1]]["target"] == "beta tgt"
 
 
 def test_get_lexeme_card_by_id_404_when_no_translation(
@@ -7272,16 +7274,25 @@ def test_get_lexeme_cards_bulk_lang_returns_missing_translation_with_null_overla
     assert merged["source_lemma"] == "bulk_with_swh"
     assert merged["examples"][0]["source"] == "with swh src"
     assert merged["examples"][0]["target"] == "with tgt"
+    assert merged["has_translation_overlay"] is True
 
     # Card lacking a swh translation row is returned with the overlay fields
-    # set to None and example source masked (target side stays intact).
+    # set to None and example source masked. Non-source-side scalars (target,
+    # version ids, pos, confidence, id) and has_translation_overlay must
+    # still reflect the canonical card.
     missing = by_id[card_without]
+    assert missing["id"] == card_without
     assert missing["target_lemma"] == target_lemma_without
+    assert missing["target_version_id"] == test_version_id_2
+    assert missing["source_version_id"] == test_version_id
+    assert missing["pos"] is None or isinstance(missing["pos"], str)
+    assert missing["confidence"] is None or isinstance(missing["confidence"], float)
     assert missing["source_lemma"] is None
     assert missing["source_surface_forms"] is None
     assert missing["senses"] is None
     assert missing["examples"][0]["source"] is None
     assert missing["examples"][0]["target"] == "without tgt"
+    assert missing["has_translation_overlay"] is False
 
 
 def test_get_lexeme_cards_bulk_no_lang_back_compat(
@@ -7463,11 +7474,14 @@ def test_get_lexeme_cards_bulk_no_source_version_id_with_lang_returns_null_overl
     assert card_without in by_id
     missing = by_id[card_without]
     assert missing["target_lemma"] == "ui_no_overlay_lemma"
+    assert missing["target_version_id"] == test_version_id_2
+    assert missing["source_version_id"] == test_version_id
     assert missing["source_lemma"] is None
     assert missing["source_surface_forms"] is None
     assert missing["senses"] is None
     assert missing["examples"][0]["source"] is None
     assert missing["examples"][0]["target"] == "no overlay tgt"
+    assert missing["has_translation_overlay"] is False
 
 
 def test_get_lexeme_cards_bulk_no_source_version_id_returns_multi_pivot_canonicals(
@@ -8293,6 +8307,256 @@ def test_get_lexeme_cards_pivot_routing_with_lang_overlay(
             PivotCandidate.pivot_iso == "eng"
         ).delete()
         db_session.commit()
+
+
+def test_get_lexeme_cards_pivot_routing_with_missing_overlay(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+):
+    """Pivot routing + no overlay: card is still returned, with null source-side
+    fields, no canonical (pivot-language) source leaking through examples, and
+    has_translation_overlay=False. Reproduces the production scenario the PR
+    fixes: UI calls (target_version_id, lang=eng), pivot rewrites source to
+    swh, no eng card_translations row exists yet.
+
+    The ``test_revision_id`` fixture is requested only to chain in
+    ``setup_agent_access`` (Group1 ↔ loading_test access) before we add our
+    own BibleVersionAccess rows below.
+    """
+    from datetime import date
+
+    from database.models import (
+        BibleRevision,
+        BibleVersion,
+        BibleVersionAccess,
+        Group,
+        LanguagePivot,
+        PivotCandidate,
+        UserDB,
+    )
+
+    _ = test_revision_id  # silence linter; fixture runs setup_agent_access
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = db_session.query(Group).filter(Group.name == "Group1").first()
+    # Pivot canonical lives in a swh BibleVersion + revision. Create them so
+    # the rewritten source resolves to a real bible_version_id whose iso is swh.
+    swh_version = BibleVersion(
+        name="pivot_missing_swh_canonical",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="PMSC",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    db_session.add(swh_version)
+    db_session.commit()
+    swh_revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=swh_version.id,
+        published=False,
+        machine_translation=False,
+    )
+    db_session.add(swh_revision)
+    db_session.commit()
+
+    target = BibleVersion(
+        name="pivot_missing_overlay_target",
+        iso_language="zga",
+        iso_script="Latn",
+        abbreviation="PMOT",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    ui_reference = BibleVersion(
+        name="pivot_missing_overlay_ui_ref",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="PMOU",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    db_session.add_all([target, ui_reference])
+    db_session.commit()
+
+    # Grant Group1 access so testuser1's group can see the example.
+    db_session.add_all(
+        [
+            BibleVersionAccess(bible_version_id=swh_version.id, group_id=group1.id),
+            BibleVersionAccess(bible_version_id=target.id, group_id=group1.id),
+            BibleVersionAccess(bible_version_id=ui_reference.id, group_id=group1.id),
+        ]
+    )
+    db_session.commit()
+
+    db_session.merge(PivotCandidate(pivot_iso="swh", pivot_revision_id=swh_revision.id))
+    db_session.commit()
+    db_session.merge(LanguagePivot(target_iso="zga", pivot_iso="swh"))
+    db_session.commit()
+
+    try:
+        # Card lives at the (swh) canonical, target=zga. The example source is
+        # canonical swh text — must NOT leak into the eng response below. The
+        # example revision_id must belong to one of the version pair, so use
+        # the swh revision we just created.
+        card_id = _create_card_with_examples(
+            client,
+            regular_token1,
+            target_lemma="pivot_missing_tgt",
+            source_lemma="pivot_missing_swh_src",
+            revision_id=swh_revision.id,
+            source_version_id=swh_version.id,
+            target_version_id=target.id,
+            examples=[
+                {"source": "leaky swh src", "target": "rendered tgt"},
+            ],
+        )
+
+        # No POST to /translation — overlay row deliberately absent.
+        response = client.get(
+            f"/v3/agent/lexeme-card?source_version_id={ui_reference.id}"
+            f"&target_version_id={target.id}&lang=eng",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        returned = next(c for c in response.json() if c["id"] == card_id)
+
+        assert returned["target_lemma"] == "pivot_missing_tgt"
+        assert returned["target_version_id"] == target.id
+        assert returned["source_lemma"] is None
+        assert returned["source_surface_forms"] is None
+        assert returned["senses"] is None
+        # Canonical (swh) example source must not leak into the eng response.
+        assert returned["examples"][0]["source"] is None
+        assert returned["examples"][0]["target"] == "rendered tgt"
+        assert returned["has_translation_overlay"] is False
+    finally:
+        db_session.query(LanguagePivot).filter(
+            LanguagePivot.target_iso == "zga"
+        ).delete()
+        db_session.query(PivotCandidate).filter(
+            PivotCandidate.pivot_iso == "swh",
+            PivotCandidate.pivot_revision_id == swh_revision.id,
+        ).delete()
+        db_session.commit()
+
+
+def test_get_lexeme_cards_bulk_missing_overlay_logs_counter(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """The missing_translation_overlay log counter matches the count of cards
+    returned with null overlay. Guards the rename from
+    `omitted_for_missing_translation` and ensures the metric stays accurate
+    so ops can see when backfill is needed."""
+    from unittest.mock import patch
+
+    card_with = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="logcounter_with_tgt",
+        source_lemma="logcounter_with_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "with en", "target": "with tgt"}],
+    )
+    card_without_a = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="logcounter_wo_a_tgt",
+        source_lemma="logcounter_wo_a_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "wo a en", "target": "wo a tgt"}],
+    )
+    card_without_b = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="logcounter_wo_b_tgt",
+        source_lemma="logcounter_wo_b_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        examples=[{"source": "wo b en", "target": "wo b tgt"}],
+    )
+    ex_id = (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id == card_with)
+        .first()
+        .id
+    )
+    client.post(
+        f"/v3/agent/lexeme-card/{card_with}/translation",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "language_iso": "swh",
+            "source_lemma": "logcounter_with_swh",
+            "examples": [{"example_id": ex_id, "source_text": "with swh"}],
+        },
+    )
+
+    # The agent_routes logger sets propagate=False, so caplog can't see it.
+    # Patch logger.info directly and inspect the structured `extra` payload.
+    with patch("agent_routes.v3.agent_routes.logger.info", autospec=True) as mock_info:
+        response = client.get(
+            f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+            f"&target_version_id={test_version_id_2}&lang=swh",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+    assert response.status_code == 200, response.text
+
+    completion_calls = [
+        c
+        for c in mock_info.call_args_list
+        if c.args and "get_lexeme_cards completed" in c.args[0]
+    ]
+    assert completion_calls, "expected get_lexeme_cards completion log"
+    extra = completion_calls[-1].kwargs.get("extra", {})
+    assert (
+        extra.get("missing_translation_overlay", 0) >= 2
+    ), f"counter should reflect ≥2 cards without an overlay, got extra={extra!r}"
+    assert extra.get("lang") == "swh"
+    assert extra.get("lang_auto_derived") is False
+
+    # Sanity: the response contains all three of our cards.
+    returned_ids = {c["id"] for c in response.json()}
+    assert {card_with, card_without_a, card_without_b}.issubset(returned_ids)
+
+
+def test_get_lexeme_card_by_id_lang_matches_canonical_iso_returns_200(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Guard against drift: by-id with ?lang equal to the card's canonical
+    source_language_iso returns 200 with canonical data, never 404 (the
+    404-on-missing-overlay path must not absorb the canonical-match path)."""
+    card_id = _create_card_with_examples(
+        client,
+        regular_token1,
+        target_lemma="byid_canonical_match_tgt",
+        source_lemma="byid_canonical_match_src",
+        revision_id=test_revision_id,
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+    )
+    response = client.get(
+        f"/v3/agent/lexeme-card/{card_id}?lang=eng",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert data["id"] == card_id
+    assert data["source_lemma"] == "byid_canonical_match_src"
 
 
 def test_check_word_in_lexeme_cards_pivot_routing(


### PR DESCRIPTION
## Summary

- `GET /v3/agent/lexeme-card` was silently dropping every card whose canonical `source_language_iso` didn't match the requested `?lang=` AND lacked a `card_translations` row. With pivot routing in production, a UI calling with `(target_version_id, lang=eng)` against a Swahili-pivot canonical got an empty list — observable in Loki as `omitted_for_missing_translation` matching the input card count.
- Now: those cards come back with `source_lemma`, `source_surface_forms`, `senses`, and each example's `source` set to `null`. Target side (target_lemma, examples[].target, surface_forms, pos, etc.) is intact, so the UI can render the card and indicate the overlay is missing.
- Log key renamed `omitted_for_missing_translation` → `missing_translation_overlay` to match the new behavior.
- `LexemeCardOut.examples[].source` doc updated to note it can be `None`.

The single-card `GET /v3/agent/lexeme-card/{id}?lang=` still 404s on a missing overlay — that path is the trigger signal for derivation and was intentionally left alone.

## Test plan

- [x] Updated `test_get_lexeme_cards_bulk_lang_omits_missing_translation` (renamed) to assert the un-translated card is returned with nulled overlay fields.
- [x] Updated `test_get_lexeme_cards_bulk_no_source_version_id_with_lang_omits_missing` similarly.
- [x] All 139 lexeme-card tests pass locally.
- [x] All 7 lexeme card access-control tests pass.
- [ ] UI smoke test (downstream `aqua-django-app`) to confirm cards now render in the lang view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)