### PR TITLE
Add include_deleted query param to GET /v3/version (#699)

### DIFF
--- a/bible_routes/v3/version_routes.py
+++ b/bible_routes/v3/version_routes.py
@@ -24,20 +24,27 @@ router = fastapi.APIRouter()
 
 @router.get("/version", response_model=List[VersionOut])
 async def list_version(
+    include_deleted: bool = False,
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
     """
     Get a list of all versions that the current user is authorized to access.
+
+    Admins may pass ``include_deleted=true`` to also return soft-deleted
+    versions, so downstream mirrors can satisfy FK constraints against
+    revisions whose parent version has been soft-deleted. Non-admin callers
+    never receive soft-deleted versions regardless of this flag.
     """
+
+    admin_include_deleted = include_deleted and current_user.is_admin
 
     # Step 1: Fetch all versions the user can access
     if current_user.is_admin:
-        result = await db.execute(
-            select(BibleVersionModel)
-            .where(BibleVersionModel.deleted.is_(False))
-            .order_by(BibleVersionModel.id)
-        )
+        stmt = select(BibleVersionModel).order_by(BibleVersionModel.id)
+        if not admin_include_deleted:
+            stmt = stmt.where(BibleVersionModel.deleted.is_(False))
+        result = await db.execute(stmt)
         versions = result.scalars().all()
     else:
         user_groups_subq = (

--- a/models.py
+++ b/models.py
@@ -98,6 +98,7 @@ class VersionOut_v3(BaseModel):
     owner_id: Union[int, None] = None
     group_ids: List[int] = []
     is_reference: bool = False
+    deleted: bool = False
 
     model_config = {
         "json_schema_extra": {
@@ -111,6 +112,7 @@ class VersionOut_v3(BaseModel):
                 "is_reference": False,
                 "owner_id": 1,
                 "group_ids": [1, 2],
+                "deleted": False,
             }
         },
         "from_attributes": True,

--- a/models.py
+++ b/models.py
@@ -100,6 +100,12 @@ class VersionOut_v3(BaseModel):
     is_reference: bool = False
     deleted: bool = False
 
+    @field_validator("deleted", mode="before")
+    @classmethod
+    def _coerce_deleted_null_to_false(cls, value):
+        # BibleVersion.deleted column is nullable; legacy rows have NULL.
+        return False if value is None else value
+
     model_config = {
         "json_schema_extra": {
             "example": {

--- a/test/test_bible_routes/test_version_routes.py
+++ b/test/test_bible_routes/test_version_routes.py
@@ -535,6 +535,42 @@ class TestIncludeDeleted:
         assert deleted_id not in by_id
         assert by_id[kept_id]["deleted"] is False
 
+    def test_admin_include_deleted_handles_null_deleted_column(
+        self, client, admin_token, regular_token1, db_session
+    ):
+        # BibleVersion.deleted is a nullable Boolean column; legacy rows may
+        # have NULL. Force one row to NULL and confirm the response coerces
+        # it to False rather than 500ing on Pydantic validation.
+        group_1 = db_session.query(Group).filter_by(name="Group1").first()
+        regular_headers = {"Authorization": f"Bearer {regular_token1}"}
+        admin_headers = {"Authorization": f"Bearer {admin_token}"}
+
+        legacy_params = {
+            **new_version_data,
+            "name": "Legacy Version",
+            "abbreviation": "LV",
+            "add_to_groups": [group_1.id],
+        }
+        legacy_id = client.post(
+            f"{prefix}/version", json=legacy_params, headers=regular_headers
+        ).json()["id"]
+
+        legacy_row = (
+            db_session.query(BibleVersionModel).filter_by(id=legacy_id).first()
+        )
+        legacy_row.deleted = None
+        db_session.commit()
+
+        list_response = client.get(
+            f"{prefix}/version",
+            params={"include_deleted": "true"},
+            headers=admin_headers,
+        )
+        assert list_response.status_code == 200, list_response.text
+        by_id = {v["id"]: v for v in list_response.json()}
+        assert legacy_id in by_id
+        assert by_id[legacy_id]["deleted"] is False
+
 
 class TestVersionValidation:
     def test_create_version_without_add_to_groups(self, client, regular_token1):

--- a/test/test_bible_routes/test_version_routes.py
+++ b/test/test_bible_routes/test_version_routes.py
@@ -530,9 +530,10 @@ class TestIncludeDeleted:
             headers=regular_headers,
         )
         assert list_response.status_code == 200
-        listed_ids = {v["id"] for v in list_response.json()}
-        assert kept_id in listed_ids
-        assert deleted_id not in listed_ids
+        by_id = {v["id"]: v for v in list_response.json()}
+        assert kept_id in by_id
+        assert deleted_id not in by_id
+        assert by_id[kept_id]["deleted"] is False
 
 
 class TestVersionValidation:

--- a/test/test_bible_routes/test_version_routes.py
+++ b/test/test_bible_routes/test_version_routes.py
@@ -438,6 +438,103 @@ class TestListExcludesDeleted:
         assert deleted_id not in listed_ids
 
 
+class TestIncludeDeleted:
+    """Admins can opt-in to soft-deleted versions via ``include_deleted=true``
+    so downstream mirrors can satisfy FK constraints from /revision.
+    """
+
+    def _create_and_delete_pair(
+        self, client, regular_token, admin_token, db_session
+    ):
+        group_1 = db_session.query(Group).filter_by(name="Group1").first()
+        assert group_1 is not None
+        regular_headers = {"Authorization": f"Bearer {regular_token}"}
+        admin_headers = {"Authorization": f"Bearer {admin_token}"}
+
+        kept_params = {
+            **new_version_data,
+            "name": "Kept Version",
+            "abbreviation": "KV2",
+            "add_to_groups": [group_1.id],
+        }
+        kept_id = client.post(
+            f"{prefix}/version", json=kept_params, headers=regular_headers
+        ).json()["id"]
+
+        deleted_params = {
+            **new_version_data,
+            "name": "Doomed Version",
+            "abbreviation": "DV2",
+            "add_to_groups": [group_1.id],
+        }
+        deleted_id = client.post(
+            f"{prefix}/version", json=deleted_params, headers=regular_headers
+        ).json()["id"]
+
+        delete_response = client.delete(
+            f"{prefix}/version", params={"id": deleted_id}, headers=admin_headers
+        )
+        assert delete_response.status_code == 200
+
+        return kept_id, deleted_id
+
+    def test_admin_include_deleted_true_returns_soft_deleted_versions(
+        self, client, admin_token, regular_token1, db_session
+    ):
+        admin_headers = {"Authorization": f"Bearer {admin_token}"}
+        kept_id, deleted_id = self._create_and_delete_pair(
+            client, regular_token1, admin_token, db_session
+        )
+
+        list_response = client.get(
+            f"{prefix}/version",
+            params={"include_deleted": "true"},
+            headers=admin_headers,
+        )
+        assert list_response.status_code == 200
+        by_id = {v["id"]: v for v in list_response.json()}
+        assert kept_id in by_id
+        assert deleted_id in by_id
+        assert by_id[kept_id]["deleted"] is False
+        assert by_id[deleted_id]["deleted"] is True
+
+    def test_admin_include_deleted_false_still_hides_deleted(
+        self, client, admin_token, regular_token1, db_session
+    ):
+        admin_headers = {"Authorization": f"Bearer {admin_token}"}
+        kept_id, deleted_id = self._create_and_delete_pair(
+            client, regular_token1, admin_token, db_session
+        )
+
+        list_response = client.get(
+            f"{prefix}/version",
+            params={"include_deleted": "false"},
+            headers=admin_headers,
+        )
+        assert list_response.status_code == 200
+        listed_ids = {v["id"] for v in list_response.json()}
+        assert kept_id in listed_ids
+        assert deleted_id not in listed_ids
+
+    def test_non_admin_cannot_see_deleted_even_with_include_deleted(
+        self, client, admin_token, regular_token1, db_session
+    ):
+        regular_headers = {"Authorization": f"Bearer {regular_token1}"}
+        kept_id, deleted_id = self._create_and_delete_pair(
+            client, regular_token1, admin_token, db_session
+        )
+
+        list_response = client.get(
+            f"{prefix}/version",
+            params={"include_deleted": "true"},
+            headers=regular_headers,
+        )
+        assert list_response.status_code == 200
+        listed_ids = {v["id"] for v in list_response.json()}
+        assert kept_id in listed_ids
+        assert deleted_id not in listed_ids
+
+
 class TestVersionValidation:
     def test_create_version_without_add_to_groups(self, client, regular_token1):
         """Test that creating a version without add_to_groups fails with 422."""

--- a/test/test_bible_routes/test_version_routes.py
+++ b/test/test_bible_routes/test_version_routes.py
@@ -443,9 +443,7 @@ class TestIncludeDeleted:
     so downstream mirrors can satisfy FK constraints from /revision.
     """
 
-    def _create_and_delete_pair(
-        self, client, regular_token, admin_token, db_session
-    ):
+    def _create_and_delete_pair(self, client, regular_token, admin_token, db_session):
         group_1 = db_session.query(Group).filter_by(name="Group1").first()
         assert group_1 is not None
         regular_headers = {"Authorization": f"Bearer {regular_token}"}
@@ -555,9 +553,7 @@ class TestIncludeDeleted:
             f"{prefix}/version", json=legacy_params, headers=regular_headers
         ).json()["id"]
 
-        legacy_row = (
-            db_session.query(BibleVersionModel).filter_by(id=legacy_id).first()
-        )
+        legacy_row = db_session.query(BibleVersionModel).filter_by(id=legacy_id).first()
         legacy_row.deleted = None
         db_session.commit()
 


### PR DESCRIPTION
## Summary
- Adds optional `include_deleted` query parameter to `GET /v3/version`. When `true` AND the caller is an admin, soft-deleted versions are returned alongside live ones. Non-admins never see soft-deleted versions regardless of the flag.
- Exposes `deleted: bool` on `VersionOut_v3` so downstream mirrors (e.g. `aqua-django-app`) can mark their own soft-delete state correctly.
- Tests cover all three branches: admin opt-in returns deleted, admin default still hides deleted, and non-admins can't escalate via the flag.

Closes #699.

## Why
`GET /revision` returns revisions whose parent version was soft-deleted, but `GET /version` filters those parents out — `aqua-django-app`'s `sync_api_data` then fails with an FK violation and rolls back the entire batch (staging is ~12,800 revisions behind upstream). The new flag lets admin mirrors fetch the parents they need.

## Test plan
- [x] `pytest test/test_bible_routes/test_version_routes.py -v` — 9 passed locally (3 new in `TestIncludeDeleted`).
- [ ] CI green.
- [ ] Confirm `aqua-django-app` sync runs cleanly against staging once deployed.