### PR TITLE
feat(lexeme-card): PATCH /translation primitive splits source/target writes

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1238,8 +1238,13 @@ async def patch_lexeme_card_translation(
     and disambiguation is required.
 
     ``is_user_edit=true`` bumps ``last_user_edit`` on every row this patch
-    touches — the user is implicitly approving target-side state when they
-    save an edit that included a source-side change, and vice versa.
+    actually writes to: the canonical row when target-side/shared fields
+    are in the body, the overlay row when source-side fields are in the
+    body. A source-only edit does NOT bump the canonical's
+    ``last_user_edit`` — the user didn't approve the target state, they
+    just changed the source view. The response's top-level
+    ``last_user_edit`` is the max of the two so the UI can render
+    "edited recently" without having to inspect both timestamps.
 
     ``examples`` are not yet supported in the overlay branch (when
     ``language_iso != canonical iso``); pass the full overlay including
@@ -1331,13 +1336,19 @@ async def patch_lexeme_card_translation(
         if "examples" in provided_fields:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=(
-                    "examples patching is not supported when language_iso "
-                    "differs from the card's canonical source_language_iso "
-                    f"(canonical={card.source_language_iso!r}). Use "
-                    "POST /v3/agent/lexeme-card/{card_id}/translation to "
-                    "rewrite the full overlay including example translations."
-                ),
+                detail={
+                    "message": (
+                        "examples patching is not supported when language_iso "
+                        "differs from the card's canonical source_language_iso "
+                        f"(canonical={card.source_language_iso!r}). Use "
+                        f"POST /v3/agent/lexeme-card/{card.id}/translation to "
+                        "rewrite the full overlay including example translations."
+                    ),
+                    "card_id": card.id,
+                    "overlay_post_url": (
+                        f"/v3/agent/lexeme-card/{card.id}/translation"
+                    ),
+                },
             )
 
         canonical_fields = provided_fields & _CANONICAL_PATCH_FIELDS
@@ -1362,15 +1373,17 @@ async def patch_lexeme_card_translation(
 
         # --- Canonical-side patches ---------------------------------------
         if "target_lemma" in canonical_fields:
+            # patch_data.target_lemma was NFC-lowercased by the validator on
+            # the way in, and the stored canonical column was likewise
+            # lowercased at write time. Compare directly.
             new_target = patch_data.target_lemma
-            if new_target.lower() != card.target_lemma.lower():
+            if new_target != card.target_lemma:
                 # Uniqueness is enforced on (LOWER(target_lemma),
                 # source_version_id, target_version_id). Check before write
                 # to give a 409 instead of a 500 from the constraint.
                 dup = await db.scalar(
                     select(AgentLexemeCard).where(
-                        sql_func.lower(AgentLexemeCard.target_lemma)
-                        == new_target.lower(),
+                        sql_func.lower(AgentLexemeCard.target_lemma) == new_target,
                         AgentLexemeCard.source_version_id == card.source_version_id,
                         AgentLexemeCard.target_version_id == card.target_version_id,
                         AgentLexemeCard.id != card.id,
@@ -1637,6 +1650,18 @@ async def _build_lexeme_card_out_for_lang(
         source_surface_forms = card.source_surface_forms
         senses = card.senses
 
+    # last_user_edit: surface the most recent of (canonical, overlay) so the
+    # UI's "edited recently" indicator catches source-only overlay edits.
+    # The bulk GET returns canonical's value only; matches that shape when no
+    # overlay exists, surfaces the overlay timestamp when one does.
+    effective_last_user_edit = card.last_user_edit
+    if overlay is not None and overlay.last_user_edit is not None:
+        if (
+            effective_last_user_edit is None
+            or overlay.last_user_edit > effective_last_user_edit
+        ):
+            effective_last_user_edit = overlay.last_user_edit
+
     return LexemeCardOut.model_validate(
         {
             "id": card.id,
@@ -1654,7 +1679,7 @@ async def _build_lexeme_card_out_for_lang(
             "build_version": card.build_version,
             "created_at": card.created_at,
             "last_updated": card.last_updated,
-            "last_user_edit": card.last_user_edit,
+            "last_user_edit": effective_last_user_edit,
             "examples": examples_out,
             "has_translation_overlay": (not requires_merge) or (overlay is not None),
         }
@@ -1734,6 +1759,119 @@ async def patch_lexeme_card_by_id(
     except SQLAlchemyError as e:
         await db.rollback()
         logger.error(f"Error patching lexeme card: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(e)}",
+        ) from e
+
+
+@router.patch(
+    "/agent/lexeme-card",
+    response_model=LexemeCardOut,
+    deprecated=True,
+)
+async def patch_lexeme_card_by_lemma_DEPRECATED(
+    patch_data: LexemeCardPatch,
+    target_lemma: str,
+    source_version_id: int,
+    target_version_id: int,
+    source_lemma: str = None,
+    list_mode: ListMode = ListMode.append,
+    is_user_edit: bool = False,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """**DEPRECATED — internal callers only.** Use
+    ``PATCH /v3/agent/lexeme-card/translation`` instead.
+
+    Partially update a lexeme card by lemma lookup, writing directly to the
+    canonical ``agent_lexeme_cards`` row. This endpoint is **unsafe for UI
+    callers**: when the canonical's source language is the pivot (e.g. swh)
+    and the UI is viewing the card in another language (e.g. eng), a write
+    to ``source_lemma`` here will silently overwrite the pivot canonical
+    with the UI's language text and corrupt every other consumer's view.
+
+    The new ``/agent/lexeme-card/translation`` endpoint solves that by
+    routing source-side writes to the per-language ``card_translations``
+    overlay row. UI clients MUST migrate.
+
+    This endpoint is kept only because aqua-assessments' derivation pipeline
+    (``word_memory_builder.update_lexeme_by_lemma_api``) uses it as a
+    POST→409 fallback to patch ``surface_forms`` / ``source_surface_forms``
+    / ``alignment_scores`` on the canonical it just built. Those writes are
+    safe because the caller knows the canonical's source language matches
+    what it's writing. Once that pipeline migrates to the by-id PATCH or to
+    the new translation endpoint, this route should be removed.
+
+    Query Parameters:
+    - target_lemma: str (required) - The target language lemma
+    - source_version_id: int (required) - Bible version ID for source
+    - target_version_id: int (required) - Bible version ID for target
+    - source_lemma: str (optional) - Disambiguates when multiple cards
+      share the same (target_lemma, source_version_id, target_version_id).
+    - list_mode: str (optional, default="append") - append / replace / merge.
+    - is_user_edit: bool (optional, default=False) - Sets last_user_edit.
+
+    Body: LexemeCardPatch (all fields optional, only provided fields update).
+    """
+    request_start = time.perf_counter()
+    try:
+        from sqlalchemy import select
+        from sqlalchemy.sql import func as sql_func
+
+        query = select(AgentLexemeCard).where(
+            sql_func.lower(AgentLexemeCard.target_lemma) == target_lemma.lower(),
+            AgentLexemeCard.source_version_id == source_version_id,
+            AgentLexemeCard.target_version_id == target_version_id,
+        )
+        if source_lemma is not None:
+            query = query.where(
+                sql_func.lower(AgentLexemeCard.source_lemma) == source_lemma.lower()
+            )
+        cards = (await db.execute(query)).scalars().all()
+
+        if not cards:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Lexeme card not found for target_lemma={target_lemma}, "
+                    f"source_version_id={source_version_id}, "
+                    f"target_version_id={target_version_id}"
+                    + (f", source_lemma={source_lemma}" if source_lemma else "")
+                ),
+            )
+        if len(cards) > 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Multiple lexeme cards found ({len(cards)}). "
+                    "Please provide source_lemma to disambiguate."
+                ),
+            )
+
+        result_card = await _apply_lexeme_card_patch(
+            cards[0], patch_data, list_mode, current_user, db, is_user_edit
+        )
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"patch_lexeme_card_by_lemma (deprecated) completed in {duration}s",
+            extra={
+                "method": "PATCH",
+                "path": "/agent/lexeme-card",
+                "deprecated": True,
+                "target_lemma": target_lemma,
+                "source_version_id": source_version_id,
+                "target_version_id": target_version_id,
+                "duration_s": duration,
+            },
+        )
+        return result_card
+
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error(f"Error patching lexeme card by lemma (deprecated): {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Database error: {str(e)}",

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -968,6 +968,17 @@ async def _apply_lexeme_card_patch(
 
     provided_fields = patch_data.model_fields_set
 
+    # target_lemma is NOT NULL; reject explicit null with 400 rather than
+    # letting the DB raise an opaque 500 IntegrityError downstream.
+    if "target_lemma" in provided_fields and patch_data.target_lemma is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "target_lemma cannot be null. To leave it unchanged, omit "
+                "the field from the patch body."
+            ),
+        )
+
     # Check if changing target_lemma would create a duplicate
     # Uniqueness is enforced on (LOWER(target_lemma), source_version_id, target_version_id)
     if (
@@ -992,9 +1003,16 @@ async def _apply_lexeme_card_patch(
                 },
             )
 
-    # Scalar fields - update if provided
+    # Scalar fields - update if provided. source_lemma is lowercased here
+    # (the Pydantic validator only NFC-normalizes) to honor the canonical
+    # source_lemma case-insensitive index; the overlay write path elsewhere
+    # preserves casing instead.
     if "source_lemma" in provided_fields:
-        card.source_lemma = patch_data.source_lemma
+        card.source_lemma = (
+            patch_data.source_lemma.lower()
+            if patch_data.source_lemma is not None
+            else None
+        )
     if "target_lemma" in provided_fields:
         card.target_lemma = patch_data.target_lemma
     if "pos" in provided_fields:
@@ -1377,6 +1395,16 @@ async def patch_lexeme_card_translation(
             # the way in, and the stored canonical column was likewise
             # lowercased at write time. Compare directly.
             new_target = patch_data.target_lemma
+            if new_target is None:
+                # Column is NOT NULL; reject explicit null with 400 rather
+                # than letting the DB raise an opaque 500 IntegrityError.
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=(
+                        "target_lemma cannot be null. To leave it unchanged, "
+                        "omit the field from the patch body."
+                    ),
+                )
             if new_target != card.target_lemma:
                 # Uniqueness is enforced on (LOWER(target_lemma),
                 # source_version_id, target_version_id). Check before write
@@ -2919,6 +2947,7 @@ async def add_lexeme_card_translation(
         build_version=translation_row.build_version,
         created_at=translation_row.created_at,
         last_updated=translation_row.last_updated,
+        last_user_edit=translation_row.last_user_edit,
         examples=[
             {
                 "id": e.id,

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1174,6 +1174,493 @@ async def _apply_lexeme_card_patch(
     return LexemeCardOut.model_validate(card_dict)
 
 
+# Fields in LexemeCardPatch routed to the canonical agent_lexeme_cards row
+# in overlay-mode patching. Includes target-side and shared-metadata fields
+# that have no per-language overlay column.
+_CANONICAL_PATCH_FIELDS = {
+    "target_lemma",
+    "surface_forms",
+    "pos",
+    "confidence",
+    "english_lemma",
+    "alignment_scores",
+    "build_version",
+}
+# Fields routed to the card_translations overlay row for (card_id, language_iso)
+# in overlay-mode patching. Source-side identity and senses.
+_OVERLAY_PATCH_FIELDS = {
+    "source_lemma",
+    "source_surface_forms",
+    "senses",
+}
+
+
+# NOTE: this literal-path route MUST be declared before
+# @router.patch("/agent/lexeme-card/{card_id}") below — FastAPI matches routes
+# in declaration order, and "translation" would otherwise be captured as a
+# card_id and fail Pydantic int validation.
+@router.patch("/agent/lexeme-card/translation", response_model=LexemeCardOut)
+async def patch_lexeme_card_translation(
+    patch_data: LexemeCardPatch,
+    target_lemma: str,
+    target_version_id: int,
+    language_iso: str = Query(min_length=3, max_length=3),
+    source_version_id: int | None = None,
+    list_mode: ListMode = ListMode.append,
+    is_user_edit: bool = False,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Patch a lexeme card in the (target_version_id, language_iso) view.
+
+    This is the UI's PATCH primitive. The UI thinks in terms of "I am editing
+    the card I'm looking at in language X" — without any awareness of pivot
+    routing or canonical-vs-overlay storage. The endpoint splits the body
+    internally:
+
+    - Source-side fields (source_lemma, source_surface_forms, senses) land in
+      the ``card_translations`` overlay row for ``(card_id, language_iso)``,
+      upserted on conflict. The canonical's source-side stays untouched, so
+      edits in (target, eng) view can't corrupt the (target, swh) pivot.
+    - Target-side and shared fields (target_lemma, surface_forms, pos,
+      confidence, english_lemma, alignment_scores, build_version) land in
+      the canonical ``agent_lexeme_cards`` row. There is only one target
+      column physically, so all overlays project the same target text — fixing
+      a typo from any language view fixes it everywhere.
+    - When ``language_iso`` equals the card's canonical ``source_language_iso``
+      (no pivot routing in play, or pivot resolves back to the requested
+      lang), everything goes to the canonical row — there is no overlay to
+      write to.
+
+    Lookup is pivot-routed via ``_effective_source_version_expr``: pass
+    ``source_version_id`` (typically the UI's reference version) only when
+    multiple canonicals share the same ``(target_lemma, target_version_id)``
+    and disambiguation is required.
+
+    ``is_user_edit=true`` bumps ``last_user_edit`` on every row this patch
+    touches — the user is implicitly approving target-side state when they
+    save an edit that included a source-side change, and vice versa.
+
+    ``examples`` are not yet supported in the overlay branch (when
+    ``language_iso != canonical iso``); pass the full overlay including
+    example translations via ``POST /v3/agent/lexeme-card/{card_id}/translation``
+    instead. They are supported in the canonical-match branch via the
+    existing canonical patch path.
+
+    Returns the resulting card shaped as if ``GET /v3/agent/lexeme-card``
+    had just been called with the same ``language_iso``, so the UI can
+    rebind its form state directly from the response.
+    """
+    request_start = time.perf_counter()
+    try:
+        from sqlalchemy import select
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+        from sqlalchemy.sql import func as sql_func
+
+        language_iso_lower = language_iso.lower()
+        target_lemma_lower = unicodedata.normalize("NFC", target_lemma).lower()
+
+        conditions = [
+            sql_func.lower(AgentLexemeCard.target_lemma) == target_lemma_lower,
+            AgentLexemeCard.target_version_id == target_version_id,
+        ]
+        if source_version_id is not None:
+            conditions.append(
+                AgentLexemeCard.source_version_id
+                == _effective_source_version_expr(source_version_id, target_version_id)
+            )
+        cards = (
+            (await db.execute(select(AgentLexemeCard).where(*conditions)))
+            .scalars()
+            .all()
+        )
+
+        if not cards:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"Lexeme card not found for target_lemma={target_lemma}, "
+                    f"target_version_id={target_version_id}, "
+                    f"language_iso={language_iso_lower}"
+                    + (
+                        f", source_version_id={source_version_id}"
+                        if source_version_id is not None
+                        else ""
+                    )
+                ),
+            )
+        if len(cards) > 1:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Multiple lexeme cards ({len(cards)}) matched "
+                    f"(target_lemma={target_lemma}, target_version_id={target_version_id}). "
+                    "Provide source_version_id to disambiguate."
+                ),
+            )
+        card = cards[0]
+
+        provided_fields = patch_data.model_fields_set
+        canonical_match = language_iso_lower == card.source_language_iso
+
+        if canonical_match:
+            # Degenerate case: the requested lang IS the canonical lang. There
+            # is no overlay table for it; everything goes to the canonical
+            # row exactly like PATCH by id.
+            result_card = await _apply_lexeme_card_patch(
+                card, patch_data, list_mode, current_user, db, is_user_edit
+            )
+            duration = round(time.perf_counter() - request_start, 2)
+            logger.info(
+                f"patch_lexeme_card_translation completed in {duration}s",
+                extra={
+                    "method": "PATCH",
+                    "path": "/agent/lexeme-card/translation",
+                    "card_id": card.id,
+                    "language_iso": language_iso_lower,
+                    "canonical_match": True,
+                    "overlay_written": False,
+                    "canonical_written": True,
+                    "duration_s": duration,
+                },
+            )
+            return result_card
+
+        # Overlay mode: split the patch between the canonical row and the
+        # (card_id, language_iso) overlay row.
+        if "examples" in provided_fields:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    "examples patching is not supported when language_iso "
+                    "differs from the card's canonical source_language_iso "
+                    f"(canonical={card.source_language_iso!r}). Use "
+                    "POST /v3/agent/lexeme-card/{card_id}/translation to "
+                    "rewrite the full overlay including example translations."
+                ),
+            )
+
+        canonical_fields = provided_fields & _CANONICAL_PATCH_FIELDS
+        overlay_fields = provided_fields & _OVERLAY_PATCH_FIELDS
+        unknown_fields = (
+            provided_fields - canonical_fields - overlay_fields - {"examples"}
+        )
+        if unknown_fields:
+            # Defensive: a future patch model addition would route to neither
+            # destination. Fail loudly rather than silently dropping the edit.
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=(
+                    f"Unsupported patch fields for overlay mode: "
+                    f"{sorted(unknown_fields)}"
+                ),
+            )
+
+        now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+        canonical_touched = False
+        overlay_touched = False
+
+        # --- Canonical-side patches ---------------------------------------
+        if "target_lemma" in canonical_fields:
+            new_target = patch_data.target_lemma
+            if new_target.lower() != card.target_lemma.lower():
+                # Uniqueness is enforced on (LOWER(target_lemma),
+                # source_version_id, target_version_id). Check before write
+                # to give a 409 instead of a 500 from the constraint.
+                dup = await db.scalar(
+                    select(AgentLexemeCard).where(
+                        sql_func.lower(AgentLexemeCard.target_lemma)
+                        == new_target.lower(),
+                        AgentLexemeCard.source_version_id == card.source_version_id,
+                        AgentLexemeCard.target_version_id == card.target_version_id,
+                        AgentLexemeCard.id != card.id,
+                    )
+                )
+                if dup is not None:
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "message": (
+                                f"Cannot change target_lemma to {new_target!r} — "
+                                "another card with this target_lemma already "
+                                "exists for this language pair."
+                            ),
+                            "existing_card_id": dup.id,
+                        },
+                    )
+            card.target_lemma = new_target
+            canonical_touched = True
+        if "pos" in canonical_fields:
+            card.pos = patch_data.pos
+            canonical_touched = True
+        if "confidence" in canonical_fields:
+            card.confidence = patch_data.confidence
+            canonical_touched = True
+        if "english_lemma" in canonical_fields:
+            card.english_lemma = patch_data.english_lemma
+            canonical_touched = True
+        if "build_version" in canonical_fields:
+            card.build_version = patch_data.build_version
+            canonical_touched = True
+        if "alignment_scores" in canonical_fields:
+            if patch_data.alignment_scores is None:
+                card.alignment_scores = None
+            else:
+                existing_scores = (
+                    dict(card.alignment_scores) if card.alignment_scores else {}
+                )
+                for key, value in patch_data.alignment_scores.items():
+                    if value is None:
+                        existing_scores.pop(key, None)
+                    else:
+                        existing_scores[key] = value
+                if existing_scores:
+                    card.alignment_scores = dict(
+                        sorted(
+                            existing_scores.items(),
+                            key=lambda x: x[1],
+                            reverse=True,
+                        )
+                    )
+                else:
+                    card.alignment_scores = None
+            canonical_touched = True
+        if "surface_forms" in canonical_fields:
+            if list_mode == ListMode.replace:
+                card.surface_forms = patch_data.surface_forms
+            elif list_mode == ListMode.merge:
+                card.surface_forms = _merge_lists_case_insensitive(
+                    card.surface_forms, patch_data.surface_forms
+                )
+            else:  # append
+                card.surface_forms = (card.surface_forms or []) + (
+                    patch_data.surface_forms or []
+                )
+            canonical_touched = True
+
+        if canonical_touched:
+            card.last_updated = now
+            if is_user_edit:
+                card.last_user_edit = now
+
+        # --- Overlay-side patches -----------------------------------------
+        # Build the overlay column values from the existing row (if any) so
+        # list-mode append/merge can see what's already stored. The upsert
+        # below writes back the full overlay row; conflict triggers DO UPDATE.
+        if overlay_fields:
+            existing_overlay = await db.scalar(
+                select(CardTranslation).where(
+                    CardTranslation.card_id == card.id,
+                    CardTranslation.language_iso == language_iso_lower,
+                )
+            )
+            new_source_lemma = (
+                patch_data.source_lemma
+                if "source_lemma" in overlay_fields
+                else (existing_overlay.source_lemma if existing_overlay else None)
+            )
+            if "source_surface_forms" in overlay_fields:
+                existing_ssf = (
+                    existing_overlay.source_surface_forms if existing_overlay else None
+                )
+                if list_mode == ListMode.replace:
+                    new_source_surface_forms = patch_data.source_surface_forms
+                elif list_mode == ListMode.merge:
+                    new_source_surface_forms = _merge_lists_case_insensitive(
+                        existing_ssf, patch_data.source_surface_forms
+                    )
+                else:  # append
+                    new_source_surface_forms = (existing_ssf or []) + (
+                        patch_data.source_surface_forms or []
+                    )
+            else:
+                new_source_surface_forms = (
+                    existing_overlay.source_surface_forms if existing_overlay else None
+                )
+            if "senses" in overlay_fields:
+                existing_senses = existing_overlay.senses if existing_overlay else None
+                if list_mode == ListMode.replace:
+                    new_senses = patch_data.senses
+                else:  # append/merge (dicts don't dedupe meaningfully)
+                    new_senses = (existing_senses or []) + (patch_data.senses or [])
+            else:
+                new_senses = existing_overlay.senses if existing_overlay else None
+
+            upsert_stmt = (
+                pg_insert(CardTranslation)
+                .values(
+                    card_id=card.id,
+                    language_iso=language_iso_lower,
+                    source_lemma=new_source_lemma,
+                    source_surface_forms=new_source_surface_forms,
+                    senses=new_senses,
+                    last_updated=now,
+                    last_user_edit=now if is_user_edit else None,
+                )
+                .on_conflict_do_update(
+                    index_elements=["card_id", "language_iso"],
+                    set_={
+                        "source_lemma": new_source_lemma,
+                        "source_surface_forms": new_source_surface_forms,
+                        "senses": new_senses,
+                        "last_updated": now,
+                        **({"last_user_edit": now} if is_user_edit else {}),
+                    },
+                )
+            )
+            await db.execute(upsert_stmt)
+            overlay_touched = True
+
+        await db.commit()
+        await db.refresh(card)
+
+        result_card = await _build_lexeme_card_out_for_lang(
+            card, language_iso_lower, current_user, db
+        )
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"patch_lexeme_card_translation completed in {duration}s",
+            extra={
+                "method": "PATCH",
+                "path": "/agent/lexeme-card/translation",
+                "card_id": card.id,
+                "language_iso": language_iso_lower,
+                "canonical_match": False,
+                "overlay_written": overlay_touched,
+                "canonical_written": canonical_touched,
+                "duration_s": duration,
+            },
+        )
+        return result_card
+
+    except HTTPException:
+        raise
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error(f"Error in patch_lexeme_card_translation: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {str(e)}",
+        ) from e
+
+
+async def _build_lexeme_card_out_for_lang(
+    card: AgentLexemeCard,
+    language_iso: str,
+    current_user: UserModel,
+    db: AsyncSession,
+) -> LexemeCardOut:
+    """Build LexemeCardOut for ``card`` in the requested ``language_iso`` view.
+
+    Mirrors the GET /agent/lexeme-card response shape: if ``language_iso``
+    matches the canonical, returns canonical fields verbatim; otherwise
+    merges the matching card_translations overlay and sets
+    ``has_translation_overlay`` accordingly. Examples are filtered to
+    revisions the current user has access to.
+    """
+    from sqlalchemy import select
+
+    requires_merge = language_iso != card.source_language_iso
+    overlay = None
+    overlay_examples: dict[int, str] = {}
+    if requires_merge:
+        overlay = await db.scalar(
+            select(CardTranslation).where(
+                CardTranslation.card_id == card.id,
+                CardTranslation.language_iso == language_iso,
+            )
+        )
+        if overlay is not None:
+            te_rows = (
+                await db.execute(
+                    select(
+                        CardTranslationExample.example_id,
+                        CardTranslationExample.source_text,
+                    ).where(CardTranslationExample.card_translation_id == overlay.id)
+                )
+            ).all()
+            overlay_examples = {row.example_id: row.source_text for row in te_rows}
+
+    examples_query = (
+        select(AgentLexemeCardExample)
+        .where(AgentLexemeCardExample.lexeme_card_id == card.id)
+        .order_by(AgentLexemeCardExample.id)
+    )
+    if not current_user.is_admin:
+        authorized_revisions_subq = (
+            select(BibleRevision.id)
+            .distinct()
+            .join(BibleVersion, BibleVersion.id == BibleRevision.bible_version_id)
+            .join(
+                BibleVersionAccess,
+                BibleVersionAccess.bible_version_id == BibleVersion.id,
+            )
+            .join(UserGroup, UserGroup.group_id == BibleVersionAccess.group_id)
+            .where(
+                UserGroup.user_id == current_user.id,
+                BibleVersion.id.in_([card.source_version_id, card.target_version_id]),
+            )
+        )
+        examples_query = examples_query.where(
+            AgentLexemeCardExample.revision_id.in_(authorized_revisions_subq)
+        )
+    example_rows = (await db.execute(examples_query)).scalars().all()
+
+    if requires_merge and overlay is None:
+        # Same shape the bulk GET returns for missing overlays: null out
+        # source-side fields and example source text.
+        examples_out = [
+            {"id": ex.id, "source": None, "target": ex.target_text}
+            for ex in example_rows
+        ]
+        source_lemma = None
+        source_surface_forms = None
+        senses = None
+    elif requires_merge:
+        examples_out = [
+            {
+                "id": ex.id,
+                "source": overlay_examples.get(ex.id, ex.source_text),
+                "target": ex.target_text,
+            }
+            for ex in example_rows
+        ]
+        source_lemma = overlay.source_lemma
+        source_surface_forms = overlay.source_surface_forms
+        senses = overlay.senses
+    else:
+        examples_out = [
+            {"id": ex.id, "source": ex.source_text, "target": ex.target_text}
+            for ex in example_rows
+        ]
+        source_lemma = card.source_lemma
+        source_surface_forms = card.source_surface_forms
+        senses = card.senses
+
+    return LexemeCardOut.model_validate(
+        {
+            "id": card.id,
+            "source_lemma": source_lemma,
+            "target_lemma": card.target_lemma,
+            "source_version_id": card.source_version_id,
+            "target_version_id": card.target_version_id,
+            "pos": card.pos,
+            "surface_forms": card.surface_forms,
+            "source_surface_forms": source_surface_forms,
+            "senses": senses,
+            "confidence": card.confidence,
+            "english_lemma": card.english_lemma,
+            "alignment_scores": card.alignment_scores,
+            "build_version": card.build_version,
+            "created_at": card.created_at,
+            "last_updated": card.last_updated,
+            "last_user_edit": card.last_user_edit,
+            "examples": examples_out,
+            "has_translation_overlay": (not requires_merge) or (overlay is not None),
+        }
+    )
+
+
 @router.patch("/agent/lexeme-card/{card_id}", response_model=LexemeCardOut)
 async def patch_lexeme_card_by_id(
     card_id: int,
@@ -1247,117 +1734,6 @@ async def patch_lexeme_card_by_id(
     except SQLAlchemyError as e:
         await db.rollback()
         logger.error(f"Error patching lexeme card: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Database error: {str(e)}",
-        ) from e
-
-
-@router.patch("/agent/lexeme-card", response_model=LexemeCardOut)
-async def patch_lexeme_card_by_lemma(
-    patch_data: LexemeCardPatch,
-    target_lemma: str,
-    source_version_id: int,
-    target_version_id: int,
-    source_lemma: str = None,
-    list_mode: ListMode = ListMode.append,
-    is_user_edit: bool = False,
-    db: AsyncSession = Depends(get_db),
-    current_user: UserModel = Depends(get_current_user),
-):
-    """
-    Partially update a lexeme card by lemma lookup.
-
-    Query Parameters:
-    - target_lemma: str (required) - The target language lemma
-    - source_version_id: int (required) - Bible version ID for source
-    - target_version_id: int (required) - Bible version ID for target
-    - source_lemma: str (optional) - The source language lemma
-    - list_mode: str (optional, default="append") - How to handle list fields:
-      - "append": Add new items to existing lists (no deduplication)
-      - "replace": Overwrite entire lists
-      - "merge": Append + deduplicate case-insensitively (for string lists like
-        surface_forms); preserves original casing of existing items
-    - is_user_edit: bool (optional, default=False) - If True, sets the last_user_edit
-      timestamp. Use for user-initiated writes to distinguish from automated updates.
-
-    Note: The POST endpoint's append behavior differs - it uses case-sensitive
-    deduplication via set(). Use list_mode="merge" here for smart deduplication.
-
-    Body:
-    - LexemeCardPatch: Partial update data. Only provided fields are updated.
-      - source_lemma, target_lemma, pos, confidence, english_lemma: Scalar fields
-      - surface_forms, source_surface_forms: String list fields
-      - senses: List of sense dictionaries
-      - examples: List of example dicts, each must include revision_id
-      - alignment_scores: Dict - keys merge with existing; null value removes key
-
-    Returns:
-    - LexemeCardOut: The updated lexeme card
-    """
-    request_start = time.perf_counter()
-    try:
-        from sqlalchemy import select
-
-        # Fetch the card by lemma lookup (case-insensitive)
-        # Build query with required fields
-        from sqlalchemy.sql import func as sql_func
-
-        query = select(AgentLexemeCard).where(
-            sql_func.lower(AgentLexemeCard.target_lemma) == target_lemma.lower(),
-            AgentLexemeCard.source_version_id == source_version_id,
-            AgentLexemeCard.target_version_id == target_version_id,
-        )
-
-        # Only filter by source_lemma if explicitly provided
-        if source_lemma is not None:
-            query = query.where(
-                sql_func.lower(AgentLexemeCard.source_lemma) == source_lemma.lower()
-            )
-
-        result = await db.execute(query)
-        cards = result.scalars().all()
-
-        if not cards:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"Lexeme card not found for target_lemma={target_lemma}, "
-                f"source_version_id={source_version_id}, "
-                f"target_version_id={target_version_id}"
-                + (f", source_lemma={source_lemma}" if source_lemma else ""),
-            )
-
-        if len(cards) > 1:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Multiple lexeme cards found ({len(cards)}). "
-                "Please provide source_lemma to disambiguate.",
-            )
-
-        card = cards[0]
-
-        result_card = await _apply_lexeme_card_patch(
-            card, patch_data, list_mode, current_user, db, is_user_edit
-        )
-        duration = round(time.perf_counter() - request_start, 2)
-        logger.info(
-            f"patch_lexeme_card_by_lemma completed in {duration}s",
-            extra={
-                "method": "PATCH",
-                "path": "/agent/lexeme-card",
-                "target_lemma": target_lemma,
-                "source_version_id": source_version_id,
-                "target_version_id": target_version_id,
-                "duration_s": duration,
-            },
-        )
-        return result_card
-
-    except HTTPException:
-        raise
-    except SQLAlchemyError as e:
-        await db.rollback()
-        logger.error(f"Error patching lexeme card by lemma: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Database error: {str(e)}",

--- a/alembic/migrations/versions/c8e1f4a72b9d_add_last_user_edit_to_card_translations.py
+++ b/alembic/migrations/versions/c8e1f4a72b9d_add_last_user_edit_to_card_translations.py
@@ -1,0 +1,34 @@
+"""Add last_user_edit to card_translations
+
+Revision ID: c8e1f4a72b9d
+Revises: a3c1e7b9d4f0
+Create Date: 2026-05-19
+
+The UI's PATCH /v3/agent/lexeme-card/translation routes user edits to the
+overlay row when the requested ``language_iso`` is not the card's canonical
+source language. Without this column the overlay row had no way to distinguish
+user-initiated edits from automated derivation updates — the canonical row
+already tracks this via its own ``last_user_edit``, so we mirror that here.
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c8e1f4a72b9d"
+down_revision = "a3c1e7b9d4f0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "card_translations",
+        sa.Column("last_user_edit", sa.TIMESTAMP(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("card_translations", "last_user_edit")

--- a/database/models.py
+++ b/database/models.py
@@ -596,6 +596,7 @@ class CardTranslation(Base):
     build_version = Column(Text, nullable=True)
     created_at = Column(TIMESTAMP, server_default=func.now(), nullable=False)
     last_updated = Column(TIMESTAMP, server_default=func.now(), nullable=False)
+    last_user_edit = Column(TIMESTAMP, nullable=True)
 
     __table_args__ = (
         Index(

--- a/models.py
+++ b/models.py
@@ -1014,6 +1014,7 @@ class CardTranslationOut(BaseModel):
     build_version: Optional[str] = None
     created_at: Optional[datetime.datetime] = None
     last_updated: Optional[datetime.datetime] = None
+    last_user_edit: Optional[datetime.datetime] = None
     examples: List[CardTranslationExampleOut] = []
 
 

--- a/models.py
+++ b/models.py
@@ -885,10 +885,14 @@ class LexemeCardPatch(BaseModel):
     def normalize_target_lemma(cls, v):
         return unicodedata.normalize("NFC", v).lower() if v else v
 
+    # NFC-only here (no .lower()). The canonical write path lowercases at the
+    # call site to honor the canonical source_lemma index; the overlay write
+    # path preserves casing (overlay source_lemma has no lookup-key role and
+    # is display data, matching CardTranslationIn's preservation contract).
     @field_validator("source_lemma")
     @classmethod
     def normalize_source_lemma(cls, v):
-        return unicodedata.normalize("NFC", v).lower() if v else v
+        return unicodedata.normalize("NFC", v) if v else v
 
     pos: Optional[str] = None
     confidence: Optional[float] = None

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -4373,110 +4373,6 @@ def test_patch_lexeme_card_by_id_unauthorized(client, test_revision_id):
     assert patch_response.status_code == 401
 
 
-def test_patch_lexeme_card_by_lemma_success(
-    client,
-    regular_token1,
-    db_session,
-    test_revision_id,
-    test_version_id,
-    test_version_id_2,
-):
-    """Test PATCH by lemma lookup works correctly."""
-    # Create initial card
-    response = client.post(
-        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "source_lemma": "lemma_lookup_test",
-            "target_lemma": "tafuta",
-            "source_version_id": test_version_id,
-            "target_version_id": test_version_id_2,
-            "confidence": 0.6,
-        },
-    )
-    assert response.status_code == 200
-
-    # PATCH by lemma lookup
-    patch_response = client.patch(
-        "/v3/agent/lexeme-card"
-        "?target_lemma=tafuta"
-        f"&source_version_id={test_version_id}"
-        f"&target_version_id={test_version_id_2}"
-        "&source_lemma=lemma_lookup_test",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "confidence": 0.9,
-            "surface_forms": ["tafuta", "anatafuta"],
-        },
-    )
-
-    assert patch_response.status_code == 200
-    data = patch_response.json()
-    assert data["confidence"] == 0.9
-    assert data["target_lemma"] == "tafuta"
-    assert len(data["surface_forms"]) == 2
-
-
-def test_patch_lexeme_card_by_lemma_not_found(
-    client, regular_token1, db_session, test_version_id, test_version_id_2
-):
-    """Test PATCH by lemma lookup returns 404 for non-existent card."""
-    patch_response = client.patch(
-        "/v3/agent/lexeme-card"
-        "?target_lemma=nonexistent"
-        f"&source_version_id={test_version_id}"
-        f"&target_version_id={test_version_id_2}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "confidence": 0.5,
-        },
-    )
-
-    assert patch_response.status_code == 404
-
-
-def test_patch_lexeme_card_by_lemma_without_source_lemma(
-    client,
-    regular_token1,
-    db_session,
-    test_revision_id,
-    test_version_id,
-    test_version_id_2,
-):
-    """Test PATCH by lemma lookup works when source_lemma is not provided."""
-    # Create initial card WITH a source_lemma
-    response = client.post(
-        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "source_lemma": "some_source",  # Card has source_lemma
-            "target_lemma": "lengo_bila",
-            "source_version_id": test_version_id,
-            "target_version_id": test_version_id_2,
-            "confidence": 0.6,
-        },
-    )
-    assert response.status_code == 200
-
-    # PATCH by lemma lookup WITHOUT source_lemma - should still find the card
-    patch_response = client.patch(
-        "/v3/agent/lexeme-card"
-        "?target_lemma=lengo_bila"
-        f"&source_version_id={test_version_id}"
-        f"&target_version_id={test_version_id_2}",
-        # Note: no source_lemma parameter
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "confidence": 0.95,
-        },
-    )
-
-    assert patch_response.status_code == 200
-    data = patch_response.json()
-    assert data["confidence"] == 0.95
-    assert data["source_lemma"] == "some_source"  # Original source_lemma preserved
-
-
 def test_post_lexeme_card_duplicate_returns_409_conflict(
     client,
     regular_token1,
@@ -6018,37 +5914,6 @@ def test_post_lexeme_card_case_insensitive_different_source_lemma_returns_409(
     assert resp2.status_code == 409
 
 
-def test_patch_lexeme_card_by_lemma_case_insensitive_lookup(
-    client,
-    regular_token1,
-    db_session,
-    test_revision_id,
-    test_version_id,
-    test_version_id_2,
-):
-    """PATCH by lemma should find the card regardless of case."""
-    # Create card
-    client.post(
-        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "source_lemma": "eat",
-            "target_lemma": "kula_ci_patch",
-            "source_version_id": test_version_id,
-            "target_version_id": test_version_id_2,
-        },
-    )
-
-    # PATCH using different case
-    resp = client.patch(
-        f"/v3/agent/lexeme-card?target_lemma=KULA_CI_PATCH&source_version_id={test_version_id}&target_version_id={test_version_id_2}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={"confidence": 0.99},
-    )
-    assert resp.status_code == 200
-    assert resp.json()["confidence"] == 0.99
-
-
 def test_patch_lexeme_card_normalizes_target_lemma(
     client,
     regular_token1,
@@ -6185,78 +6050,6 @@ def test_post_lexeme_card_case_only_source_lemma_diff_is_upsert(
     assert resp2.status_code == 200
     assert resp2.json()["id"] == card_id
     assert resp2.json()["confidence"] == 0.9
-
-
-def test_patch_lexeme_card_by_lemma_source_lemma_case_insensitive(
-    client,
-    regular_token1,
-    test_revision_id,
-    test_version_id,
-    test_version_id_2,
-):
-    """PATCH by lemma should match source_lemma case-insensitively when the
-    stored value is mixed case (e.g. legacy rows that predate the backfill)."""
-    # Insert a legacy-style mixed-case source_lemma directly, bypassing the
-    # Pydantic validator that now lowercases on the way in.
-    legacy_id = _raw_psycopg2_fetchone(
-        "INSERT INTO agent_lexeme_cards "
-        "(source_lemma, target_lemma, source_version_id, target_version_id, "
-        " confidence, created_at, last_updated) "
-        "VALUES (%s, %s, %s, %s, %s, now(), now()) RETURNING id",
-        (
-            "Jesus_LegacyCase",
-            "yesu_legacycase",
-            test_version_id,
-            test_version_id_2,
-            0.5,
-        ),
-    )[0]
-
-    # PATCH using lowercased source_lemma — must still find the mixed-case row
-    resp = client.patch(
-        f"/v3/agent/lexeme-card?target_lemma=yesu_legacycase"
-        f"&source_version_id={test_version_id}"
-        f"&target_version_id={test_version_id_2}"
-        f"&source_lemma=jesus_legacycase",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={"confidence": 0.95},
-    )
-    assert resp.status_code == 200
-    assert resp.json()["id"] == legacy_id
-    assert resp.json()["confidence"] == 0.95
-
-
-def test_patch_lexeme_card_by_lemma_without_source_lemma_param(
-    client,
-    regular_token1,
-    test_revision_id,
-    test_version_id,
-    test_version_id_2,
-):
-    """PATCH by lemma must not crash when source_lemma is omitted (None path).
-    Regression guard for the `if source_lemma is not None:` filter — without
-    that guard, sql_func.lower(None) would explode."""
-    client.post(
-        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={
-            "source_lemma": "sleep_noparam",
-            "target_lemma": "lala_noparam",
-            "source_version_id": test_version_id,
-            "target_version_id": test_version_id_2,
-            "confidence": 0.5,
-        },
-    )
-
-    resp = client.patch(
-        f"/v3/agent/lexeme-card?target_lemma=lala_noparam"
-        f"&source_version_id={test_version_id}"
-        f"&target_version_id={test_version_id_2}",
-        headers={"Authorization": f"Bearer {regular_token1}"},
-        json={"confidence": 0.88},
-    )
-    assert resp.status_code == 200
-    assert resp.json()["confidence"] == 0.88
 
 
 def test_post_lexeme_card_upsert_normalizes_legacy_mixed_case_source_lemma(
@@ -8577,6 +8370,489 @@ def test_get_lexeme_card_by_id_lang_matches_canonical_iso_returns_200(
     data = response.json()
     assert data["id"] == card_id
     assert data["source_lemma"] == "byid_canonical_match_src"
+
+
+# ---------------------------------------------------------------------------
+# PATCH /v3/agent/lexeme-card/translation — overlay-routing edit primitive
+# ---------------------------------------------------------------------------
+
+
+def _create_pivot_card(
+    db_session, *, owner_username="testuser1", canonical_iso, target_iso
+):
+    """Build a freshly isolated (canonical-source-iso, target-iso) card with
+    one canonical example, plus Group1 access to every involved version. Used
+    by PATCH-translation tests that need a non-eng canonical so the overlay
+    branch fires."""
+    from datetime import date
+
+    from database.models import (
+        AgentLexemeCard,
+        AgentLexemeCardExample,
+        BibleRevision,
+        BibleVersion,
+        BibleVersionAccess,
+        Group,
+        UserDB,
+    )
+
+    user = db_session.query(UserDB).filter(UserDB.username == owner_username).first()
+    group1 = db_session.query(Group).filter(Group.name == "Group1").first()
+
+    src_version = BibleVersion(
+        name=f"patchtrans_src_{canonical_iso}_{target_iso}",
+        iso_language=canonical_iso,
+        iso_script="Latn",
+        abbreviation=f"PTS_{canonical_iso}_{target_iso}".upper()[:30],
+        owner_id=user.id,
+        is_reference=True,
+    )
+    tgt_version = BibleVersion(
+        name=f"patchtrans_tgt_{canonical_iso}_{target_iso}",
+        iso_language=target_iso,
+        iso_script="Latn",
+        abbreviation=f"PTT_{canonical_iso}_{target_iso}".upper()[:30],
+        owner_id=user.id,
+        is_reference=False,
+    )
+    db_session.add_all([src_version, tgt_version])
+    db_session.commit()
+
+    db_session.add_all(
+        [
+            BibleVersionAccess(bible_version_id=src_version.id, group_id=group1.id),
+            BibleVersionAccess(bible_version_id=tgt_version.id, group_id=group1.id),
+        ]
+    )
+    db_session.commit()
+
+    src_revision = BibleRevision(
+        date=date.today(),
+        bible_version_id=src_version.id,
+        published=False,
+        machine_translation=False,
+    )
+    db_session.add(src_revision)
+    db_session.commit()
+
+    card = AgentLexemeCard(
+        source_lemma=f"canon_{canonical_iso}_src",
+        target_lemma=f"canon_{target_iso}_tgt",
+        source_version_id=src_version.id,
+        target_version_id=tgt_version.id,
+        source_language_iso=canonical_iso,
+        confidence=0.5,
+        surface_forms=[f"canon_{target_iso}_tgt"],
+        source_surface_forms=[f"canon_{canonical_iso}_src"],
+        senses=[{"definition": f"canonical {canonical_iso} sense"}],
+    )
+    db_session.add(card)
+    db_session.commit()
+
+    example = AgentLexemeCardExample(
+        lexeme_card_id=card.id,
+        revision_id=src_revision.id,
+        source_text=f"canon {canonical_iso} example",
+        target_text=f"canon {target_iso} example",
+    )
+    db_session.add(example)
+    db_session.commit()
+    return card, example, src_version, tgt_version
+
+
+def test_patch_lexeme_card_translation_source_only_writes_overlay_only(
+    client, regular_token1, db_session
+):
+    """Source-side edits in overlay mode land in card_translations only.
+    The canonical row's source_lemma must not be touched."""
+    from database.models import AgentLexemeCard, CardTranslation
+
+    card, _, src_version, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+    canonical_source_lemma_before = card.source_lemma
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace"
+        f"&is_user_edit=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == card.id
+    assert body["source_lemma"] == "grace"
+    assert body["has_translation_overlay"] is True
+
+    # Canonical row untouched.
+    db_session.expire_all()
+    canonical = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    assert canonical.source_lemma == canonical_source_lemma_before
+    assert canonical.last_user_edit is None
+
+    # Overlay row exists with the new value and a user-edit timestamp.
+    overlay = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .one()
+    )
+    assert overlay.source_lemma == "grace"
+    assert overlay.last_user_edit is not None
+
+
+def test_patch_lexeme_card_translation_target_only_writes_canonical_only(
+    client, regular_token1, db_session
+):
+    """Target-side edits in overlay mode land in agent_lexeme_cards only.
+    No overlay row should be created for a target-only edit."""
+    from database.models import AgentLexemeCard, CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace"
+        f"&is_user_edit=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"target_lemma": "uwiilá", "confidence": 0.9},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["target_lemma"] == "uwiilá"
+    assert body["confidence"] == 0.9
+    # No overlay was written, so no overlay exists → has_translation_overlay=False
+    assert body["has_translation_overlay"] is False
+
+    db_session.expire_all()
+    canonical = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    assert canonical.target_lemma == "uwiilá"
+    assert canonical.confidence == 0.9
+    assert canonical.last_user_edit is not None
+
+    overlay_count = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .count()
+    )
+    assert overlay_count == 0
+
+
+def test_patch_lexeme_card_translation_mixed_edit_bumps_both_user_edit(
+    client, regular_token1, db_session
+):
+    """Mixed edit: source-side → overlay, target-side → canonical. With
+    is_user_edit=true, last_user_edit bumps on both rows because the user is
+    implicitly approving the canonical state of the target."""
+    from database.models import AgentLexemeCard, CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace"
+        f"&is_user_edit=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "love", "confidence": 0.95},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source_lemma"] == "love"
+    assert body["confidence"] == 0.95
+    assert body["has_translation_overlay"] is True
+
+    db_session.expire_all()
+    canonical = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    overlay = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .one()
+    )
+    assert canonical.last_user_edit is not None
+    assert overlay.last_user_edit is not None
+    # And they should be close in time (same request, same `now`).
+    assert abs((canonical.last_user_edit - overlay.last_user_edit).total_seconds()) < 1
+
+
+def test_patch_lexeme_card_translation_creates_overlay_when_missing(
+    client, regular_token1, db_session
+):
+    """First source-side edit creates the card_translations row for that
+    language (upsert insert path)."""
+    from database.models import CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+    # Sanity: no overlay exists yet.
+    assert (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .count()
+        == 0
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace", "source_surface_forms": ["grace", "graces"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    db_session.expire_all()
+    overlay = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .one()
+    )
+    assert overlay.source_lemma == "grace"
+    assert overlay.source_surface_forms == ["grace", "graces"]
+
+
+def test_patch_lexeme_card_translation_canonical_match_routes_to_canonical(
+    client, regular_token1, db_session
+):
+    """When language_iso equals the canonical's source_language_iso, source-
+    side fields go to the canonical row (degenerate case — no overlay table
+    exists for the canonical's own language)."""
+    from database.models import AgentLexemeCard, CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=swh"
+        f"&list_mode=replace"
+        f"&is_user_edit=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "neema_updated"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["source_lemma"] == "neema_updated"
+
+    db_session.expire_all()
+    canonical = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    assert canonical.source_lemma == "neema_updated"
+    # No overlay row should have been created for swh (the canonical lang).
+    overlay_count = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="swh")
+        .count()
+    )
+    assert overlay_count == 0
+
+
+def test_patch_lexeme_card_translation_lookup_is_pivot_routed(
+    client, regular_token1, db_session
+):
+    """The lookup must apply pivot routing — UI sends its English reference
+    source_version_id, the swh-canonical card still resolves. This is the
+    direct regression guard for the staging bug."""
+    from datetime import date
+
+    from database.models import (
+        BibleRevision,
+        BibleVersion,
+        BibleVersionAccess,
+        Group,
+        LanguagePivot,
+        PivotCandidate,
+        UserDB,
+    )
+
+    card, _, src_version, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="zga"
+    )
+
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = db_session.query(Group).filter(Group.name == "Group1").first()
+
+    # UI sees the English reference version, not the swh canonical's version.
+    eng_ref = BibleVersion(
+        name="patchtrans_eng_ref",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="PTER",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    db_session.add(eng_ref)
+    db_session.commit()
+    db_session.add(BibleVersionAccess(bible_version_id=eng_ref.id, group_id=group1.id))
+    db_session.commit()
+
+    # Pivot: target zga → swh canonical. PivotCandidate points at the swh
+    # revision so the pivot rewrites source_version_id to src_version.id.
+    swh_revision = (
+        db_session.query(BibleRevision)
+        .filter(BibleRevision.bible_version_id == src_version.id)
+        .first()
+    )
+    db_session.merge(PivotCandidate(pivot_iso="swh", pivot_revision_id=swh_revision.id))
+    db_session.commit()
+    db_session.merge(LanguagePivot(target_iso="zga", pivot_iso="swh"))
+    db_session.commit()
+
+    try:
+        resp = client.patch(
+            f"/v3/agent/lexeme-card/translation"
+            f"?target_lemma={card.target_lemma}"
+            f"&target_version_id={tgt_version.id}"
+            f"&source_version_id={eng_ref.id}"
+            f"&language_iso=eng"
+            f"&list_mode=replace",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+            json={"source_lemma": "grace"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["source_lemma"] == "grace"
+    finally:
+        db_session.query(LanguagePivot).filter_by(target_iso="zga").delete()
+        db_session.query(PivotCandidate).filter_by(
+            pivot_iso="swh", pivot_revision_id=swh_revision.id
+        ).delete()
+        db_session.commit()
+
+
+def test_patch_lexeme_card_translation_rejects_examples_in_overlay_mode(
+    client, regular_token1, db_session
+):
+    """v1 limitation: examples patching is not supported in overlay mode —
+    callers must use POST /v3/agent/lexeme-card/{id}/translation for full
+    overlay rewrites."""
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "grace",
+            "examples": [
+                {"source": "by grace", "target": "kwa neema", "revision_id": 1}
+            ],
+        },
+    )
+    assert resp.status_code == 400
+    assert "examples patching is not supported" in resp.json()["detail"]
+
+
+def test_patch_lexeme_card_translation_not_found(client, regular_token1, db_session):
+    """Unknown target_lemma → 404. The error message echoes the lookup
+    parameters so the caller can tell pivot routing from a real miss."""
+    _, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma=does_not_exist_anywhere"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace"},
+    )
+    assert resp.status_code == 404
+
+
+def test_patch_lexeme_card_translation_case_insensitive_target_lemma(
+    client, regular_token1, db_session
+):
+    """target_lemma is matched case-insensitively (and NFC-normalized) —
+    the UI may send whatever case it has displayed."""
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma.upper()}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["source_lemma"] == "grace"
+
+
+def test_patch_lexeme_card_translation_no_user_edit_skips_user_edit_timestamp(
+    client, regular_token1, db_session
+):
+    """is_user_edit defaults to false — automated callers (derivation,
+    consolidation) must not bump last_user_edit on either row."""
+    from database.models import AgentLexemeCard, CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace", "confidence": 0.7},
+    )
+    assert resp.status_code == 200, resp.text
+
+    db_session.expire_all()
+    canonical = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    overlay = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .one()
+    )
+    assert canonical.last_user_edit is None
+    assert overlay.last_user_edit is None
+
+
+def test_patch_lexeme_card_translation_rejects_invalid_language_iso(
+    client, regular_token1, db_session
+):
+    """language_iso must be exactly 3 chars (Query validation, 422)."""
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=en",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace"},
+    )
+    assert resp.status_code == 422
 
 
 def test_check_word_in_lexeme_cards_pivot_routing(

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -8761,7 +8761,8 @@ def test_patch_lexeme_card_translation_rejects_examples_in_overlay_mode(
         },
     )
     assert resp.status_code == 400
-    assert "examples patching is not supported" in resp.json()["detail"]
+    detail = resp.json()["detail"]
+    assert "examples patching is not supported" in detail["message"]
 
 
 def test_patch_lexeme_card_translation_not_found(client, regular_token1, db_session):
@@ -8853,6 +8854,486 @@ def test_patch_lexeme_card_translation_rejects_invalid_language_iso(
         json={"source_lemma": "grace"},
     )
     assert resp.status_code == 422
+
+
+def test_patch_lexeme_card_translation_target_only_with_existing_overlay_keeps_overlay(
+    client, regular_token1, db_session
+):
+    """Regression: when an overlay already exists, a target-only PATCH must
+    still report has_translation_overlay=True and surface the overlay's
+    source-side fields in the response. The build-response helper queries
+    the overlay independently of whether this request wrote to it; this test
+    guards against a future refactor that conflates the two."""
+    from database.models import CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+    # Seed an existing eng overlay first.
+    seed = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace"
+        f"&is_user_edit=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace"},
+    )
+    assert seed.status_code == 200
+
+    # Now a target-only PATCH in the same lang view.
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"confidence": 0.77},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["confidence"] == 0.77
+    assert body["has_translation_overlay"] is True
+    assert body["source_lemma"] == "grace"  # overlay's value, not canonical's
+
+
+def test_patch_lexeme_card_translation_response_last_user_edit_reflects_overlay(
+    client, regular_token1, db_session
+):
+    """After a source-only edit, the response's top-level last_user_edit
+    must reflect the overlay's timestamp (the canonical's is unchanged) so
+    the UI's 'edited recently' indicator catches source-only edits."""
+    from database.models import AgentLexemeCard
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+    # Canonical has no last_user_edit yet.
+    assert (
+        db_session.query(AgentLexemeCard).filter_by(id=card.id).one().last_user_edit
+        is None
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace"
+        f"&is_user_edit=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # last_user_edit in the response is the overlay's (canonical's is still
+    # None because the source-only edit didn't touch the canonical).
+    assert body["last_user_edit"] is not None
+
+    db_session.expire_all()
+    canonical_after = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    assert canonical_after.last_user_edit is None
+
+
+def test_patch_lexeme_card_translation_multi_card_ambiguity_returns_400(
+    client, regular_token1, db_session
+):
+    """When (target_lemma, target_version_id) matches two canonicals (e.g.
+    two different source pivots), omitting source_version_id must return 400.
+    Providing source_version_id picks the right one."""
+    from datetime import date
+
+    from database.models import (
+        AgentLexemeCard,
+        BibleRevision,
+        BibleVersion,
+        BibleVersionAccess,
+        Group,
+        UserDB,
+    )
+
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = db_session.query(Group).filter(Group.name == "Group1").first()
+    target_ver = BibleVersion(
+        name="ambig_target",
+        iso_language="ngq",
+        iso_script="Latn",
+        abbreviation="ATGT",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    src_swh = BibleVersion(
+        name="ambig_src_swh",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="ASRC_S",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    src_eng = BibleVersion(
+        name="ambig_src_eng",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="ASRC_E",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    db_session.add_all([target_ver, src_swh, src_eng])
+    db_session.commit()
+    db_session.add_all(
+        [
+            BibleVersionAccess(bible_version_id=target_ver.id, group_id=group1.id),
+            BibleVersionAccess(bible_version_id=src_swh.id, group_id=group1.id),
+            BibleVersionAccess(bible_version_id=src_eng.id, group_id=group1.id),
+        ]
+    )
+    db_session.commit()
+
+    # Build a revision in each source so example FKs are satisfiable.
+    rev_swh = BibleRevision(
+        date=date.today(),
+        bible_version_id=src_swh.id,
+        published=False,
+        machine_translation=False,
+    )
+    rev_eng = BibleRevision(
+        date=date.today(),
+        bible_version_id=src_eng.id,
+        published=False,
+        machine_translation=False,
+    )
+    db_session.add_all([rev_swh, rev_eng])
+    db_session.commit()
+    _ = rev_swh, rev_eng
+
+    # Two canonicals with the same target_lemma, different sources.
+    card_swh = AgentLexemeCard(
+        source_lemma="neema",
+        target_lemma="ambig_tgt_lemma",
+        source_version_id=src_swh.id,
+        target_version_id=target_ver.id,
+        source_language_iso="swh",
+        confidence=0.5,
+    )
+    card_eng = AgentLexemeCard(
+        source_lemma="grace",
+        target_lemma="ambig_tgt_lemma",
+        source_version_id=src_eng.id,
+        target_version_id=target_ver.id,
+        source_language_iso="eng",
+        confidence=0.5,
+    )
+    db_session.add_all([card_swh, card_eng])
+    db_session.commit()
+
+    # No source_version_id → 400 ambiguity.
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma=ambig_tgt_lemma"
+        f"&target_version_id={target_ver.id}"
+        f"&language_iso=eng",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace_updated"},
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert "Multiple lexeme cards" in detail
+    assert "source_version_id" in detail
+
+    # With source_version_id → 200 on the right card.
+    resp_ok = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma=ambig_tgt_lemma"
+        f"&target_version_id={target_ver.id}"
+        f"&source_version_id={src_eng.id}"
+        f"&language_iso=eng",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace_updated"},
+    )
+    assert resp_ok.status_code == 200, resp_ok.text
+    assert resp_ok.json()["id"] == card_eng.id
+
+
+def test_patch_lexeme_card_translation_merge_source_surface_forms_dedupes(
+    client, regular_token1, db_session
+):
+    """list_mode=merge against an existing overlay's source_surface_forms
+    must case-insensitively dedupe and preserve the original casing of items
+    already stored."""
+    from database.models import CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    seed = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_surface_forms": ["grace", "graces"]},
+    )
+    assert seed.status_code == 200
+
+    merge = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=merge",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_surface_forms": ["GRACE", "gracious"]},
+    )
+    assert merge.status_code == 200, merge.text
+
+    db_session.expire_all()
+    overlay = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .one()
+    )
+    # Dedup: "GRACE" recognized as case-insensitive duplicate of "grace";
+    # original casing preserved.
+    assert overlay.source_surface_forms == ["grace", "graces", "gracious"]
+
+
+def test_patch_lexeme_card_translation_non_user_edit_preserves_existing_user_edit(
+    client, regular_token1, db_session
+):
+    """When the overlay already has last_user_edit set (a real human edit),
+    a subsequent automated/non-user-edit PATCH must NOT clear it — the
+    update-branch of the upsert omits last_user_edit from set_ in that case.
+    """
+    from database.models import CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    # First call: real user edit.
+    r1 = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace"
+        f"&is_user_edit=true",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "grace"},
+    )
+    assert r1.status_code == 200
+    db_session.expire_all()
+    overlay = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .one()
+    )
+    user_edit_ts = overlay.last_user_edit
+    assert user_edit_ts is not None
+
+    # Second call: automated, is_user_edit=false. Must preserve user_edit_ts.
+    r2 = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"source_lemma": "amazing_grace"},
+    )
+    assert r2.status_code == 200
+    db_session.expire_all()
+    overlay_after = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .one()
+    )
+    assert overlay_after.source_lemma == "amazing_grace"  # field did update
+    assert overlay_after.last_user_edit == user_edit_ts  # timestamp preserved
+
+
+def test_patch_lexeme_card_translation_duplicate_target_lemma_returns_409(
+    client, regular_token1, db_session
+):
+    """Renaming target_lemma in overlay mode must 409 if another card already
+    holds the new target_lemma in the same (source, target) version pair."""
+    from database.models import AgentLexemeCard
+
+    card_a, _, src_version, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+    # Add a second card under the same version pair with a different target.
+    card_b = AgentLexemeCard(
+        source_lemma="other_canon",
+        target_lemma="dup_tgt_lemma",
+        source_version_id=src_version.id,
+        target_version_id=tgt_version.id,
+        source_language_iso="swh",
+        confidence=0.5,
+    )
+    db_session.add(card_b)
+    db_session.commit()
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card_a.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"target_lemma": "dup_tgt_lemma"},
+    )
+    assert resp.status_code == 409, resp.text
+    detail = resp.json()["detail"]
+    assert detail["existing_card_id"] == card_b.id
+
+
+def test_patch_lexeme_card_translation_examples_400_includes_resolved_card_id(
+    client, regular_token1, db_session
+):
+    """The examples-rejection 400 must include the resolved card.id so the
+    caller can use POST /v3/agent/lexeme-card/{id}/translation without a
+    second round-trip to discover the id."""
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "examples": [
+                {"source": "by grace", "target": "kwa neema", "revision_id": 1}
+            ]
+        },
+    )
+    assert resp.status_code == 400
+    detail = resp.json()["detail"]
+    assert detail["card_id"] == card.id
+    assert detail["overlay_post_url"] == (
+        f"/v3/agent/lexeme-card/{card.id}/translation"
+    )
+    assert "{card_id}" not in detail["message"]
+
+
+def test_patch_lexeme_card_translation_empty_body_is_noop(
+    client, regular_token1, db_session
+):
+    """Empty body is a no-op 200 — no canonical or overlay writes. Documents
+    the contract so a future 'require at least one field' guard doesn't
+    silently break automated callers."""
+    from database.models import AgentLexemeCard, CardTranslation
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+    canonical_before = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    target_lemma_before = canonical_before.target_lemma
+    confidence_before = canonical_before.confidence
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=replace",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={},
+    )
+    assert resp.status_code == 200, resp.text
+
+    db_session.expire_all()
+    canonical_after = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    assert canonical_after.target_lemma == target_lemma_before
+    assert canonical_after.confidence == confidence_before
+    overlay_count = (
+        db_session.query(CardTranslation)
+        .filter_by(card_id=card.id, language_iso="eng")
+        .count()
+    )
+    assert overlay_count == 0
+
+
+def test_patch_lexeme_card_translation_canonical_surface_forms_append(
+    client, regular_token1, db_session
+):
+    """surface_forms (target-side list) PATCHed via the new endpoint in
+    overlay mode lands on the canonical row with list_mode honored. Replaces
+    the coverage lost when by-lemma PATCH was removed."""
+    from database.models import AgentLexemeCard
+
+    card, _, _, tgt_version = _create_pivot_card(
+        db_session, canonical_iso="swh", target_iso="ngq"
+    )
+
+    resp = client.patch(
+        f"/v3/agent/lexeme-card/translation"
+        f"?target_lemma={card.target_lemma}"
+        f"&target_version_id={tgt_version.id}"
+        f"&language_iso=eng"
+        f"&list_mode=append",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"surface_forms": ["new_form"]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Original was ["canon_ngq_tgt"] from _create_pivot_card; append adds.
+    assert body["surface_forms"] == ["canon_ngq_tgt", "new_form"]
+    db_session.expire_all()
+    canonical = db_session.query(AgentLexemeCard).filter_by(id=card.id).one()
+    assert canonical.surface_forms == ["canon_ngq_tgt", "new_form"]
+
+
+def test_patch_lexeme_card_by_lemma_deprecated_still_works_for_internal_callers(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """The deprecated by-lemma PATCH is kept for aqua-assessments'
+    word_memory_builder POST→409 fallback. Verify it still works on
+    surface_forms / source_surface_forms / alignment_scores merges against
+    a same-language canonical (safe use case)."""
+    # Build a card via the public POST (eng/eng = no overlay routing issue).
+    resp = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "depr_src",
+            "target_lemma": "depr_tgt",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+            "surface_forms": ["depr_tgt"],
+        },
+    )
+    assert resp.status_code == 200
+
+    patch_resp = client.patch(
+        "/v3/agent/lexeme-card"
+        "?target_lemma=depr_tgt"
+        f"&source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}"
+        "&list_mode=merge",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "surface_forms": ["depr_tgt", "depr_alt"],
+            "alignment_scores": {"some_word": 0.8},
+        },
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    body = patch_resp.json()
+    assert "depr_alt" in body["surface_forms"]
+    assert body["alignment_scores"] == {"some_word": 0.8}
 
 
 def test_check_word_in_lexeme_cards_pivot_routing(

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -8670,8 +8670,6 @@ def test_patch_lexeme_card_translation_lookup_is_pivot_routed(
     """The lookup must apply pivot routing — UI sends its English reference
     source_version_id, the swh-canonical card still resolves. This is the
     direct regression guard for the staging bug."""
-    from datetime import date
-
     from database.models import (
         BibleRevision,
         BibleVersion,
@@ -8864,8 +8862,6 @@ def test_patch_lexeme_card_translation_target_only_with_existing_overlay_keeps_o
     source-side fields in the response. The build-response helper queries
     the overlay independently of whether this request wrote to it; this test
     guards against a future refactor that conflates the two."""
-    from database.models import CardTranslation
-
     card, _, _, tgt_version = _create_pivot_card(
         db_session, canonical_iso="swh", target_iso="ngq"
     )

--- a/test/test_agent_routes/test_lexeme_card_access_control.py
+++ b/test/test_agent_routes/test_lexeme_card_access_control.py
@@ -517,13 +517,14 @@ def test_patch_lexeme_card_filters_examples_by_user_access(
     assert admin_sources == {"the sun", "bright sun"}
 
 
-def test_patch_lexeme_card_by_lemma_filters_examples_by_user_access(
+def test_patch_lexeme_card_translation_canonical_match_filters_examples_by_user_access(
     client, regular_token1, regular_token2, admin_token, db_session
 ):
     """
-    The by-lemma PATCH endpoint funnels through the same _apply_lexeme_card_patch
-    helper as the by-id endpoint. Pin its access-control behaviour separately so
-    a future refactor that diverges the two endpoints doesn't slip past CI.
+    PATCH /agent/lexeme-card/translation with language_iso matching the card's
+    canonical source_language_iso funnels through _apply_lexeme_card_patch (same
+    as PATCH-by-id). Pin its access-control behaviour separately so a future
+    refactor that diverges the two paths doesn't slip past CI.
     """
     user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
     user2 = db_session.query(UserDB).filter(UserDB.username == "testuser2").first()
@@ -587,10 +588,13 @@ def test_patch_lexeme_card_by_lemma_filters_examples_by_user_access(
         },
     )
 
+    # language_iso=eng matches the canonical source_language_iso, so this
+    # routes through _apply_lexeme_card_patch — same code path the old
+    # by-lemma endpoint used.
     patch_url = (
-        f"/v3/agent/lexeme-card?target_lemma={target_lemma}"
+        f"/v3/agent/lexeme-card/translation?target_lemma={target_lemma}"
         f"&source_version_id={version_a.id}&target_version_id={version_b.id}"
-        "&list_mode=merge"
+        f"&language_iso=eng&list_mode=merge"
     )
 
     resp_user2 = client.patch(


### PR DESCRIPTION
## Summary

Adds **`PATCH /v3/agent/lexeme-card/translation`**, the UI's edit primitive in the pivot-routed world. The UI thinks "I am editing the card I see in language X" — no awareness of canonical vs overlay storage — and the endpoint splits the body internally:

- **Source-side fields** (`source_lemma`, `source_surface_forms`, `senses`) → `card_translations` overlay row for `(card_id, language_iso)`, upserted. The canonical source-side stays untouched, so edits in a (target, eng) view can't corrupt the (target, swh) pivot canonical.
- **Target-side and shared fields** (`target_lemma`, `surface_forms`, `pos`, `confidence`, `english_lemma`, `alignment_scores`, `build_version`) → canonical `agent_lexeme_cards` row. There's only one target column physically, so all overlays project the same target text — fixing a typo from any language view fixes it everywhere.
- **`language_iso == canonical source_language_iso`** → everything routes to the canonical row (degenerate case; no overlay table exists for the canonical's own language).

Lookup is pivot-routed via `_effective_source_version_expr` so the UI can pass its English reference `source_version_id` (or omit it) instead of having to know the swh canonical's identity.

`is_user_edit=true` bumps `last_user_edit` on every row the patch actually writes to — a source-only edit doesn't claim implicit canonical approval. The response's top-level `last_user_edit` is the max of canonical and overlay so the UI's "edited recently" indicator catches source-only overlay edits.

## Deprecation, not removal

`PATCH /v3/agent/lexeme-card` (the by-lemma canonical endpoint) is **kept and marked deprecated**. aqua-assessments' `word_memory_builder` uses it as a POST→409 fallback to merge `surface_forms` / `source_surface_forms` / `alignment_scores` into a freshly-built canonical it owns end-to-end — that use case is safe (the caller knows the canonical's source language). The route carries a strong docstring warning that **UI clients MUST migrate to the new `/translation` endpoint**.

The dangerous staging scenario this fixes:
```
PATCH /v3/agent/lexeme-card/?target_lemma=uwiila&source_version_id=12309
  &target_version_id=13347&list_mode=replace&source_lemma=grace
```
Becomes:
```
PATCH /v3/agent/lexeme-card/translation?target_lemma=uwiila
  &target_version_id=13347&language_iso=eng&list_mode=replace
  &is_user_edit=true
body: {"source_lemma": "grace"}
```

UI migration: see [aqua-django-app #379](https://github.com/sil-ai/aqua-django-app/issues/379). Once the UI is off the deprecated route, the by-lemma endpoint can be removed in a follow-up.

## Schema

Migration `c8e1f4a72b9d` adds `last_user_edit` to `card_translations` (parallel to the canonical row's existing column). Down-revision is `a3c1e7b9d4f0`. Nullable add — safe to deploy before the app server.

## Case-handling

`LexemeCardPatch.source_lemma` now NFC-normalizes only (no longer lowercases at the validator level). The canonical write path lowercases at the call site to honor the canonical's case-insensitive index; the overlay write path preserves casing, matching `CardTranslationIn`'s preservation contract. Net behavior on canonical-side writes is unchanged; overlay-side writes no longer lose user casing.

## v1 limitation

`examples` patching is rejected (400) when `language_iso != canonical source_language_iso`. The error detail now carries the resolved `card_id` and the suggested `POST /v3/agent/lexeme-card/{id}/translation` URL so callers don't need a second round-trip. Splitting per-example `source` (overlay) from per-example `target` (canonical) needs more design before v2.

## Test plan

- [x] 21 patch-translation tests: source-only, target-only, mixed (both `last_user_edit` bump), overlay-creation, canonical-match degenerate, pivot-routed lookup with a UI-style `source_version_id`, examples rejection with resolved card_id in error, not-found, case-insensitive target_lemma, is_user_edit=false leaves timestamps alone, invalid `language_iso` length, target-only with pre-existing overlay keeps overlay visible, response surfaces overlay's last_user_edit, multi-card ambiguity 400, merge mode dedupes source_surface_forms, non-user-edit upsert preserves prior user_edit_ts, duplicate target_lemma 409 in overlay mode, empty-body no-op, canonical surface_forms append, deprecated by-lemma endpoint still works for internal callers.
- [x] ACL test repointed at the canonical-match branch (same code path through `_apply_lexeme_card_patch`).
- [x] 6 obsolete by-lemma tests deleted.
- [x] 157 lexeme-card tests + 7 access-control tests pass locally.
- [ ] UI smoke test against the new endpoint URL (tracked in [aqua-django-app #379](https://github.com/sil-ai/aqua-django-app/issues/379)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
