### PR TITLE
fix(correctness): tz-aware UTC datetimes for assessment/training timestamps

### DIFF
--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -148,10 +148,13 @@ async def _upsert_profile(
     else:
         for key, value in payload.model_dump(exclude_unset=True).items():
             setattr(profile, key, value)
-        # Force the onupdate trigger to fire even when no fields changed,
-        # so repeat PUTs always refresh updated_at. The column is currently
-        # TIMESTAMP WITHOUT TIME ZONE (out of #720 scope), so use a naive
-        # UTC value to satisfy asyncpg's type checking.
+        # Explicitly bump updated_at so repeat PUTs always advance it,
+        # even when no scalar fields actually changed (SQLAlchemy's
+        # onupdate=func.now() only fires when other columns mutate).
+        # LanguageProfile.updated_at is still TIMESTAMP WITHOUT TIME ZONE
+        # — converting it is out of scope for #720 (which targets
+        # assessment/training_job columns) — so we write a naive UTC
+        # value here to satisfy asyncpg's column-type check.
         profile.updated_at = datetime.datetime.utcnow()
     await db.flush()
     return profile

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -5,6 +5,7 @@ import socket
 import time
 import unicodedata
 from collections import defaultdict
+from datetime import timezone
 from typing import Optional
 
 import fastapi
@@ -150,7 +151,7 @@ async def _upsert_profile(
             setattr(profile, key, value)
         # Force the onupdate trigger to fire even when no fields changed,
         # so repeat PUTs always refresh updated_at.
-        profile.updated_at = datetime.datetime.utcnow()
+        profile.updated_at = datetime.datetime.now(timezone.utc)
     await db.flush()
     return profile
 

--- a/agent_routes/v3/tokenizer_routes.py
+++ b/agent_routes/v3/tokenizer_routes.py
@@ -5,7 +5,6 @@ import socket
 import time
 import unicodedata
 from collections import defaultdict
-from datetime import timezone
 from typing import Optional
 
 import fastapi
@@ -150,8 +149,10 @@ async def _upsert_profile(
         for key, value in payload.model_dump(exclude_unset=True).items():
             setattr(profile, key, value)
         # Force the onupdate trigger to fire even when no fields changed,
-        # so repeat PUTs always refresh updated_at.
-        profile.updated_at = datetime.datetime.now(timezone.utc)
+        # so repeat PUTs always refresh updated_at. The column is currently
+        # TIMESTAMP WITHOUT TIME ZONE (out of #720 scope), so use a naive
+        # UTC value to satisfy asyncpg's type checking.
+        profile.updated_at = datetime.datetime.utcnow()
     await db.flush()
     return profile
 

--- a/alembic/migrations/versions/b720f1c8a4d2_assessment_training_tz_aware_timestamps.py
+++ b/alembic/migrations/versions/b720f1c8a4d2_assessment_training_tz_aware_timestamps.py
@@ -1,0 +1,61 @@
+"""convert assessment and training_job timestamps to TIMESTAMP WITH TIME ZONE
+
+Revision ID: b720f1c8a4d2
+Revises: 1d460bf9ea55
+Create Date: 2026-05-20
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b720f1c8a4d2"
+down_revision: Union[str, None] = "1d460bf9ea55"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# Columns to convert. See aqua-api#720: writers had been mixing
+# datetime.now() (naive local) and datetime.utcnow() (naive UTC) into
+# TIMESTAMP WITHOUT TIME ZONE columns. We standardize Python callers on
+# datetime.now(timezone.utc) and widen the columns to TIMESTAMP WITH
+# TIME ZONE so subsequent reads/writes round-trip with tzinfo. Existing
+# rows are stored without a tz designator; Postgres' USING clause
+# interprets the legacy values as UTC so we don't shift wall-clock
+# meaning for naive-UTC writes (datetime.utcnow). Rows previously
+# written via datetime.now() on a non-UTC host were already wrong by
+# the host's offset; this migration does not attempt to reconstruct the
+# original instant — it only stops further drift.
+_COLUMNS = [
+    ("assessment", "requested_time"),
+    ("assessment", "start_time"),
+    ("assessment", "end_time"),
+    ("training_job", "requested_time"),
+    ("training_job", "deleted_at"),
+]
+
+
+def upgrade() -> None:
+    for table, column in _COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.TIMESTAMP(timezone=True),
+            existing_type=sa.TIMESTAMP(timezone=False),
+            postgresql_using=f"{column} AT TIME ZONE 'UTC'",
+        )
+
+
+def downgrade() -> None:
+    for table, column in _COLUMNS:
+        op.alter_column(
+            table,
+            column,
+            type_=sa.TIMESTAMP(timezone=False),
+            existing_type=sa.TIMESTAMP(timezone=True),
+            postgresql_using=f"{column} AT TIME ZONE 'UTC'",
+        )

--- a/assessment_routes/v1/assessment_routes.py
+++ b/assessment_routes/v1/assessment_routes.py
@@ -3,7 +3,7 @@ __version__ = "v1"
 import base64
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import fastapi
@@ -116,7 +116,7 @@ async def add_assessment(a: AssessmentIn = Depends(), modal_suffix: str = ""):
     if not reference_id:
         reference_id = None
     assessment_type_fixed = str(a.type)
-    requested_time = datetime.now().isoformat()
+    requested_time = datetime.now(timezone.utc).isoformat()
     assessment_status = "queued"
 
     new_assessment = queries.add_assessment_query()

--- a/assessment_routes/v2/assessment_routes.py
+++ b/assessment_routes/v2/assessment_routes.py
@@ -3,7 +3,7 @@ __version__ = "v2"
 import base64
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 
 import fastapi
@@ -125,7 +125,7 @@ async def add_assessment(
     if not reference_id:
         reference_id = None
     assessment_type_fixed = str(a.type)
-    requested_time = datetime.now().isoformat()
+    requested_time = datetime.now(timezone.utc).isoformat()
     assessment_status = "queued"
 
     new_assessment = queries.add_assessment_query()

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -3,7 +3,7 @@ __version__ = "v3"
 import json
 import os
 import socket
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import List, Optional
 
 import fastapi
@@ -416,7 +416,9 @@ async def add_assessment(
 
     # Check for duplicate in-progress assessment (admins can bypass)
     if not current_user.is_admin:
-        stale_cutoff = datetime.now() - timedelta(hours=STALE_ASSESSMENT_HOURS)
+        stale_cutoff = datetime.now(timezone.utc) - timedelta(
+            hours=STALE_ASSESSMENT_HOURS
+        )
         stmt = (
             select(Assessment.id)
             .where(
@@ -462,7 +464,7 @@ async def add_assessment(
         reference_id=a.reference_id,
         type=a.type,
         status="queued",
-        requested_time=datetime.now(),
+        requested_time=datetime.now(timezone.utc),
         owner_id=current_user.id,
         kwargs=parsed_kwargs,
     )
@@ -573,10 +575,10 @@ async def update_assessment_status(
         assessment.percent_complete = update.percent_complete
 
     if assessment.start_time is None and update.status != "queued":
-        assessment.start_time = datetime.utcnow()
+        assessment.start_time = datetime.now(timezone.utc)
 
     if update.status in ASSESSMENT_TERMINAL_STATUSES:
-        assessment.end_time = datetime.utcnow()
+        assessment.end_time = datetime.now(timezone.utc)
 
     await db.commit()
     await db.refresh(assessment)

--- a/assessment_routes/v3/timeout_sweep_routes.py
+++ b/assessment_routes/v3/timeout_sweep_routes.py
@@ -1,7 +1,7 @@
 __version__ = "v3"
 
 import socket
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 
 import fastapi
@@ -43,10 +43,12 @@ class TimeoutSweepResult(BaseModel):
 async def sweep_stuck_assessments(
     db: AsyncSession, hours: int = DEFAULT_TIMEOUT_HOURS
 ) -> TimeoutSweepResult:
-    # Match the convention used elsewhere when writing requested_time
-    # (assessment_routes.v3.assessment_routes uses datetime.now()) so the
-    # cutoff comparison stays consistent regardless of server timezone.
-    now = datetime.now()
+    # Use tz-aware UTC so the cutoff comparison stays correct regardless of
+    # the server's local timezone. requested_time is also written as
+    # tz-aware UTC (see assessment_routes.v3.assessment_routes); pre-existing
+    # naive rows are interpreted by Postgres as the session's timezone when
+    # compared against a tz-aware bound, which is harmless here.
+    now = datetime.now(timezone.utc)
     cutoff = now - timedelta(hours=hours)
     stmt = (
         update(Assessment)

--- a/assessment_routes/v3/timeout_sweep_routes.py
+++ b/assessment_routes/v3/timeout_sweep_routes.py
@@ -44,10 +44,10 @@ async def sweep_stuck_assessments(
     db: AsyncSession, hours: int = DEFAULT_TIMEOUT_HOURS
 ) -> TimeoutSweepResult:
     # Use tz-aware UTC so the cutoff comparison stays correct regardless of
-    # the server's local timezone. requested_time is also written as
-    # tz-aware UTC (see assessment_routes.v3.assessment_routes); pre-existing
-    # naive rows are interpreted by Postgres as the session's timezone when
-    # compared against a tz-aware bound, which is harmless here.
+    # the server's local timezone. requested_time is now a TIMESTAMP WITH
+    # TIME ZONE column written as tz-aware UTC by all assessment writers
+    # (see #720 migration b720f1c8a4d2 — legacy naive rows were converted
+    # by `AT TIME ZONE 'UTC'`, so the comparison is unambiguous).
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(hours=hours)
     stmt = (

--- a/database/models.py
+++ b/database/models.py
@@ -138,9 +138,9 @@ class Assessment(Base):
     status_detail = Column(Text, nullable=True)
     percent_complete = Column(Float, nullable=True)
     is_training = Column(Boolean, nullable=False, default=False, server_default="false")
-    requested_time = Column(TIMESTAMP, default=func.now())
-    start_time = Column(TIMESTAMP)
-    end_time = Column(TIMESTAMP)
+    requested_time = Column(TIMESTAMP(timezone=True), default=func.now())
+    start_time = Column(TIMESTAMP(timezone=True))
+    end_time = Column(TIMESTAMP(timezone=True))
     assessment_version = Column(String, default="1")
     deleted = Column(Boolean, default=False)
     deletedAt = Column(TIMESTAMP, default=None)
@@ -189,7 +189,7 @@ class TrainingJob(Base):
 
     options = Column(JSONB, nullable=True)
 
-    requested_time = Column(TIMESTAMP, default=func.now())
+    requested_time = Column(TIMESTAMP(timezone=True), default=func.now())
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=True)
 
     session_id = Column(Text, nullable=True)
@@ -204,7 +204,7 @@ class TrainingJob(Base):
     )
 
     deleted = Column(Boolean, default=False)
-    deleted_at = Column(TIMESTAMP, nullable=True)
+    deleted_at = Column(TIMESTAMP(timezone=True), nullable=True)
 
     source_revision = relationship("BibleRevision", foreign_keys=[source_revision_id])
     target_revision = relationship("BibleRevision", foreign_keys=[target_revision_id])

--- a/security_routes/auth_routes.py
+++ b/security_routes/auth_routes.py
@@ -1,6 +1,6 @@
 # auth_routes.py
 import socket
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -42,9 +42,9 @@ async def authenticate_user(username: str, password: str, db: AsyncSession):
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
     to_encode = data.copy()
     if expires_delta:
-        expire = datetime.utcnow() + expires_delta
+        expire = datetime.now(timezone.utc) + expires_delta
     else:
-        expire = datetime.utcnow() + timedelta(minutes=15)
+        expire = datetime.now(timezone.utc) + timedelta(minutes=15)
     to_encode.update({"exp": expire})
     encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
     return encoded_jwt

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -5264,13 +5264,13 @@ def test_get_critique_issues_all_assessments_false(
 ):
     """Test getting critique issues from only the latest assessment when all_assessments=False."""
     import time
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     from database.models import Assessment
 
     # Create two assessments with different end times
     # Use a very far future time to ensure this is definitely the latest assessment
-    base_time = datetime.now() + timedelta(days=365)
+    base_time = datetime.now(timezone.utc) + timedelta(days=365)
 
     older_assessment = Assessment(
         revision_id=test_revision_id,

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -724,7 +724,7 @@ def test_duplicate_assessment_stale_allowed(
     client, regular_token1, db_session, test_db_session
 ):
     """Assessment older than stale cutoff should not block a new one."""
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -746,7 +746,7 @@ def test_duplicate_assessment_stale_allowed(
         assessment = (
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
-        assessment.requested_time = datetime.now() - timedelta(hours=3)
+        assessment.requested_time = datetime.now(timezone.utc) - timedelta(hours=3)
         db_session.commit()
 
         second = client.post(
@@ -864,7 +864,7 @@ def test_completed_assessment_returns_409(
     client, regular_token1, db_session, test_db_session
 ):
     """POST assessment that already completed returns 409 with existing ID."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -889,7 +889,7 @@ def test_completed_assessment_returns_409(
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
         assessment.status = "finished"
-        assessment.end_time = datetime.now()
+        assessment.end_time = datetime.now(timezone.utc)
         db_session.commit()
 
         second = client.post(
@@ -906,7 +906,7 @@ def test_completed_assessment_force_rerun(
     client, regular_token1, db_session, test_db_session
 ):
     """force=true allows rerunning a completed assessment."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -931,7 +931,7 @@ def test_completed_assessment_force_rerun(
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
         assessment.status = "finished"
-        assessment.end_time = datetime.now()
+        assessment.end_time = datetime.now(timezone.utc)
         db_session.commit()
 
         # force=true should allow rerun
@@ -949,7 +949,7 @@ def test_completed_assessment_different_type_allowed(
     client, regular_token1, db_session, test_db_session
 ):
     """Completed assessment of different type should not block."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -977,7 +977,7 @@ def test_completed_assessment_different_type_allowed(
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
         assessment.status = "finished"
-        assessment.end_time = datetime.now()
+        assessment.end_time = datetime.now(timezone.utc)
         db_session.commit()
 
         # Different type should succeed
@@ -997,7 +997,7 @@ def test_completed_assessment_different_kwargs_blocked(
     client, regular_token1, db_session, test_db_session
 ):
     """Finished assessment with different kwargs still blocks (same type+revision)."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -1024,7 +1024,7 @@ def test_completed_assessment_different_kwargs_blocked(
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
         assessment.status = "finished"
-        assessment.end_time = datetime.now()
+        assessment.end_time = datetime.now(timezone.utc)
         db_session.commit()
 
         # Different kwargs on same type+revision still blocked
@@ -1045,7 +1045,7 @@ def test_completed_assessment_different_vref_allowed(
     client, regular_token1, db_session, test_db_session
 ):
     """Completed assessment with different verse range should not block."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -1072,7 +1072,7 @@ def test_completed_assessment_different_vref_allowed(
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
         assessment.status = "finished"
-        assessment.end_time = datetime.now()
+        assessment.end_time = datetime.now(timezone.utc)
         db_session.commit()
 
         # Different verse range should succeed
@@ -1092,7 +1092,7 @@ def test_completed_assessment_same_vref_blocked(
     client, regular_token1, db_session, test_db_session
 ):
     """Completed assessment with same verse range should block (409)."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -1119,7 +1119,7 @@ def test_completed_assessment_same_vref_blocked(
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
         assessment.status = "finished"
-        assessment.end_time = datetime.now()
+        assessment.end_time = datetime.now(timezone.utc)
         db_session.commit()
 
         # Same verse range should be blocked
@@ -1140,7 +1140,7 @@ def test_completed_assessment_no_vref_not_blocked_by_vref(
     client, regular_token1, db_session, test_db_session
 ):
     """Full-Bible run (no vref) should not be blocked by a partial-range assessment."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -1167,7 +1167,7 @@ def test_completed_assessment_no_vref_not_blocked_by_vref(
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
         assessment.status = "finished"
-        assessment.end_time = datetime.now()
+        assessment.end_time = datetime.now(timezone.utc)
         db_session.commit()
 
         # Full-Bible run (no vref) should not be blocked
@@ -1186,7 +1186,7 @@ def test_completed_assessment_admin_also_blocked(
     client, regular_token1, admin_token, db_session, test_db_session
 ):
     """Admin users are also blocked by completed assessment check (must use force)."""
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     version_id = create_bible_version(client, regular_token1, db_session)
     revision_id = upload_revision(client, regular_token1, version_id)
@@ -1211,7 +1211,7 @@ def test_completed_assessment_admin_also_blocked(
             db_session.query(Assessment).filter(Assessment.id == first_id).first()
         )
         assessment.status = "finished"
-        assessment.end_time = datetime.now()
+        assessment.end_time = datetime.now(timezone.utc)
         db_session.commit()
 
         # Admin without force should still be blocked

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -2795,7 +2795,7 @@ def test_search_include_alignments_auto_picks_latest_finished(
     client, regular_token1, test_db_session
 ):
     """When multiple finished assessments exist for the pair, the latest wins."""
-    from datetime import datetime, timedelta
+    from datetime import datetime, timedelta, timezone
 
     main_revision_id, comp_revision_id = setup_search_test_data(test_db_session)
 
@@ -2813,7 +2813,7 @@ def test_search_include_alignments_auto_picks_latest_finished(
     )
     # Stamp end_times explicitly so ordering isn't relying on insertion order
     # or the id tie-breaker doing the right thing accidentally.
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     older = test_db_session.query(Assessment).filter(Assessment.id == older_id).one()
     newer = test_db_session.query(Assessment).filter(Assessment.id == newer_id).one()
     older.end_time = now - timedelta(days=1)

--- a/test/test_assessment_routes/test_timeout_sweep_routes.py
+++ b/test/test_assessment_routes/test_timeout_sweep_routes.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from assessment_routes.v3.timeout_sweep_routes import TIMEOUT_STATUS_DETAIL
 from database.models import Assessment
@@ -41,8 +41,8 @@ def test_timeout_sweep_marks_old_running_and_queued_failed(
     revision_id = test_db_session.test_revision_id_1
     reference_id = test_db_session.test_revision_id_2
 
-    old = datetime.now() - timedelta(hours=48)
-    recent = datetime.now() - timedelta(minutes=5)
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    recent = datetime.now(timezone.utc) - timedelta(minutes=5)
 
     stuck_running = _create_assessment(
         db_session, revision_id, reference_id, status="running", requested_time=old
@@ -142,8 +142,8 @@ def test_timeout_sweep_respects_custom_hours(
     revision_id = test_db_session.test_revision_id_1
     reference_id = test_db_session.test_revision_id_2
 
-    five_hours_ago = datetime.now() - timedelta(hours=5)
-    one_hour_ago = datetime.now() - timedelta(hours=1)
+    five_hours_ago = datetime.now(timezone.utc) - timedelta(hours=5)
+    one_hour_ago = datetime.now(timezone.utc) - timedelta(hours=1)
 
     older_than_3h = _create_assessment(
         db_session,
@@ -193,7 +193,7 @@ def test_timeout_sweep_requires_admin(
 ):
     revision_id = test_db_session.test_revision_id_1
     reference_id = test_db_session.test_revision_id_2
-    old = datetime.now() - timedelta(hours=48)
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
     stuck = _create_assessment(
         db_session, revision_id, reference_id, status="running", requested_time=old
     )
@@ -228,3 +228,59 @@ def test_timeout_sweep_rejects_hours_above_ceiling(client, admin_token):
         headers={"Authorization": f"Bearer {admin_token}"},
     )
     assert response.status_code == 422
+
+
+def test_timeout_sweep_uses_utc_cutoff_regardless_of_server_timezone(
+    client, admin_token, db_session, test_db_session
+):
+    """Regression for aqua-api#720: timeout sweep cutoff must be tz-aware UTC
+    so that the age comparison against ``requested_time`` does not silently
+    drift by the server's local UTC offset.
+
+    Without this property, a host in (say) UTC-10 would treat a row
+    requested 23h ago as if it were 13h old and skip sweeping it (or, in
+    the opposite direction, sweep something that was only 1h old). We assert
+    the round-tripped cutoff carries tzinfo and matches now(timezone.utc).
+    """
+    revision_id = test_db_session.test_revision_id_1
+    reference_id = test_db_session.test_revision_id_2
+
+    before = datetime.now(timezone.utc)
+    response = client.post(
+        f"{prefix}/assessment/timeout-sweep?hours=24",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    after = datetime.now(timezone.utc)
+    assert response.status_code == 200, response.text
+
+    cutoff_iso = response.json()["cutoff"]
+    cutoff = datetime.fromisoformat(cutoff_iso)
+    assert cutoff.tzinfo is not None, "cutoff must be tz-aware"
+
+    # The cutoff is hours=24 in the past, computed between `before` and `after`.
+    assert (before - timedelta(hours=24, seconds=5)) <= cutoff
+    assert cutoff <= (after - timedelta(hours=24) + timedelta(seconds=5))
+
+    # And the sweep correctly identifies a stuck row whose requested_time is
+    # tz-aware UTC and well past the cutoff.
+    old = datetime.now(timezone.utc) - timedelta(hours=48)
+    stuck = _create_assessment(
+        db_session, revision_id, reference_id, status="running", requested_time=old
+    )
+    try:
+        response = client.post(
+            f"{prefix}/assessment/timeout-sweep",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert response.status_code == 200, response.text
+        assert stuck.id in set(response.json()["swept_ids"])
+
+        db_session.expire_all()
+        refreshed = (
+            db_session.query(Assessment).filter(Assessment.id == stuck.id).first()
+        )
+        # end_time written by the route must be tz-aware UTC.
+        assert refreshed.end_time is not None
+        assert refreshed.end_time.tzinfo is not None
+    finally:
+        _delete_assessments(db_session, [stuck])

--- a/train_routes/v3/train_routes.py
+++ b/train_routes/v3/train_routes.py
@@ -5,7 +5,7 @@ import os
 import socket
 import unicodedata
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 import fastapi
@@ -786,7 +786,7 @@ async def create_training_job(
             reference_id=source_revision_id,
             type=training_type.value,
             status="queued",
-            requested_time=datetime.utcnow(),
+            requested_time=datetime.now(timezone.utc),
             owner_id=current_user.id,
             kwargs=training_options,
             is_training=True,
@@ -802,7 +802,7 @@ async def create_training_job(
             source_version_id=source_version.id,
             target_version_id=target_version.id,
             options=training_options,
-            requested_time=datetime.utcnow(),
+            requested_time=datetime.now(timezone.utc),
             owner_id=current_user.id,
             session_id=session_id,
             assessment_id=assessment_id,
@@ -864,7 +864,7 @@ async def create_training_job(
         # runner never got a chance to advance it past `queued`. Skip
         # soft-deleted rows defensively even though they can't appear in
         # this code path today (assessments are freshly created above).
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         failed_assessments = (
             (
                 await db.execute(
@@ -1755,6 +1755,6 @@ async def delete_training_job(
         )
 
     job.deleted = True
-    job.deleted_at = datetime.utcnow()
+    job.deleted_at = datetime.now(timezone.utc)
     await db.commit()
     return {"detail": f"Training job {job_id} deleted successfully"}


### PR DESCRIPTION
## Summary

- Replaces all naive `datetime.now()` / `datetime.utcnow()` writers for assessment and training-job timestamps with `datetime.now(timezone.utc)`. Previously the timeout-sweep cutoff and the `requested_time` it compared against were in different timezones on any non-UTC host, so stuck jobs were swept too early or not at all depending on the host's UTC offset.
- Widens `assessment.{requested_time, start_time, end_time}` and `training_job.{requested_time, deleted_at}` from `TIMESTAMP WITHOUT TIME ZONE` to `TIMESTAMP WITH TIME ZONE`, matching the pattern already used by `predict_jobs.completed_at`. New alembic migration `b720f1c8a4d2` interprets existing naive rows as UTC.
- Also fixes the tz-naive writer in `security_routes/auth_routes.py` (JWT expiry — safe because PyJWT serializes to a Unix timestamp).
- `agent_routes/v3/tokenizer_routes.py` (LanguageProfile.updated_at) was deliberately left naive: that column is still `TIMESTAMP WITHOUT TIME ZONE`, and widening it is out of scope for #720 (assessment/training only). An in-code comment documents the scope boundary.
- Adds a regression test asserting the timeout-sweep cutoff is tz-aware UTC and that `end_time` written by the sweep route round-trips with tzinfo intact.

Fixes #720

## Test plan

- [x] black / isort / flake8 clean locally
- [x] Migration validates (single head, down_revision points to current `1d460bf9ea55`)
- [ ] CI runs `alembic upgrade head` then full pytest suite — relies on CI for full integration because the shared dev DB is at a different revision (other parallel agents working on #721/#722)
- [ ] New tz-aware roundtrip regression test passes in CI

Heads-up for reviewers: parallel PRs for #721 and #722 may also add migrations; whichever lands second will rebase its `down_revision` onto the merged ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)