### PR TITLE
docs(notebook): document build_mode and per-call model selection

### DIFF
--- a/alembic/migrations/versions/e2ad1ed4a64a_drop_null_target_version_id_affixes_and_morphemes.py
+++ b/alembic/migrations/versions/e2ad1ed4a64a_drop_null_target_version_id_affixes_and_morphemes.py
@@ -49,12 +49,8 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.execute(
-        "DELETE FROM language_affixes WHERE target_version_id IS NULL"
-    )
-    op.execute(
-        "DELETE FROM language_morphemes WHERE target_version_id IS NULL"
-    )
+    op.execute("DELETE FROM language_affixes WHERE target_version_id IS NULL")
+    op.execute("DELETE FROM language_morphemes WHERE target_version_id IS NULL")
 
 
 def downgrade() -> None:

--- a/notebooks/train_predict_demo.ipynb
+++ b/notebooks/train_predict_demo.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Aqua API \u2014 Train & Predict demo\n",
+    "# Aqua API — Train & Predict demo\n",
     "\n",
     "End-to-end walk-through of the typical client flow:\n",
     "\n",
@@ -14,12 +14,12 @@
     "4. **Look up the reference revision** you want to align against (here: NIV, revision id `1592`).\n",
     "5. **Trigger training** for all available apps (semantic-similarity, tfidf, word-alignment, ngrams, agent-critique).\n",
     "6. **Poll training status** until every job reaches a terminal state.\n",
-    "7. **Inspect training results** \u2014 interleaved per-vref scores from each app.\n",
+    "7. **Inspect training results** — interleaved per-vref scores from each app.\n",
     "8. **Run `/predict`** on a new (or adjusted) verse pair using the artifacts you just trained.\n",
     "\n",
     "Edit the `BASE_URL`, `USERNAME`, and `PASSWORD` cells to point at the environment you want to use.\n",
     "\n",
-    "> The Aqua API uses the [vref convention](https://github.com/BibleNLP/ebible/blob/main/metadata/vref.txt) \u2014 every revision is a 41,899-line text file where line N corresponds to canonical verse reference N. Lines may be blank for verses you haven't translated."
+    "> The Aqua API uses the [vref convention](https://github.com/BibleNLP/ebible/blob/main/metadata/vref.txt) — every revision is a 41,899-line text file where line N corresponds to canonical verse reference N. Lines may be blank for verses you haven't translated."
    ]
   },
   {
@@ -34,10 +34,10 @@
     "| App | What it does | Strength |\n",
     "| --- | --- | --- |\n",
     "| **semantic-similarity** | Compares sentence-pair embeddings from a fine-tuned model. | Catches meaning drift even when the two sides share no surface vocabulary (e.g. a paraphrase that lost the actual meaning). |\n",
-    "| **tfidf** | Builds a [TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) + truncated-SVD encoder over the corpus and returns the nearest-neighbour verses to a query \u2014 i.e. the verses whose wording is most similar. | Useful when reviewing a verse: surfaces other places in the corpus that read similarly, so the translator can check consistency or pull comparable renderings. |\n",
+    "| **tfidf** | Builds a [TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) + truncated-SVD encoder over the corpus and returns the nearest-neighbour verses to a query — i.e. the verses whose wording is most similar. | Useful when reviewing a verse: surfaces other places in the corpus that read similarly, so the translator can check consistency or pull comparable renderings. |\n",
     "| **word-alignment** | Word-level alignment between source and target. With `use_eflomal=true` it uses [eflomal](https://github.com/robertostling/eflomal) (statistical alignment); otherwise FastAlign. | Surfaces added words, omitted words, and systematic mistranslations of specific terms. |\n",
     "| **ngrams** | Mines frequent multi-word phrases from the training corpus, so translators can compare translation consistency of those phrases. | Catches verses that are missing the recurring phrases your translation team usually uses. |\n",
-    "| **agent-critique** *(likely to be renamed `ai-notes`)* | LLM-driven pipeline. Produces structured per-verse issues (omissions, additions, replacements, severity), an automatic back-translation, lexeme cards, and a grammar sketch. | Surfaces semantic and theological issues a statistical model would miss, plus the back-translation / lexeme / grammar artefacts give human reviewers context to work from. Most expensive of the five \u2014 call it via `/predict` on the verses you actually want inspected, not over the whole training set. |\n",
+    "| **agent-critique** *(likely to be renamed `ai-notes`)* | LLM-driven pipeline. Produces structured per-verse issues (omissions, additions, replacements, severity), an automatic back-translation, lexeme cards, and a grammar sketch. | Surfaces semantic and theological issues a statistical model would miss, plus the back-translation / lexeme / grammar artefacts give human reviewers context to work from. Most expensive of the five — call it via `/predict` on the verses you actually want inspected, not over the whole training set. |\n",
     "\n",
     "You can fan out to a subset by passing `apps=[...]` on `/train` or `/predict`. Omit it to run all five."
    ]
@@ -87,7 +87,7 @@
     "BASE_URL = \"https://cp3by92k8p.us-east-1.awsapprunner.com\"  # development\n",
     "# BASE_URL = \"https://tmv9bz5v4q.us-east-1.awsapprunner.com\"  # production\n",
     "\n",
-    "# All v3 routes are reachable at /latest/ as well \u2014 we use /latest/ here.\n",
+    "# All v3 routes are reachable at /latest/ as well — we use /latest/ here.\n",
     "PREFIX = \"latest\"\n",
     "\n",
     "USERNAME = \"dev@paratext.org\"  # e.g. your email or login name\n",
@@ -151,7 +151,7 @@
    "outputs": [],
    "source": [
     "# Look up your groups so the new version can be shared with one of them.\n",
-    "# /version requires `add_to_groups` to be non-empty \u2014 without a group, no\n",
+    "# /version requires `add_to_groups` to be non-empty — without a group, no\n",
     "# other user could see the version. Pick deliberately: this version will\n",
     "# be visible to every member of every group you list here.\n",
     "my_groups = check(requests.get(f\"{BASE_URL}/{PREFIX}/groups/me\", headers=AUTH)).json()\n",
@@ -168,7 +168,7 @@
     "\n",
     "version_payload = {\n",
     "    \"name\": \"Demo Chichewa Version\",\n",
-    "    \"iso_language\": \"nya\",  # ISO 639-3 \u2014 Nyanja / Chichewa\n",
+    "    \"iso_language\": \"nya\",  # ISO 639-3 — Nyanja / Chichewa\n",
     "    \"iso_script\": \"Latn\",   # ISO 15924\n",
     "    \"abbreviation\": \"NYADEMO\",\n",
     "    \"rights\": \"Public domain demo\",\n",
@@ -208,7 +208,7 @@
    "outputs": [],
    "source": [
     "# Pull the revision text directly from the BibleNLP ebible corpus on GitHub\n",
-    "# and forward it as a multipart upload \u2014 no need to write a local file.\n",
+    "# and forward it as a multipart upload — no need to write a local file.\n",
     "revision_bytes = check(requests.get(REVISION_URL)).content\n",
     "line_count = revision_bytes.count(b\"\\n\") + (0 if revision_bytes.endswith(b\"\\n\") else 1)\n",
     "print(f\"Downloaded {len(revision_bytes):,} bytes ({line_count:,} lines)\")\n",
@@ -237,7 +237,7 @@
     "\n",
     "Both `/train` and `/predict` are keyed on **versions**. By default the API picks the latest non-deleted revision under the version when training, so a fresh upload to the same version automatically becomes the next training input.\n",
     "\n",
-    "If you need to pin training to a specific revision (e.g. retraining against an older draft for comparison), pass `source_revision_id` / `target_revision_id` instead \u2014 see the next cell.\n",
+    "If you need to pin training to a specific revision (e.g. retraining against an older draft for comparison), pass `source_revision_id` / `target_revision_id` instead — see the next cell.\n",
     "\n",
     "We need the NIV's `bible_version_id` for the train + predict steps below. If you already know it, you can hardcode `REFERENCE_VERSION_ID` directly. Otherwise, the lookup below scans your accessible revisions for `id == REFERENCE_REVISION_ID`."
    ]
@@ -275,7 +275,7 @@
     "\n",
     "`POST /latest/train` queues training jobs for every app at once and returns a `session_id` you can poll. Pass `apps=[...]` to restrict to specific apps; omit it to train all of them.\n",
     "\n",
-    "The pair is identified by **`source_version_id` / `target_version_id`** \u2014 the API resolves each side to its latest non-deleted revision. To pin a side to a specific revision (e.g. retrain against an older draft), swap that side's `*_version_id` for `*_revision_id`; you can mix the two across sides.\n",
+    "The pair is identified by **`source_version_id` / `target_version_id`** — the API resolves each side to its latest non-deleted revision. To pin a side to a specific revision (e.g. retrain against an older draft), swap that side's `*_version_id` for `*_revision_id`; you can mix the two across sides.\n",
     "\n",
     "`use_eflomal=true` opts the word-alignment app into the eflomal alignment path."
    ]
@@ -286,28 +286,7 @@
    "id": "206f3ff6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "train_payload = {\n",
-    "    \"source_version_id\": REFERENCE_VERSION_ID,    # NIV reference (latest revision)\n",
-    "    \"target_version_id\": VERSION_ID,              # your translation (latest revision)\n",
-    "    \"options\": {\"use_eflomal\": True},             # Will probably become default soon\n",
-    "    # To pin a side to a specific revision instead of \"latest under the version\":\n",
-    "    # \"source_revision_id\": REFERENCE_REVISION_ID,\n",
-    "    # \"target_revision_id\": REVISION_ID,\n",
-    "    # \"apps\": [\"semantic-similarity\", \"word-alignment\"]  # optional subset\n",
-    "}\n",
-    "\n",
-    "resp = check(requests.post(\n",
-    "    f\"{BASE_URL}/{PREFIX}/train\",\n",
-    "    json=train_payload,\n",
-    "    headers=AUTH,\n",
-    "))\n",
-    "training_response = resp.json()\n",
-    "SESSION_ID = training_response[\"session_id\"]\n",
-    "print(f\"Session id: {SESSION_ID}\")\n",
-    "for job in training_response[\"training_jobs\"]:\n",
-    "    print(f\"  job {job['id']:>4}  {job['type']:<22}  status={job['status']}\")"
-   ]
+   "source": "train_payload = {\n    \"source_version_id\": REFERENCE_VERSION_ID,    # NIV reference (latest revision)\n    \"target_version_id\": VERSION_ID,              # your translation (latest revision)\n    \"options\": {\n        \"use_eflomal\": True,                      # Will probably become default soon\n        # \"build_mode\": \"rebuild\",                # ⚠️ Clean-slate rebuild: deletes every\n                                                  # training artifact for `target_version_id`\n                                                  # (language affixes, morphemes, the per-version\n                                                  # training_artifacts row, *and* the lexeme cards\n                                                  # at the canonical source/target pair) before\n                                                  # retraining from scratch. Use when an earlier\n                                                  # build went wrong and you want a fresh start;\n                                                  # otherwise omit and the default (\"auto\") will\n                                                  # reuse existing artifacts.\n        # ── Per-call model selection ───────────────────────────────────────\n        # The two Claude options cap their no-vref train runs at different\n        # word counts (Haiku: top 300, Sonnet: top 100) so that the *total*\n        # run cost lands in roughly the same $20–35 envelope despite Haiku\n        # being ~3× cheaper per token. The trade-off is quality-per-word:\n        # Sonnet covers fewer words but builds richer cards for each.\n        # \"model\": \"haiku-4-5\",                   # Claude Haiku 4.5 (Bedrock). Top 300 target\n                                                  # words. Similar instruction-following quality\n                                                  # to Sonnet 4.6 on Malila in A/B tests.\n        # \"model\": \"sonnet-4-6\",                  # Claude Sonnet 4.6 (Bedrock). Top 100 target\n                                                  # words. Highest quality per card.\n        # Omit `model` for the deploy default — gpt-oss-120b on Bedrock,\n        # 1000-word cap. Cheapest by far, looser on tool-call discipline.\n    },\n    # To pin a side to a specific revision instead of \"latest under the version\":\n    # \"source_revision_id\": REFERENCE_REVISION_ID,\n    # \"target_revision_id\": REVISION_ID,\n    # \"apps\": [\"semantic-similarity\", \"word-alignment\"]  # optional subset\n}\n\nresp = check(requests.post(\n    f\"{BASE_URL}/{PREFIX}/train\",\n    json=train_payload,\n    headers=AUTH,\n))\ntraining_response = resp.json()\nSESSION_ID = training_response[\"session_id\"]\nprint(f\"Session id: {SESSION_ID}\")\nfor job in training_response[\"training_jobs\"]:\n    print(f\"  job {job['id']:>4}  {job['type']:<22}  status={job['status']}\")"
   },
   {
    "cell_type": "markdown",
@@ -316,16 +295,16 @@
    "source": [
     "## 6. Poll training status\n",
     "\n",
-    "`GET /latest/train/status?session_id=...` returns the same payload shape as `/train`, so you can watch each job tick from `queued` \u2192 `running` \u2192 `finished` (or `failed`).\n",
+    "`GET /latest/train/status?session_id=...` returns the same payload shape as `/train`, so you can watch each job tick from `queued` → `running` → `finished` (or `failed`).\n",
     "\n",
     "Typical durations on dev with the Nyanja Bible demo revision:\n",
     "\n",
     "| App | Typical |\n",
     "| --- | --- |\n",
     "| semantic-similarity | ~20-40 min |\n",
-    "| tfidf | ~1\u20132 min |\n",
+    "| tfidf | ~1–2 min |\n",
     "| ngrams | ~3 min |\n",
-    "| word-alignment (eflomal) | ~10\u201315 min |\n",
+    "| word-alignment (eflomal) | ~10–15 min |\n",
     "| agent-critique | ~10-15 min |"
    ]
   },
@@ -375,7 +354,7 @@
     "\n",
     "`GET /latest/train/status/{session_id}/results` returns per-verse rows from every completed app, interleaved by `vref`. You can filter by `book` / `chapter` / `verse` and paginate with `page` + `page_size`.\n",
     "\n",
-    "Conceptually these results are `/predict` run over **the whole training text** \u2014 every app scores every verse you uploaded against the reference, so you get a free pre-scored pass over your translation as a side effect of training. That holds for `semantic-similarity`, `tfidf`, `word-alignment`, and `ngrams`.\n",
+    "Conceptually these results are `/predict` run over **the whole training text** — every app scores every verse you uploaded against the reference, so you get a free pre-scored pass over your translation as a side effect of training. That holds for `semantic-similarity`, `tfidf`, `word-alignment`, and `ngrams`.\n",
     "\n",
     "The exception is **`agent-critique`**: running it on the entire submitted text would be prohibitively expensive (it's an LLM-driven critique loop). Training only fits the agent artifacts; it does not return per-verse agent results here. To get agent-critique scores for specific verses, call `/predict` (next section) with `apps=[\"agent-critique\"]` and the verses you actually want critiqued.\n",
     "\n",
@@ -405,16 +384,16 @@
    "source": [
     "## 8. Run `/predict` on a new verse pair\n",
     "\n",
-    "Once training is done, `/predict` scores arbitrary `(source_text, target_text)` pairs against the trained artifacts. The expectation is that each pair is either a **brand-new draft verse** that was not in the training data, or a **revised version of a verse** that was \u2014 so you can score quality after each translator edit without retraining.\n",
+    "Once training is done, `/predict` scores arbitrary `(source_text, target_text)` pairs against the trained artifacts. The expectation is that each pair is either a **brand-new draft verse** that was not in the training data, or a **revised version of a verse** that was — so you can score quality after each translator edit without retraining.\n",
     "\n",
     "Throughout the API the convention is **`source` = reference language (what you're translating *from*), `target` = the translation being scored (what you're translating *to*)**. Here that means `source_text` / `source_version_id` is the NIV English side, and `target_text` / `target_version_id` is the Nyanja draft.\n",
     "\n",
-    "- `pairs` \u2014 list of `{vref, source_text, target_text}`. **Scoring runs on the strings**: ngrams checks overlap with the trained ngram set, semantic-similarity compares text embeddings, and so on. `vref` is an optional convenience identifier \u2014 the API echoes it back alongside each pair's results so you can match scores to verses on the client side, but it does not drive scoring.\n",
-    "- `source_version_id` / `target_version_id` \u2014 the version pair the artifacts were trained under. Both `/train` and `/predict` are **keyed on versions**: training artifacts are shared across every revision within a version (so a fresh revision of an in-progress translation reuses the same trained models without retraining), but they don't leak across versions \u2014 two different versions in the same language are isolated, and you'll need to train each one separately.\n",
-    "- `apps` \u2014 optional list to fan out to a subset.\n",
-    "- `include_translation` / `include_critique` \u2014 opt the agent app into its heavier LLM passes. These don't block the synchronous response: the fast pieces of the agent (lexeme cards, grammar sketch, language profiles) come back immediately, and the slow translation/critique work runs in the background. The response includes a `job` handle you poll at `/predict/jobs/{id}` to pick up the slow result. See the next section for the polling code.\n",
+    "- `pairs` — list of `{vref, source_text, target_text}`. **Scoring runs on the strings**: ngrams checks overlap with the trained ngram set, semantic-similarity compares text embeddings, and so on. `vref` is an optional convenience identifier — the API echoes it back alongside each pair's results so you can match scores to verses on the client side, but it does not drive scoring.\n",
+    "- `source_version_id` / `target_version_id` — the version pair the artifacts were trained under. Both `/train` and `/predict` are **keyed on versions**: training artifacts are shared across every revision within a version (so a fresh revision of an in-progress translation reuses the same trained models without retraining), but they don't leak across versions — two different versions in the same language are isolated, and you'll need to train each one separately.\n",
+    "- `apps` — optional list to fan out to a subset.\n",
+    "- `include_translation` / `include_critique` — opt the agent app into its heavier LLM passes. These don't block the synchronous response: the fast pieces of the agent (lexeme cards, grammar sketch, language profiles) come back immediately, and the slow translation/critique work runs in the background. The response includes a `job` handle you poll at `/predict/jobs/{id}` to pick up the slow result. See the next section for the polling code.\n",
     "\n",
-    "Below we score two pairs at GEN 1:1: the first uses the NIV English source paired with the real Nyanja draft (a known-good match), the second pairs the English GEN 1:2 source with a deliberately wrong Nyanja text (the Nyanja rendering of GEN 1:3 \u2014 same language, different verse) so you can see the score collapse.\n"
+    "Below we score two pairs at GEN 1:1: the first uses the NIV English source paired with the real Nyanja draft (a known-good match), the second pairs the English GEN 1:2 source with a deliberately wrong Nyanja text (the Nyanja rendering of GEN 1:3 — same language, different verse) so you can see the score collapse.\n"
    ]
   },
   {
@@ -423,7 +402,7 @@
    "id": "b24d670b",
    "metadata": {},
    "outputs": [],
-   "source": "# Pull the actual Nyanja rendering of GEN 1:1 from the corpus we uploaded.\n# GEN 1:1 is the very first canonical vref (1-indexed); see vref.txt at\n# https://github.com/BibleNLP/ebible/blob/main/metadata/vref.txt\nnya_gen_1_1 = REVISION_LINES[0]\n# GEN 1:3 is two verses later, same language. We use it below as the\n# Nyanja side of a deliberately mismatched pair so the scores collapse.\nnya_gen_1_3 = REVISION_LINES[2]\nprint(f\"GEN 1:1 (Nyanja): {nya_gen_1_1!r}\")\nprint(f\"GEN 1:3 (Nyanja, used as the bad pair): {nya_gen_1_3!r}\")\n\n# A reasonable English rendering of GEN 1:1 to use as the source side.\nENGLISH_GEN_1_1 = (\n    \"In the beginning God created the heavens and the earth.\"\n)\nENGLISH_GEN_1_2 = (\n    \"Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.\"\n)\n\n# Stash the slow-path job id in a known sentinel so the polling cell\n# below stays restart-safe even if you re-run it without re-running this\n# cell. The real value is set after the predict response below.\nJOB_ID = None\n\npredict_payload = {\n    \"pairs\": [\n        {\n            \"vref\": \"GEN 1:1\",\n            \"source_text\": ENGLISH_GEN_1_1,\n            \"target_text\": nya_gen_1_1,\n        },\n        {\n            \"vref\": \"GEN 1:2\",\n            \"source_text\": ENGLISH_GEN_1_2,\n            # Now the Nyanja target is GEN 1:3's text \u2014 clearly\n            # not a translation of GEN 1:2, so every app should score it low.\n            \"target_text\": nya_gen_1_3,\n        },\n    ],\n    \"source_version_id\": REFERENCE_VERSION_ID,  # NIV\n    \"target_version_id\": VERSION_ID,             # your Nyanja translation\n    # \"apps\": [\"semantic-similarity\", \"ngrams\"],  # optional subset\n    # Opt the agent into the heavier LLM passes. Both default to False.\n    # Setting either to True does NOT make the call block \u2014 the slow\n    # work is spawned in the background and the response carries a\n    # `job` handle you poll for the result (see section 8b below).\n    # `include_critique` requires `include_translation=True`.\n    \"include_translation\": True,\n    # \"include_critique\": True,\n}\n\nresp = check(requests.post(\n    f\"{BASE_URL}/{PREFIX}/predict\",\n    json=predict_payload,\n    headers=AUTH,\n))\npredictions = resp.json()\n\n# Save the full response to a file so it's easy to inspect later. The\n# response carries Nyanja text and other non-ASCII characters; passing\n# `ensure_ascii=False` keeps them as-is rather than escaping every\n# non-ASCII codepoint to \\uXXXX. Writing in UTF-8 to match.\noutput_path = Path(\"predict_output.json\")\noutput_path.write_text(\n    json.dumps(predictions, indent=2, ensure_ascii=False),\n    encoding=\"utf-8\",\n)\nprint(f\"Saved full predict response to {output_path.resolve()}\")\n\n# Per-app status summary so the cell is still informative without\n# dumping the whole payload.\nfor app_name, result in predictions.get(\"results\", {}).items():\n    status_str = result.get(\"status\", \"?\")\n    note = \"\"\n    if status_str == \"ok\":\n        n_pairs = len(result.get(\"data\", {}).get(\"pairs\", []))\n        note = f\"({n_pairs} pair(s) returned)\"\n    elif result.get(\"error\"):\n        note = f\"error: {result['error']}\"\n    print(f\"  {app_name:<20} {status_str:<6} {note}\")\n\n# If we asked for translation or critique, the response carries a job\n# handle pointing at the polling endpoint. Stash the id for the next cell.\nJOB_ID = (predictions.get(\"job\") or {}).get(\"id\")\nif JOB_ID:\n    print(f\"\\nSpawned slow agent path: job_id={JOB_ID}\")\n    print(f\"Poll at: {predictions['job']['poll_url']}\")\nelse:\n    print(\"\\nNo slow-path job \u2014 translation/critique were not requested.\")\n"
+   "source": "# Pull the actual Nyanja rendering of GEN 1:1 from the corpus we uploaded.\n# GEN 1:1 is the very first canonical vref (1-indexed); see vref.txt at\n# https://github.com/BibleNLP/ebible/blob/main/metadata/vref.txt\nnya_gen_1_1 = REVISION_LINES[0]\n# GEN 1:3 is two verses later, same language. We use it below as the\n# Nyanja side of a deliberately mismatched pair so the scores collapse.\nnya_gen_1_3 = REVISION_LINES[2]\nprint(f\"GEN 1:1 (Nyanja): {nya_gen_1_1!r}\")\nprint(f\"GEN 1:3 (Nyanja, used as the bad pair): {nya_gen_1_3!r}\")\n\n# A reasonable English rendering of GEN 1:1 to use as the source side.\nENGLISH_GEN_1_1 = (\n    \"In the beginning God created the heavens and the earth.\"\n)\nENGLISH_GEN_1_2 = (\n    \"Now the earth was formless and void, and darkness was over the surface of the deep. And the Spirit of God was hovering over the surface of the waters.\"\n)\n\n# Stash the slow-path job id in a known sentinel so the polling cell\n# below stays restart-safe even if you re-run it without re-running this\n# cell. The real value is set after the predict response below.\nJOB_ID = None\n\npredict_payload = {\n    \"pairs\": [\n        {\n            \"vref\": \"GEN 1:1\",\n            \"source_text\": ENGLISH_GEN_1_1,\n            \"target_text\": nya_gen_1_1,\n        },\n        {\n            \"vref\": \"GEN 1:2\",\n            \"source_text\": ENGLISH_GEN_1_2,\n            # Now the Nyanja target is GEN 1:3's text — clearly\n            # not a translation of GEN 1:2, so every app should score it low.\n            \"target_text\": nya_gen_1_3,\n        },\n    ],\n    \"source_version_id\": REFERENCE_VERSION_ID,  # NIV\n    \"target_version_id\": VERSION_ID,             # your Nyanja translation\n    # \"apps\": [\"semantic-similarity\", \"ngrams\"],  # optional subset\n    # Opt the agent into the heavier LLM passes. Both default to False.\n    # Setting either to True does NOT make the call block — the slow\n    # work is spawned in the background and the response carries a\n    # `job` handle you poll for the result (see section 8b below).\n    # `include_critique` requires `include_translation=True`.\n    \"include_translation\": True,\n    # \"include_critique\": True,\n    # Per-call model selection for the agent app. Routes word-memory,\n    # translation, and critique LLM calls to the chosen model; other\n    # apps ignore this field. Picked per call — the predict-time model\n    # does NOT have to match whatever model was used at /train time.\n    # \"model\": \"haiku-4-5\",   # Claude Haiku 4.5 via Bedrock — ~3× cheaper\n    #                         # than Sonnet 4.6 with similar quality on Malila.\n    # \"model\": \"sonnet-4-6\",  # Claude Sonnet 4.6 via Bedrock — top quality,\n    #                         # most expensive.\n    # Omit `model` to use the deploy default (gpt-oss-120b on Bedrock).\n}\n\nresp = check(requests.post(\n    f\"{BASE_URL}/{PREFIX}/predict\",\n    json=predict_payload,\n    headers=AUTH,\n))\npredictions = resp.json()\n\n# Save the full response to a file so it's easy to inspect later. The\n# response carries Nyanja text and other non-ASCII characters; passing\n# `ensure_ascii=False` keeps them as-is rather than escaping every\n# non-ASCII codepoint to \\uXXXX. Writing in UTF-8 to match.\noutput_path = Path(\"predict_output.json\")\noutput_path.write_text(\n    json.dumps(predictions, indent=2, ensure_ascii=False),\n    encoding=\"utf-8\",\n)\nprint(f\"Saved full predict response to {output_path.resolve()}\")\n\n# Per-app status summary so the cell is still informative without\n# dumping the whole payload.\nfor app_name, result in predictions.get(\"results\", {}).items():\n    status_str = result.get(\"status\", \"?\")\n    note = \"\"\n    if status_str == \"ok\":\n        n_pairs = len(result.get(\"data\", {}).get(\"pairs\", []))\n        note = f\"({n_pairs} pair(s) returned)\"\n    elif result.get(\"error\"):\n        note = f\"error: {result['error']}\"\n    print(f\"  {app_name:<20} {status_str:<6} {note}\")\n\n# If we asked for translation or critique, the response carries a job\n# handle pointing at the polling endpoint. Stash the id for the next cell.\nJOB_ID = (predictions.get(\"job\") or {}).get(\"id\")\nif JOB_ID:\n    print(f\"\\nSpawned slow agent path: job_id={JOB_ID}\")\n    print(f\"Poll at: {predictions['job']['poll_url']}\")\nelse:\n    print(\"\\nNo slow-path job — translation/critique were not requested.\")\n"
   },
   {
    "cell_type": "markdown",
@@ -431,15 +410,15 @@
    "source": [
     "## 8b. Poll the slow agent path for translation / critique\n",
     "\n",
-    "When `/predict` was called with `include_translation=True` (and/or `include_critique=True`), the response above includes a `job` handle. The slow LLM passes can take a few minutes for a chapter-sized batch \u2014 far longer than the 2-minute API request limit \u2014 so they run in the background and you fetch them via `GET /predict/jobs/{id}`.\n",
+    "When `/predict` was called with `include_translation=True` (and/or `include_critique=True`), the response above includes a `job` handle. The slow LLM passes can take a few minutes for a chapter-sized batch — far longer than the 2-minute API request limit — so they run in the background and you fetch them via `GET /predict/jobs/{id}`.\n",
     "\n",
     "The polling endpoint returns one of three statuses:\n",
     "\n",
-    "- `running` \u2014 not done yet. The response carries a `Retry-After` header (currently 10 seconds) suggesting a polite poll cadence.\n",
-    "- `complete` \u2014 `pairs` is populated with `translation` (and `critique` if you asked for it) for each submitted pair, in the same order they were submitted. Every pair echoes back its original `vref`, `source_text`, and `target_text`, so callers that submit without a `vref` can still match results to inputs by index.\n",
-    "- `failed` \u2014 the slow Modal call raised. The `error` field carries a short reason; the synchronous `/predict` response above is unaffected.\n",
+    "- `running` — not done yet. The response carries a `Retry-After` header (currently 10 seconds) suggesting a polite poll cadence.\n",
+    "- `complete` — `pairs` is populated with `translation` (and `critique` if you asked for it) for each submitted pair, in the same order they were submitted. Every pair echoes back its original `vref`, `source_text`, and `target_text`, so callers that submit without a `vref` can still match results to inputs by index.\n",
+    "- `failed` — the slow Modal call raised. The `error` field carries a short reason; the synchronous `/predict` response above is unaffected.\n",
     "\n",
-    "Jobs are scoped to the user that created them \u2014 only that account (or an admin) can read the result. Job records are kept in the database and survive container restarts, so you can poll from a different process if you need to.\n"
+    "Jobs are scoped to the user that created them — only that account (or an admin) can read the result. Job records are kept in the database and survive container restarts, so you can poll from a different process if you need to.\n"
    ],
    "id": "polling-md"
   },
@@ -448,7 +427,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "POLL_INTERVAL = 10  # the API also advertises this via Retry-After\nTERMINAL = {\"complete\", \"failed\"}\n\n\ndef _format_critique(critique: dict) -> str:\n    \"\"\"Render a per-verse critique dict (omissions / additions / replacements)\n    in a way that's readable in a notebook print loop. Returns an empty\n    string when no issues were flagged.\"\"\"\n    if not critique:\n        return \"\"\n    bits = []\n    for o in critique.get(\"omissions\") or []:\n        sev = o.get(\"severity\", \"?\") if isinstance(o, dict) else \"?\"\n        text = o.get(\"source_text\") if isinstance(o, dict) else o\n        comments = o.get(\"comments\", \"\") if isinstance(o, dict) else \"\"\n        bits.append(f\"- omission [{sev}]: {text!r}{(' \u2014 ' + comments) if comments else ''}\")\n    for a in critique.get(\"additions\") or []:\n        sev = a.get(\"severity\", \"?\") if isinstance(a, dict) else \"?\"\n        text = a.get(\"draft_text\") if isinstance(a, dict) else a\n        comments = a.get(\"comments\", \"\") if isinstance(a, dict) else \"\"\n        bits.append(f\"- addition [{sev}]: {text!r}{(' \u2014 ' + comments) if comments else ''}\")\n    for r in critique.get(\"replacements\") or []:\n        if isinstance(r, dict):\n            sev = r.get(\"severity\", \"?\")\n            comments = r.get(\"comments\", \"\")\n            bits.append(\n                f\"- replacement [{sev}]: {r.get('source_text')!r} \u2192 {r.get('draft_text')!r}\"\n                + ((\" \u2014 \" + comments) if comments else \"\")\n            )\n        else:\n            bits.append(f\"- replacement: {r}\")\n    return \"\\n\".join(bits)\n\n\nif not JOB_ID:\n    print(\"Skipping \u2014 no job to poll (set include_translation=True above to try this).\")\nelse:\n    while True:\n        resp = check(requests.get(\n            f\"{BASE_URL}/{PREFIX}/predict/jobs/{JOB_ID}\",\n            headers=AUTH,\n        ))\n        job = resp.json()\n        print(f\"[{time.strftime('%H:%M:%S')}] status={job['status']}\")\n        if job[\"status\"] in TERMINAL:\n            break\n        # The Retry-After header is the API's preferred cadence; fall\n        # back to POLL_INTERVAL if the proxy strips it.\n        time.sleep(int(resp.headers.get(\"Retry-After\", POLL_INTERVAL)))\n\n    if job[\"status\"] == \"complete\":\n        print(f\"\\nGot {len(job['pairs'])} pair(s):\\n\")\n        critique_requested = \"critique\" in (job.get(\"includes\") or [])\n        for p in job[\"pairs\"]:\n            label = p.get(\"vref\") or f\"(no vref) target={p['target_text'][:30]!r}\"\n            t = (p.get(\"translation\") or {}).get(\"literal\", \"<no translation>\")\n            print(f\"  {label}\")\n            print(f\"    back-translation: {t[:160]}\")\n            critique_block = _format_critique(p.get(\"critique\") or {})\n            if critique_block:\n                indented = \"\\n\".join(\"    \" + line for line in critique_block.splitlines())\n                print(f\"    critique:\\n{indented}\")\n            elif critique_requested:\n                print(f\"    critique: (no issues flagged)\")\n    else:\n        print(f\"\\nJob failed: {job.get('error')!r}\")\n",
+   "source": "POLL_INTERVAL = 10  # the API also advertises this via Retry-After\nTERMINAL = {\"complete\", \"failed\"}\n\n\ndef _format_critique(critique: dict) -> str:\n    \"\"\"Render a per-verse critique dict (omissions / additions / replacements)\n    in a way that's readable in a notebook print loop. Returns an empty\n    string when no issues were flagged.\"\"\"\n    if not critique:\n        return \"\"\n    bits = []\n    for o in critique.get(\"omissions\") or []:\n        sev = o.get(\"severity\", \"?\") if isinstance(o, dict) else \"?\"\n        text = o.get(\"source_text\") if isinstance(o, dict) else o\n        comments = o.get(\"comments\", \"\") if isinstance(o, dict) else \"\"\n        bits.append(f\"- omission [{sev}]: {text!r}{(' — ' + comments) if comments else ''}\")\n    for a in critique.get(\"additions\") or []:\n        sev = a.get(\"severity\", \"?\") if isinstance(a, dict) else \"?\"\n        text = a.get(\"draft_text\") if isinstance(a, dict) else a\n        comments = a.get(\"comments\", \"\") if isinstance(a, dict) else \"\"\n        bits.append(f\"- addition [{sev}]: {text!r}{(' — ' + comments) if comments else ''}\")\n    for r in critique.get(\"replacements\") or []:\n        if isinstance(r, dict):\n            sev = r.get(\"severity\", \"?\")\n            comments = r.get(\"comments\", \"\")\n            bits.append(\n                f\"- replacement [{sev}]: {r.get('source_text')!r} → {r.get('draft_text')!r}\"\n                + ((\" — \" + comments) if comments else \"\")\n            )\n        else:\n            bits.append(f\"- replacement: {r}\")\n    return \"\\n\".join(bits)\n\n\nif not JOB_ID:\n    print(\"Skipping — no job to poll (set include_translation=True above to try this).\")\nelse:\n    while True:\n        resp = check(requests.get(\n            f\"{BASE_URL}/{PREFIX}/predict/jobs/{JOB_ID}\",\n            headers=AUTH,\n        ))\n        job = resp.json()\n        print(f\"[{time.strftime('%H:%M:%S')}] status={job['status']}\")\n        if job[\"status\"] in TERMINAL:\n            break\n        # The Retry-After header is the API's preferred cadence; fall\n        # back to POLL_INTERVAL if the proxy strips it.\n        time.sleep(int(resp.headers.get(\"Retry-After\", POLL_INTERVAL)))\n\n    if job[\"status\"] == \"complete\":\n        print(f\"\\nGot {len(job['pairs'])} pair(s):\\n\")\n        critique_requested = \"critique\" in (job.get(\"includes\") or [])\n        for p in job[\"pairs\"]:\n            label = p.get(\"vref\") or f\"(no vref) target={p['target_text'][:30]!r}\"\n            t = (p.get(\"translation\") or {}).get(\"literal\", \"<no translation>\")\n            print(f\"  {label}\")\n            print(f\"    back-translation: {t[:160]}\")\n            critique_block = _format_critique(p.get(\"critique\") or {})\n            if critique_block:\n                indented = \"\\n\".join(\"    \" + line for line in critique_block.splitlines())\n                print(f\"    critique:\\n{indented}\")\n            elif critique_requested:\n                print(f\"    critique: (no issues flagged)\")\n    else:\n        print(f\"\\nJob failed: {job.get('error')!r}\")\n",
    "id": "polling-code"
   },
   {
@@ -458,7 +437,7 @@
    "source": [
     "## 9. (Optional) Cleanup\n",
     "\n",
-    "Demo runs accumulate. The cells below remove the revision and version you created. Run them only when you're done \u2014 they don't touch the reference (NIV) data.\n",
+    "Demo runs accumulate. The cells below remove the revision and version you created. Run them only when you're done — they don't touch the reference (NIV) data.\n",
     "\n",
     "Training jobs auto-clean themselves once they reach a terminal state, so there's nothing extra to delete on the training side."
    ]


### PR DESCRIPTION
## Summary

Two options on the \`/train\` and \`/predict\` API are documented in config.yaml and endpoint docstrings but were invisible from the demo notebook. Both are valuable to callers — surface them as commented-out alternatives next to the existing payloads.

### \`build_mode=\"rebuild\"\`

Added inside the \`/train\` payload's \`options\` dict (commented out). Comment spells out exactly what it deletes for \`target_version_id\`:

- language affixes
- language morphemes
- the per-version \`training_artifacts\` row
- lexeme cards at the canonical source/target pair

And when to reach for it (recovery after a bad build; otherwise leave it off and \"auto\" reuses prior artifacts).

### \`model\" selection (per-call)

Added in both cells:

- **Train cell** (inside \`options\`): \`haiku-4-5\` and \`sonnet-4-6\` commented out. The comment frames the choice as quality-per-word at roughly equal total-run cost — Haiku caps at 300 words, Sonnet at 100, calibrated to land in the same ~\$20–35 envelope despite Haiku being ~3× cheaper per token. Default omitted = gpt-oss-120b (1000-word cap).
- **Predict cell** (top-level on \`predict_payload\`): same two options, with the cheapness claim re-asserted because predict has no per-run cap — there \"Haiku ~3× cheaper\" actually bites.
- Note in the predict cell that the predict-time model does **not** have to match the train-time model.

## Test plan

- [x] Notebook still parses as valid JSON (NotebookEdit roundtrip).
- [ ] Manual: run the notebook end-to-end with one of the commented options uncommented (already exercised via \`scripts/demo_rebuild.py\` and \`scripts/demo_predict_haiku.py\` outside this repo, with \`model=\"haiku-4-5\"\` + \`build_mode=\"rebuild\"\` — both ran cleanly).

No code changes. Stacks on top of #705 (the NULL-affix cleanup migration) but doesn't depend on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)