### PR TITLE
Add bulk DELETE /v3/agent/lexeme-card by target_version_id (#703)

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -40,6 +40,7 @@ from models import (
     AgentWordAlignmentBulkRequest,
     AgentWordAlignmentIn,
     AgentWordAlignmentOut,
+    BulkLexemeCardDeleteResponse,
     CardTranslationIn,
     CardTranslationOut,
     CritiqueIssueOut,
@@ -51,7 +52,10 @@ from models import (
     ListMode,
 )
 from security_routes.auth_routes import get_current_user
-from security_routes.utilities import is_user_authorized_for_assessment
+from security_routes.utilities import (
+    is_user_authorized_for_assessment,
+    is_user_authorized_for_bible_version,
+)
 from utils.logging_config import setup_logger
 
 container_id = socket.gethostname()
@@ -1904,6 +1908,112 @@ async def patch_lexeme_card_by_lemma_DEPRECATED(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Database error: {str(e)}",
         ) from e
+
+
+@router.delete(
+    "/agent/lexeme-card",
+    response_model=BulkLexemeCardDeleteResponse,
+)
+async def delete_lexeme_cards_for_target_version(
+    target_version_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Wipe every lexeme card for a target_version_id, across all source pairs.
+
+    Cards for a given target_version_id can live at multiple source_version_ids
+    (current pivot, pre-pivot reference version, function-word extraction era).
+    The per-card DELETE plus a GET keyed on (source, target) misses cards at
+    other source pairs, leaving rebuilds dirty. This endpoint deletes by
+    target_version_id alone, regardless of source_version_id.
+
+    Cascades to ``agent_lexeme_card_examples`` and ``card_translations`` via
+    their ON DELETE CASCADE FKs (and ``card_translation_examples`` via theirs).
+
+    This is the bulk counterpart to ``DELETE /v3/agent/lexeme-card/{card_id}``
+    and the shape mirrors ``DELETE /v3/tokenizer/training-artifacts/{version_id}``
+    so aqua-assessments' Phase 4 rebuild can call them together.
+
+    Status codes:
+    - 200: returns row counts deleted (zeros if nothing existed — idempotent)
+    - 403: caller not authorized for this version — also returned for
+      non-existent version_ids when the caller is a regular user (no
+      enumeration leak)
+    - 404: admin caller requesting a version_id that doesn't exist
+    """
+    request_start = time.perf_counter()
+
+    if not await is_user_authorized_for_bible_version(
+        current_user.id, target_version_id, db
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User not authorized to access this bible_version",
+        )
+
+    from sqlalchemy import delete, func, select
+
+    version_lookup = await db.execute(
+        select(BibleVersion.id).where(BibleVersion.id == target_version_id)
+    )
+    if version_lookup.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No bible_version with id {target_version_id}",
+        )
+
+    try:
+        card_ids_subquery = select(AgentLexemeCard.id).where(
+            AgentLexemeCard.target_version_id == target_version_id
+        )
+
+        examples_count_result = await db.execute(
+            select(func.count()).where(
+                AgentLexemeCardExample.lexeme_card_id.in_(card_ids_subquery)
+            )
+        )
+        examples_count = examples_count_result.scalar() or 0
+
+        translations_count_result = await db.execute(
+            select(func.count()).where(CardTranslation.card_id.in_(card_ids_subquery))
+        )
+        translations_count = translations_count_result.scalar() or 0
+
+        card_delete_result = await db.execute(
+            delete(AgentLexemeCard).where(
+                AgentLexemeCard.target_version_id == target_version_id
+            )
+        )
+        await db.commit()
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error("Failed to bulk-delete lexeme cards", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {e}",
+        ) from e
+
+    response = BulkLexemeCardDeleteResponse(
+        target_version_id=target_version_id,
+        lexeme_cards_deleted=card_delete_result.rowcount or 0,
+        examples_deleted=examples_count,
+        card_translations_deleted=translations_count,
+    )
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"delete_lexeme_cards_for_target_version completed in {duration}s",
+        extra={
+            "method": "DELETE",
+            "path": "/agent/lexeme-card",
+            "target_version_id": target_version_id,
+            "lexeme_cards_deleted": response.lexeme_cards_deleted,
+            "examples_deleted": response.examples_deleted,
+            "card_translations_deleted": response.card_translations_deleted,
+            "duration_s": duration,
+        },
+    )
+    return response
 
 
 @router.delete("/agent/lexeme-card/{card_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1927,8 +1927,10 @@ async def delete_lexeme_cards_for_target_version(
     other source pairs, leaving rebuilds dirty. This endpoint deletes by
     target_version_id alone, regardless of source_version_id.
 
-    Cascades to ``agent_lexeme_card_examples`` and ``card_translations`` via
-    their ON DELETE CASCADE FKs (and ``card_translation_examples`` via theirs).
+    Deletes child rows explicitly in child-to-parent order so each row count
+    is authoritative (no pre-delete SELECT COUNTs that could drift under
+    concurrent writes). ``card_translation_examples`` rows are wiped via the
+    ``card_translations`` cascade — they share a parent and never escape it.
 
     This is the bulk counterpart to ``DELETE /v3/agent/lexeme-card/{card_id}``
     and the shape mirrors ``DELETE /v3/tokenizer/training-artifacts/{version_id}``
@@ -1951,7 +1953,7 @@ async def delete_lexeme_cards_for_target_version(
             detail="User not authorized to access this bible_version",
         )
 
-    from sqlalchemy import delete, func, select
+    from sqlalchemy import delete, select
 
     version_lookup = await db.execute(
         select(BibleVersion.id).where(BibleVersion.id == target_version_id)
@@ -1967,22 +1969,25 @@ async def delete_lexeme_cards_for_target_version(
             AgentLexemeCard.target_version_id == target_version_id
         )
 
-        examples_count_result = await db.execute(
-            select(func.count()).where(
-                AgentLexemeCardExample.lexeme_card_id.in_(card_ids_subquery)
-            )
+        # child → parent order so each rowcount reflects only that table's
+        # deletes; the parent DELETE's cascade then has nothing left to do.
+        # synchronize_session=False on the subquery-bearing deletes — SQLA
+        # can't evaluate a Select in Python, and we commit right after so
+        # in-session ORM state would be discarded anyway.
+        translations_delete = await db.execute(
+            delete(CardTranslation)
+            .where(CardTranslation.card_id.in_(card_ids_subquery))
+            .execution_options(synchronize_session=False)
         )
-        examples_count = examples_count_result.scalar() or 0
-
-        translations_count_result = await db.execute(
-            select(func.count()).where(CardTranslation.card_id.in_(card_ids_subquery))
+        examples_delete = await db.execute(
+            delete(AgentLexemeCardExample)
+            .where(AgentLexemeCardExample.lexeme_card_id.in_(card_ids_subquery))
+            .execution_options(synchronize_session=False)
         )
-        translations_count = translations_count_result.scalar() or 0
-
-        card_delete_result = await db.execute(
-            delete(AgentLexemeCard).where(
-                AgentLexemeCard.target_version_id == target_version_id
-            )
+        cards_delete = await db.execute(
+            delete(AgentLexemeCard)
+            .where(AgentLexemeCard.target_version_id == target_version_id)
+            .execution_options(synchronize_session=False)
         )
         await db.commit()
     except SQLAlchemyError as e:
@@ -1995,9 +2000,9 @@ async def delete_lexeme_cards_for_target_version(
 
     response = BulkLexemeCardDeleteResponse(
         target_version_id=target_version_id,
-        lexeme_cards_deleted=card_delete_result.rowcount or 0,
-        examples_deleted=examples_count,
-        card_translations_deleted=translations_count,
+        lexeme_cards_deleted=cards_delete.rowcount or 0,
+        examples_deleted=examples_delete.rowcount or 0,
+        card_translations_deleted=translations_delete.rowcount or 0,
     )
 
     duration = round(time.perf_counter() - request_start, 2)
@@ -2007,6 +2012,7 @@ async def delete_lexeme_cards_for_target_version(
             "method": "DELETE",
             "path": "/agent/lexeme-card",
             "target_version_id": target_version_id,
+            "username": current_user.username,
             "lexeme_cards_deleted": response.lexeme_cards_deleted,
             "examples_deleted": response.examples_deleted,
             "card_translations_deleted": response.card_translations_deleted,

--- a/models.py
+++ b/models.py
@@ -1827,6 +1827,20 @@ class TrainingArtifactsDeleteResponse(BaseModel):
     morphemes_deleted: int
 
 
+class BulkLexemeCardDeleteResponse(BaseModel):
+    """Row counts deleted by DELETE /v3/agent/lexeme-card?target_version_id=X.
+
+    Wipes every lexeme card for the given target_version_id regardless of
+    source_version_id (cards built under different pivots all go), plus
+    cascades to examples and card_translations.
+    """
+
+    target_version_id: int
+    lexeme_cards_deleted: int
+    examples_deleted: int
+    card_translations_deleted: int
+
+
 class TokenizerRunOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6578,11 +6578,14 @@ def test_bulk_delete_lexeme_cards_across_source_pairs_with_cascades(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["target_version_id"] == test_version_id
-    assert body["lexeme_cards_deleted"] == 2
-    assert body["examples_deleted"] == 3
-    assert body["card_translations_deleted"] == 1
+    # Pin the full response shape so a field rename/addition trips the
+    # contract test that aqua-assessments depends on.
+    assert resp.json() == {
+        "target_version_id": test_version_id,
+        "lexeme_cards_deleted": 2,
+        "examples_deleted": 3,
+        "card_translations_deleted": 1,
+    }
 
     db_session.expire_all()
     assert (
@@ -6608,39 +6611,48 @@ def test_bulk_delete_lexeme_cards_across_source_pairs_with_cascades(
         == 0
     )
 
-
-def test_bulk_delete_lexeme_cards_idempotent(
-    client,
-    regular_token1,
-    db_session,
-    test_version_id,
-):
-    """Calling DELETE on a target with no cards returns zero counts.
-    Calling it twice in a row still returns zero counts the second time."""
-    # Make sure no cards exist for this target.
-    db_session.query(AgentLexemeCard).filter(
-        AgentLexemeCard.target_version_id == test_version_id
-    ).delete(synchronize_session=False)
-    db_session.commit()
-
-    first = client.delete(
+    # Calling DELETE again on the same target now returns zero counts —
+    # this is the real "delete real data, second call is a no-op"
+    # idempotency check the rebuild path relies on.
+    second = client.delete(
         _bulk_delete_url(test_version_id),
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
-    assert first.status_code == 200, first.text
-    assert first.json() == {
+    assert second.status_code == 200, second.text
+    assert second.json() == {
         "target_version_id": test_version_id,
         "lexeme_cards_deleted": 0,
         "examples_deleted": 0,
         "card_translations_deleted": 0,
     }
 
-    second = client.delete(
+
+def test_bulk_delete_lexeme_cards_idempotent_on_empty_target(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+):
+    """Calling DELETE on a target with no cards returns zero counts —
+    rebuild semantics are 'ensure nothing exists', not 'something was
+    there'. (The 'delete-then-redelete with data' path is covered by
+    the cascade test above.)"""
+    db_session.query(AgentLexemeCard).filter(
+        AgentLexemeCard.target_version_id == test_version_id
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+    resp = client.delete(
         _bulk_delete_url(test_version_id),
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
-    assert second.status_code == 200, second.text
-    assert second.json()["lexeme_cards_deleted"] == 0
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "target_version_id": test_version_id,
+        "lexeme_cards_deleted": 0,
+        "examples_deleted": 0,
+        "card_translations_deleted": 0,
+    }
 
 
 def test_bulk_delete_lexeme_cards_preserves_other_target_versions(
@@ -6652,6 +6664,12 @@ def test_bulk_delete_lexeme_cards_preserves_other_target_versions(
 ):
     """Cards stamped to other target_version_ids must not be touched —
     the whole point of the endpoint is target-scoped wipe."""
+    # Pre-clean so the deleted-count is exact, not a lower bound.
+    db_session.query(AgentLexemeCard).filter(
+        AgentLexemeCard.target_version_id == test_version_id
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
     keep_card = AgentLexemeCard(
         target_lemma="bulkdel_keep",
         source_version_id=test_version_id,
@@ -6673,7 +6691,7 @@ def test_bulk_delete_lexeme_cards_preserves_other_target_versions(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["lexeme_cards_deleted"] >= 1
+    assert resp.json()["lexeme_cards_deleted"] == 1
 
     db_session.expire_all()
     assert (
@@ -6685,6 +6703,65 @@ def test_bulk_delete_lexeme_cards_preserves_other_target_versions(
     db_session.query(AgentLexemeCard).filter(AgentLexemeCard.id == keep_id).delete(
         synchronize_session=False
     )
+    db_session.commit()
+
+
+def test_bulk_delete_lexeme_cards_does_not_touch_training_artifacts(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+):
+    """Lexeme cards and tokenizer artifacts have separate DELETE endpoints
+    that are designed to be called together during rebuild but stay
+    independent. Pin the invariant so a future refactor that accidentally
+    cascaded through some new relationship would be caught here. Mirror
+    of `test_delete_training_artifacts_does_not_touch_lexeme_cards`.
+
+    Tests against `training_artifacts` as a sentinel — it has no extra
+    FK dependencies, so the test setup is small. Morphemes/affixes belong
+    to the same family and would behave identically."""
+    from database.models import TrainingArtifact
+
+    db_session.query(AgentLexemeCard).filter(
+        AgentLexemeCard.target_version_id == test_version_id
+    ).delete(synchronize_session=False)
+    db_session.query(TrainingArtifact).filter(
+        TrainingArtifact.target_version_id == test_version_id
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+    db_session.add(
+        AgentLexemeCard(
+            target_lemma="bulkdel_to_be_wiped",
+            source_version_id=test_version_id,
+            target_version_id=test_version_id,
+            source_language_iso="eng",
+        )
+    )
+    db_session.add(
+        TrainingArtifact(target_version_id=test_version_id, grammar_sketch="stays_put")
+    )
+    db_session.commit()
+
+    resp = client.delete(
+        _bulk_delete_url(test_version_id),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["lexeme_cards_deleted"] == 1
+
+    db_session.expire_all()
+    assert (
+        db_session.query(TrainingArtifact)
+        .filter(TrainingArtifact.target_version_id == test_version_id)
+        .count()
+        == 1
+    ), "bulk-delete lexeme cards must not touch training_artifacts"
+
+    db_session.query(TrainingArtifact).filter(
+        TrainingArtifact.target_version_id == test_version_id
+    ).delete(synchronize_session=False)
     db_session.commit()
 
 

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -6491,6 +6491,254 @@ def test_delete_lexeme_card_unauthorized(client):
 
 
 # --------------------------------------------------------------------------
+# Bulk DELETE /v3/agent/lexeme-card?target_version_id=X (issue #703)
+# --------------------------------------------------------------------------
+
+
+def _bulk_delete_url(target_version_id):
+    return f"/v3/agent/lexeme-card?target_version_id={target_version_id}"
+
+
+def test_bulk_delete_lexeme_cards_across_source_pairs_with_cascades(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """Cards for a target_version_id can live at multiple source_version_ids
+    (different pivots, legacy pre-pivot writes). The bulk DELETE wipes them
+    all, regardless of source, and cascades to examples + card_translations."""
+    # Pre-clean any cards left behind by earlier tests in this module so the
+    # row counts in the response are deterministic.
+    db_session.query(AgentLexemeCard).filter(
+        AgentLexemeCard.target_version_id == test_version_id
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+    # Two cards at the same target but different source_version_ids.
+    card_a = AgentLexemeCard(
+        target_lemma="bulkdel_a",
+        source_version_id=test_version_id_2,
+        target_version_id=test_version_id,
+        source_language_iso="eng",
+    )
+    card_b = AgentLexemeCard(
+        target_lemma="bulkdel_b",
+        source_version_id=test_version_id,
+        target_version_id=test_version_id,
+        source_language_iso="eng",
+    )
+    db_session.add_all([card_a, card_b])
+    db_session.flush()
+
+    ex_a = AgentLexemeCardExample(
+        lexeme_card_id=card_a.id,
+        revision_id=test_revision_id,
+        source_text="bulk a src",
+        target_text="bulk a tgt",
+    )
+    ex_b1 = AgentLexemeCardExample(
+        lexeme_card_id=card_b.id,
+        revision_id=test_revision_id,
+        source_text="bulk b src 1",
+        target_text="bulk b tgt 1",
+    )
+    ex_b2 = AgentLexemeCardExample(
+        lexeme_card_id=card_b.id,
+        revision_id=test_revision_id,
+        source_text="bulk b src 2",
+        target_text="bulk b tgt 2",
+    )
+    db_session.add_all([ex_a, ex_b1, ex_b2])
+    db_session.flush()
+
+    tr_a = CardTranslation(
+        card_id=card_a.id,
+        language_iso="swh",
+        source_lemma="bulk_a_swh",
+    )
+    db_session.add(tr_a)
+    db_session.flush()
+    db_session.add(
+        CardTranslationExample(
+            card_translation_id=tr_a.id,
+            example_id=ex_a.id,
+            source_text="bulk a swh",
+        )
+    )
+    db_session.commit()
+
+    card_a_id, card_b_id = card_a.id, card_b.id
+    tr_a_id = tr_a.id
+
+    resp = client.delete(
+        _bulk_delete_url(test_version_id),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["target_version_id"] == test_version_id
+    assert body["lexeme_cards_deleted"] == 2
+    assert body["examples_deleted"] == 3
+    assert body["card_translations_deleted"] == 1
+
+    db_session.expire_all()
+    assert (
+        db_session.query(AgentLexemeCard)
+        .filter(AgentLexemeCard.id.in_([card_a_id, card_b_id]))
+        .count()
+        == 0
+    )
+    assert (
+        db_session.query(AgentLexemeCardExample)
+        .filter(AgentLexemeCardExample.lexeme_card_id.in_([card_a_id, card_b_id]))
+        .count()
+        == 0
+    )
+    assert (
+        db_session.query(CardTranslation).filter(CardTranslation.id == tr_a_id).first()
+        is None
+    )
+    assert (
+        db_session.query(CardTranslationExample)
+        .filter(CardTranslationExample.card_translation_id == tr_a_id)
+        .count()
+        == 0
+    )
+
+
+def test_bulk_delete_lexeme_cards_idempotent(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+):
+    """Calling DELETE on a target with no cards returns zero counts.
+    Calling it twice in a row still returns zero counts the second time."""
+    # Make sure no cards exist for this target.
+    db_session.query(AgentLexemeCard).filter(
+        AgentLexemeCard.target_version_id == test_version_id
+    ).delete(synchronize_session=False)
+    db_session.commit()
+
+    first = client.delete(
+        _bulk_delete_url(test_version_id),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert first.status_code == 200, first.text
+    assert first.json() == {
+        "target_version_id": test_version_id,
+        "lexeme_cards_deleted": 0,
+        "examples_deleted": 0,
+        "card_translations_deleted": 0,
+    }
+
+    second = client.delete(
+        _bulk_delete_url(test_version_id),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["lexeme_cards_deleted"] == 0
+
+
+def test_bulk_delete_lexeme_cards_preserves_other_target_versions(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id,
+    test_version_id_2,
+):
+    """Cards stamped to other target_version_ids must not be touched —
+    the whole point of the endpoint is target-scoped wipe."""
+    keep_card = AgentLexemeCard(
+        target_lemma="bulkdel_keep",
+        source_version_id=test_version_id,
+        target_version_id=test_version_id_2,
+        source_language_iso="eng",
+    )
+    wipe_card = AgentLexemeCard(
+        target_lemma="bulkdel_wipe",
+        source_version_id=test_version_id,
+        target_version_id=test_version_id,
+        source_language_iso="eng",
+    )
+    db_session.add_all([keep_card, wipe_card])
+    db_session.commit()
+    keep_id = keep_card.id
+
+    resp = client.delete(
+        _bulk_delete_url(test_version_id),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["lexeme_cards_deleted"] >= 1
+
+    db_session.expire_all()
+    assert (
+        db_session.query(AgentLexemeCard).filter(AgentLexemeCard.id == keep_id).first()
+        is not None
+    )
+
+    # Clean up the leftover.
+    db_session.query(AgentLexemeCard).filter(AgentLexemeCard.id == keep_id).delete(
+        synchronize_session=False
+    )
+    db_session.commit()
+
+
+def test_bulk_delete_lexeme_cards_403_when_user_lacks_version_access(
+    client, regular_token2, test_version_id
+):
+    """A user without group access to the version cannot bulk-wipe its cards."""
+    resp = client.delete(
+        _bulk_delete_url(test_version_id),
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+def test_bulk_delete_lexeme_cards_403_when_version_unknown_to_regular_user(
+    client, regular_token1
+):
+    """No enumeration leak: a non-admin caller asking about a non-existent
+    version gets the same 403 they'd get for a real version they can't reach."""
+    resp = client.delete(
+        _bulk_delete_url(999999999),
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+def test_bulk_delete_lexeme_cards_404_when_version_unknown_to_admin(
+    client, admin_token
+):
+    """Admins bypass the auth helper, so they reach the version lookup and
+    get a real 404 for non-existent versions."""
+    resp = client.delete(
+        _bulk_delete_url(999999999),
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+def test_bulk_delete_lexeme_cards_unauthenticated(client, test_version_id):
+    """Endpoint requires authentication."""
+    resp = client.delete(_bulk_delete_url(test_version_id))
+    assert resp.status_code == 401
+
+
+def test_bulk_delete_lexeme_cards_requires_target_version_id(client, regular_token1):
+    """Missing target_version_id query param is a 422."""
+    resp = client.delete(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+# --------------------------------------------------------------------------
 # Card translation endpoints (pivot-language architecture, issue #669)
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Add `DELETE /v3/agent/lexeme-card?target_version_id=X` that wipes every lexeme card for the target regardless of `source_version_id`. Cascades through to `agent_lexeme_card_examples` and `card_translations` via the existing ON DELETE CASCADE FKs (no migration needed).
- Returns row counts in the same shape as `DELETE /v3/tokenizer/training-artifacts/{version_id}` so aqua-assessments' Phase 4 rebuild path can call both together.
- Auth mirrors the tokenizer DELETE: 200 with counts, 403 for unauthorized callers (including non-existent versions, to avoid enumeration), 404 for admins on missing versions, idempotent on empty.
- Per-card `DELETE /v3/agent/lexeme-card/{card_id}` is untouched.

Fixes #703

## Test plan

- [x] `test_bulk_delete_lexeme_cards_across_source_pairs_with_cascades` — proves cards at two different `source_version_id`s for the same target get wiped, examples + `card_translations` cascade.
- [x] `test_bulk_delete_lexeme_cards_idempotent` — zero counts on empty target, zero counts again on the second call.
- [x] `test_bulk_delete_lexeme_cards_preserves_other_target_versions` — cards at other targets are not touched.
- [x] `test_bulk_delete_lexeme_cards_403_when_user_lacks_version_access` / `..._403_when_version_unknown_to_regular_user` — non-admin can't enumerate.
- [x] `test_bulk_delete_lexeme_cards_404_when_version_unknown_to_admin` — admin reaches the version lookup.
- [x] `test_bulk_delete_lexeme_cards_unauthenticated` — 401 without a token.
- [x] `test_bulk_delete_lexeme_cards_requires_target_version_id` — 422 with no query param.
- [x] Full `test/test_agent_routes/test_agent_routes.py` (248 tests) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)