### PR TITLE
chore(.gitignore): ignore local AI tooling state and notebook artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,11 @@ Scripts
 
 # GitHub Copilot
 .github/copilot-instructions.md
+
+# Local AI tooling state (Claude Code, OpenAI Codex, worktree managers)
+.claude/
+.codex
+.worktrees/
+
+# Demo / notebook execution artifacts
+notebooks/predict_output.json


### PR DESCRIPTION
## Summary

Stop cluttering \`git status\` with files that nobody should be committing:

- \`.claude/\`, \`.codex\`, \`.worktrees/\` — per-developer state directories created by Claude Code, OpenAI Codex, and external worktree managers. Anyone running those tools alongside the repo currently sees them as untracked on every \`git status\`.
- \`notebooks/predict_output.json\` — written by \`notebooks/train_predict_demo.ipynb\` every time the predict cell runs. Not a checked-in fixture; just an execution artifact.

Pure ignore additions — no code behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)