### PR TITLE
fix(security): fail fast at startup when SECRET_KEY is missing

### DIFF
--- a/security_routes/utilities.py
+++ b/security_routes/utilities.py
@@ -17,7 +17,8 @@ from database.models import (  # Your SQLAlchemy model
 )
 
 SECRET_KEY = os.getenv("SECRET_KEY")
-if not SECRET_KEY:
+# Treat whitespace-only values as missing — they're a config typo, not a key.
+if SECRET_KEY is None or not SECRET_KEY.strip():
     raise ValueError("SECRET_KEY environment variable is required for JWT signing")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30

--- a/security_routes/utilities.py
+++ b/security_routes/utilities.py
@@ -18,9 +18,7 @@ from database.models import (  # Your SQLAlchemy model
 
 SECRET_KEY = os.getenv("SECRET_KEY")
 if not SECRET_KEY:
-    raise ValueError(
-        "SECRET_KEY environment variable is required for JWT signing"
-    )
+    raise ValueError("SECRET_KEY environment variable is required for JWT signing")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/security_routes/utilities.py
+++ b/security_routes/utilities.py
@@ -17,6 +17,10 @@ from database.models import (  # Your SQLAlchemy model
 )
 
 SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise ValueError(
+        "SECRET_KEY environment variable is required for JWT signing"
+    )
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,12 @@ import os
 # run before `from app import app` regardless of pytest collection order.
 os.environ["AQUA_DB_POOLCLASS"] = "null"
 
+# security_routes.utilities now raises at import time when SECRET_KEY is
+# missing (issue #716). Provide a dummy value for local/ad-hoc test runs so
+# collection works; CI and real deployments set their own real SECRET_KEY.
+# setdefault so we never override a real value the environment provides.
+os.environ.setdefault("SECRET_KEY", "test-secret-key-not-for-production")
+
 from datetime import date  # noqa: E402
 
 import bcrypt  # noqa: E402

--- a/test/test_security_routes/test_utilities.py
+++ b/test/test_security_routes/test_utilities.py
@@ -16,11 +16,12 @@ from security_routes.utilities import (
 )
 
 
-@pytest.mark.parametrize("missing_value", [None, ""])
+@pytest.mark.parametrize("missing_value", [None, "", "   ", "\t\n"])
 def test_secret_key_required_at_import(monkeypatch, missing_value):
     """Importing security_routes.utilities must fail fast if SECRET_KEY is
-    missing or empty — otherwise python-jose silently signs JWTs with a
-    falsy key, which any other instance/attacker can also produce.
+    missing, empty, or whitespace-only — otherwise python-jose silently
+    signs JWTs with an effectively-empty key, which any other instance or
+    attacker can also produce.
     """
     if missing_value is None:
         monkeypatch.delenv("SECRET_KEY", raising=False)

--- a/test/test_security_routes/test_utilities.py
+++ b/test/test_security_routes/test_utilities.py
@@ -1,5 +1,7 @@
 # tests/utilities/test_verify_password.py
 
+import importlib
+import sys
 from datetime import date
 
 import bcrypt
@@ -12,6 +14,24 @@ from security_routes.utilities import (
     is_user_authorized_for_revision,
     verify_password,
 )
+
+
+@pytest.mark.parametrize("missing_value", [None, ""])
+def test_secret_key_required_at_import(monkeypatch, missing_value):
+    """Importing security_routes.utilities must fail fast if SECRET_KEY is
+    missing or empty — otherwise python-jose silently signs JWTs with a
+    falsy key, which any other instance/attacker can also produce.
+    """
+    if missing_value is None:
+        monkeypatch.delenv("SECRET_KEY", raising=False)
+    else:
+        monkeypatch.setenv("SECRET_KEY", missing_value)
+
+    # Force a fresh import so the module-level check runs again.
+    monkeypatch.delitem(sys.modules, "security_routes.utilities", raising=False)
+
+    with pytest.raises(ValueError, match="SECRET_KEY"):
+        importlib.import_module("security_routes.utilities")
 
 
 def test_verify_password():


### PR DESCRIPTION
## Summary
- `security_routes/utilities.py` loaded `SECRET_KEY` with `os.getenv("SECRET_KEY")` and never validated the result. When the env var was missing or empty, `python-jose` silently signed JWTs with a falsy key — any other instance (or an attacker) could forge the same tokens.
- Mirror the `DATABASE_URL` pattern in `database/dependencies.py` and raise `ValueError` at import time when `SECRET_KEY` is missing or empty, so the process refuses to start in an insecure configuration.
- Add a parametrized regression test covering both the missing (`None`) and empty (`""`) cases.

Fixes #716

## Test plan
- [x] `pytest test/test_security_routes/test_utilities.py::test_secret_key_required_at_import` passes for both `None` and `""` parametrizations.
- [x] `pytest test/test_security_routes/test_utilities.py::test_verify_password` still passes (no regression in the existing fast tests).
- [x] `black --check` and `isort --check` clean.
- [ ] CI green on the release base branch.

Generated with [Claude Code](https://claude.com/claude-code)