### PR TITLE
fix(rebuild): drop legacy NULL-stamped affixes/morphemes

### DIFF
--- a/alembic/migrations/versions/e2ad1ed4a64a_drop_null_target_version_id_affixes_and_morphemes.py
+++ b/alembic/migrations/versions/e2ad1ed4a64a_drop_null_target_version_id_affixes_and_morphemes.py
@@ -1,0 +1,62 @@
+"""Drop legacy NULL-stamped language_affixes / language_morphemes rows
+
+Revision ID: e2ad1ed4a64a
+Revises: c8e1f4a72b9d
+Create Date: 2026-05-20
+
+Background
+----------
+``language_affixes`` and ``language_morphemes`` rows are now version-stamped
+(``target_version_id`` set on insert). Reads at ``GET /affixes-by-version``
+and ``GET /morphemes-by-version`` still do a "soft union" — they include
+both rows stamped to the requested version *and* legacy rows with
+``target_version_id IS NULL`` that share the same ISO. The DELETE that
+backs ``build_mode="rebuild"`` (``DELETE /tokenizer/training-artifacts/
+{version_id}``) only clears rows stamped to ``version_id``, so the legacy
+NULL rows survive a rebuild and the agent picks them right back up via
+the soft union.
+
+Why drop instead of stamp
+-------------------------
+These rows are reproducible: the agent's affix-inventory and grammar-
+discovery steps regenerate them from scratch on the next training run for
+each version. Migrating them onto a specific ``target_version_id`` would
+require guessing which version "owns" them (often there's more than one
+version per ISO with no clear primary), so we take the simpler path —
+delete them and let the agent rebuild against each version cleanly.
+
+What this migration does NOT do
+-------------------------------
+- Does not add a ``NOT NULL`` constraint. The POST/PUT ``/affixes`` API
+  contract still accepts an optional ``revision_id`` (and infers
+  ``target_version_id`` from it). Tightening the schema would require a
+  matching API change to reject NULL-target writes — deferred so this
+  migration stays small.
+- Does not change the soft-union reads. Those still ``OR target_version_id
+  IS NULL``; the branch will simply match nothing after this migration.
+  Drop the branch in a follow-up once we're confident no new NULLs appear.
+
+Downgrade is intentionally a no-op: the deleted rows are reproducible, so
+restoring them isn't meaningful.
+"""
+
+from alembic import op
+
+revision = "e2ad1ed4a64a"
+down_revision = "c8e1f4a72b9d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "DELETE FROM language_affixes WHERE target_version_id IS NULL"
+    )
+    op.execute(
+        "DELETE FROM language_morphemes WHERE target_version_id IS NULL"
+    )
+
+
+def downgrade() -> None:
+    # No-op: the deleted rows are reproducible by re-running the agent.
+    pass


### PR DESCRIPTION
## Summary

- `build_mode=\"rebuild\"` couldn't actually clear affix/morpheme state because the per-version DELETE behind it (`DELETE /v3/tokenizer/training-artifacts/{version_id}`) only clears rows stamped to that `version_id`, but the GET readers do a **soft union** that also returns `target_version_id IS NULL` legacy rows. The agent's next \"Loading affixes\" step picks up those survivors and skips fresh extraction — exactly what the symptom looked like in #missing-cards triage.
- Drops the legacy NULL-stamped rows in both `language_affixes` and `language_morphemes` so the rebuild contract holds.
- Rows are agent-reproducible — downgrade is a no-op.

## Prod state at the time of this PR

- Already applied on prod (`alembic upgrade head` was authorized + run while triaging). Prod alembic head: `e2ad1ed4a64a`.
- Before: 387 NULL-stamped affixes across 19 ISOs, 0 stamped, 0 morphemes.
- After: 0 NULL, 0 stamped, 0 morphemes — every existing version's next training run will re-extract affixes (~1-2 min of agent time per version, one-time).
- Same shape on dev — same 387 NULL / 0 stamped (the population was identical because the writes had never been version-keyed before).

## Why drop instead of stamp

These rows are reproducible. Migrating them onto a chosen `target_version_id` would mean guessing which version \"owns\" each ISO (often >1 nya version, etc.), and the agent will rebuild on next training anyway. The migration file's docstring spells this out.

## Deliberately not in this PR

- **No `NOT NULL` constraint** on `target_version_id` yet. POST/PUT `/affixes` still accept an optional `revision_id` (affix_routes.py:214, 442); the constraint would surface NULL writes as 500s rather than 422s. Tighten in a follow-up alongside an API contract change.
- **No change to soft-union reads** (`affix_routes.py:88-93`, etc.). After this migration the `OR target_version_id IS NULL` branch becomes dead code; cleanest to drop it once we're confident no new NULLs leak in.

## Test plan

- [x] Migration runs cleanly on prod (`a3c1e7b9d4f0` → `c8e1f4a72b9d` → `e2ad1ed4a64a`).
- [x] Post-state verified: 0 NULL rows in either table on prod; `card_translations.last_user_edit` column present.
- [ ] Confirm next agent training run for an existing version re-extracts affixes (sanity check on the rebuild contract; will play out organically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)