### PR TITLE
fix(predict): surface discovered lexeme_cards on slow-path poll (#707)

### DIFF
--- a/models.py
+++ b/models.py
@@ -467,6 +467,7 @@ class PredictJobPair(BaseModel):
     target_text: str
     translation: Optional[Dict[str, Any]] = None
     critique: Optional[Dict[str, Any]] = None
+    lexeme_cards: Optional[List[Dict[str, Any]]] = None
 
 
 class PredictJobStatusResponse(BaseModel):

--- a/predict_routes/v3/predict_routes.py
+++ b/predict_routes/v3/predict_routes.py
@@ -99,12 +99,13 @@ def _job_pairs_response(job: PredictJob) -> list[PredictJobPair]:
     still match results to inputs by index, and so a hypothetical agent
     bug that mangled echo fields wouldn't propagate to the response.
 
-    `lexeme_cards` here is the agent's *filtered* per-pair view of cards
-    relevant to that pair's target text (including any newly minted via
-    record_new_lexeme during this run). The sync /predict path cannot
-    return discoveries because translation/critique are flagged off there
-    (see ``spawn_slow_agent`` below), so this poll endpoint is the only
-    place clients see them.
+    `lexeme_cards` here is the agent's filtered per-pair view of cards
+    relevant to that pair's target text, including any new ones the
+    agent minted during this run. The sync /predict path can't return
+    those discoveries — translation/critique are forced off there
+    (see `spawn_slow_agent` below), so the LLM never runs and no new
+    cards are produced — making this poll endpoint the only surface
+    where clients see them.
     """
     result = job.result or {}
     agent_pairs = result.get("pairs") or []

--- a/predict_routes/v3/predict_routes.py
+++ b/predict_routes/v3/predict_routes.py
@@ -93,11 +93,18 @@ def _job_pairs_response(job: PredictJob) -> list[PredictJobPair]:
     """Reconstitute the per-pair slow-path payload, ordered as submitted.
 
     The agent app preserves input order in its response, so translation /
-    critique are pulled positionally from `agent_pairs[idx]`. The vref /
-    source_text / target_text echo always comes from the original
+    critique / lexeme_cards are pulled positionally from `agent_pairs[idx]`.
+    The vref / source_text / target_text echo always comes from the original
     `pairs_input` so callers that omit `vref` (an optional label) can
     still match results to inputs by index, and so a hypothetical agent
     bug that mangled echo fields wouldn't propagate to the response.
+
+    `lexeme_cards` here is the agent's *filtered* per-pair view of cards
+    relevant to that pair's target text (including any newly minted via
+    record_new_lexeme during this run). The sync /predict path cannot
+    return discoveries because translation/critique are flagged off there
+    (see ``spawn_slow_agent`` below), so this poll endpoint is the only
+    place clients see them.
     """
     result = job.result or {}
     agent_pairs = result.get("pairs") or []
@@ -111,6 +118,7 @@ def _job_pairs_response(job: PredictJob) -> list[PredictJobPair]:
                 target_text=submitted.get("target_text", ""),
                 translation=agent_pair.get("translation"),
                 critique=agent_pair.get("critique"),
+                lexeme_cards=agent_pair.get("lexeme_cards"),
             )
         )
     return out

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -841,6 +841,104 @@ def test_predict_job_complete_returns_pairs_in_submitted_order(client, regular_t
         assert out["translation"]["literal"] == f"{chr(ord('A') + idx)}-translation"
 
 
+def test_predict_job_complete_forwards_lexeme_cards(client, regular_token1):
+    """Regression for #707: discovered lexeme cards landed in the agent's
+    per-pair response but were dropped by the poll shaper. The slow-path
+    is the ONLY surface where clients can see cards discovered during a
+    predict run — the sync /predict path runs the agent with
+    include_translation=False, so it has no LLM, no record_new_lexeme
+    invocations, and only prefetched cards. If this endpoint drops the
+    field, those discoveries are unreachable to clients.
+    """
+    import modal
+
+    submitted_pairs = [
+        {"vref": "GEN 1:1", "source_text": "src-A", "target_text": "tgt-A"},
+        {"vref": "GEN 1:2", "source_text": "src-B", "target_text": "tgt-B"},
+    ]
+    job_id = _spawn_agent_and_get_job(
+        client,
+        regular_token1,
+        body_overrides={"pairs": submitted_pairs},
+    )
+
+    # The agent returns per-pair `lexeme_cards` — its filtered view of
+    # cards relevant to that pair's target text, including any that were
+    # newly minted via record_new_lexeme during this run. Each pair may
+    # have a different subset; pair 1 here has two cards, pair 2 has one.
+    agent_complete = {
+        "pairs": [
+            {
+                "translation": {"literal": "A-translation"},
+                "critique": None,
+                "lexeme_cards": [
+                    {"id": 100, "target_lemma": "tgt-A-lemma-1", "confidence": 0.9},
+                    {"id": 101, "target_lemma": "tgt-A-lemma-2", "confidence": 0.8},
+                ],
+            },
+            {
+                "translation": {"literal": "B-translation"},
+                "critique": None,
+                "lexeme_cards": [
+                    {"id": 200, "target_lemma": "tgt-B-lemma", "confidence": 0.95},
+                ],
+            },
+        ]
+    }
+    fc_mock = AsyncMock()
+    fc_mock.get.aio = AsyncMock(return_value=agent_complete)
+    with patch.object(modal.FunctionCall, "from_id", return_value=fc_mock):
+        response = client.get(
+            f"/{prefix}/predict/jobs/{job_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "complete"
+    assert len(body["pairs"]) == 2
+
+    # Pair 1: two cards, in agent-supplied order
+    cards_a = body["pairs"][0]["lexeme_cards"]
+    assert cards_a is not None
+    assert [c["id"] for c in cards_a] == [100, 101]
+    assert [c["target_lemma"] for c in cards_a] == ["tgt-A-lemma-1", "tgt-A-lemma-2"]
+
+    # Pair 2: one card
+    cards_b = body["pairs"][1]["lexeme_cards"]
+    assert cards_b is not None
+    assert [c["id"] for c in cards_b] == [200]
+
+
+def test_predict_job_complete_handles_missing_lexeme_cards(client, regular_token1):
+    """When the agent's per-pair payload omits `lexeme_cards` (e.g. a
+    pair the agent didn't process, or an older agent build), the poll
+    response surfaces `None` rather than 500ing. Belt-and-suspenders for
+    #707 — the route shouldn't assume the agent always populates the
+    field."""
+    import modal
+
+    job_id = _spawn_agent_and_get_job(client, regular_token1)
+
+    agent_complete = {
+        "pairs": [
+            {"translation": {"literal": "ok"}, "critique": None},  # no lexeme_cards key
+        ]
+    }
+    fc_mock = AsyncMock()
+    fc_mock.get.aio = AsyncMock(return_value=agent_complete)
+    with patch.object(modal.FunctionCall, "from_id", return_value=fc_mock):
+        response = client.get(
+            f"/{prefix}/predict/jobs/{job_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "complete"
+    assert body["pairs"][0]["lexeme_cards"] is None
+
+
 def test_predict_job_complete_is_cached(client, regular_token1):
     """Once a job lands in a terminal state we don't go back to Modal —
     the second poll must serve from the DB."""

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -764,6 +764,9 @@ def test_predict_job_running_returns_retry_after(client, regular_token1, timeout
     assert body["pairs"][0]["vref"] == "GEN 1:1"
     assert body["pairs"][0]["translation"] is None
     assert body["pairs"][0]["critique"] is None
+    # Discovered cards likewise null until the slow path lands; pinned
+    # so a future change that leaks partial cards mid-run gets caught.
+    assert body["pairs"][0]["lexeme_cards"] is None
 
 
 def test_predict_job_complete_returns_pairs_in_submitted_order(client, regular_token1):
@@ -842,13 +845,10 @@ def test_predict_job_complete_returns_pairs_in_submitted_order(client, regular_t
 
 
 def test_predict_job_complete_forwards_lexeme_cards(client, regular_token1):
-    """Regression for #707: discovered lexeme cards landed in the agent's
-    per-pair response but were dropped by the poll shaper. The slow-path
-    is the ONLY surface where clients can see cards discovered during a
-    predict run — the sync /predict path runs the agent with
-    include_translation=False, so it has no LLM, no record_new_lexeme
-    invocations, and only prefetched cards. If this endpoint drops the
-    field, those discoveries are unreachable to clients.
+    """Regression for #707: discovered lexeme cards were dropped by the
+    poll shaper. The slow path is the only surface where clients see
+    cards discovered during a predict run (sync /predict forces
+    translation/critique off, so its agent leg can't produce new ones).
     """
     import modal
 
@@ -862,10 +862,7 @@ def test_predict_job_complete_forwards_lexeme_cards(client, regular_token1):
         body_overrides={"pairs": submitted_pairs},
     )
 
-    # The agent returns per-pair `lexeme_cards` — its filtered view of
-    # cards relevant to that pair's target text, including any that were
-    # newly minted via record_new_lexeme during this run. Each pair may
-    # have a different subset; pair 1 here has two cards, pair 2 has one.
+    # Pair 1 has two cards, pair 2 has one — exercising per-pair independence.
     agent_complete = {
         "pairs": [
             {
@@ -937,6 +934,131 @@ def test_predict_job_complete_handles_missing_lexeme_cards(client, regular_token
     body = response.json()
     assert body["status"] == "complete"
     assert body["pairs"][0]["lexeme_cards"] is None
+
+
+def test_predict_job_complete_lexeme_cards_empty_list(client, regular_token1):
+    """An explicit empty list is semantically distinct from None: the
+    agent ran lexeme discovery and found nothing for this pair, vs the
+    agent didn't include the field at all. The shaper must preserve the
+    distinction since clients may render the two states differently."""
+    import modal
+
+    job_id = _spawn_agent_and_get_job(client, regular_token1)
+
+    agent_complete = {
+        "pairs": [
+            {"translation": {"literal": "ok"}, "critique": None, "lexeme_cards": []},
+        ]
+    }
+    fc_mock = AsyncMock()
+    fc_mock.get.aio = AsyncMock(return_value=agent_complete)
+    with patch.object(modal.FunctionCall, "from_id", return_value=fc_mock):
+        response = client.get(
+            f"/{prefix}/predict/jobs/{job_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["pairs"][0]["lexeme_cards"] == []
+
+
+def test_predict_job_complete_lexeme_cards_partial_agent_response(
+    client, regular_token1
+):
+    """If the agent returns fewer pairs than the client submitted (mid-
+    stream snapshot, agent-side filter dropped some), pairs without an
+    agent counterpart must surface `lexeme_cards=None` alongside the
+    `None` translation/critique. Verifies the `else {}` fallback at the
+    `idx >= len(agent_pairs)` boundary in the shaper."""
+    import modal
+
+    submitted_pairs = [
+        {"vref": "GEN 1:1", "source_text": "src-A", "target_text": "tgt-A"},
+        {"vref": "GEN 1:2", "source_text": "src-B", "target_text": "tgt-B"},
+        {"vref": "GEN 1:3", "source_text": "src-C", "target_text": "tgt-C"},
+    ]
+    job_id = _spawn_agent_and_get_job(
+        client,
+        regular_token1,
+        body_overrides={"pairs": submitted_pairs},
+    )
+
+    agent_complete = {
+        "pairs": [
+            {
+                "translation": {"literal": "A"},
+                "critique": None,
+                "lexeme_cards": [{"id": 1, "target_lemma": "lemma-A"}],
+            },
+            {
+                "translation": {"literal": "B"},
+                "critique": None,
+                "lexeme_cards": [{"id": 2, "target_lemma": "lemma-B"}],
+            },
+            # Agent omitted pair index 2.
+        ]
+    }
+    fc_mock = AsyncMock()
+    fc_mock.get.aio = AsyncMock(return_value=agent_complete)
+    with patch.object(modal.FunctionCall, "from_id", return_value=fc_mock):
+        response = client.get(
+            f"/{prefix}/predict/jobs/{job_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200
+    pairs = response.json()["pairs"]
+    assert len(pairs) == 3
+    # First two pairs carry their agent-supplied cards
+    assert pairs[0]["lexeme_cards"][0]["id"] == 1
+    assert pairs[1]["lexeme_cards"][0]["id"] == 2
+    # Third pair is echoed back with everything from the agent side null
+    assert pairs[2]["vref"] == "GEN 1:3"
+    assert pairs[2]["translation"] is None
+    assert pairs[2]["lexeme_cards"] is None
+
+
+def test_predict_job_cached_read_preserves_lexeme_cards(client, regular_token1):
+    """The cached path (terminal job re-served from the DB without
+    calling Modal) must also surface lexeme_cards. job.result is
+    persisted as JSONB; this pins the round-trip so a future change to
+    that storage shape doesn't silently drop the field."""
+    import modal
+
+    job_id = _spawn_agent_and_get_job(client, regular_token1)
+
+    agent_complete = {
+        "pairs": [
+            {
+                "translation": {"literal": "ok"},
+                "critique": None,
+                "lexeme_cards": [
+                    {"id": 42, "target_lemma": "stored-lemma", "confidence": 0.9},
+                ],
+            }
+        ]
+    }
+    fc_mock = AsyncMock()
+    fc_mock.get.aio = AsyncMock(return_value=agent_complete)
+    with patch.object(modal.FunctionCall, "from_id", return_value=fc_mock) as patched:
+        first = client.get(
+            f"/{prefix}/predict/jobs/{job_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        second = client.get(
+            f"/{prefix}/predict/jobs/{job_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        # Second poll served from cache; Modal not consulted again.
+        assert patched.call_count == 1
+
+    assert first.json()["pairs"][0]["lexeme_cards"] == [
+        {"id": 42, "target_lemma": "stored-lemma", "confidence": 0.9}
+    ]
+    assert second.json()["pairs"][0]["lexeme_cards"] == [
+        {"id": 42, "target_lemma": "stored-lemma", "confidence": 0.9}
+    ]
 
 
 def test_predict_job_complete_is_cached(client, regular_token1):


### PR DESCRIPTION
Closes #707.

## Summary

The slow-path poll (`GET /predict/jobs/{id}`) was dropping every discovered lexeme card the agent produced. The cards persist to the DB fine, but the response shape never forwarded them to the client — so today there's **no path through `/predict` that surfaces discovered cards** to callers.

This is because the sync `/predict` path force-disables `include_translation`/`include_critique` on the agent fan-out when either is requested (so the slow leg can carry them async). No LLM runs synchronously, no `record_new_lexeme` invocations, and `results.agent.data.pairs[].lexeme_cards` in the sync response carries prefetched cards only. The slow path is the only window.

## Fix

Two surgical changes per the issue's proposal:

**`models.py`** — declare the field on `PredictJobPair`:
```python
lexeme_cards: Optional[List[Dict[str, Any]]] = None
```

**`predict_routes/v3/predict_routes.py`** — forward it in `_job_pairs_response`:
```python
lexeme_cards=agent_pair.get("lexeme_cards"),
```

Also expanded the docstring on `_job_pairs_response` to explain why this endpoint is the only place clients see discoveries.

## Tests

- `test_predict_job_complete_forwards_lexeme_cards` — populated agent response, asserts cards flow through per pair with order preserved.
- `test_predict_job_complete_handles_missing_lexeme_cards` — agent payload omits the field; response surfaces `None` (covers older agent builds / unfilled pairs).

All 44 tests in `test/test_predict_routes/test_predict_routes.py` pass locally:

```
======================= 44 passed, 12 warnings in 4.96s ========================
```

## Out of scope

The agent returns the **filtered** per-pair view (cards relevant to that pair's target text). The issue notes a possible follow-up — exposing the full bag of discovered cards (e.g. for telemetry on how many were minted in a run) as a separate top-level field. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)