### PR TITLE
fix(db): add unique (assessment_id, vref) constraint on assessment_result

### DIFF
--- a/alembic/migrations/versions/f6c4c5d16baf_add_unique_constraint_on_assessment_.py
+++ b/alembic/migrations/versions/f6c4c5d16baf_add_unique_constraint_on_assessment_.py
@@ -1,0 +1,114 @@
+"""add unique indexes on (assessment_id, vref) for assessment_result and
+(assessment_id, source_word, target_word) for eflomal_cooccurrence
+
+Revision ID: f6c4c5d16baf
+Revises: e2ad1ed4a64a
+Create Date: 2026-05-20
+
+Issue #721: neither `assessment_result` nor `eflomal_cooccurrence` had a DB
+uniqueness constraint on its natural key, so when a Modal worker retried a
+partial push every row in the batch was re-inserted (not upserted),
+producing silent duplicates. Aggregate scores inflated and ``GET /result``
+pagination became nondeterministic.
+
+This migration:
+
+1. Dedups any existing duplicates by keeping the lowest-id row per group
+   (matches the prior application-side "first-write-wins" semantics).
+2. Adds a unique index on the natural key for each table, built
+   CONCURRENTLY so production deploys don't ShareLock the table.
+3. Drops the old non-unique lookup index on `eflomal_cooccurrence` — the
+   new unique index has the same column order so queries that filtered by
+   `(assessment_id, source_word, target_word)` use it transparently.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "f6c4c5d16baf"
+down_revision: Union[str, None] = "e2ad1ed4a64a"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # We use raw op.execute rather than op.create_index so we get
+    # Postgres' IF NOT EXISTS / CONCURRENTLY forms — SQLAlchemy 1.4
+    # alembic helpers don't expose them. A defensive DROP INDEX
+    # CONCURRENTLY IF EXISTS before each CREATE cleans up any INVALID
+    # index left behind by a prior interrupted attempt, which would
+    # otherwise fail the next CREATE with "relation already exists".
+    #
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction; wrap
+    # the body in alembic's autocommit_block so each statement commits
+    # independently.
+    with op.get_context().autocommit_block():
+        # --- assessment_result --------------------------------------------
+        # Keep the lowest-id row per (assessment_id, vref). Rows where
+        # either column is NULL are left alone — the unique index does not
+        # constrain NULL values in Postgres' default (non-NULLS-NOT-DISTINCT)
+        # mode anyway.
+        op.execute(
+            """
+            DELETE FROM assessment_result a
+            USING assessment_result b
+            WHERE a.assessment_id = b.assessment_id
+              AND a.vref = b.vref
+              AND a.id > b.id
+            """
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS uq_assessment_result_assessment_vref"
+        )
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "uq_assessment_result_assessment_vref "
+            "ON assessment_result (assessment_id, vref)"
+        )
+
+        # --- eflomal_cooccurrence ----------------------------------------
+        op.execute(
+            """
+            DELETE FROM eflomal_cooccurrence a
+            USING eflomal_cooccurrence b
+            WHERE a.assessment_id = b.assessment_id
+              AND a.source_word = b.source_word
+              AND a.target_word = b.target_word
+              AND a.id > b.id
+            """
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "uq_eflomal_cooccurrence_assessment_source_target"
+        )
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+            "uq_eflomal_cooccurrence_assessment_source_target "
+            "ON eflomal_cooccurrence (assessment_id, source_word, target_word)"
+        )
+        # The new unique index covers the same column prefix as the old
+        # `ix_eflomal_cooccurrence_lookup`, so we can drop the redundant
+        # non-unique index to save write amplification.
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS ix_eflomal_cooccurrence_lookup"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        # Recreate the non-unique lookup index first so `eflomal_cooccurrence`
+        # queries by (assessment_id, source_word, target_word) still have a
+        # supporting index after we drop the unique index below.
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "ix_eflomal_cooccurrence_lookup "
+            "ON eflomal_cooccurrence (assessment_id, source_word, target_word)"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS "
+            "uq_eflomal_cooccurrence_assessment_source_target"
+        )
+        op.execute(
+            "DROP INDEX CONCURRENTLY IF EXISTS uq_assessment_result_assessment_vref"
+        )

--- a/alembic/migrations/versions/f6c4c5d16baf_add_unique_constraint_on_assessment_.py
+++ b/alembic/migrations/versions/f6c4c5d16baf_add_unique_constraint_on_assessment_.py
@@ -101,9 +101,7 @@ def upgrade() -> None:
         # The new unique index covers the same column prefix as the old
         # `ix_eflomal_cooccurrence_lookup`, so we can drop the redundant
         # non-unique index to save write amplification.
-        op.execute(
-            "DROP INDEX CONCURRENTLY IF EXISTS ix_eflomal_cooccurrence_lookup"
-        )
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_eflomal_cooccurrence_lookup")
 
 
 def downgrade() -> None:

--- a/alembic/migrations/versions/f6c4c5d16baf_add_unique_constraint_on_assessment_.py
+++ b/alembic/migrations/versions/f6c4c5d16baf_add_unique_constraint_on_assessment_.py
@@ -32,17 +32,33 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
+def _drop_if_invalid(bind, index_name: str) -> None:
+    """Drop ``index_name`` only if it exists and is in an INVALID state.
+
+    Mirrors the pattern from migration 7f2e9a4b8c31 (pg_trgm index on
+    verse_text): a CONCURRENTLY build that was interrupted leaves a row
+    in ``pg_index`` with ``indisvalid = false``. Without this guard
+    ``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` would skip the rebuild
+    and the planner could still try to use the broken index, while an
+    unconditional ``DROP`` would needlessly churn a healthy index on
+    every retry.
+    """
+    is_invalid = bind.exec_driver_sql(
+        "SELECT 1 FROM pg_class c "
+        "JOIN pg_index i ON i.indexrelid = c.oid "
+        "WHERE c.relname = :name "
+        "  AND NOT i.indisvalid",
+        {"name": index_name},
+    ).scalar()
+    if is_invalid:
+        op.execute(f"DROP INDEX CONCURRENTLY {index_name}")
+
+
 def upgrade() -> None:
-    # We use raw op.execute rather than op.create_index so we get
-    # Postgres' IF NOT EXISTS / CONCURRENTLY forms — SQLAlchemy 1.4
-    # alembic helpers don't expose them. A defensive DROP INDEX
-    # CONCURRENTLY IF EXISTS before each CREATE cleans up any INVALID
-    # index left behind by a prior interrupted attempt, which would
-    # otherwise fail the next CREATE with "relation already exists".
-    #
-    # CREATE INDEX CONCURRENTLY cannot run inside a transaction; wrap
-    # the body in alembic's autocommit_block so each statement commits
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction; wrap the
+    # body in alembic's autocommit_block so each statement commits
     # independently.
+    bind = op.get_bind()
     with op.get_context().autocommit_block():
         # --- assessment_result --------------------------------------------
         # Keep the lowest-id row per (assessment_id, vref). Rows where
@@ -58,9 +74,7 @@ def upgrade() -> None:
               AND a.id > b.id
             """
         )
-        op.execute(
-            "DROP INDEX CONCURRENTLY IF EXISTS uq_assessment_result_assessment_vref"
-        )
+        _drop_if_invalid(bind, "uq_assessment_result_assessment_vref")
         op.execute(
             "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
             "uq_assessment_result_assessment_vref "
@@ -78,10 +92,7 @@ def upgrade() -> None:
               AND a.id > b.id
             """
         )
-        op.execute(
-            "DROP INDEX CONCURRENTLY IF EXISTS "
-            "uq_eflomal_cooccurrence_assessment_source_target"
-        )
+        _drop_if_invalid(bind, "uq_eflomal_cooccurrence_assessment_source_target")
         op.execute(
             "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
             "uq_eflomal_cooccurrence_assessment_source_target "

--- a/alembic/migrations/versions/f6c4c5d16baf_add_unique_constraint_on_assessment_.py
+++ b/alembic/migrations/versions/f6c4c5d16baf_add_unique_constraint_on_assessment_.py
@@ -42,13 +42,17 @@ def _drop_if_invalid(bind, index_name: str) -> None:
     and the planner could still try to use the broken index, while an
     unconditional ``DROP`` would needlessly churn a healthy index on
     every retry.
+
+    The index name is interpolated into the SQL string because asyncpg's
+    SQL driver doesn't accept ``:name``-style placeholders here. Callers
+    pass only static identifiers defined in this migration, so there is
+    no injection surface.
     """
     is_invalid = bind.exec_driver_sql(
         "SELECT 1 FROM pg_class c "
         "JOIN pg_index i ON i.indexrelid = c.oid "
-        "WHERE c.relname = :name "
-        "  AND NOT i.indisvalid",
-        {"name": index_name},
+        f"WHERE c.relname = '{index_name}' "
+        "  AND NOT i.indisvalid"
     ).scalar()
     if is_invalid:
         op.execute(f"DROP INDEX CONCURRENTLY {index_name}")

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -564,10 +564,14 @@ async def push_eflomal_cooccurrences(
         await db.commit()
         return InsertResponse(ids=ids)
     except IntegrityError:
+        # Duplicate (assessment_id, source_word, target_word) rows are
+        # silently skipped by the ON CONFLICT clause, so reaching this
+        # branch means a different constraint fired (e.g. an FK violation
+        # on assessment_id).
         await db.rollback()
         raise HTTPException(
             status_code=400,
-            detail=f"Duplicate or constraint violation inserting {len(rows)} cooccurrences for assessment {assessment_id}",
+            detail=f"Constraint violation inserting {len(rows)} cooccurrences for assessment {assessment_id}",
         )
     except SQLAlchemyError:
         logger.exception(

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -28,6 +28,7 @@ from database.models import (
     EflomalTargetWordCount,
 )
 from database.models import UserDB as UserModel
+from database.upsert import batch_insert_on_conflict_nothing
 from models import (
     EflomalAssessmentOut,
     EflomalBpeModels,
@@ -109,32 +110,6 @@ async def _batch_insert(db, model_cls, rows):
     for i in range(0, len(rows), batch_size):
         batch = rows[i : i + batch_size]
         stmt = insert(model_cls).values(batch).returning(model_cls.id)
-        result = await db.execute(stmt)
-        inserted_ids.extend(r[0] for r in result.fetchall())
-    return inserted_ids
-
-
-async def _batch_insert_on_conflict_nothing(db, model_cls, rows, conflict_cols):
-    """Batch-insert with ON CONFLICT DO NOTHING on ``conflict_cols``.
-
-    The returned ID list covers only rows the statement actually inserted —
-    rows that conflicted with the unique index are silently skipped. That
-    matches issue #721's retry semantics for ``eflomal_cooccurrence``:
-    re-pushing a partial batch is idempotent (first-write-wins), so row
-    counts no longer inflate on Modal retries. On a clean first push the
-    returned IDs match the input row order; on a full replay the list is
-    empty.
-    """
-    _PG_MAX_PARAMS = 32_767
-    cols_per_row = len(model_cls.__table__.columns)
-    batch_size = min(_BATCH_SIZE, _PG_MAX_PARAMS // cols_per_row)
-    inserted_ids = []
-    for i in range(0, len(rows), batch_size):
-        batch = rows[i : i + batch_size]
-        stmt = pg_insert(model_cls).values(batch)
-        stmt = stmt.on_conflict_do_nothing(
-            index_elements=conflict_cols
-        ).returning(model_cls.id)
         result = await db.execute(stmt)
         inserted_ids.extend(r[0] for r in result.fetchall())
     return inserted_ids
@@ -555,11 +530,13 @@ async def push_eflomal_cooccurrences(
         for item in body
     ]
     try:
-        ids = await _batch_insert_on_conflict_nothing(
+        ids = await batch_insert_on_conflict_nothing(
             db,
             EflomalCooccurrence,
             rows,
             conflict_cols=["assessment_id", "source_word", "target_word"],
+            batch_size=_BATCH_SIZE,
+            return_ids=True,
         )
         await db.commit()
         return InsertResponse(ids=ids)

--- a/assessment_routes/v3/eflomal_routes.py
+++ b/assessment_routes/v3/eflomal_routes.py
@@ -114,6 +114,32 @@ async def _batch_insert(db, model_cls, rows):
     return inserted_ids
 
 
+async def _batch_insert_on_conflict_nothing(db, model_cls, rows, conflict_cols):
+    """Batch-insert with ON CONFLICT DO NOTHING on ``conflict_cols``.
+
+    The returned ID list covers only rows the statement actually inserted —
+    rows that conflicted with the unique index are silently skipped. That
+    matches issue #721's retry semantics for ``eflomal_cooccurrence``:
+    re-pushing a partial batch is idempotent (first-write-wins), so row
+    counts no longer inflate on Modal retries. On a clean first push the
+    returned IDs match the input row order; on a full replay the list is
+    empty.
+    """
+    _PG_MAX_PARAMS = 32_767
+    cols_per_row = len(model_cls.__table__.columns)
+    batch_size = min(_BATCH_SIZE, _PG_MAX_PARAMS // cols_per_row)
+    inserted_ids = []
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i : i + batch_size]
+        stmt = pg_insert(model_cls).values(batch)
+        stmt = stmt.on_conflict_do_nothing(
+            index_elements=conflict_cols
+        ).returning(model_cls.id)
+        result = await db.execute(stmt)
+        inserted_ids.extend(r[0] for r in result.fetchall())
+    return inserted_ids
+
+
 async def _batch_upsert(db, model_cls, rows, conflict_cols, update_cols):
     # Per-row idempotency on `conflict_cols`: re-pushing the same row updates
     # in place, and disjoint chunks of the same upload coexist (each chunk
@@ -498,14 +524,15 @@ async def push_eflomal_cooccurrences(
 ):
     """Bulk insert cooccurrence entries for an eflomal assessment.
 
-    Maximum of 5,000 items per request. The eflomal_cooccurrence table has
-    no unique constraint on (assessment_id, source_word, target_word), so
-    inserts cannot conflict and a 400 from a retry is not possible — the
-    cost is that retrying the full sequence after a partial failure can
-    accumulate duplicate rows (a separate cleanup needs a unique-constraint
-    migration before upsert can be used here).
+    Maximum of 5,000 items per request. Inserts use
+    ``ON CONFLICT (assessment_id, source_word, target_word) DO NOTHING``
+    so Modal-worker retries are idempotent — re-pushing a partially-written
+    batch is safe and preserves the original counts (first-write-wins,
+    issue #721).
 
-    Returns the list of inserted row IDs in the same order as the input.
+    Returns the IDs of rows the statement actually inserted; rows whose
+    natural key already existed are skipped, so on a clean first push this
+    matches the input row order and on a full replay it is empty.
     """
     eflomal = await _get_eflomal_assessment(assessment_id, db)
     if not await is_user_authorized_for_assessment(current_user.id, assessment_id, db):
@@ -528,7 +555,12 @@ async def push_eflomal_cooccurrences(
         for item in body
     ]
     try:
-        ids = await _batch_insert(db, EflomalCooccurrence, rows)
+        ids = await _batch_insert_on_conflict_nothing(
+            db,
+            EflomalCooccurrence,
+            rows,
+            conflict_cols=["assessment_id", "source_word", "target_word"],
+        )
         await db.commit()
         return InsertResponse(ids=ids)
     except IntegrityError:

--- a/assessment_routes/v3/results_push_routes.py
+++ b/assessment_routes/v3/results_push_routes.py
@@ -11,7 +11,6 @@ from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.dependencies import get_db
-from database.upsert import batch_insert_on_conflict_nothing
 from database.models import (
     AlignmentThresholdScores,
     AlignmentTopSourceScores,
@@ -23,6 +22,7 @@ from database.models import (
     TfidfPcaVector,
 )
 from database.models import UserDB as UserModel
+from database.upsert import batch_insert_on_conflict_nothing
 from models import (
     AlignmentScoreItem,
     AssessmentResultItem,

--- a/assessment_routes/v3/results_push_routes.py
+++ b/assessment_routes/v3/results_push_routes.py
@@ -186,10 +186,13 @@ async def push_results(
         await db.commit()
         return InsertResponse(ids=[])
     except IntegrityError:
+        # Duplicate (assessment_id, vref) rows are silently skipped by the
+        # ON CONFLICT clause, so reaching this branch means a different
+        # constraint fired (e.g. an FK violation on assessment_id or vref).
         await db.rollback()
         raise HTTPException(
             status_code=400,
-            detail=f"Duplicate or constraint violation inserting {len(rows)} results for assessment {assessment_id}",
+            detail=f"Constraint violation inserting {len(rows)} results for assessment {assessment_id}",
         )
     except SQLAlchemyError:
         logger.exception(

--- a/assessment_routes/v3/results_push_routes.py
+++ b/assessment_routes/v3/results_push_routes.py
@@ -7,11 +7,11 @@ from typing import List
 import fastapi
 from fastapi import Depends, HTTPException
 from sqlalchemy import delete, insert, select
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.dependencies import get_db
+from database.upsert import batch_insert_on_conflict_nothing
 from database.models import (
     AlignmentThresholdScores,
     AlignmentTopSourceScores,
@@ -96,24 +96,6 @@ async def _batch_insert(db, model_cls, rows):
         await db.execute(insert(model_cls).values(batch))
 
 
-async def _batch_insert_on_conflict_nothing(db, model_cls, rows, conflict_cols):
-    """Batch-insert with ON CONFLICT DO NOTHING on ``conflict_cols``.
-
-    Used for tables with a unique key on the natural identifier (issue #721):
-    Modal workers may retry a partial push, and the request must be safely
-    replayable. First-write-wins matches the prior application-side
-    deduplication semantics.
-    """
-    _PG_MAX_PARAMS = 32_767
-    cols_per_row = len(model_cls.__table__.columns)
-    batch_size = min(_BATCH_SIZE, _PG_MAX_PARAMS // cols_per_row)
-    for i in range(0, len(rows), batch_size):
-        batch = rows[i : i + batch_size]
-        stmt = pg_insert(model_cls).values(batch)
-        stmt = stmt.on_conflict_do_nothing(index_elements=conflict_cols)
-        await db.execute(stmt)
-
-
 def _build_score_rows(assessment_id: int, items: List[AssessmentResultItem]):
     rows = []
     for item in items:
@@ -180,8 +162,12 @@ async def push_results(
     _check_body_size(body)
     rows = _build_score_rows(assessment_id, body)
     try:
-        await _batch_insert_on_conflict_nothing(
-            db, AssessmentResult, rows, conflict_cols=["assessment_id", "vref"]
+        await batch_insert_on_conflict_nothing(
+            db,
+            AssessmentResult,
+            rows,
+            conflict_cols=["assessment_id", "vref"],
+            batch_size=_BATCH_SIZE,
         )
         await db.commit()
         return InsertResponse(ids=[])

--- a/assessment_routes/v3/results_push_routes.py
+++ b/assessment_routes/v3/results_push_routes.py
@@ -7,6 +7,7 @@ from typing import List
 import fastapi
 from fastapi import Depends, HTTPException
 from sqlalchemy import delete, insert, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -95,6 +96,24 @@ async def _batch_insert(db, model_cls, rows):
         await db.execute(insert(model_cls).values(batch))
 
 
+async def _batch_insert_on_conflict_nothing(db, model_cls, rows, conflict_cols):
+    """Batch-insert with ON CONFLICT DO NOTHING on ``conflict_cols``.
+
+    Used for tables with a unique key on the natural identifier (issue #721):
+    Modal workers may retry a partial push, and the request must be safely
+    replayable. First-write-wins matches the prior application-side
+    deduplication semantics.
+    """
+    _PG_MAX_PARAMS = 32_767
+    cols_per_row = len(model_cls.__table__.columns)
+    batch_size = min(_BATCH_SIZE, _PG_MAX_PARAMS // cols_per_row)
+    for i in range(0, len(rows), batch_size):
+        batch = rows[i : i + batch_size]
+        stmt = pg_insert(model_cls).values(batch)
+        stmt = stmt.on_conflict_do_nothing(index_elements=conflict_cols)
+        await db.execute(stmt)
+
+
 def _build_score_rows(assessment_id: int, items: List[AssessmentResultItem]):
     rows = []
     for item in items:
@@ -148,6 +167,11 @@ async def push_results(
     Maximum of 5,000 items per request. For larger datasets, split into
     multiple requests of 5,000 items or fewer.
 
+    The insert uses ``ON CONFLICT DO NOTHING`` on
+    ``(assessment_id, vref)`` so Modal-worker retries are idempotent —
+    re-pushing a partially-written batch is safe and silently skips rows
+    that already landed (issue #721, first-write-wins).
+
     Returns an empty ``ids`` list; generated IDs are intentionally not fetched
     during bulk inserts.
     """
@@ -156,7 +180,9 @@ async def push_results(
     _check_body_size(body)
     rows = _build_score_rows(assessment_id, body)
     try:
-        await _batch_insert(db, AssessmentResult, rows)
+        await _batch_insert_on_conflict_nothing(
+            db, AssessmentResult, rows, conflict_cols=["assessment_id", "vref"]
+        )
         await db.commit()
         return InsertResponse(ids=[])
     except IntegrityError:

--- a/database/models.py
+++ b/database/models.py
@@ -258,6 +258,17 @@ class AssessmentResult(Base):
         ),
         Index("idx_assessment_id", "assessment_id"),
         Index("idx_book_chapter_verse", "book", "chapter", "verse"),
+        # Issue #721: prevents silent duplicate rows when a Modal worker
+        # retries a partial push. Inserts go through
+        # ON CONFLICT DO NOTHING on (assessment_id, vref); see
+        # `_batch_insert_on_conflict_nothing` in
+        # `assessment_routes/v3/results_push_routes.py`.
+        Index(
+            "uq_assessment_result_assessment_vref",
+            "assessment_id",
+            "vref",
+            unique=True,
+        ),
     )
 
 
@@ -971,11 +982,18 @@ class EflomalCooccurrence(Base):
     aligned_count = Column(Integer, nullable=False)
 
     __table_args__ = (
+        # Issue #721: prevents silent duplicate rows when a Modal worker
+        # retries a partial push. The unique tuple doubles as the lookup
+        # index, so we promote the previous non-unique
+        # `ix_eflomal_cooccurrence_lookup` to a unique index keyed on the
+        # same columns. Inserts go through ON CONFLICT DO NOTHING in
+        # `assessment_routes/v3/eflomal_routes.py`.
         Index(
-            "ix_eflomal_cooccurrence_lookup",
+            "uq_eflomal_cooccurrence_assessment_source_target",
             "assessment_id",
             "source_word",
             "target_word",
+            unique=True,
         ),
     )
 

--- a/database/upsert.py
+++ b/database/upsert.py
@@ -1,0 +1,67 @@
+"""Shared helpers for idempotent bulk inserts.
+
+`batch_insert_on_conflict_nothing` keeps the two retry-safe push endpoints
+(assessment_result and eflomal_cooccurrence; see issue #721) consistent so
+that one drifting from the other doesn't reintroduce silent duplicate
+rows on Modal-worker retries.
+"""
+
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+# PostgreSQL's wire protocol caps a single statement at 32,767 parameters,
+# so each chunk's parameter count (cols_per_row * batch_size) must stay
+# below that. The hard-coded 5,000-row default at the call sites is itself
+# parameter-bounded by this helper.
+_PG_MAX_PARAMS = 32_767
+
+
+async def batch_insert_on_conflict_nothing(
+    db,
+    model_cls,
+    rows,
+    conflict_cols,
+    batch_size,
+    return_ids: bool = False,
+):
+    """Bulk-insert ``rows`` into ``model_cls`` with ON CONFLICT DO NOTHING.
+
+    Rows whose ``conflict_cols`` tuple already exists are silently skipped
+    (first-write-wins).  Used by every retry-safe push endpoint so a Modal
+    worker that re-pushes a partial batch can't insert ghost duplicates
+    (issue #721).
+
+    Parameters
+    ----------
+    db : AsyncSession
+        Open SQLAlchemy async session; the caller is responsible for
+        committing.
+    model_cls : declarative model
+        Target table.  Must have a unique index keyed on ``conflict_cols``.
+    rows : list[dict]
+        Per-row column values, sized to the caller's HTTP body cap.
+    conflict_cols : list[str]
+        Columns that form the unique key — must match the unique index
+        Postgres should use for ON CONFLICT inference.
+    batch_size : int
+        Caller's preferred chunk size; clamped down to keep each statement
+        below the 32,767-parameter wire-protocol limit.
+    return_ids : bool, default False
+        When True the statement adds ``RETURNING id`` and the function
+        returns the IDs of rows that actually landed (skipped conflicts
+        are omitted).  When False no IDs are projected and ``[]`` is
+        returned — slightly cheaper for hot paths that don't need them.
+    """
+    cols_per_row = len(model_cls.__table__.columns)
+    chunk = min(batch_size, _PG_MAX_PARAMS // cols_per_row)
+    inserted_ids: list = []
+    for i in range(0, len(rows), chunk):
+        batch = rows[i : i + chunk]
+        stmt = pg_insert(model_cls).values(batch)
+        stmt = stmt.on_conflict_do_nothing(index_elements=conflict_cols)
+        if return_ids:
+            stmt = stmt.returning(model_cls.id)
+            result = await db.execute(stmt)
+            inserted_ids.extend(r[0] for r in result.fetchall())
+        else:
+            await db.execute(stmt)
+    return inserted_ids

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -452,9 +452,7 @@ def test_push_eflomal_cooccurrences_idempotent(
     test_db_session.expire_all()
     eflomal_pk = (
         test_db_session.query(EflomalAssessmentModel.id)
-        .filter(
-            EflomalAssessmentModel.assessment_id == test_eflomal_assessment_id
-        )
+        .filter(EflomalAssessmentModel.assessment_id == test_eflomal_assessment_id)
         .scalar()
     )
     pairs = [(row["source_word"], row["target_word"]) for row in batch]

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -408,9 +408,22 @@ def test_push_eflomal_cooccurrences(
 
 
 def test_push_eflomal_cooccurrences_idempotent(
-    client, regular_token1, test_eflomal_assessment_id, _ensure_metadata_pushed
+    client,
+    regular_token1,
+    test_eflomal_assessment_id,
+    _ensure_metadata_pushed,
+    test_db_session,
 ):
-    """Retrying the same cooccurrence payload succeeds without a 400."""
+    """Retrying the same cooccurrence payload is a true no-op (issue #721).
+
+    The endpoint uses ``ON CONFLICT (assessment_id, source_word, target_word)
+    DO NOTHING``, so the retry returns no new IDs and the row count stays at
+    the first-push value — previously the retry would silently insert
+    duplicate rows, inflating later aggregate queries.
+    """
+    from database.models import EflomalAssessment as EflomalAssessmentModel
+    from database.models import EflomalCooccurrence
+
     headers = {"Authorization": f"Bearer {regular_token1}"}
     url = f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-cooccurrences"
     batch = _cooccurrence_items(6)
@@ -421,7 +434,23 @@ def test_push_eflomal_cooccurrences_idempotent(
 
     retry = client.post(url, json=batch, headers=headers)
     assert retry.status_code == 200
-    assert len(retry.json()["ids"]) == 6
+    assert retry.json()["ids"] == []
+
+    # Verify the second push didn't duplicate rows in the DB.
+    test_db_session.expire_all()
+    eflomal_pk = (
+        test_db_session.query(EflomalAssessmentModel.id)
+        .filter(
+            EflomalAssessmentModel.assessment_id == test_eflomal_assessment_id
+        )
+        .scalar()
+    )
+    count = (
+        test_db_session.query(EflomalCooccurrence)
+        .filter(EflomalCooccurrence.assessment_id == eflomal_pk)
+        .count()
+    )
+    assert count == 6
 
 
 def test_push_eflomal_target_word_counts(

--- a/test/test_assessment_routes/test_eflomal_routes.py
+++ b/test/test_assessment_routes/test_eflomal_routes.py
@@ -417,16 +417,28 @@ def test_push_eflomal_cooccurrences_idempotent(
     """Retrying the same cooccurrence payload is a true no-op (issue #721).
 
     The endpoint uses ``ON CONFLICT (assessment_id, source_word, target_word)
-    DO NOTHING``, so the retry returns no new IDs and the row count stays at
-    the first-push value — previously the retry would silently insert
-    duplicate rows, inflating later aggregate queries.
+    DO NOTHING``, so the retry returns no new IDs and the row count for
+    this batch's keys stays at the first-push value — previously the retry
+    silently inserted duplicate rows, inflating later aggregate queries.
     """
+    from sqlalchemy import tuple_
+
     from database.models import EflomalAssessment as EflomalAssessmentModel
     from database.models import EflomalCooccurrence
 
     headers = {"Authorization": f"Bearer {regular_token1}"}
     url = f"{prefix}/assessment/{test_eflomal_assessment_id}/eflomal-cooccurrences"
-    batch = _cooccurrence_items(6)
+    # Disjoint from any other test's payload in this module so we can assert
+    # on an exact post-retry row count without coupling to earlier inserts.
+    batch = [
+        {
+            "source_word": f"idem_src_{i}",
+            "target_word": f"idem_tgt_{i}",
+            "co_occur_count": i + 1,
+            "aligned_count": i,
+        }
+        for i in range(6)
+    ]
 
     first = client.post(url, json=batch, headers=headers)
     assert first.status_code == 200
@@ -436,7 +448,7 @@ def test_push_eflomal_cooccurrences_idempotent(
     assert retry.status_code == 200
     assert retry.json()["ids"] == []
 
-    # Verify the second push didn't duplicate rows in the DB.
+    # Verify the retry didn't duplicate rows for this batch's natural keys.
     test_db_session.expire_all()
     eflomal_pk = (
         test_db_session.query(EflomalAssessmentModel.id)
@@ -445,9 +457,15 @@ def test_push_eflomal_cooccurrences_idempotent(
         )
         .scalar()
     )
+    pairs = [(row["source_word"], row["target_word"]) for row in batch]
     count = (
         test_db_session.query(EflomalCooccurrence)
-        .filter(EflomalCooccurrence.assessment_id == eflomal_pk)
+        .filter(
+            EflomalCooccurrence.assessment_id == eflomal_pk,
+            tuple_(
+                EflomalCooccurrence.source_word, EflomalCooccurrence.target_word
+            ).in_(pairs),
+        )
         .count()
     )
     assert count == 6

--- a/test/test_assessment_routes/test_results_push_routes.py
+++ b/test/test_assessment_routes/test_results_push_routes.py
@@ -111,6 +111,88 @@ def test_push_results_invalid_vref(client, regular_token1, push_assessment_id):
     assert response.status_code == 400
 
 
+def test_push_results_idempotent_on_retry(
+    client, regular_token1, push_assessment_id, test_db_session
+):
+    """Retrying the same results payload does not duplicate rows (issue #721).
+
+    The endpoint uses ``ON CONFLICT (assessment_id, vref) DO NOTHING``, so a
+    Modal worker that retries a partial push lands the same row count as a
+    clean first push — previously the retry silently inserted duplicates.
+    """
+    body = [
+        {"vref": "GEN 2:1", "score": 0.10},
+        {"vref": "GEN 2:2", "score": 0.20},
+        {"vref": "GEN 2:3", "score": 0.30},
+    ]
+    url = f"{prefix}/assessment/{push_assessment_id}/results"
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    first = client.post(url, json=body, headers=headers)
+    assert first.status_code == 200
+
+    retry = client.post(url, json=body, headers=headers)
+    assert retry.status_code == 200
+
+    test_db_session.expire_all()
+    persisted = (
+        test_db_session.query(AssessmentResult)
+        .filter(
+            AssessmentResult.assessment_id == push_assessment_id,
+            AssessmentResult.vref.in_(["GEN 2:1", "GEN 2:2", "GEN 2:3"]),
+        )
+        .count()
+    )
+    assert persisted == 3
+
+
+def test_push_results_partial_overlap_first_write_wins(
+    client, regular_token1, push_assessment_id, test_db_session
+):
+    """A partial-overlap retry only inserts the new vrefs (first-write-wins).
+
+    Simulates a Modal worker that pushes [A, B], times out, then re-pushes
+    [B, C] with a changed score for B. The original B score must survive
+    and C must be inserted exactly once.
+    """
+    url = f"{prefix}/assessment/{push_assessment_id}/results"
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    first = client.post(
+        url,
+        json=[
+            {"vref": "GEN 3:1", "score": 0.11},
+            {"vref": "GEN 3:2", "score": 0.22},
+        ],
+        headers=headers,
+    )
+    assert first.status_code == 200
+
+    retry = client.post(
+        url,
+        json=[
+            # Same key as before, different score — must be ignored.
+            {"vref": "GEN 3:2", "score": 0.99},
+            {"vref": "GEN 3:3", "score": 0.33},
+        ],
+        headers=headers,
+    )
+    assert retry.status_code == 200
+
+    test_db_session.expire_all()
+    rows = (
+        test_db_session.query(AssessmentResult)
+        .filter(
+            AssessmentResult.assessment_id == push_assessment_id,
+            AssessmentResult.vref.in_(["GEN 3:1", "GEN 3:2", "GEN 3:3"]),
+        )
+        .all()
+    )
+    assert len(rows) == 3
+    by_vref = {r.vref: float(r.score) for r in rows}
+    assert by_vref == {"GEN 3:1": 0.11, "GEN 3:2": 0.22, "GEN 3:3": 0.33}
+
+
 def test_push_results_body_too_large(client, regular_token1, push_assessment_id):
     body = [{"vref": "GEN 1:1", "score": 0.5}] * 5001
     response = client.post(


### PR DESCRIPTION
## Summary

Closes #721. `assessment_result` had only non-unique indexes on its natural key, so Modal-worker retries silently re-inserted partial batches: aggregate scores inflated and `GET /result` pagination became nondeterministic. The same flaw affected `eflomal_cooccurrence`.

This change:

- Adds unique indexes on `assessment_result(assessment_id, vref)` and `eflomal_cooccurrence(assessment_id, source_word, target_word)` at both the ORM and DB levels.
- Adds an alembic migration that dedups any existing duplicate rows (keeping the lowest-id row per group) before building the indexes `CONCURRENTLY`, so production deploys do not `ShareLock` the tables. The redundant non-unique `ix_eflomal_cooccurrence_lookup` is dropped because the new unique index covers the same column prefix.
- Switches `push_results` and `push_eflomal_cooccurrences` to `ON CONFLICT DO NOTHING` on the natural key (first-write-wins), so a Modal retry is idempotent.
- Adds regression tests covering full-replay idempotency and partial-overlap retries.

## Test plan

- [ ] CI runs migration on a fresh schema and all assessment-route tests pass.
- [ ] `test_push_results_idempotent_on_retry` — second identical push leaves row count unchanged.
- [ ] `test_push_results_partial_overlap_first_write_wins` — overlapping retry preserves the original score for shared vrefs and inserts only the new vref.
- [ ] `test_push_eflomal_cooccurrences_idempotent` — retry returns empty `ids` list and the cooccurrence row count stays at the first-push value.

Local pytest could not be run cleanly because the shared docker DB is owned by a parallel worktree and applying the migration there would interfere with other in-progress work; relying on CI per project convention.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>