### PR TITLE
Add attempt_count + increment endpoint for retry-aware lifecycle (#314)

### DIFF
--- a/alembic/migrations/versions/f3b8e2d5c1a9_add_attempt_count_to_assessment.py
+++ b/alembic/migrations/versions/f3b8e2d5c1a9_add_attempt_count_to_assessment.py
@@ -1,0 +1,54 @@
+"""Add attempt_count to assessment
+
+Revision ID: f3b8e2d5c1a9
+Revises: e2ad1ed4a64a
+Create Date: 2026-05-22
+
+Background
+----------
+Modal `assess()` retries on worker preemption (PR #294 added `retries=3`).
+The lifecycle currently marks an assessment ``failed`` on the *first*
+attempt failure, even when more retries are coming, which produces a
+misleading user-visible status. To make the lifecycle retry-aware we
+need a server-authoritative attempt counter that survives across Modal
+worker retries (per-process counters reset on preemption).
+
+This migration adds ``attempt_count`` to ``assessment``, defaulting to
+0. The runner's lifecycle helper will atomically increment it via
+``POST /v3/assessment/{id}/increment-attempts`` on each retry, and only
+PATCH ``failed`` once ``attempt_count >= max_attempts``.
+
+``server_default="0"`` makes the migration zero-downtime: in-flight rows
+that pre-date the migration get ``0`` on read, and any subsequent
+increment makes them behave correctly (they will fail on attempt 1 →
+the existing "fail on first attempt" behavior, preserving backward
+compatibility during deploy).
+
+Downgrade drops the column. No data backfill is needed — the column is
+purely operational state, not historical record.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "f3b8e2d5c1a9"
+down_revision = "e2ad1ed4a64a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "assessment",
+        sa.Column(
+            "attempt_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("assessment", "attempt_count")

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -829,14 +829,24 @@ async def increment_assessment_attempts(
                 detail="Not authorized to update this assessment",
             )
 
+    # Filter on `deleted is not True` in the UPDATE so a race with a
+    # concurrent DELETE between the SELECT above and this UPDATE doesn't
+    # increment a freshly-deleted row. If the row was deleted in that
+    # window, `scalar_one_or_none()` returns None and we 404.
     stmt = (
         update(Assessment)
-        .where(Assessment.id == assessment_id)
+        .where(Assessment.id == assessment_id, Assessment.deleted.is_not(True))
         .values(attempt_count=Assessment.attempt_count + 1)
         .returning(Assessment.attempt_count)
     )
     res = await db.execute(stmt)
-    new_count = res.scalar_one()
+    new_count = res.scalar_one_or_none()
+    if new_count is None:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assessment not found",
+        )
     await db.commit()
     return {"attempt_count": new_count}
 

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 
 # Third party imports
 from fastapi import Depends, HTTPException, Query, status
-from sqlalchemy import JSON, BigInteger, bindparam, or_, select, text
+from sqlalchemy import JSON, BigInteger, bindparam, or_, select, text, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
@@ -773,6 +773,72 @@ async def update_assessment_status(
     await db.commit()
     await db.refresh(assessment)
     return AssessmentOut.model_validate(assessment)
+
+
+@router.post("/assessment/{assessment_id}/increment-attempts")
+async def increment_assessment_attempts(
+    assessment_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Atomically increment ``attempt_count`` for an assessment and return
+    the new value.
+
+    Called by the Modal runner's lifecycle helper at the start of each
+    attempt (after the initial `running` PATCH, so terminal-409 retries
+    don't bump the counter for no-ops). The lifecycle uses the returned
+    count to decide whether to PATCH ``failed`` on exception (only once
+    ``attempt_count >= max_attempts``).
+
+    The UPDATE ... RETURNING runs as a single atomic statement so two
+    concurrent retries on the same row can't observe the same
+    pre-increment value — Postgres serializes the writes and each call
+    sees its own post-increment count.
+
+    Auth: admin, assessment owner, or any user with group access to the
+    assessment's bible version. Mirrors ``update_assessment_status``.
+    """
+    result = await db.execute(select(Assessment).where(Assessment.id == assessment_id))
+    assessment = result.scalars().first()
+    if not assessment or assessment.deleted:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Assessment not found",
+        )
+
+    if not current_user.is_admin and assessment.owner_id != current_user.id:
+        revision = await db.get(BibleRevision, assessment.revision_id)
+        if not revision:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Assessment revision not found",
+            )
+        version_access = await db.execute(
+            select(BibleVersionAccess.bible_version_id).where(
+                BibleVersionAccess.group_id.in_(
+                    select(UserGroup.group_id).where(
+                        UserGroup.user_id == current_user.id
+                    )
+                )
+            )
+        )
+        accessible_version_ids = {row[0] for row in version_access.all()}
+        if revision.bible_version_id not in accessible_version_ids:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not authorized to update this assessment",
+            )
+
+    stmt = (
+        update(Assessment)
+        .where(Assessment.id == assessment_id)
+        .values(attempt_count=Assessment.attempt_count + 1)
+        .returning(Assessment.attempt_count)
+    )
+    res = await db.execute(stmt)
+    new_count = res.scalar_one()
+    await db.commit()
+    return {"attempt_count": new_count}
 
 
 @router.delete("/assessment")

--- a/database/models.py
+++ b/database/models.py
@@ -148,6 +148,7 @@ class Assessment(Base):
     deletedAt = Column(TIMESTAMP, default=None)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=True, default=None)
     kwargs = Column(JSONB, nullable=True, default=None)
+    attempt_count = Column(Integer, nullable=False, server_default="0", default=0)
 
     results = relationship(
         "AssessmentResult", cascade="all, delete", back_populates="assessment"

--- a/models.py
+++ b/models.py
@@ -327,6 +327,7 @@ class AssessmentOut(BaseModel):
     percent_complete: Optional[float] = None
     is_training: bool = False
     kwargs: Optional[Dict[str, Any]] = None
+    attempt_count: int = 0
 
     model_config = {
         "json_schema_extra": {
@@ -341,6 +342,7 @@ class AssessmentOut(BaseModel):
                 "end_time": "2024-06-01T12:00:00",
                 "owner_id": 1,
                 "kwargs": None,
+                "attempt_count": 0,
             }
         },
         "from_attributes": True,

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -2647,3 +2647,26 @@ def test_increment_attempts_admin_can_increment(
     resp = _increment_attempts(client, admin_token, aid)
     assert resp.status_code == 200
     assert resp.json() == {"attempt_count": 1}
+
+
+def test_assessment_out_exposes_attempt_count(
+    client, regular_token1, db_session, test_db_session
+):
+    """GET /assessment includes ``attempt_count`` in the response payload,
+    starting at 0 for a freshly-created row and reflecting subsequent
+    increments."""
+    aid = _create_assessment(client, regular_token1, db_session)
+
+    resp = list_assessment(client, regular_token1, ids=aid)
+    assert resp.status_code == 200
+    bodies = [row for row in resp.json() if row["id"] == aid]
+    assert len(bodies) == 1
+    assert bodies[0]["attempt_count"] == 0
+
+    inc = _increment_attempts(client, regular_token1, aid)
+    assert inc.status_code == 200
+
+    resp = list_assessment(client, regular_token1, ids=aid)
+    assert resp.status_code == 200
+    bodies = [row for row in resp.json() if row["id"] == aid]
+    assert bodies[0]["attempt_count"] == 1

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -2532,3 +2532,118 @@ def test_create_assessment_blocked_when_existing_row_is_running(
     )
     assert dup.status_code == 409
     assert str(first_id) in dup.json()["detail"]
+
+
+# --- POST /assessment/{id}/increment-attempts tests (issue #314) ---
+
+
+def _increment_attempts(client, token, assessment_id):
+    return client.post(
+        f"{prefix}/assessment/{assessment_id}/increment-attempts",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+
+def test_increment_attempts_zero_to_one_to_two(
+    client, regular_token1, db_session, test_db_session
+):
+    """Successive increments return the post-increment value (0→1, 1→2)."""
+    aid = _create_assessment(client, regular_token1, db_session)
+
+    # Newly-created row should have attempt_count=0 (server_default).
+    db_session.expire_all()
+    row = db_session.query(Assessment).filter(Assessment.id == aid).first()
+    assert row.attempt_count == 0
+
+    resp = _increment_attempts(client, regular_token1, aid)
+    assert resp.status_code == 200
+    assert resp.json() == {"attempt_count": 1}
+
+    resp = _increment_attempts(client, regular_token1, aid)
+    assert resp.status_code == 200
+    assert resp.json() == {"attempt_count": 2}
+
+    db_session.expire_all()
+    row = db_session.query(Assessment).filter(Assessment.id == aid).first()
+    assert row.attempt_count == 2
+
+
+def test_increment_attempts_concurrent_race_free(
+    client, regular_token1, db_session, test_db_session
+):
+    """Two concurrent increments on the same row must observe distinct
+    post-increment values (the UPDATE ... RETURNING is atomic). Asserts
+    the union of results is {1, 2} — never {1, 1}."""
+    import asyncio
+
+    import httpx
+
+    aid = _create_assessment(client, regular_token1, db_session)
+
+    async def _run():
+        from app import app as fastapi_app  # FastAPI app object
+
+        # ASGITransport drives the FastAPI app in-process so the two
+        # requests share the same event loop and can actually interleave.
+        transport = httpx.ASGITransport(app=fastapi_app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as ac:
+            headers = {"Authorization": f"Bearer {regular_token1}"}
+            r1, r2 = await asyncio.gather(
+                ac.post(
+                    f"/{prefix}/assessment/{aid}/increment-attempts", headers=headers
+                ),
+                ac.post(
+                    f"/{prefix}/assessment/{aid}/increment-attempts", headers=headers
+                ),
+            )
+            return r1, r2
+
+    r1, r2 = asyncio.run(_run())
+    assert r1.status_code == 200, r1.text
+    assert r2.status_code == 200, r2.text
+    counts = {r1.json()["attempt_count"], r2.json()["attempt_count"]}
+    assert counts == {1, 2}, f"expected {{1, 2}}, got {counts}"
+
+    db_session.expire_all()
+    row = db_session.query(Assessment).filter(Assessment.id == aid).first()
+    assert row.attempt_count == 2
+
+
+def test_increment_attempts_not_found(
+    client, regular_token1, db_session, test_db_session
+):
+    """404 when the assessment doesn't exist."""
+    resp = _increment_attempts(client, regular_token1, 9999999)
+    assert resp.status_code == 404
+
+
+def test_increment_attempts_deleted(
+    client, regular_token1, db_session, test_db_session
+):
+    """404 when the assessment row is soft-deleted."""
+    aid = _create_assessment(client, regular_token1, db_session)
+    delete_assessment(client, regular_token1, aid)
+
+    resp = _increment_attempts(client, regular_token1, aid)
+    assert resp.status_code == 404
+
+
+def test_increment_attempts_unauthorized_non_owner(
+    client, regular_token1, regular_token2, db_session, test_db_session
+):
+    """A user in a different group is denied (403)."""
+    aid = _create_assessment(client, regular_token1, db_session)
+
+    resp = _increment_attempts(client, regular_token2, aid)
+    assert resp.status_code == 403
+
+
+def test_increment_attempts_admin_can_increment(
+    client, regular_token1, admin_token, db_session, test_db_session
+):
+    """Admin can increment any assessment."""
+    aid = _create_assessment(client, regular_token1, db_session)
+
+    resp = _increment_attempts(client, admin_token, aid)
+    assert resp.status_code == 200
+    assert resp.json() == {"attempt_count": 1}


### PR DESCRIPTION
## Summary

Modal `assess()` retries on worker preemption (PR #294), but the lifecycle helper in aqua-assessments currently PATCHes `failed` on the *first* attempt that raises — producing a misleading user-visible terminal status while Modal is still going to retry. Persisting the attempt count server-side lets the lifecycle only mark `failed` when retries are genuinely exhausted.

This PR adds the **server-side primitives** consumed by the corresponding aqua-assessments PR (paired with issue #314 in this repo's tracker).

- `assessment.attempt_count` column (Integer, NOT NULL, `server_default="0"`)
- `POST /v3/assessment/{id}/increment-attempts` — atomic `UPDATE ... RETURNING`
- `AssessmentOut.attempt_count` exposed for dashboards

## Why `server_default="0"` (zero-downtime deploy)

In-flight rows that pre-date the migration read as `attempt_count=0`. On the next retry the lifecycle increments to 1, and the existing "fail on first attempt" behavior kicks in — so even if the worker is still on the old code (or the new code talks to the old API briefly during deploy), nothing breaks.

## Atomicity

`POST /increment-attempts` runs a single `UPDATE assessment SET attempt_count = attempt_count + 1 WHERE id = :id RETURNING attempt_count`. Two concurrent retries on the same row are serialized by Postgres — each call sees its own post-increment value (test asserts the union is `{1, 2}`, never `{1, 1}`).

## Test plan

- [x] `test_increment_attempts_zero_to_one_to_two` — successive increments return 1, then 2; row state matches
- [x] `test_increment_attempts_concurrent_race_free` — `asyncio.gather` of two increments over in-process ASGI transport produces `{1, 2}`
- [x] `test_increment_attempts_not_found` — 404 on unknown id
- [x] `test_increment_attempts_deleted` — 404 on soft-deleted row
- [x] `test_increment_attempts_unauthorized_non_owner` — 403 for user without group access
- [x] `test_increment_attempts_admin_can_increment` — admin bypasses ownership check
- [x] Full `test_assessment_routes/` suite still passes (339 tests, including the existing PATCH /status tests)
- [x] `black --check`, `isort --check`, `flake8` all pass

## Deploy order

This PR must merge + deploy **first**. The corresponding aqua-assessments PR (referenced from issue #314) calls this endpoint; it fails-open if the endpoint returns an error (treats `attempts=1`, preserving legacy "fail on first attempt" behavior), but the cleaner timeline is endpoint-first.

Closes part of #314 (aqua-assessments issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)