### PR TITLE
fix(security): patch SQL injection in v1/v2 verse routes (#710)

### DIFF
--- a/bible_routes/v1/verse_routes.py
+++ b/bible_routes/v1/verse_routes.py
@@ -56,10 +56,10 @@ async def get_chapter(revision_id: int, book: str, chapter: int):
     connection = postgres_conn()
     cursor = connection.cursor()
 
-    chapter_reference = "'" + book + " " + str(chapter) + "'"
-    get_chapters = queries.get_chapter_query(chapter_reference)
+    chapter_reference = book + " " + str(chapter)
+    get_chapters = queries.get_chapter_query()
 
-    cursor.execute(get_chapters, (revision_id,))
+    cursor.execute(get_chapters, (revision_id, chapter_reference))
     result = cursor.fetchall()
 
     chapter_data = []
@@ -90,11 +90,11 @@ async def get_verse(revision_id: int, book: str, chapter: int, verse: int):
     connection = postgres_conn()
     cursor = connection.cursor()
 
-    verse_reference = "'" + book + " " + str(chapter) + ":" + str(verse) + "'"
+    verse_reference = book + " " + str(chapter) + ":" + str(verse)
 
-    get_verses = queries.get_verses_query(verse_reference)
+    get_verses = queries.get_verses_query()
 
-    cursor.execute(get_verses, (revision_id,))
+    cursor.execute(get_verses, (revision_id, verse_reference))
     result = cursor.fetchall()
     verse = result[0]  # There should only be one result
 

--- a/bible_routes/v1/verse_routes.py
+++ b/bible_routes/v1/verse_routes.py
@@ -124,14 +124,13 @@ async def get_book(revision: int, verse: str):
     connection = postgres_conn()
     cursor = connection.cursor()
 
-    book_reference = '"' + verse + '"'
     get_book_data = queries.get_book_query()
 
     cursor.execute(
         get_book_data,
         (
             revision,
-            book_reference,
+            verse,
         ),
     )
     result = cursor.fetchall()

--- a/bible_routes/v2/verse_routes.py
+++ b/bible_routes/v2/verse_routes.py
@@ -53,10 +53,10 @@ async def get_chapter(revision_id: int, book: str, chapter: int):
     connection = postgres_conn()
     cursor = connection.cursor()
 
-    chapter_reference = "'" + book + " " + str(chapter) + "'"
-    get_chapters = queries.get_chapter_query(chapter_reference)
+    chapter_reference = book + " " + str(chapter)
+    get_chapters = queries.get_chapter_query()
 
-    cursor.execute(get_chapters, (revision_id,))
+    cursor.execute(get_chapters, (revision_id, chapter_reference))
     result = cursor.fetchall()
 
     chapter_data = []
@@ -92,11 +92,11 @@ async def get_verse(revision_id: int, book: str, chapter: int, verse: int):
     connection = postgres_conn()
     cursor = connection.cursor()
 
-    verse_reference = "'" + book + " " + str(chapter) + ":" + str(verse) + "'"
+    verse_reference = book + " " + str(chapter) + ":" + str(verse)
 
-    get_verses = queries.get_verses_query(verse_reference)
+    get_verses = queries.get_verses_query()
 
-    cursor.execute(get_verses, (revision_id,))
+    cursor.execute(get_verses, (revision_id, verse_reference))
     result = cursor.fetchall()
 
     verse_list = []

--- a/queries.py
+++ b/queries.py
@@ -190,28 +190,24 @@ def fetch_version_data():
     return fetch_version
 
 
-def get_chapter_query(chapter_reference):
+def get_chapter_query():
     get_chapter = """
                 SELECT * FROM "verse_text" "vt"
                   INNER JOIN "verse_reference" "vr" ON vt.verse_reference = fullverseid
                   WHERE bible_revision=(%s)
-                    AND vr.chapter = {}
+                    AND vr.chapter = (%s)
                     ORDER BY vt.id;
-                """.format(
-        chapter_reference
-    )
+                """
 
     return get_chapter
 
 
-def get_verses_query(verse_reference):
+def get_verses_query():
     get_verses = """
                 SELECT * FROM "verse_text"
                   WHERE bible_revision=(%s)
-                    AND verse_reference={};
-                """.format(
-        verse_reference
-    )
+                    AND verse_reference=(%s);
+                """
 
     return get_verses
 

--- a/test/queries_test.py
+++ b/test/queries_test.py
@@ -1,0 +1,28 @@
+"""
+Regression tests for queries.py — specifically that user-supplied values
+cannot be string-interpolated into raw SQL.
+
+These cover the SQL injection patched in issue #710:
+`get_chapter_query` and `get_verses_query` previously embedded the `book`
+query parameter directly into the SQL with `str.format()`.
+"""
+
+import queries
+
+
+def test_get_chapter_query_is_parametrized():
+    """get_chapter_query must take no arguments and emit %s placeholders only."""
+    sql = queries.get_chapter_query()
+    # Both bible_revision and chapter must use %s placeholders.
+    assert sql.count("%s") == 2
+    # No str.format-style braces should remain (these were the injection vector).
+    assert "{" not in sql
+    assert "}" not in sql
+
+
+def test_get_verses_query_is_parametrized():
+    """get_verses_query must take no arguments and emit %s placeholders only."""
+    sql = queries.get_verses_query()
+    assert sql.count("%s") == 2
+    assert "{" not in sql
+    assert "}" not in sql


### PR DESCRIPTION
## Summary
- Replace `str.format()` interpolation in `get_chapter_query` / `get_verses_query` with `%s` placeholders so the user-supplied `book` parameter is passed via `cursor.execute()` params, not concatenated into raw SQL.
- Update v1 and v2 verse-route callers to drop the wrapping single quotes (the `.format()` was injecting them as SQL literal delimiters) and pass the chapter / verse reference as the second bound parameter.
- Drop a pre-existing double-quote wrapping bug in the v1 `/book` handler (surfaced by review): `book_reference = '"' + verse + '"'` made the bound param `"GEN"` instead of `GEN`, guaranteed to miss every row.
- Add `test/queries_test.py` regression to lock in `%s`-only placeholders and assert no `str.format()`-style braces remain.

Closes #710.

## Test plan
- [x] `.venv/bin/python -m pytest test/queries_test.py -v` — both regressions pass
- [x] `AQUA_DB=... .venv/bin/python -m pytest test/test_bible_routes/test_verse_routes.py -v` — all 55 v3 verse-route tests still pass
- [x] `black --check` / `isort --check` clean on changed files

## Test scope note
Coverage is structural-only at the unit level. Behavioral integration tests for v1/v2 `/chapter` / `/verse` would require fixing pre-existing connection plumbing — v1's `postgres_conn()` URL parser is positional and v2's `psycopg2.connect()` doesn't accept the `postgresql+asyncpg://` scheme the test fixture uses. v1/v2 are on the deprecation path per issue #710, so this gap is an accepted residual risk. The SQL semantic equivalence between `WHERE vr.chapter = 'GEN 1'` (old, injected literal) and `WHERE vr.chapter = %s` with bound value `'GEN 1'` (new, parameterized) is well-established.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
