### PR TITLE
fix(agent): return existing_card_id on POST /agent/lexeme-card 409

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -920,13 +920,42 @@ async def add_lexeme_card(
     except IntegrityError as e:
         await db.rollback()
         if "ix_agent_lexeme_cards_unique" in str(e.orig):
+            # The DB unique index is on (LOWER(target_lemma), source_language_iso,
+            # target_version_id). The Python pre-check above keys on
+            # source_version_id, so a conflict here means an existing card has
+            # the same source language but a different source_version_id (e.g. a
+            # different reference version was the pivot at write time). Look up
+            # the conflicting card via the actual unique key so callers can PATCH
+            # by id; PATCH-by-lemma would 404 because it uses source_version_id.
+            from sqlalchemy import select
+            from sqlalchemy.sql import func
+
+            existing_card = await db.scalar(
+                select(AgentLexemeCard).where(
+                    func.lower(AgentLexemeCard.target_lemma)
+                    == card.target_lemma.lower(),
+                    AgentLexemeCard.source_language_iso
+                    == (
+                        select(BibleVersion.iso_language)
+                        .where(BibleVersion.id == card.source_version_id)
+                        .scalar_subquery()
+                    ),
+                    AgentLexemeCard.target_version_id == card.target_version_id,
+                )
+            )
+            detail = {
+                "message": f"A lexeme card for target_lemma='{card.target_lemma}' "
+                f"already exists for this language pair. "
+                f"Use PATCH /v3/agent/lexeme-card/{{card_id}} with the "
+                f"returned existing_card_id to update.",
+            }
+            if existing_card is not None:
+                detail["existing_card_id"] = existing_card.id
+                detail["existing_source_lemma"] = existing_card.source_lemma
+                detail["existing_source_version_id"] = existing_card.source_version_id
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "message": f"A lexeme card for target_lemma='{card.target_lemma}' "
-                    f"already exists for this language pair. "
-                    f"Use PATCH to update the existing card.",
-                },
+                detail=detail,
             ) from e
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -527,9 +527,14 @@ async def add_lexeme_card(
     """
     Add a new lexeme card entry or update an existing one.
 
-    Uniqueness is enforced on (target_lemma, source_version_id, target_version_id).
-    If a card with the same target_lemma and language pair already exists,
-    it will be updated instead of creating a duplicate.
+    Uniqueness is enforced at the DB level on (LOWER(target_lemma),
+    source_language_iso, target_version_id) — i.e. one canonical card per
+    (lemma, source language, target version), regardless of which specific
+    source_version_id the card was written via. The Python pre-check below
+    keys on source_version_id so callers that re-POST the same exact pair
+    upsert, but cross-source-version collisions inside the same source
+    language fall through to the IntegrityError handler and return 409
+    with the conflicting card's id so callers can PATCH by id.
 
     Input:
     - card: LexemeCardIn - The lexeme card data
@@ -666,6 +671,7 @@ async def add_lexeme_card(
                         f"Use PATCH to update the existing card.",
                         "existing_card_id": existing_card.id,
                         "existing_source_lemma": existing_card.source_lemma,
+                        "existing_source_version_id": existing_card.source_version_id,
                     },
                 )
             # Migrate any pre-backfill mixed-case value to the validator-normalized form.
@@ -927,9 +933,7 @@ async def add_lexeme_card(
             # different reference version was the pivot at write time). Look up
             # the conflicting card via the actual unique key so callers can PATCH
             # by id; PATCH-by-lemma would 404 because it uses source_version_id.
-            from sqlalchemy import select
-            from sqlalchemy.sql import func
-
+            # `select` and `func` are already imported at the top of the `try`.
             existing_card = await db.scalar(
                 select(AgentLexemeCard).where(
                     func.lower(AgentLexemeCard.target_lemma)

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -4419,6 +4419,102 @@ def test_post_lexeme_card_duplicate_returns_409_conflict(
     assert "already exists" in detail["message"]
 
 
+def test_post_lexeme_card_cross_source_version_same_language_returns_409_with_existing_id(
+    client,
+    regular_token1,
+    db_session,
+    test_version_id_2,
+):
+    """Regression for #775: when an existing card has the same source language
+    but a different source_version_id, POST must return 409 with
+    ``existing_card_id`` populated so the caller can PATCH by id.
+
+    The DB unique index is on (LOWER(target_lemma), source_language_iso,
+    target_version_id), but the POST handler's Python pre-check keys on
+    source_version_id and misses the conflict. The INSERT then raises an
+    IntegrityError, and without the existing_card_id in the response the
+    agent's POST→409→PATCH-by-lemma fallback loops to 404 because the
+    PATCH-by-lemma lookup also uses source_version_id."""
+    from database.models import BibleVersion, UserDB
+
+    user1 = db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+
+    # Two eng source versions and one target — both sources share
+    # source_language_iso="eng", so a card written via source_v1 collides
+    # with a write via source_v2 on the DB unique index even though the
+    # source_version_ids differ.
+    source_v1 = BibleVersion(
+        name="cross_src_v1_775",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="CSV1775",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    source_v2 = BibleVersion(
+        name="cross_src_v2_775",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="CSV2775",
+        owner_id=user1.id,
+        is_reference=True,
+    )
+    target = BibleVersion(
+        name="cross_tgt_775",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="CTGT775",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    db_session.add_all([source_v1, source_v2, target])
+    db_session.commit()
+
+    # First card stored at source_v1.
+    resp1 = client.post(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "src_v1_lemma",
+            "target_lemma": "shared_775_lemma",
+            "source_version_id": source_v1.id,
+            "target_version_id": target.id,
+        },
+    )
+    assert resp1.status_code == 200, resp1.text
+    card_v1_id = resp1.json()["id"]
+
+    # Second POST uses source_v2 — same source language, different
+    # source_version_id. The Python pre-check misses (different
+    # source_version_id), the INSERT hits the language-keyed unique index,
+    # and the IntegrityError handler must surface the existing card's id.
+    resp2 = client.post(
+        "/v3/agent/lexeme-card",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "source_lemma": "src_v2_lemma",
+            "target_lemma": "shared_775_lemma",
+            "source_version_id": source_v2.id,
+            "target_version_id": target.id,
+        },
+    )
+    assert resp2.status_code == 409, resp2.text
+    detail = resp2.json()["detail"]
+    assert detail["existing_card_id"] == card_v1_id
+    assert detail["existing_source_version_id"] == source_v1.id
+    assert detail["existing_source_lemma"] == "src_v1_lemma"
+
+    # PATCH by id (using the existing_card_id from the 409) must succeed,
+    # proving the recovery path the agent relies on.
+    patch_resp = client.patch(
+        f"/v3/agent/lexeme-card/{card_v1_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"surface_forms": ["new_form_from_v2_caller"]},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+    assert "new_form_from_v2_caller" in patch_resp.json()["surface_forms"]
+
+
 def test_patch_lexeme_card_omitted_fields_unchanged(
     client,
     regular_token1,

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -4416,6 +4416,7 @@ def test_post_lexeme_card_duplicate_returns_409_conflict(
     detail = response2.json()["detail"]
     assert detail["existing_card_id"] == card1_id
     assert detail["existing_source_lemma"] == "source_one"
+    assert detail["existing_source_version_id"] == test_version_id
     assert "already exists" in detail["message"]
 
 


### PR DESCRIPTION
## Summary

- Fixes the POST→409→PATCH-by-lemma→404 cycle described in #775.
- The DB unique index for `agent_lexeme_cards` is on `(LOWER(target_lemma), source_language_iso, target_version_id)`, but the POST pre-check and the deprecated PATCH-by-lemma lookup both key on `source_version_id`. When an existing card has the same source language but a different `source_version_id`, POST falls through to INSERT, hits the DB index, and returns 409 — but the 409 detail omits the existing card's id, leaving the agent with no recoverable path.
- The fix looks up the conflicting card via the actual unique key (deriving `source_language_iso` from the incoming `source_version_id`) and includes `existing_card_id` / `existing_source_lemma` / `existing_source_version_id` in the 409 detail. This matches the shape already returned by the pre-check 409 path, so callers can PATCH by id to recover.

## Impact

For the benchmark run cited in #775 (arb → acw), ~27 high-frequency lemmas (`في`, `ما`, `مو`, …) had POST 409s land on existing cards stored at a different `source_version_id`. The agent's PATCH-by-lemma fallback then 404'd, costing 5–10 retry rounds per lemma. With the fix, the 409 carries the existing card id and the agent can PATCH directly.

Fixes #775

## Test plan

- [x] New regression test `test_post_lexeme_card_cross_source_version_same_language_returns_409_with_existing_id` covers the exact scenario: two source versions in the same language, a card written via v1, then a POST via v2 returns 409 with `existing_card_id`, and a subsequent PATCH by id succeeds.
- [x] Existing 409/conflict/duplicate tests still pass (25/25).
- [x] Full lexeme test suite passes (167/167).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)