### PR TITLE
fix(predict): mark job failed when Modal container times out

### DIFF
--- a/predict_routes/v3/predict_routes.py
+++ b/predict_routes/v3/predict_routes.py
@@ -350,6 +350,23 @@ async def get_predict_job(
         try:
             fc = modal.FunctionCall.from_id(job.modal_call_id)
             data = await fc.get.aio(timeout=0)
+        except (
+            modal.exception.FunctionTimeoutError,
+            modal.exception.OutputExpiredError,
+        ) as exc:
+            # The Modal container itself hit its timeout (or the result
+            # expired before we polled). Both subclass the builtin
+            # TimeoutError, so they must be caught BEFORE the bare
+            # `TimeoutError` block below — otherwise they'd be silently
+            # treated as "still running" and the DB status would never flip.
+            logger.warning(
+                f"predict job {job.id} timed out on Modal: {type(exc).__name__}: {exc}",
+                exc_info=True,
+            )
+            job.status = "failed"
+            job.error = f"{type(exc).__name__}: {exc}"
+            job.completed_at = datetime.now(timezone.utc)
+            await db.commit()
         except (TimeoutError, modal.exception.TimeoutError):
             # modal._functions.poll_function raises the builtin TimeoutError
             # (not modal.exception.TimeoutError, which doesn't subclass it)

--- a/test/test_predict_routes/test_predict_routes.py
+++ b/test/test_predict_routes/test_predict_routes.py
@@ -1105,6 +1105,42 @@ def test_predict_job_failed_records_error(client, regular_token1):
     assert body["error"] == "RuntimeError"
 
 
+@pytest.mark.parametrize(
+    "exc_name",
+    ["FunctionTimeoutError", "OutputExpiredError"],
+)
+def test_predict_job_modal_container_timeout_marks_failed(
+    client, regular_token1, exc_name
+):
+    """When Modal kills the container at its timeout (or the result expires),
+    `fc.get` raises `modal.exception.FunctionTimeoutError` /
+    `OutputExpiredError`. Both subclass the builtin `TimeoutError`, so they
+    have to be caught BEFORE the bare `TimeoutError` block — otherwise
+    they're silently treated as "still running" and the DB row never flips
+    to `failed`. Regression for a job that sat in `running` indefinitely
+    after its container timed out."""
+    import modal
+
+    job_id = _spawn_agent_and_get_job(client, regular_token1)
+
+    exc_cls = getattr(modal.exception, exc_name)
+    fc_mock = AsyncMock()
+    fc_mock.get.aio = AsyncMock(side_effect=exc_cls("container hit timeout"))
+    with patch.object(modal.FunctionCall, "from_id", return_value=fc_mock):
+        response = client.get(
+            f"/{prefix}/predict/jobs/{job_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "failed"
+    assert exc_name in body["error"]
+    assert "container hit timeout" in body["error"]
+    # No Retry-After — the caller should stop polling.
+    assert "Retry-After" not in response.headers
+
+
 def test_predict_job_unknown_returns_404(client, regular_token1):
     """A job id that doesn't exist returns 404, not 500."""
     response = client.get(


### PR DESCRIPTION
## Summary
- `modal.exception.FunctionTimeoutError` inherits from Python's builtin `TimeoutError`, so when Modal kills a `predict` container at its timeout limit the poller at `predict_routes.py:353` was catching the error as "no result yet" and the `predict_jobs.status` row sat at `running` indefinitely. Caller had to update the DB by hand.
- Catch `FunctionTimeoutError` and `OutputExpiredError` explicitly (both subclass `TimeoutError`) *before* the bare-`TimeoutError` retry-after branch, flip the row to `failed`, write the error message, and set `completed_at`. The genuine "still running" path is unchanged.
- Adds `test_predict_job_modal_container_timeout_marks_failed` parametrized over both exception classes; reuses the existing `_spawn_agent_and_get_job` helper so it mirrors `test_predict_job_failed_records_error` exactly.

## Test plan
- [x] `pytest test/test_predict_routes/test_predict_routes.py` — 49 passed locally
- [x] New parametrized test asserts: status flips to `failed`, error string includes the exception class + message, no `Retry-After` header (so clients stop polling)
- [x] Existing `test_predict_job_running_returns_retry_after` still passes for both `TimeoutError` and `modal.exception.TimeoutError` — the bare-`TimeoutError` "still running" path was not regressed
- [x] `black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)