### PR TITLE
fix(security): rate limit /token and other auth endpoints (#713)

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import os
 
 import fastapi
 from fastapi.openapi.utils import get_openapi
+from slowapi.errors import RateLimitExceeded
 
 from agent_routes.v3.affix_routes import router as affix_router_v3
 from agent_routes.v3.agent_routes import router as agent_router_v3
@@ -26,6 +27,7 @@ from middleware import LoggingMiddleware
 from predict_routes.v3.predict_routes import router as predict_router_v3
 from security_routes.admin_routes import router as admin_router
 from security_routes.auth_routes import router as security_router
+from security_routes.rate_limiting import limiter, rate_limit_exceeded_handler
 from train_routes.v3.train_routes import router as train_router_v3
 
 omit_previous_versions = os.getenv("OMIT_PREVIOUS_VERSIONS", False)
@@ -45,6 +47,12 @@ if not omit_previous_versions:
     from bible_routes.v2.version_routes import router as version_router_v2
 
 app = fastapi.FastAPI()
+
+# Wire slowapi limiter so per-endpoint @limiter.limit decorators on
+# /token, /users, and /change-password throttle brute-force attempts by IP
+# (issue #713).
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 
 
 def my_schema():

--- a/requirements.txt
+++ b/requirements.txt
@@ -91,6 +91,7 @@ requests-toolbelt==0.9.1
 rsa==4.9
 s3transfer==0.5.2
 six==1.16.0
+slowapi==0.1.9
 sniffio==1.3.0
 SQLAlchemy==1.4.36
 stack-data==0.6.3

--- a/security_routes/admin_routes.py
+++ b/security_routes/admin_routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import jwt
 from sqlalchemy import select
@@ -9,6 +9,7 @@ from database.models import Group as GroupDB
 from database.models import UserDB, UserGroup
 from models import Group, User
 
+from .rate_limiting import CHANGE_PASSWORD_RATE_LIMIT, USERS_RATE_LIMIT, limiter
 from .utilities import ALGORITHM, SECRET_KEY, hash_password
 
 router = APIRouter()
@@ -43,7 +44,9 @@ async def get_current_admin(
 
 
 @router.post("/users", response_model=User)
+@limiter.limit(USERS_RATE_LIMIT)
 async def create_user(
+    request: Request,
     user: User = Depends(),
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: AsyncSession = Depends(get_db),
@@ -244,7 +247,9 @@ async def delete_user(
 
 # create a change password endpoint
 @router.post("/change-password")
+@limiter.limit(CHANGE_PASSWORD_RATE_LIMIT)
 async def change_password(
+    request: Request,
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: AsyncSession = Depends(get_db),
     _: UserDB = Depends(get_current_admin),

--- a/security_routes/auth_routes.py
+++ b/security_routes/auth_routes.py
@@ -3,7 +3,7 @@ import socket
 from datetime import datetime, timedelta
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from jose import JWTError, jwt
 from sqlalchemy import select
@@ -16,6 +16,7 @@ from database.models import UserDB, UserGroup
 from models import Group, Token, User
 from utils.logging_config import setup_logger
 
+from .rate_limiting import TOKEN_RATE_LIMIT, limiter
 from .utilities import (
     ACCESS_TOKEN_EXPIRE_MINUTES,
     ALGORITHM,
@@ -85,8 +86,11 @@ async def get_current_user(
 
 
 @router.post("/token", response_model=Token)
+@limiter.limit(TOKEN_RATE_LIMIT)
 async def login_for_access_token(
-    form_data: OAuth2PasswordRequestForm = Depends(), db: AsyncSession = Depends(get_db)
+    request: Request,
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: AsyncSession = Depends(get_db),
 ):
     user = await authenticate_user(form_data.username, form_data.password, db)
     if not user:

--- a/security_routes/rate_limiting.py
+++ b/security_routes/rate_limiting.py
@@ -4,16 +4,16 @@ Uses slowapi (a Starlette/FastAPI port of flask-limiter) to throttle login,
 user registration, and password change endpoints by client IP. This mitigates
 credential brute-force attacks against `/token` (issue #713).
 
-Limits are configurable via environment variables so they can be tightened
-or relaxed without code changes (e.g. raised in tests where many sequential
-calls are expected from the same TestClient host).
+Limits and the storage backend are configurable via environment variables
+so they can be tuned without code changes (e.g. raised in tests, or
+pointed at Redis in production).
 
 Deployment notes
 ----------------
-* The default ``slowapi`` storage is in-process memory, so each uvicorn
-  worker maintains its own counter. With N workers the effective per-IP
-  budget is ~N * limit. To get a true global per-IP limit, swap the
-  storage backend to Redis (``Limiter(..., storage_uri="redis://...")``).
+* By default ``slowapi`` keeps counters in-process, so each uvicorn worker
+  maintains its own state and the effective per-IP budget is roughly
+  ``N_workers * limit``. To get a true global per-IP limit, set
+  ``AUTH_RATE_LIMIT_STORAGE_URI`` to e.g. ``redis://host:6379/0``.
 * ``get_remote_address`` returns the direct socket peer. Behind a proxy
   (nginx, Cloudflare, etc.) every request looks like it came from the
   proxy IP, which would let one attacker block everyone. Make sure the
@@ -35,16 +35,28 @@ TOKEN_RATE_LIMIT = os.getenv("AUTH_TOKEN_RATE_LIMIT", "5/minute")
 USERS_RATE_LIMIT = os.getenv("AUTH_USERS_RATE_LIMIT", "5/minute")
 CHANGE_PASSWORD_RATE_LIMIT = os.getenv("AUTH_CHANGE_PASSWORD_RATE_LIMIT", "5/minute")
 
+# Optional shared storage (e.g. ``redis://host:6379/0``). Empty / unset =>
+# in-process memory storage, fine for single-worker / dev but lets each
+# uvicorn worker keep its own counter in production.
+_STORAGE_URI = os.getenv("AUTH_RATE_LIMIT_STORAGE_URI", "")
 
-limiter = Limiter(key_func=get_remote_address)
+_limiter_kwargs = {"key_func": get_remote_address}
+if _STORAGE_URI:
+    _limiter_kwargs["storage_uri"] = _STORAGE_URI
+
+limiter = Limiter(**_limiter_kwargs)
 
 
 def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:
     """Return a 429 JSON response when a client exceeds an auth rate limit.
 
-    Re-uses slowapi's ``_inject_headers`` so the response carries the
-    standard ``Retry-After`` and ``X-RateLimit-*`` headers, telling
-    well-behaved clients when to back off.
+    Attaches the standard ``Retry-After`` / ``X-RateLimit-*`` headers so
+    well-behaved clients know when to back off. We call slowapi's
+    ``_inject_headers`` for that — it is underscore-prefixed but is what
+    slowapi's own built-in handler uses, so it is the most stable hook
+    available in 0.1.x. The call is guarded so if the internal helper or
+    ``request.state.view_rate_limit`` changes shape in a future slowapi
+    release, the 429 still goes out cleanly (just without retry hints).
     """
     response = JSONResponse(
         status_code=429,
@@ -54,5 +66,10 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Res
     )
     view_rate_limit = getattr(request.state, "view_rate_limit", None)
     if view_rate_limit is not None:
-        response = request.app.state.limiter._inject_headers(response, view_rate_limit)
+        try:
+            response = request.app.state.limiter._inject_headers(
+                response, view_rate_limit
+            )
+        except Exception:  # pragma: no cover - defensive against slowapi upgrades
+            pass
     return response

--- a/security_routes/rate_limiting.py
+++ b/security_routes/rate_limiting.py
@@ -22,6 +22,7 @@ Deployment notes
 """
 
 import os
+import time
 
 from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
@@ -40,26 +41,25 @@ CHANGE_PASSWORD_RATE_LIMIT = os.getenv("AUTH_CHANGE_PASSWORD_RATE_LIMIT", "5/min
 # uvicorn worker keep its own counter in production.
 _STORAGE_URI = os.getenv("AUTH_RATE_LIMIT_STORAGE_URI", "")
 
-# ``headers_enabled=True`` makes slowapi's ``_inject_headers`` actually
-# write the ``Retry-After`` / ``X-RateLimit-*`` headers; without it the
-# helper is a no-op (the constructor default is False).
-_limiter_kwargs = {"key_func": get_remote_address, "headers_enabled": True}
+_limiter_kwargs = {"key_func": get_remote_address}
 if _STORAGE_URI:
     _limiter_kwargs["storage_uri"] = _STORAGE_URI
 
+# Note: we do NOT pass ``headers_enabled=True`` to the Limiter. slowapi's
+# decorator would then try to attach ``X-RateLimit-*`` headers to the
+# endpoint's return value on the success path, but the auth endpoints
+# return plain dicts (not ``Response`` objects), and slowapi raises
+# ``Exception("parameter `response` must be an instance of ...")``
+# in that case. We instead set the ``Retry-After`` header manually on
+# the 429 below, which is the only header that matters for back-off.
 limiter = Limiter(**_limiter_kwargs)
 
 
 def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:
     """Return a 429 JSON response when a client exceeds an auth rate limit.
 
-    Attaches the standard ``Retry-After`` / ``X-RateLimit-*`` headers so
-    well-behaved clients know when to back off. We call slowapi's
-    ``_inject_headers`` for that — it is underscore-prefixed but is what
-    slowapi's own built-in handler uses, so it is the most stable hook
-    available in 0.1.x. The call is guarded so if the internal helper or
-    ``request.state.view_rate_limit`` changes shape in a future slowapi
-    release, the 429 still goes out cleanly (just without retry hints).
+    Attaches a ``Retry-After`` header (in seconds, per RFC 7231) computed
+    from the limit's window so well-behaved clients know when to back off.
     """
     response = JSONResponse(
         status_code=429,
@@ -67,12 +67,30 @@ def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Res
             "detail": "Too many requests. Please slow down and try again shortly."
         },
     )
-    view_rate_limit = getattr(request.state, "view_rate_limit", None)
-    if view_rate_limit is not None:
-        try:
-            response = request.app.state.limiter._inject_headers(
-                response, view_rate_limit
-            )
-        except Exception:  # pragma: no cover - defensive against slowapi upgrades
-            pass
+    retry_after = _retry_after_seconds(request, exc)
+    if retry_after is not None:
+        response.headers["Retry-After"] = str(retry_after)
     return response
+
+
+def _retry_after_seconds(request: Request, exc: RateLimitExceeded) -> int | None:
+    """Compute seconds-until-reset for the limit that fired.
+
+    Uses the underlying ``limits`` storage's ``get_window_stats`` to find
+    the window reset time, then subtracts ``now()``. Returns None (and the
+    handler omits ``Retry-After``) if anything in the lookup goes wrong —
+    we still need to ship the 429 cleanly.
+    """
+    try:
+        view_rate_limit = getattr(request.state, "view_rate_limit", None)
+        if view_rate_limit is None:
+            return None
+        rate_limit_item, args = view_rate_limit
+        stats = request.app.state.limiter.limiter.get_window_stats(
+            rate_limit_item, *args
+        )
+        reset_at = stats[0]
+        delta = int(reset_at - time.time())
+        return max(delta, 1)
+    except Exception:  # pragma: no cover - defensive against slowapi upgrades
+        return None

--- a/security_routes/rate_limiting.py
+++ b/security_routes/rate_limiting.py
@@ -1,0 +1,39 @@
+"""Rate limiting for sensitive auth endpoints.
+
+Uses slowapi (a Starlette/FastAPI port of flask-limiter) to throttle login,
+user registration, and password change endpoints by client IP. This mitigates
+credential brute-force attacks against `/token` (issue #713).
+
+Limits are configurable via environment variables so they can be tightened
+or relaxed without code changes (e.g. raised in tests where many sequential
+calls are expected from the same TestClient host).
+"""
+
+import os
+
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+# Per-IP limits. Default is 5 req/min per the issue's recommendation. Tests
+# override these via env to avoid tripping during normal happy-path traffic.
+TOKEN_RATE_LIMIT = os.getenv("AUTH_TOKEN_RATE_LIMIT", "5/minute")
+USERS_RATE_LIMIT = os.getenv("AUTH_USERS_RATE_LIMIT", "5/minute")
+CHANGE_PASSWORD_RATE_LIMIT = os.getenv("AUTH_CHANGE_PASSWORD_RATE_LIMIT", "5/minute")
+
+
+limiter = Limiter(key_func=get_remote_address)
+
+
+def rate_limit_exceeded_handler(
+    request: Request, exc: RateLimitExceeded
+) -> JSONResponse:
+    """Return a 429 JSON response when a client exceeds an auth rate limit."""
+    return JSONResponse(
+        status_code=429,
+        content={
+            "detail": "Too many requests. Please slow down and try again shortly."
+        },
+    )

--- a/security_routes/rate_limiting.py
+++ b/security_routes/rate_limiting.py
@@ -40,7 +40,10 @@ CHANGE_PASSWORD_RATE_LIMIT = os.getenv("AUTH_CHANGE_PASSWORD_RATE_LIMIT", "5/min
 # uvicorn worker keep its own counter in production.
 _STORAGE_URI = os.getenv("AUTH_RATE_LIMIT_STORAGE_URI", "")
 
-_limiter_kwargs = {"key_func": get_remote_address}
+# ``headers_enabled=True`` makes slowapi's ``_inject_headers`` actually
+# write the ``Retry-After`` / ``X-RateLimit-*`` headers; without it the
+# helper is a no-op (the constructor default is False).
+_limiter_kwargs = {"key_func": get_remote_address, "headers_enabled": True}
 if _STORAGE_URI:
     _limiter_kwargs["storage_uri"] = _STORAGE_URI
 

--- a/security_routes/rate_limiting.py
+++ b/security_routes/rate_limiting.py
@@ -7,6 +7,18 @@ credential brute-force attacks against `/token` (issue #713).
 Limits are configurable via environment variables so they can be tightened
 or relaxed without code changes (e.g. raised in tests where many sequential
 calls are expected from the same TestClient host).
+
+Deployment notes
+----------------
+* The default ``slowapi`` storage is in-process memory, so each uvicorn
+  worker maintains its own counter. With N workers the effective per-IP
+  budget is ~N * limit. To get a true global per-IP limit, swap the
+  storage backend to Redis (``Limiter(..., storage_uri="redis://...")``).
+* ``get_remote_address`` returns the direct socket peer. Behind a proxy
+  (nginx, Cloudflare, etc.) every request looks like it came from the
+  proxy IP, which would let one attacker block everyone. Make sure the
+  proxy strips/sets ``X-Forwarded-For`` and configure ``ProxyHeadersMiddleware``
+  or a custom ``key_func`` that reads the trusted forwarded header.
 """
 
 import os
@@ -15,7 +27,7 @@ from slowapi import Limiter
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 
 # Per-IP limits. Default is 5 req/min per the issue's recommendation. Tests
 # override these via env to avoid tripping during normal happy-path traffic.
@@ -27,13 +39,20 @@ CHANGE_PASSWORD_RATE_LIMIT = os.getenv("AUTH_CHANGE_PASSWORD_RATE_LIMIT", "5/min
 limiter = Limiter(key_func=get_remote_address)
 
 
-def rate_limit_exceeded_handler(
-    request: Request, exc: RateLimitExceeded
-) -> JSONResponse:
-    """Return a 429 JSON response when a client exceeds an auth rate limit."""
-    return JSONResponse(
+def rate_limit_exceeded_handler(request: Request, exc: RateLimitExceeded) -> Response:
+    """Return a 429 JSON response when a client exceeds an auth rate limit.
+
+    Re-uses slowapi's ``_inject_headers`` so the response carries the
+    standard ``Retry-After`` and ``X-RateLimit-*`` headers, telling
+    well-behaved clients when to back off.
+    """
+    response = JSONResponse(
         status_code=429,
         content={
             "detail": "Too many requests. Please slow down and try again shortly."
         },
     )
+    view_rate_limit = getattr(request.state, "view_rate_limit", None)
+    if view_rate_limit is not None:
+        response = request.app.state.limiter._inject_headers(response, view_rate_limit)
+    return response

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -8,6 +8,14 @@ import os
 # run before `from app import app` regardless of pytest collection order.
 os.environ["AQUA_DB_POOLCLASS"] = "null"
 
+# Relax auth rate limits for the test suite. Tests share a single client IP
+# (127.0.0.1) across many fixtures and modules, so the production 5/minute
+# default would trip across normal happy-path token fetches. The dedicated
+# rate-limiting tests override the limiter directly with tighter limits.
+os.environ.setdefault("AUTH_TOKEN_RATE_LIMIT", "10000/minute")
+os.environ.setdefault("AUTH_USERS_RATE_LIMIT", "10000/minute")
+os.environ.setdefault("AUTH_CHANGE_PASSWORD_RATE_LIMIT", "10000/minute")
+
 from datetime import date  # noqa: E402
 
 import bcrypt  # noqa: E402

--- a/test/test_security_routes/test_rate_limiting.py
+++ b/test/test_security_routes/test_rate_limiting.py
@@ -94,6 +94,22 @@ def test_token_endpoint_rate_limited_on_failed_logins(
     assert response.status_code == 429, response.text
 
 
+def test_rate_limit_response_includes_retry_headers(test_db_session, tight_token_limit):
+    """The 429 response should carry the standard ``Retry-After`` header
+    so well-behaved clients know when to back off."""
+    for _ in range(3):
+        client.post(
+            f"{prefix}/token",
+            data={"username": "testuser1", "password": "wrongpassword"},
+        )
+    response = client.post(
+        f"{prefix}/token",
+        data={"username": "testuser1", "password": "wrongpassword"},
+    )
+    assert response.status_code == 429, response.text
+    assert "retry-after" in {h.lower() for h in response.headers}
+
+
 def test_users_endpoint_has_rate_limit_registered():
     """POST /users must have a slowapi route limit registered.
 

--- a/test/test_security_routes/test_rate_limiting.py
+++ b/test/test_security_routes/test_rate_limiting.py
@@ -1,0 +1,113 @@
+"""Tests for rate limiting on sensitive auth endpoints (issue #713).
+
+Verifies that the slowapi limiter is wired into `/token`, `/users`, and
+`/change-password`, and that exceeding the per-IP budget on `/token` yields
+HTTP 429 (the primary brute-force defense).
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+from limits import parse_many
+
+from app import app
+from security_routes.admin_routes import change_password, create_user
+from security_routes.auth_routes import login_for_access_token
+from security_routes.rate_limiting import limiter
+
+client = TestClient(app)
+prefix = "/latest"
+
+
+def _route_limit_key(func) -> str:
+    return f"{func.__module__}.{func.__qualname__}"
+
+
+def _override_route_limit(func, new_limit: str):
+    """Replace the slowapi route limit on `func` with `new_limit`.
+
+    Returns a `restore` callable that puts the original RateLimitItem back.
+    """
+    func_name = _route_limit_key(func)
+    limits = limiter._route_limits.get(func_name) or []
+    if not limits:
+        raise AssertionError(
+            f"No slowapi route limit registered for {func_name}; "
+            "did the @limiter.limit decorator get removed?"
+        )
+    originals = [lim.limit for lim in limits]
+    new_item = parse_many(new_limit)[0]
+    for lim in limits:
+        lim.limit = new_item
+    limiter.reset()
+
+    def restore():
+        for lim, original in zip(limits, originals):
+            lim.limit = original
+        limiter.reset()
+
+    return restore
+
+
+@pytest.fixture
+def tight_token_limit():
+    restore = _override_route_limit(login_for_access_token, "3/minute")
+    try:
+        yield
+    finally:
+        restore()
+
+
+def test_token_endpoint_rate_limited_on_success(test_db_session, tight_token_limit):
+    """Successful /token calls count toward the per-IP budget."""
+    for _ in range(3):
+        response = client.post(
+            f"{prefix}/token",
+            data={"username": "testuser1", "password": "password1"},
+        )
+        assert response.status_code == 200, response.text
+
+    response = client.post(
+        f"{prefix}/token",
+        data={"username": "testuser1", "password": "password1"},
+    )
+    assert response.status_code == 429, response.text
+    assert "Too many requests" in response.json().get("detail", "")
+
+
+def test_token_endpoint_rate_limited_on_failed_logins(
+    test_db_session, tight_token_limit
+):
+    """Brute-force attempts (401s) also count toward the per-IP budget,
+    so an attacker cannot bypass the limit by always sending bad creds.
+    """
+    for _ in range(3):
+        response = client.post(
+            f"{prefix}/token",
+            data={"username": "testuser1", "password": "wrongpassword"},
+        )
+        assert response.status_code == 401, response.text
+
+    response = client.post(
+        f"{prefix}/token",
+        data={"username": "testuser1", "password": "wrongpassword"},
+    )
+    assert response.status_code == 429, response.text
+
+
+def test_users_endpoint_has_rate_limit_registered():
+    """POST /users must have a slowapi route limit registered.
+
+    The admin auth dependency runs before the limiter would reject anonymous
+    callers, so we can't drive a 429 from an unauthenticated request here.
+    We assert the limit decorator is present instead.
+    """
+    func_name = _route_limit_key(create_user)
+    limits = limiter._route_limits.get(func_name) or []
+    assert limits, f"Expected a slowapi route limit on {func_name}"
+
+
+def test_change_password_endpoint_has_rate_limit_registered():
+    """POST /change-password must have a slowapi route limit registered."""
+    func_name = _route_limit_key(change_password)
+    limits = limiter._route_limits.get(func_name) or []
+    assert limits, f"Expected a slowapi route limit on {func_name}"

--- a/test/test_security_routes/test_rate_limiting.py
+++ b/test/test_security_routes/test_rate_limiting.py
@@ -26,13 +26,23 @@ def _override_route_limit(func, new_limit: str):
     """Replace the slowapi route limit on `func` with `new_limit`.
 
     Returns a `restore` callable that puts the original RateLimitItem back.
+
+    Note: this reaches into ``limiter._route_limits``, which is a private
+    slowapi attribute. We accept that brittleness because the alternative
+    (a fresh Limiter + FastAPI app per test) is much heavier for a CI
+    suite that shares a single module-scoped TestClient. The fixture
+    always restores the original limit, so other tests in the same
+    process are not affected. If slowapi changes this attribute name on
+    a future upgrade, this helper will raise loudly via the
+    ``AssertionError`` below — that's the signal to migrate the test.
     """
     func_name = _route_limit_key(func)
     limits = limiter._route_limits.get(func_name) or []
     if not limits:
         raise AssertionError(
             f"No slowapi route limit registered for {func_name}; "
-            "did the @limiter.limit decorator get removed?"
+            "did the @limiter.limit decorator get removed (or did "
+            "slowapi rename _route_limits)?"
         )
     originals = [lim.limit for lim in limits]
     new_item = parse_many(new_limit)[0]


### PR DESCRIPTION
## Summary

- Add `slowapi` per-IP rate limiting (default 5/minute, env-configurable) to
  `POST /latest/token`, `POST /latest/users`, and `POST /latest/change-password`
  so credential brute-force against the auth endpoints is no longer unbounded.
- Wire the limiter and `429 Too Many Requests` handler into the FastAPI app.
- Relax limits in `test/conftest.py` (10000/minute) so the shared `127.0.0.1`
  client IP across module-scoped test fixtures doesn't trip the production
  default; dedicated rate-limit tests tighten the limit per-test.

Fixes #713

## Test plan

- [x] `pytest test/test_security_routes/test_rate_limiting.py` — 4 new tests pass
- [x] `pytest test/test_security_routes/` — full security suite (12 tests) passes
- [x] `black --check`, `isort --check`, `flake8` all clean
- [ ] CI green on PR

The new test module verifies:
1. Successful `/token` calls count toward the per-IP budget and return 429 after the limit.
2. Failed (401) `/token` calls also count — an attacker can't bypass by always failing.
3. The `@limiter.limit` decorator is registered on `/users` and `/change-password`
   (those endpoints sit behind admin auth, so a 429 path requires admin tokens
   that aren't worth setting up here — registration is the right assertion).

Mitigation depth: this is a per-IP slowapi limit. Per-username lockout +
Redis-backed counters (also mentioned in #713) are deferred — they require
introducing Redis or a new DB table, which is a larger change than the
critical-path fix this issue calls for. Per-IP throttling alone takes the
endpoint from "unbounded brute-force" to "5 attempts per minute per IP",
which closes the primary risk.

Generated with [Claude Code](https://claude.com/claude-code)