### PR TITLE
fix: parse OMIT_PREVIOUS_VERSIONS env var correctly

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,12 @@ from security_routes.admin_routes import router as admin_router
 from security_routes.auth_routes import router as security_router
 from train_routes.v3.train_routes import router as train_router_v3
 
-omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", False)
+
+def _omit_previous_versions() -> bool:
+    return os.getenv("OMIT_PREVIOUS_VERSIONS", "").lower() in ("1", "true", "yes")
+
+
+omit_previous_versions = _omit_previous_versions()
 
 if not omit_previous_versions:
     from assessment_routes.v1.assessment_routes import router as assessment_router_v1
@@ -83,7 +88,7 @@ def configure_routing(app):
 
     # !!!: send a deprecation notice but leave the v1 route for awhile
     # if v2 is introduced but change /latest and / to /v2/language_routes.router
-    omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", False)
+    omit_previous_versions = _omit_previous_versions()
 
     if not omit_previous_versions:
         app.include_router(language_router_v1, prefix="/v1", tags=["Version 1"])

--- a/app.py
+++ b/app.py
@@ -88,8 +88,8 @@ def configure_routing(app):
 
     # !!!: send a deprecation notice but leave the v1 route for awhile
     # if v2 is introduced but change /latest and / to /v2/language_routes.router
-    omit_previous_versions = _omit_previous_versions()
-
+    # Reuse the module-level value so router registration stays consistent with
+    # the conditional v1/v2 imports above (which only run when this is False).
     if not omit_previous_versions:
         app.include_router(language_router_v1, prefix="/v1", tags=["Version 1"])
         app.include_router(revision_router_v1, prefix="/v1", tags=["Version 1"])

--- a/test/test_omit_previous_versions.py
+++ b/test/test_omit_previous_versions.py
@@ -1,0 +1,34 @@
+"""
+Tests for the OMIT_PREVIOUS_VERSIONS env var parsing in app.py.
+
+Regression test for https://github.com/sil-ai/aqua-api/issues/712: the previous
+implementation used `os.getenv("OMIT_PREVIOUS_VERSIONS", False)` which treated
+any non-empty string (including ``"False"``, ``"false"``, ``"0"``) as truthy.
+"""
+
+import pytest
+
+from app import _omit_previous_versions
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["1", "true", "True", "TRUE", "yes", "Yes", "YES"],
+)
+def test_omit_previous_versions_truthy_values(monkeypatch, value):
+    monkeypatch.setenv("OMIT_PREVIOUS_VERSIONS", value)
+    assert _omit_previous_versions() is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["0", "false", "False", "FALSE", "no", "No", "NO", "", "anything-else"],
+)
+def test_omit_previous_versions_falsy_values(monkeypatch, value):
+    monkeypatch.setenv("OMIT_PREVIOUS_VERSIONS", value)
+    assert _omit_previous_versions() is False
+
+
+def test_omit_previous_versions_unset(monkeypatch):
+    monkeypatch.delenv("OMIT_PREVIOUS_VERSIONS", raising=False)
+    assert _omit_previous_versions() is False


### PR DESCRIPTION
## Summary
- `os.getenv("OMIT_PREVIOUS_VERSIONS", False)` returned any non-empty string as truthy, so `OMIT_PREVIOUS_VERSIONS=False` (or `false`, `0`) *still disabled* v1/v2 routes — opposite of intent.
- Replace with a `_omit_previous_versions()` helper that only treats `1`/`true`/`yes` (case-insensitive) as true. Used at both call sites (module-level import gate and `configure_routing`).
- Add regression tests covering truthy values, common falsy strings, and the unset case.

Fixes #712

## Test plan
- [x] `pytest test/test_omit_previous_versions.py -v` — 17/17 pass locally
- [x] `black --check` / `isort --check-only` clean
- [ ] CI green on the PR