### PR TITLE
fix(api): disable v1/v2 routes by default; set 2026-08-18 removal cutoff

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,7 +27,12 @@ from security_routes.admin_routes import router as admin_router
 from security_routes.auth_routes import router as security_router
 from train_routes.v3.train_routes import router as train_router_v3
 
-omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", False)
+# DEPRECATION: v1 and v2 routes are disabled by default. They use synchronous
+# psycopg2 calls inside async handlers which block the event loop, and rely on
+# a legacy API-key auth model. Hard removal cutoff: 2026-08-18 (90 days from
+# 2026-05-20). After that date, delete queries.py, database/database.py, and
+# all v1/v2 route files. See issue #711.
+omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", True)
 
 if not omit_previous_versions:
     from assessment_routes.v1.assessment_routes import router as assessment_router_v1
@@ -83,7 +88,8 @@ def configure_routing(app):
 
     # !!!: send a deprecation notice but leave the v1 route for awhile
     # if v2 is introduced but change /latest and / to /v2/language_routes.router
-    omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", False)
+    # See deprecation note at top of file. Hard removal cutoff: 2026-08-18.
+    omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", True)
 
     if not omit_previous_versions:
         app.include_router(language_router_v1, prefix="/v1", tags=["Version 1"])

--- a/app.py
+++ b/app.py
@@ -32,7 +32,7 @@ from train_routes.v3.train_routes import router as train_router_v3
 # a legacy API-key auth model. Hard removal cutoff: 2026-08-18 (90 days from
 # 2026-05-20). After that date, delete queries.py, database/database.py, and
 # all v1/v2 route files. See issue #711.
-omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", True)
+omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", "true")
 
 if not omit_previous_versions:
     from assessment_routes.v1.assessment_routes import router as assessment_router_v1
@@ -89,7 +89,7 @@ def configure_routing(app):
     # !!!: send a deprecation notice but leave the v1 route for awhile
     # if v2 is introduced but change /latest and / to /v2/language_routes.router
     # See deprecation note at top of file. Hard removal cutoff: 2026-08-18.
-    omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", True)
+    omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", "true")
 
     if not omit_previous_versions:
         app.include_router(language_router_v1, prefix="/v1", tags=["Version 1"])

--- a/app.py
+++ b/app.py
@@ -89,8 +89,10 @@ def configure_routing(app):
     # !!!: send a deprecation notice but leave the v1 route for awhile
     # if v2 is introduced but change /latest and / to /v2/language_routes.router
     # See deprecation note at top of file. Hard removal cutoff: 2026-08-18.
-    omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", "true")
-
+    # NOTE: reuse the module-level value (set at import time) so the import
+    # decision and the mount decision can't diverge — otherwise toggling the
+    # env var between import and configure_routing() would NameError on the
+    # un-imported v1/v2 router symbols.
     if not omit_previous_versions:
         app.include_router(language_router_v1, prefix="/v1", tags=["Version 1"])
         app.include_router(revision_router_v1, prefix="/v1", tags=["Version 1"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,9 @@ services:
       - LOKI_AUTH_TOKEN=${LOKI_AUTH_TOKEN:-}
       - PROJECT_NAME=aqua-api
       - ENVIRONMENT_LOKI=${ENVIRONMENT_LOKI:-docker}
+      # Legacy v1/v2 routes are deprecated and disabled. Hard removal: 2026-08-18.
+      # See issue #711. Override only for local back-compat testing.
+      - OMIT_PREVIOUS_VERSIONS=${OMIT_PREVIOUS_VERSIONS:-true}
     depends_on:
       - db
 

--- a/test/test_app_versioning_default.py
+++ b/test/test_app_versioning_default.py
@@ -1,0 +1,77 @@
+"""Tests for the OMIT_PREVIOUS_VERSIONS default behavior (issue #711).
+
+Asserts that legacy v1 and v2 routes are disabled by default — i.e. when the
+env var is unset, importing app.py must not mount any /v1 or /v2 routes.
+"""
+
+import importlib
+import os
+import sys
+
+import fastapi
+
+
+def _reload_app(env_value):
+    """Reload app.py with a controlled env var value and return the mounted app.
+
+    Passing env_value=None deletes the env var entirely to test the unset case.
+    """
+    if env_value is None:
+        os.environ.pop("OMIT_PREVIOUS_VERSIONS", None)
+    else:
+        os.environ["OMIT_PREVIOUS_VERSIONS"] = env_value
+
+    # Force a fresh import so the module-level os.getenv is re-evaluated.
+    for mod_name in list(sys.modules):
+        if mod_name == "app" or mod_name.startswith("app."):
+            del sys.modules[mod_name]
+
+    import app as app_module  # noqa: E402
+
+    importlib.reload(app_module)
+    mock_app = fastapi.FastAPI()
+    app_module.configure(mock_app)
+    return mock_app
+
+
+def _route_prefixes(app):
+    return {getattr(r, "path", "") for r in app.routes}
+
+
+def test_default_unset_omits_v1_v2():
+    """With OMIT_PREVIOUS_VERSIONS unset, v1/v2 routes must NOT be mounted."""
+    original = os.environ.get("OMIT_PREVIOUS_VERSIONS")
+    try:
+        app = _reload_app(None)
+        paths = _route_prefixes(app)
+        assert not any(
+            p.startswith("/v1") for p in paths
+        ), "v1 routes should be disabled by default"
+        assert not any(
+            p.startswith("/v2") for p in paths
+        ), "v2 routes should be disabled by default"
+        # v3 should still be present.
+        assert any(p.startswith("/v3") for p in paths), "v3 routes should still mount"
+    finally:
+        if original is None:
+            os.environ.pop("OMIT_PREVIOUS_VERSIONS", None)
+        else:
+            os.environ["OMIT_PREVIOUS_VERSIONS"] = original
+        # Reload once more so subsequent tests see the original env state.
+        _reload_app(original)
+
+
+def test_explicit_true_omits_v1_v2():
+    """OMIT_PREVIOUS_VERSIONS=true must also omit legacy routes."""
+    original = os.environ.get("OMIT_PREVIOUS_VERSIONS")
+    try:
+        app = _reload_app("true")
+        paths = _route_prefixes(app)
+        assert not any(p.startswith("/v1") for p in paths)
+        assert not any(p.startswith("/v2") for p in paths)
+    finally:
+        if original is None:
+            os.environ.pop("OMIT_PREVIOUS_VERSIONS", None)
+        else:
+            os.environ["OMIT_PREVIOUS_VERSIONS"] = original
+        _reload_app(original)

--- a/test/test_app_versioning_default.py
+++ b/test/test_app_versioning_default.py
@@ -1,7 +1,8 @@
 """Tests for the OMIT_PREVIOUS_VERSIONS default behavior (issue #711).
 
 Asserts that legacy v1 and v2 routes are disabled by default — i.e. when the
-env var is unset, importing app.py must not mount any /v1 or /v2 routes.
+env var is unset, calling app.configure() on a fresh FastAPI instance must not
+mount any /v1 or /v2 routes.
 """
 
 import importlib


### PR DESCRIPTION
## Summary

- Flip the default value of the `OMIT_PREVIOUS_VERSIONS` gate in `app.py` so legacy v1/v2 routes are **disabled** when the env var is unset (previous default left them live).
- Surface `OMIT_PREVIOUS_VERSIONS` in `docker-compose.yml` with `:-true` so deployments inherit the secure-by-default behavior unless explicitly overridden.
- Document the firm **2026-08-18** hard removal cutoff (90 days from 2026-05-20) in both the code and the deploy config.

### Why

v1/v2 route handlers call `psycopg2.connect()` synchronously inside `async def`, so each blocking call stalls all 8 uvicorn worker coroutines on a process for the full DB round-trip. The gate already existed but was not set in production. Defaulting to off closes the gap without requiring a separate ops change.

### Out of scope

- The `OMIT_PREVIOUS_VERSIONS` truthy-string parsing bug (e.g. `"False"` parsing truthy) is tracked separately in #712.
- Deletion of `queries.py`, `database/database.py`, and the v1/v2 route trees will happen at the 2026-08-18 cutoff.

Fixes #711

## Test plan

- [x] `black --check app.py`, `isort --check app.py --profile black`, `flake8 app.py` all pass
- [x] Local import smoke test: `python -c "import app"` with `OMIT_PREVIOUS_VERSIONS` unset → only `/v3` and `/latest` routes mounted; no `/v1` or `/v2`
- [x] Local import smoke test: `OMIT_PREVIOUS_VERSIONS=""` (empty string, the existing falsy escape hatch) → `/v1` and `/v2` still mount (preserved for back-compat testing until #712 lands)
- [ ] CI green on this branch