### PR TITLE
Add model-build provenance to agent lexeme cards (#787)

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -1286,8 +1286,8 @@ async def patch_lexeme_card_translation(
       upserted on conflict. The canonical's source-side stays untouched, so
       edits in (target, eng) view can't corrupt the (target, swh) pivot.
     - Target-side and shared fields (target_lemma, surface_forms, pos,
-      confidence, english_lemma, alignment_scores, build_version) land in
-      the canonical ``agent_lexeme_cards`` row. There is only one target
+      confidence, english_lemma, alignment_scores, build_version, model) land
+      in the canonical ``agent_lexeme_cards`` row. There is only one target
       column physically, so all overlays project the same target text — fixing
       a typo from any language view fixes it everywhere.
     - When ``language_iso`` equals the card's canonical ``source_language_iso``
@@ -2447,7 +2447,7 @@ async def get_lexeme_cards(
     target_word: str = None,
     target_words: str = None,
     pos: str = None,
-    model: str | None = None,
+    model: str | None = Query(default=None, min_length=1),
     lang: str | None = Query(default=None, min_length=3, max_length=3),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -682,6 +682,7 @@ async def add_lexeme_card(
             existing_card.english_lemma = card.english_lemma
             existing_card.alignment_scores = sorted_alignment_scores
             existing_card.build_version = card.build_version
+            existing_card.model = card.model
             existing_card.last_updated = func.now()
             if is_user_edit:
                 existing_card.last_user_edit = func.now()
@@ -814,6 +815,7 @@ async def add_lexeme_card(
                 "english_lemma": existing_card.english_lemma,
                 "alignment_scores": sorted_alignment_scores,
                 "build_version": existing_card.build_version,
+                "model": existing_card.model,
                 "created_at": existing_card.created_at,
                 "last_updated": existing_card.last_updated,
                 "last_user_edit": existing_card.last_user_edit,
@@ -844,6 +846,7 @@ async def add_lexeme_card(
                 english_lemma=card.english_lemma,
                 alignment_scores=sorted_alignment_scores,
                 build_version=card.build_version,
+                model=card.model,
                 last_user_edit=func.now() if is_user_edit else None,
             )
 
@@ -907,6 +910,7 @@ async def add_lexeme_card(
                 "english_lemma": lexeme_card.english_lemma,
                 "alignment_scores": sorted_alignment_scores,
                 "build_version": lexeme_card.build_version,
+                "model": lexeme_card.model,
                 "created_at": lexeme_card.created_at,
                 "last_updated": lexeme_card.last_updated,
                 "last_user_edit": lexeme_card.last_user_edit,
@@ -1060,6 +1064,8 @@ async def _apply_lexeme_card_patch(
         card.english_lemma = patch_data.english_lemma
     if "build_version" in provided_fields:
         card.build_version = patch_data.build_version
+    if "model" in provided_fields:
+        card.model = patch_data.model
 
     # Handle alignment_scores (dict) - merge keys, null value removes key
     if "alignment_scores" in provided_fields:
@@ -1222,6 +1228,7 @@ async def _apply_lexeme_card_patch(
         "english_lemma": card.english_lemma,
         "alignment_scores": card.alignment_scores,
         "build_version": card.build_version,
+        "model": card.model,
         "created_at": card.created_at,
         "last_updated": card.last_updated,
         "last_user_edit": card.last_user_edit,
@@ -1240,6 +1247,7 @@ _CANONICAL_PATCH_FIELDS = {
     "english_lemma",
     "alignment_scores",
     "build_version",
+    "model",
 }
 # Fields routed to the card_translations overlay row for (card_id, language_iso)
 # in overlay-mode patching. Source-side identity and senses.
@@ -1479,6 +1487,9 @@ async def patch_lexeme_card_translation(
             canonical_touched = True
         if "build_version" in canonical_fields:
             card.build_version = patch_data.build_version
+            canonical_touched = True
+        if "model" in canonical_fields:
+            card.model = patch_data.model
             canonical_touched = True
         if "alignment_scores" in canonical_fields:
             if patch_data.alignment_scores is None:
@@ -1742,6 +1753,7 @@ async def _build_lexeme_card_out_for_lang(
             "english_lemma": card.english_lemma,
             "alignment_scores": card.alignment_scores,
             "build_version": card.build_version,
+            "model": card.model,
             "created_at": card.created_at,
             "last_updated": card.last_updated,
             "last_user_edit": effective_last_user_edit,
@@ -2435,6 +2447,7 @@ async def get_lexeme_cards(
     target_word: str = None,
     target_words: str = None,
     pos: str = None,
+    model: str | None = None,
     lang: str | None = Query(default=None, min_length=3, max_length=3),
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
@@ -2462,6 +2475,10 @@ async def get_lexeme_cards(
       cards where target_lemma or any surface_form matches any of the given words
       (case-insensitive, NFC-normalized). Cannot be used with target_word.
     - pos: str (optional) - Filter by part of speech
+    - model: str (optional) - Filter by the model id/name that built the card.
+      Lets harvesters fetch only cards built by a trusted model (e.g. Sonnet)
+      and exclude poisoned ones. Exact match; cards with NULL ``model`` are
+      excluded when this filter is set.
     - lang: str (optional) - ISO 639-3 code for the desired source-side language.
       When omitted or equal to the cards' canonical source_language_iso, returns
       cards in their canonical shape (back-compat). When it differs, source-side
@@ -2523,6 +2540,13 @@ async def get_lexeme_cards(
         # Add POS filter if provided
         if pos:
             conditions.append(AgentLexemeCard.pos == pos)
+
+        # Filter by build-provenance model when provided. Exact match — NULLs
+        # are excluded by SQL ``=`` semantics, which is what we want (the
+        # caller is asking for "cards built by model X", so unstamped cards
+        # don't qualify).
+        if model:
+            conditions.append(AgentLexemeCard.model == model)
 
         # Word filtering: both source_word and target_word search
         # lemma OR surface_forms (case-insensitive exact match, NFC-normalized)
@@ -2784,6 +2808,7 @@ async def get_lexeme_cards(
                 "english_lemma": card.english_lemma,
                 "alignment_scores": card.alignment_scores,
                 "build_version": card.build_version,
+                "model": card.model,
                 "created_at": card.created_at,
                 "last_updated": card.last_updated,
                 "last_user_edit": card.last_user_edit,
@@ -3253,6 +3278,7 @@ async def get_lexeme_card_by_id(
             "english_lemma": card.english_lemma,
             "alignment_scores": card.alignment_scores,
             "build_version": card.build_version,
+            "model": card.model,
             "created_at": card.created_at,
             "last_updated": card.last_updated,
             "last_user_edit": card.last_user_edit,

--- a/alembic/migrations/versions/7adc82ec084a_add_model_to_lexeme_cards.py
+++ b/alembic/migrations/versions/7adc82ec084a_add_model_to_lexeme_cards.py
@@ -1,0 +1,32 @@
+"""Add model provenance column to lexeme cards
+
+Revision ID: 7adc82ec084a
+Revises: f3b8e2d5c1a9
+Create Date: 2026-06-01 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "7adc82ec084a"
+down_revision: Union[str, None] = "f3b8e2d5c1a9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Nullable provenance field: the model id/name that built the card.
+    # Older/back-filled cards stay NULL; only the most recent build sets it.
+    op.add_column(
+        "agent_lexeme_cards",
+        sa.Column("model", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_lexeme_cards", "model")

--- a/database/models.py
+++ b/database/models.py
@@ -470,6 +470,9 @@ class AgentLexemeCard(Base):
     # Opaque token bumped when the canonical card-builder rebuilds the card.
     # Nullable forever; only the most recent build sets it.
     build_version = Column(Text, nullable=True)
+    # Provenance: model id/name that built this card (e.g. "claude-sonnet-...",
+    # "gpt-oss-..."). Nullable forever; older/back-filled cards stay NULL.
+    model = Column(Text, nullable=True)
     pos = Column(Text)
     surface_forms = Column(JSONB)  # JSON array of target language surface forms
     source_surface_forms = Column(JSONB)  # JSON array of source language surface forms

--- a/models.py
+++ b/models.py
@@ -782,6 +782,9 @@ class LexemeCardIn(BaseModel):
     # Derived translations record this in parent_build_version so cache
     # invalidation can detect when the canonical has moved on.
     build_version: Optional[str] = None
+    # Provenance: model id/name that built this card (e.g. "claude-sonnet-...",
+    # "gpt-oss-..."). Lets downstream consumers harvest only trusted cards.
+    model: Optional[str] = None
 
     @field_validator("surface_forms")
     @classmethod
@@ -834,6 +837,7 @@ class LexemeCardIn(BaseModel):
                 "english_lemma": "love",
                 "alignment_scores": {"love": 0.92, "you": 0.88},
                 "build_version": "agent-20260514T123000Z",
+                "model": "claude-sonnet-4-6",
             }
         }
     }
@@ -858,6 +862,7 @@ class LexemeCardOut(BaseModel):
     english_lemma: Optional[str] = None
     alignment_scores: Optional[Dict[str, float]] = None
     build_version: Optional[str] = None
+    model: Optional[str] = None
     created_at: Optional[datetime.datetime] = None
     last_updated: Optional[datetime.datetime] = None
     last_user_edit: Optional[datetime.datetime] = None
@@ -907,6 +912,7 @@ class LexemeCardPatch(BaseModel):
     # Dict values can be float or None (None means remove that key)
     alignment_scores: Optional[Dict[str, Optional[float]]] = None
     build_version: Optional[str] = None
+    model: Optional[str] = None
 
     @field_validator("surface_forms")
     @classmethod

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -4053,6 +4053,177 @@ def test_lexeme_card_build_version_roundtrip(
     assert cleared.json()["build_version"] is None
 
 
+def test_lexeme_card_model_roundtrip(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """POST + GET + PATCH preserve and update the model provenance field.
+
+    `model` records which builder (e.g. claude-sonnet-..., gpt-oss-...) wrote
+    the card so downstream consumers can harvest trusted cards and skip
+    poisoned ones. Mirrors the build_version round-trip.
+    """
+    create = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "model_prov_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+            "model": "claude-sonnet-4-6",
+        },
+    )
+    assert create.status_code == 200
+    assert create.json()["model"] == "claude-sonnet-4-6"
+    card_id = create.json()["id"]
+
+    # GET single by id returns the stored model
+    single = client.get(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert single.status_code == 200
+    assert single.json()["model"] == "claude-sonnet-4-6"
+
+    # GET list also includes model
+    listing = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert listing.status_code == 200
+    in_list = next(c for c in listing.json() if c["id"] == card_id)
+    assert in_list["model"] == "claude-sonnet-4-6"
+
+    # PATCH updates the model field
+    patch = client.patch(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"model": "claude-opus-4-7"},
+    )
+    assert patch.status_code == 200
+    assert patch.json()["model"] == "claude-opus-4-7"
+
+    # POST upsert with model set overwrites the existing value
+    upsert = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "model_prov_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+            "model": "claude-haiku-4-5",
+        },
+    )
+    assert upsert.status_code == 200
+    assert upsert.json()["model"] == "claude-haiku-4-5"
+
+    # PATCH with explicit null clears the field
+    cleared = client.patch(
+        f"/v3/agent/lexeme-card/{card_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={"model": None},
+    )
+    assert cleared.status_code == 200
+    assert cleared.json()["model"] is None
+
+
+def test_lexeme_card_get_filter_by_model(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """GET /v3/agent/lexeme-card?model=<x> returns only matching cards.
+
+    Cards with NULL model are excluded by SQL ``=`` semantics — exactly what
+    a harvester filtering for "built by model X" wants.
+    """
+    # Three cards: one built by sonnet, one by gpt-oss, one unstamped.
+    sonnet_card = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "model_filter_sonnet",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+            "model": "claude-sonnet-4-6",
+        },
+    )
+    assert sonnet_card.status_code == 200
+    sonnet_id = sonnet_card.json()["id"]
+
+    gpt_card = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "model_filter_gpt",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+            "model": "gpt-oss-1",
+        },
+    )
+    assert gpt_card.status_code == 200
+    gpt_id = gpt_card.json()["id"]
+
+    unstamped = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "model_filter_none",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+        },
+    )
+    assert unstamped.status_code == 200
+    unstamped_id = unstamped.json()["id"]
+
+    # Filter on sonnet — should only return the sonnet card.
+    filtered = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}&model=claude-sonnet-4-6",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert filtered.status_code == 200
+    returned_ids = {c["id"] for c in filtered.json()}
+    assert sonnet_id in returned_ids
+    assert gpt_id not in returned_ids
+    assert unstamped_id not in returned_ids
+
+    # Filter on a model that doesn't exist — empty result.
+    none_match = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}&model=nonexistent-model",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert none_match.status_code == 200
+    none_ids = {c["id"] for c in none_match.json()}
+    assert sonnet_id not in none_ids
+    assert gpt_id not in none_ids
+    assert unstamped_id not in none_ids
+
+    # Omitting model returns all three (sanity check that the cards exist).
+    no_filter = client.get(
+        f"/v3/agent/lexeme-card?source_version_id={test_version_id}"
+        f"&target_version_id={test_version_id_2}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert no_filter.status_code == 200
+    all_ids = {c["id"] for c in no_filter.json()}
+    assert {sonnet_id, gpt_id, unstamped_id}.issubset(all_ids)
+
+
 # Lexeme Card PATCH Tests
 
 

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -4134,6 +4134,51 @@ def test_lexeme_card_model_roundtrip(
     assert cleared.json()["model"] is None
 
 
+def test_lexeme_card_post_upsert_with_omitted_model_clobbers_to_null(
+    client,
+    regular_token1,
+    db_session,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+):
+    """POST upsert is a full-field replacement: omitting ``model`` writes NULL.
+
+    Same semantics as build_version (the upsert update path unconditionally
+    assigns from the incoming payload). Callers that want to preserve an
+    existing provenance value across upserts must include ``model`` on every
+    POST, or use PATCH for partial updates.
+    """
+    # Stamp a model on a card.
+    created = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "model_clobber_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.5,
+            "model": "claude-sonnet-4-6",
+        },
+    )
+    assert created.status_code == 200
+    assert created.json()["model"] == "claude-sonnet-4-6"
+
+    # POST upsert without `model` — full-field replacement clobbers it to NULL.
+    upserted = client.post(
+        f"/v3/agent/lexeme-card?revision_id={test_revision_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+        json={
+            "target_lemma": "model_clobber_lemma",
+            "source_version_id": test_version_id,
+            "target_version_id": test_version_id_2,
+            "confidence": 0.6,
+        },
+    )
+    assert upserted.status_code == 200
+    assert upserted.json()["model"] is None
+
+
 def test_lexeme_card_get_filter_by_model(
     client,
     regular_token1,


### PR DESCRIPTION
## Summary

- Adds a nullable `model` column to `agent_lexeme_cards` recording which builder wrote the card (e.g. `claude-sonnet-4-6`, `gpt-oss-1`). Lets downstream consumers harvest only trusted cards instead of joining on opaque `build_version` timestamps.
- Plumbs `model` through `POST /v3/agent/lexeme-card` (insert + upsert paths), `PATCH /v3/agent/lexeme-card/{card_id}`, `PATCH /v3/agent/lexeme-card/translation`, and all `LexemeCardOut` response builders (single GET, bulk GET, by-id, PATCH responses).
- Adds an optional `model=<x>` filter to `GET /v3/agent/lexeme-card` mirroring the existing `pos` filter — exact match, NULL-stamped cards excluded (a harvester filtering for "built by model X" doesn't want unstamped cards).
- Alembic migration `7adc82ec084a` adds the column; nullable, no backfill — older rows stay NULL.
- The optional `route` field mentioned in the issue is deferred — `model` is the load-bearing field. Easy follow-up if needed.

Fixes #787

## Test plan

- [x] `test_lexeme_card_model_roundtrip` — POST + GET + GET-bulk + PATCH + upsert + null-clear round-trip
- [x] `test_lexeme_card_get_filter_by_model` — filter matches the right card, excludes others (incl. NULL-stamped), empty result on non-matching filter, no filter returns all
- [x] All 255 existing agent_routes tests still pass
- [x] Migration applies cleanly against the dev DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)