### PR TITLE
Serialize main-build + add workflow_dispatch (fixes #784)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+# Serialize main-branch deploys to prevent the `:latest` push race
+# where a slower workflow built from an older SHA finishes after a
+# faster newer one and regresses ECR. cancel-in-progress: true means
+# a newer merge wins (its checkout already contains the older PR).
+concurrency:
+  group: main-build
+  cancel-in-progress: true
 
 env:
   AWS_REGISTRY: 279795702643.dkr.ecr.us-east-1.amazonaws.com


### PR DESCRIPTION
Fixes #784.

## Why
The push-triggered \`main-build\` workflow has no concurrency control. Two PRs merged in quick succession on 2026-05-23 produced parallel runs whose ECR \`:latest\` pushes raced — the older PR's build finished **35 seconds after** the newer one (because it had also started 2 minutes earlier) and overwrote \`:latest\` with an image regressed below current main HEAD. App Runner then auto-deployed that regressed image and PR #783's \`/v3/assessment/{id}/increment-attempts\` endpoint never went live, silently disabling the retry-aware-failed feature on the aqua-assessments side.

## Change
Two tiny additions to \`.github/workflows/main.yml\`:

1. **\`concurrency:\`** block with \`group: main-build\` and \`cancel-in-progress: true\`. When a newer merge arrives, the in-flight older run is cancelled. Safe because the newer run's checkout already contains the older PR's commits, so the cancelled work isn't lost — only its image push (which was about to regress \`:latest\` anyway).
2. **\`workflow_dispatch:\`** trigger. Lets us manually rebuild current HEAD without a no-op commit. The immediate use is recovering from the 2026-05-23 race (need to rebuild main HEAD so \`:latest\` actually contains PR #783's endpoint).

## After this merges
Run the workflow once manually via the Actions UI ("Run workflow" on the branch-build workflow, against \`main\`) to push a fresh \`:latest\` with current main HEAD. App Runner should auto-deploy it within ~15 min and the aqua-assessments worker will start incrementing \`attempt_count\` properly.

## Risk
Low. \`concurrency\` is a built-in Actions feature; \`cancel-in-progress: true\` is the standard pattern for deploy workflows where only the latest commit matters. \`workflow_dispatch\` is purely additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)