### PR TITLE
ci(release): run alembic migrations before pushing image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ env:
 jobs:
 
   tests:
-    name: Building and pushing main branch images
+    name: Building and testing release branch image
     runs-on: ubuntu-latest
     env:
       MODAL_ENV: main
@@ -55,6 +55,66 @@ jobs:
       run: |
         pip install -r requirements.txt
         make test
+
+  migrate:
+    name: Apply Alembic migrations to production
+    needs: [tests]
+    runs-on: ubuntu-latest
+    # Concurrency guard: only one migration job may run at a time per branch.
+    # Prevents racing/overlapping migrations if multiple commits land quickly.
+    concurrency:
+      group: alembic-migrate-release
+      cancel-in-progress: false
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Show current revision before migration
+      env:
+        AQUA_DB: ${{ secrets.PROD_AQUA_DB }}
+      run: |
+        cd alembic
+        alembic current || true
+
+    - name: Apply migrations to production
+      env:
+        AQUA_DB: ${{ secrets.PROD_AQUA_DB }}
+      run: |
+        cd alembic
+        alembic upgrade head
+
+    - name: Confirm migration head
+      env:
+        AQUA_DB: ${{ secrets.PROD_AQUA_DB }}
+      run: |
+        cd alembic
+        alembic current
+
+  push:
+    name: Push image to ECR after successful migration
+    needs: [migrate]
+    runs-on: ubuntu-latest
+    env:
+      MODAL_ENV: main
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Build API
+      run: make build-actions
+      env:
+        REGISTRY: ${{ env.AWS_REGISTRY }}
+        IMAGENAME: ${{ env.IMAGE_NAME }}
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1

--- a/alembic/README.md
+++ b/alembic/README.md
@@ -47,6 +47,49 @@ alembic downgrade -1
 
 This will undo the last batch of migrations applied.
 
+## Production Deploy & Rollback Runbook
+
+### Automatic migration on deploy
+
+Pushes to the `release` branch run `.github/workflows/release.yml`. The
+pipeline executes in order:
+
+1. **tests** — lint, build the image, run the test suite against a temporary
+   local Postgres.
+2. **migrate** — runs `alembic upgrade head` against the production database
+   using the `PROD_AQUA_DB` GitHub secret. A `concurrency` group prevents
+   overlapping migration runs, so even if two commits land back-to-back only
+   one migration job runs at a time.
+3. **push** — builds and pushes the new image to ECR (which App Runner picks
+   up). This only runs once the migration has succeeded, so the running app
+   never sees a schema older than the code it shipped with.
+
+If `migrate` fails, `push` is skipped and the previous image continues to
+serve traffic against the old schema. Fix the migration on a new commit and
+re-run the workflow.
+
+### Rolling back a production migration
+
+If a migration has gone out and needs to be reverted:
+
+1. Take a logical backup of the affected tables first (or confirm a recent
+   RDS snapshot exists) — `alembic downgrade` is destructive and migrations
+   are not always perfectly reversible.
+2. From a runner with `PROD_AQUA_DB` in the environment (a GitHub Actions
+   workflow_dispatch job, or an authorised operator's shell), run:
+
+   ```
+   cd alembic
+   alembic current             # confirm what we are rolling back from
+   alembic downgrade -1        # undo the most recent migration
+   alembic current             # confirm new head
+   ```
+3. Re-deploy the previous app image so the code matches the schema.
+
+Never run `alembic downgrade` against production from a developer laptop
+without confirming the backup first. The `AQUA_DB` env var must point at the
+prod database — see the warning in the top-level README.
+
 ## Viewing Migration History
 
 To view the history of migrations, run:


### PR DESCRIPTION
## Summary
- Pushes to `release` used to build/test/push to ECR without ever touching the production schema, so anyone shipping a schema change had to remember to SSH in and run `alembic upgrade head` by hand. If migrations were ever moved to the container entrypoint, the 8 uvicorn workers would race on `alembic upgrade head` at startup.
- Split `release.yml` into three jobs: `tests` (lint + build + test as before), `migrate` (runs `alembic upgrade head` against `PROD_AQUA_DB` with a single-flight `concurrency` group so back-to-back release pushes can't stack migration runs), then `push` (gated on `migrate` succeeding, so the previous image keeps serving traffic if a migration fails).
- Document the deploy ordering and a downgrade-with-backup runbook in `alembic/README.md`.

## Test plan
- [ ] Verify `release.yml` parses (validated locally with PyYAML).
- [ ] Once merged: a `release` push should run `tests` -> `migrate` -> `push` in that order and `push` should not fire if `migrate` fails.
- [ ] Add `PROD_AQUA_DB` to the repo's GitHub Actions secrets before merging (the workflow expects it).
- [ ] Spot-check `alembic current` output in the `migrate` job log on the first release after merge.

Fixes #719

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>