### PR TITLE
feat: add /health and /ready endpoints + Dockerfile HEALTHCHECK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,7 @@ ADD utils/ /app/utils
 WORKDIR /app
 ENV PYTHONPATH=/app:$PYTHONPATH
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+    CMD curl -fsS http://localhost:8000/health || exit 1
 
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "8"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ ADD utils/ /app/utils
 WORKDIR /app
 ENV PYTHONPATH=/app:$PYTHONPATH
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:8000/health || exit 1
 
 CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "8"]

--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ from bible_routes.v3.language_routes import router as language_router_v3
 from bible_routes.v3.revision_routes import router as revision_router_v3
 from bible_routes.v3.verse_routes import router as verse_router_v3
 from bible_routes.v3.version_routes import router as version_router_v3
-from database.dependencies import AsyncSessionLocal
+from database.dependencies import engine as async_engine
 from middleware import LoggingMiddleware
 from predict_routes.v3.predict_routes import router as predict_router_v3
 from security_routes.admin_routes import router as admin_router
@@ -170,10 +170,14 @@ def configure_routing(app):
 
     @app.get("/ready", tags=["Health"])
     async def ready():
-        """Readiness probe — verifies the database is reachable."""
+        """Readiness probe — verifies the database is reachable.
+
+        Uses the engine directly (not an ORM session) so the probe is a
+        single round-trip with no implicit transaction overhead.
+        """
         try:
-            async with AsyncSessionLocal() as session:
-                await session.execute(text("SELECT 1"))
+            async with async_engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
         except Exception:
             logger.exception("Readiness check failed: database unreachable")
             return JSONResponse(

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 __version__ = "v1"
 
+import logging
 import os
 
 import fastapi
@@ -23,6 +24,7 @@ from bible_routes.v3.language_routes import router as language_router_v3
 from bible_routes.v3.revision_routes import router as revision_router_v3
 from bible_routes.v3.verse_routes import router as verse_router_v3
 from bible_routes.v3.version_routes import router as version_router_v3
+from database.dependencies import AsyncSessionLocal
 from middleware import LoggingMiddleware
 from predict_routes.v3.predict_routes import router as predict_router_v3
 from security_routes.admin_routes import router as admin_router
@@ -44,6 +46,8 @@ if not omit_previous_versions:
     from bible_routes.v2.revision_routes import router as revision_router_v2
     from bible_routes.v2.verse_routes import router as verse_router_v2
     from bible_routes.v2.version_routes import router as version_router_v2
+
+logger = logging.getLogger(__name__)
 
 app = fastapi.FastAPI()
 
@@ -167,15 +171,11 @@ def configure_routing(app):
     @app.get("/ready", tags=["Health"])
     async def ready():
         """Readiness probe — verifies the database is reachable."""
-        import logging
-
-        from database.dependencies import AsyncSessionLocal
-
         try:
             async with AsyncSessionLocal() as session:
                 await session.execute(text("SELECT 1"))
         except Exception:
-            logging.exception("Readiness check failed: database unreachable")
+            logger.exception("Readiness check failed: database unreachable")
             return JSONResponse(
                 status_code=503,
                 content={"status": "unavailable"},

--- a/app.py
+++ b/app.py
@@ -4,6 +4,8 @@ import os
 
 import fastapi
 from fastapi.openapi.utils import get_openapi
+from fastapi.responses import JSONResponse
+from sqlalchemy import text
 
 from agent_routes.v3.affix_routes import router as affix_router_v3
 from agent_routes.v3.agent_routes import router as agent_router_v3
@@ -156,6 +158,29 @@ def configure_routing(app):
         """
         Test docs"""
         return {"Hello": "World"}
+
+    @app.get("/health", tags=["Health"])
+    async def health():
+        """Liveness probe — cheap, no external dependencies."""
+        return {"status": "ok"}
+
+    @app.get("/ready", tags=["Health"])
+    async def ready():
+        """Readiness probe — verifies the database is reachable."""
+        import logging
+
+        from database.dependencies import AsyncSessionLocal
+
+        try:
+            async with AsyncSessionLocal() as session:
+                await session.execute(text("SELECT 1"))
+        except Exception:
+            logging.exception("Readiness check failed: database unreachable")
+            return JSONResponse(
+                status_code=503,
+                content={"status": "unavailable"},
+            )
+        return {"status": "ready"}
 
 
 if __name__ == "__main__":

--- a/app_test.py
+++ b/app_test.py
@@ -95,16 +95,11 @@ def test_health_endpoint(client):
 
 
 def test_ready_endpoint(client):
+    # /ready runs a SELECT 1 against the configured DB. The rest of this
+    # test suite requires the DB to be up, so we assert the success path.
     response = client.get("/ready")
-    # /ready hits the DB; in the test environment a DB is available, so
-    # it should report "ready". If the DB is unreachable, it should return
-    # 503 with a "status": "unavailable" body.
-    assert response.status_code in (200, 503)
-    body = response.json()
-    if response.status_code == 200:
-        assert body == {"status": "ready"}
-    else:
-        assert body["status"] == "unavailable"
+    assert response.status_code == 200
+    assert response.json() == {"status": "ready"}
 
 
 def test_add_version(client):

--- a/app_test.py
+++ b/app_test.py
@@ -102,6 +102,18 @@ def test_ready_endpoint(client):
     assert response.json() == {"status": "ready"}
 
 
+def test_ready_endpoint_returns_503_when_db_unreachable(client, monkeypatch):
+    # Force the engine.connect() call inside /ready to raise so we exercise
+    # the failure path and confirm the 503 contract.
+    def boom(*args, **kwargs):
+        raise RuntimeError("simulated DB outage")
+
+    monkeypatch.setattr(app, "async_engine", type("X", (), {"connect": boom})())
+    response = client.get("/ready")
+    assert response.status_code == 503
+    assert response.json() == {"status": "unavailable"}
+
+
 def test_add_version(client):
     test_version = VersionIn(
         name=version_name,

--- a/app_test.py
+++ b/app_test.py
@@ -88,6 +88,25 @@ def test_read_main(client):
     assert response.json() == {"Hello": "World"}
 
 
+def test_health_endpoint(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_ready_endpoint(client):
+    response = client.get("/ready")
+    # /ready hits the DB; in the test environment a DB is available, so
+    # it should report "ready". If the DB is unreachable, it should return
+    # 503 with a "status": "unavailable" body.
+    assert response.status_code in (200, 503)
+    body = response.json()
+    if response.status_code == 200:
+        assert body == {"status": "ready"}
+    else:
+        assert body["status"] == "unavailable"
+
+
 def test_add_version(client):
     test_version = VersionIn(
         name=version_name,


### PR DESCRIPTION
## Summary
- Add `GET /health` (liveness, no external deps) returning `{"status": "ok"}`.
- Add `GET /ready` (readiness) — runs `SELECT 1` via the async engine; returns 503 `{"status": "unavailable"}` if the DB is unreachable.
- Add `HEALTHCHECK` to the Dockerfile so Docker/orchestrators can detect hung workers or unbound ports before traffic lands.

Fixes #717

## Test plan
- [x] `pytest app_test.py -k "health or ready or read_main"` passes locally
- [x] black / isort / flake8 clean
- [ ] CI green on PR
- [ ] Manual: `curl -fsS http://localhost:8000/health` returns 200 once container is up

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with Claude Code