### PR TITLE
Critique API: unified MQM-aligned Issue (#793)

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -5,6 +5,7 @@ import socket
 import time
 import unicodedata
 from collections import Counter
+from typing import Optional
 
 import fastapi
 from fastapi import Depends, HTTPException, Query, Request, status
@@ -92,7 +93,7 @@ def _effective_source_version_expr(source_version_id: int, target_version_id: in
     return func.coalesce(pivot_version_subquery, source_version_id)
 
 
-def sanitize_text(text: str) -> str:
+def sanitize_text(text: Optional[str]) -> Optional[str]:
     """Sanitize text fields to remove control characters.
 
     LLM responses can contain literal newlines, tabs, or other control characters.
@@ -3306,7 +3307,8 @@ async def get_critique_issues(
     - book: str (optional) - Filter by book code (e.g., "JHN")
     - dimension: str (optional) - Filter by MQM dimension (e.g., "accuracy")
     - subtype: str (optional) - Filter by MQM subtype (e.g., "wrong-key-term")
-    - min_severity: int (optional) - Minimum severity level (1-5)
+    - min_severity: int (optional) - Minimum severity level (1-5). Issues with
+      severity=NULL are excluded by this filter (SQL three-valued logic).
     - is_resolved: bool (optional) - Filter by resolution status (true=resolved, false=unresolved)
 
     Returns:
@@ -3429,12 +3431,14 @@ async def get_critique_issues(
         if is_resolved is not None:
             query = query.where(AgentCritiqueIssue.is_resolved == is_resolved)
 
-        # Order by book, chapter, verse, and severity (descending)
+        # Order by book, chapter, verse, severity (desc, NULLs last so issues
+        # that omit severity sort to the bottom rather than to the top under
+        # PostgreSQL's default DESC-puts-NULLs-first behaviour).
         query = query.order_by(
             AgentCritiqueIssue.book,
             AgentCritiqueIssue.chapter,
             AgentCritiqueIssue.verse,
-            desc(AgentCritiqueIssue.severity),
+            desc(AgentCritiqueIssue.severity).nulls_last(),
         )
 
         # Execute query

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -435,6 +435,11 @@ async def add_critique_issues(
         created_issues = []
 
         for issue_in in critique.issues:
+            evidence = (
+                [sanitize_text(item) for item in issue_in.evidence]
+                if issue_in.evidence is not None
+                else None
+            )
             issue = AgentCritiqueIssue(
                 assessment_id=assessment_id,
                 agent_translation_id=critique.agent_translation_id,
@@ -442,14 +447,14 @@ async def add_critique_issues(
                 book=book,
                 chapter=chapter,
                 verse=verse,
-                dimension=issue_in.dimension,
-                subtype=issue_in.subtype,
-                detector=issue_in.detector,
+                dimension=sanitize_text(issue_in.dimension),
+                subtype=sanitize_text(issue_in.subtype),
+                detector=sanitize_text(issue_in.detector),
                 source_text=sanitize_text(issue_in.source_text),
                 draft_text=sanitize_text(issue_in.draft_text),
                 comments=sanitize_text(issue_in.comments),
                 severity=issue_in.severity,
-                evidence=issue_in.evidence,
+                evidence=evidence,
             )
             db.add(issue)
             created_issues.append(issue)

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -378,13 +378,12 @@ async def add_critique_issues(
     current_user: UserModel = Depends(get_current_user),
 ):
     """
-    Store critique issues (omissions, additions, and replacements) linked to a specific agent translation.
+    Store MQM-aligned critique issues linked to a specific agent translation.
 
     Input:
     - agent_translation_id: int - The ID of the translation being critiqued
-    - omissions: list[OmissionIssueIn] - source_text present in source but missing from draft
-    - additions: list[AdditionIssueIn] - draft_text present in draft but not in source
-    - replacements: list[ReplacementIssueIn] - source_text incorrectly rendered as draft_text
+    - issues: list[IssueIn] - MQM-aligned issues (dimension, subtype, optional
+      source_text/draft_text/comments/severity/detector/evidence)
 
     Returns:
     - List[CritiqueIssueOut]: List of all created critique issue entries
@@ -434,8 +433,7 @@ async def add_critique_issues(
 
         created_issues = []
 
-        # Create records for omissions
-        for omission in critique.omissions:
+        for issue_in in critique.issues:
             issue = AgentCritiqueIssue(
                 assessment_id=assessment_id,
                 agent_translation_id=critique.agent_translation_id,
@@ -443,45 +441,14 @@ async def add_critique_issues(
                 book=book,
                 chapter=chapter,
                 verse=verse,
-                issue_type="omission",
-                source_text=sanitize_text(omission.source_text),
-                comments=sanitize_text(omission.comments),
-                severity=omission.severity,
-            )
-            db.add(issue)
-            created_issues.append(issue)
-
-        # Create records for additions
-        for addition in critique.additions:
-            issue = AgentCritiqueIssue(
-                assessment_id=assessment_id,
-                agent_translation_id=critique.agent_translation_id,
-                vref=vref,
-                book=book,
-                chapter=chapter,
-                verse=verse,
-                issue_type="addition",
-                draft_text=sanitize_text(addition.draft_text),
-                comments=sanitize_text(addition.comments),
-                severity=addition.severity,
-            )
-            db.add(issue)
-            created_issues.append(issue)
-
-        # Create records for replacements
-        for replacement in critique.replacements:
-            issue = AgentCritiqueIssue(
-                assessment_id=assessment_id,
-                agent_translation_id=critique.agent_translation_id,
-                vref=vref,
-                book=book,
-                chapter=chapter,
-                verse=verse,
-                issue_type="replacement",
-                source_text=sanitize_text(replacement.source_text),
-                draft_text=sanitize_text(replacement.draft_text),
-                comments=sanitize_text(replacement.comments),
-                severity=replacement.severity,
+                dimension=issue_in.dimension,
+                subtype=issue_in.subtype,
+                detector=issue_in.detector,
+                source_text=sanitize_text(issue_in.source_text),
+                draft_text=sanitize_text(issue_in.draft_text),
+                comments=sanitize_text(issue_in.comments),
+                severity=issue_in.severity,
+                evidence=issue_in.evidence,
             )
             db.add(issue)
             created_issues.append(issue)
@@ -3319,7 +3286,8 @@ async def get_critique_issues(
     agent_translation_id: int = None,
     vref: str = None,
     book: str = None,
-    issue_type: str = None,
+    dimension: str = None,
+    subtype: str = None,
     min_severity: int = None,
     is_resolved: bool = None,
     db: AsyncSession = Depends(get_db),
@@ -3336,8 +3304,9 @@ async def get_critique_issues(
     - agent_translation_id: int (optional) - Filter by specific agent translation ID
     - vref: str (optional) - Filter by specific verse reference (e.g., "JHN 1:1")
     - book: str (optional) - Filter by book code (e.g., "JHN")
-    - issue_type: str (optional) - Filter by issue type ("omission" or "addition")
-    - min_severity: int (optional) - Minimum severity level (0-5)
+    - dimension: str (optional) - Filter by MQM dimension (e.g., "accuracy")
+    - subtype: str (optional) - Filter by MQM subtype (e.g., "wrong-key-term")
+    - min_severity: int (optional) - Minimum severity level (1-5)
     - is_resolved: bool (optional) - Filter by resolution status (true=resolved, false=unresolved)
 
     Returns:
@@ -3443,19 +3412,17 @@ async def get_critique_issues(
         if book:
             query = query.where(AgentCritiqueIssue.book == book)
 
-        if issue_type:
-            if issue_type not in ["omission", "addition", "replacement"]:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="issue_type must be 'omission', 'addition', or 'replacement'",
-                )
-            query = query.where(AgentCritiqueIssue.issue_type == issue_type)
+        if dimension:
+            query = query.where(AgentCritiqueIssue.dimension == dimension)
+
+        if subtype:
+            query = query.where(AgentCritiqueIssue.subtype == subtype)
 
         if min_severity is not None:
-            if min_severity < 0 or min_severity > 5:
+            if min_severity < 1 or min_severity > 5:
                 raise HTTPException(
                     status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="min_severity must be between 0 and 5",
+                    detail="min_severity must be between 1 and 5",
                 )
             query = query.where(AgentCritiqueIssue.severity >= min_severity)
 
@@ -3485,7 +3452,8 @@ async def get_critique_issues(
                 "reference_id": reference_id,
                 "vref": vref,
                 "book": book,
-                "issue_type": issue_type,
+                "dimension": dimension,
+                "subtype": subtype,
                 "duration_s": duration,
             },
         )

--- a/alembic/migrations/versions/e8a3f1c2d790_critique_mqm_unified_issue.py
+++ b/alembic/migrations/versions/e8a3f1c2d790_critique_mqm_unified_issue.py
@@ -92,10 +92,19 @@ def downgrade() -> None:
     op.drop_column("agent_critique_issue", "subtype")
     op.drop_column("agent_critique_issue", "dimension")
 
+    # server_default lets the NOT NULL column be added safely even if a row
+    # were inserted between the DELETE above and this ADD COLUMN (defence in
+    # depth — the DELETE should have left the table empty).
     op.add_column(
         "agent_critique_issue",
-        sa.Column("issue_type", sa.String(length=15), nullable=False),
+        sa.Column(
+            "issue_type",
+            sa.String(length=15),
+            nullable=False,
+            server_default="omission",
+        ),
     )
+    op.alter_column("agent_critique_issue", "issue_type", server_default=None)
     op.create_index(
         "ix_agent_critique_issue_type", "agent_critique_issue", ["issue_type"]
     )

--- a/alembic/migrations/versions/e8a3f1c2d790_critique_mqm_unified_issue.py
+++ b/alembic/migrations/versions/e8a3f1c2d790_critique_mqm_unified_issue.py
@@ -1,0 +1,111 @@
+"""Critique API: replace omission/addition/replacement buckets with unified MQM-aligned Issue
+
+Revision ID: e8a3f1c2d790
+Revises: 91243bb07389
+Create Date: 2026-06-06
+
+Drops issue_type / its index / the text-fields CHECK constraint.  Adds
+dimension, subtype, detector (String) and evidence (JSONB).  Makes severity
+nullable.  Adds indices on dimension and subtype.
+
+This is an intentional **breaking change**; existing rows are deleted as
+there is no defensible mapping from the old buckets to the MQM taxonomy.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision: str = "e8a3f1c2d790"
+down_revision: Union[str, None] = "91243bb07389"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Existing rows cannot be mapped onto the MQM taxonomy — drop them rather
+    # than carry stale data forward under bogus dimension/subtype values.
+    op.execute("DELETE FROM agent_critique_issue")
+
+    op.drop_constraint(
+        "ck_critique_issue_text_fields", "agent_critique_issue", type_="check"
+    )
+    op.drop_index("ix_agent_critique_issue_type", table_name="agent_critique_issue")
+    op.drop_column("agent_critique_issue", "issue_type")
+
+    op.add_column(
+        "agent_critique_issue",
+        sa.Column("dimension", sa.String(length=50), nullable=False),
+    )
+    op.add_column(
+        "agent_critique_issue",
+        sa.Column("subtype", sa.String(length=100), nullable=False),
+    )
+    op.add_column(
+        "agent_critique_issue",
+        sa.Column("detector", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "agent_critique_issue",
+        sa.Column("evidence", JSONB(), nullable=True),
+    )
+
+    op.alter_column(
+        "agent_critique_issue",
+        "severity",
+        existing_type=sa.Integer(),
+        nullable=True,
+    )
+
+    op.create_index(
+        "ix_agent_critique_issue_dimension",
+        "agent_critique_issue",
+        ["dimension"],
+    )
+    op.create_index(
+        "ix_agent_critique_issue_subtype",
+        "agent_critique_issue",
+        ["subtype"],
+    )
+
+
+def downgrade() -> None:
+    op.execute("DELETE FROM agent_critique_issue")
+
+    op.drop_index("ix_agent_critique_issue_subtype", table_name="agent_critique_issue")
+    op.drop_index(
+        "ix_agent_critique_issue_dimension", table_name="agent_critique_issue"
+    )
+
+    op.alter_column(
+        "agent_critique_issue",
+        "severity",
+        existing_type=sa.Integer(),
+        nullable=False,
+    )
+
+    op.drop_column("agent_critique_issue", "evidence")
+    op.drop_column("agent_critique_issue", "detector")
+    op.drop_column("agent_critique_issue", "subtype")
+    op.drop_column("agent_critique_issue", "dimension")
+
+    op.add_column(
+        "agent_critique_issue",
+        sa.Column("issue_type", sa.String(length=15), nullable=False),
+    )
+    op.create_index(
+        "ix_agent_critique_issue_type", "agent_critique_issue", ["issue_type"]
+    )
+    op.create_check_constraint(
+        "ck_critique_issue_text_fields",
+        "agent_critique_issue",
+        """
+        (issue_type = 'omission'    AND source_text IS NOT NULL AND draft_text IS NULL) OR
+        (issue_type = 'addition'    AND source_text IS NULL     AND draft_text IS NOT NULL) OR
+        (issue_type = 'replacement' AND source_text IS NOT NULL AND draft_text IS NOT NULL) OR
+        (source_text IS NULL AND draft_text IS NULL)
+        """,
+    )

--- a/database/models.py
+++ b/database/models.py
@@ -773,16 +773,17 @@ class AgentCritiqueIssue(Base):
     chapter = Column(Integer, nullable=False)
     verse = Column(Integer, nullable=False)
 
-    # Issue classification
-    issue_type = Column(
-        String(15), nullable=False
-    )  # 'omission', 'addition', or 'replacement'
+    # MQM classification
+    dimension = Column(String(50), nullable=False)
+    subtype = Column(String(100), nullable=False)
+    detector = Column(String(50), nullable=True)
 
     # Issue details
-    source_text = Column(Text, nullable=True)  # The source text (omission/replacement)
-    draft_text = Column(Text, nullable=True)  # The draft text (addition/replacement)
-    comments = Column(Text, nullable=True)  # Explanation of why this is an issue
-    severity = Column(Integer, nullable=False)  # 0=none, 5=critical
+    source_text = Column(Text, nullable=True)
+    draft_text = Column(Text, nullable=True)
+    comments = Column(Text, nullable=True)
+    severity = Column(Integer, nullable=True)  # 1-5, nullable when model omits it
+    evidence = Column(JSONB, nullable=True)  # list[str]
 
     # Resolution tracking
     is_resolved = Column(Boolean, default=False, nullable=False)
@@ -809,23 +810,12 @@ class AgentCritiqueIssue(Base):
         Index("ix_agent_critique_issue_assessment", "assessment_id"),
         Index("ix_agent_critique_issue_vref", "vref"),
         Index("ix_agent_critique_issue_book_chapter_verse", "book", "chapter", "verse"),
-        Index("ix_agent_critique_issue_type", "issue_type"),
+        Index("ix_agent_critique_issue_dimension", "dimension"),
+        Index("ix_agent_critique_issue_subtype", "subtype"),
         Index("ix_agent_critique_issue_severity", "severity"),
         Index("ix_agent_critique_issue_resolved", "is_resolved"),
         Index("ix_agent_critique_issue_resolved_by", "resolved_by_id"),
         Index("ix_agent_critique_issue_translation", "agent_translation_id"),
-        # The both-NULL clause permits legacy rows that existed before this
-        # migration with no text fields set.  New rows always satisfy the
-        # type-specific requirements via Pydantic validation.
-        CheckConstraint(
-            """
-            (issue_type = 'omission'    AND source_text IS NOT NULL AND draft_text IS NULL) OR
-            (issue_type = 'addition'    AND source_text IS NULL     AND draft_text IS NOT NULL) OR
-            (issue_type = 'replacement' AND source_text IS NOT NULL AND draft_text IS NOT NULL) OR
-            (source_text IS NULL AND draft_text IS NULL)
-            """,
-            name="ck_critique_issue_text_fields",
-        ),
     )
 
 

--- a/database/models.py
+++ b/database/models.py
@@ -782,7 +782,7 @@ class AgentCritiqueIssue(Base):
     source_text = Column(Text, nullable=True)
     draft_text = Column(Text, nullable=True)
     comments = Column(Text, nullable=True)
-    severity = Column(Integer, nullable=True)  # 1-5, nullable when model omits it
+    severity = Column(Integer, nullable=True)  # 1..5, NULL when the agent omits it
     evidence = Column(JSONB, nullable=True)  # list[str]
 
     # Resolution tracking

--- a/models.py
+++ b/models.py
@@ -1031,73 +1031,45 @@ class CardTranslationOut(BaseModel):
     examples: List[CardTranslationExampleOut] = []
 
 
-class OmissionIssueIn(BaseModel):
-    """Omission critique issue: source text missing from the draft."""
+class IssueIn(BaseModel):
+    """A single MQM-aligned critique issue."""
 
-    source_text: str = Field(min_length=1)
+    dimension: str = Field(min_length=1)
+    subtype: str = Field(min_length=1)
+    source_text: Optional[str] = None
+    draft_text: Optional[str] = None
     comments: Optional[str] = None
-    severity: int = Field(ge=0, le=5)  # 0=none, 5=critical
-
-    model_config = {"str_strip_whitespace": True}
-
-
-class AdditionIssueIn(BaseModel):
-    """Addition critique issue: draft text not present in the source."""
-
-    draft_text: str = Field(min_length=1)
-    comments: Optional[str] = None
-    severity: int = Field(ge=0, le=5)  # 0=none, 5=critical
-
-    model_config = {"str_strip_whitespace": True}
-
-
-class ReplacementIssueIn(BaseModel):
-    """Replacement critique issue: source text incorrectly rendered as draft text."""
-
-    source_text: str = Field(min_length=1)
-    draft_text: str = Field(min_length=1)
-    comments: Optional[str] = None
-    severity: int = Field(ge=0, le=5)  # 0=none, 5=critical
+    severity: Optional[int] = Field(default=None, ge=1, le=5)
+    detector: Optional[str] = None
+    evidence: Optional[List[str]] = None
 
     model_config = {"str_strip_whitespace": True}
 
 
 class CritiqueStorageRequest(BaseModel):
-    """Request to store critique results for a verse.
+    """Request to store MQM-aligned critique issues for a verse.
 
     The critique is linked to a specific agent translation by agent_translation_id.
     The assessment_id and vref are derived from the referenced translation.
     """
 
     agent_translation_id: int
-    omissions: list[OmissionIssueIn] = []
-    additions: list[AdditionIssueIn] = []
-    replacements: list[ReplacementIssueIn] = []
+    issues: list[IssueIn] = []
 
     model_config = {
         "json_schema_extra": {
             "example": {
                 "agent_translation_id": 1,
-                "omissions": [
+                "issues": [
                     {
-                        "source_text": "in the beginning",
-                        "comments": "Missing key phrase",
+                        "dimension": "accuracy",
+                        "subtype": "mistranslation/hallucination-numbers",
+                        "source_text": "forty days",
+                        "draft_text": "fourteen days",
+                        "comments": "Number mistranslated",
                         "severity": 4,
-                    }
-                ],
-                "additions": [
-                    {
-                        "draft_text": "extra words",
-                        "comments": "Not in source",
-                        "severity": 2,
-                    }
-                ],
-                "replacements": [
-                    {
-                        "source_text": "love",
-                        "draft_text": "like",
-                        "comments": "Incorrect translation",
-                        "severity": 3,
+                        "detector": "number_diff",
+                        "evidence": ["source: 40", "draft: 14"],
                     }
                 ],
             }
@@ -1115,11 +1087,14 @@ class CritiqueIssueOut(BaseModel):
     book: str
     chapter: int
     verse: int
-    issue_type: Literal["omission", "addition", "replacement"]
+    dimension: str
+    subtype: str
     source_text: Optional[str] = None
     draft_text: Optional[str] = None
     comments: Optional[str] = None
-    severity: int
+    severity: Optional[int] = None
+    detector: Optional[str] = None
+    evidence: Optional[List[str]] = None
     is_resolved: bool = False
     resolved_by_id: Optional[int] = None
     resolved_at: Optional[datetime.datetime] = None
@@ -1136,11 +1111,14 @@ class CritiqueIssueOut(BaseModel):
                 "book": "JHN",
                 "chapter": 1,
                 "verse": 1,
-                "issue_type": "omission",
-                "source_text": "in the beginning",
-                "draft_text": None,
-                "comments": "Missing key phrase from source text",
+                "dimension": "accuracy",
+                "subtype": "mistranslation/hallucination-numbers",
+                "source_text": "forty days",
+                "draft_text": "fourteen days",
+                "comments": "Number mistranslated",
                 "severity": 4,
+                "detector": "number_diff",
+                "evidence": ["source: 40", "draft: 14"],
                 "is_resolved": False,
                 "resolved_by_id": None,
                 "resolved_at": None,

--- a/models.py
+++ b/models.py
@@ -1034,13 +1034,13 @@ class CardTranslationOut(BaseModel):
 class IssueIn(BaseModel):
     """A single MQM-aligned critique issue."""
 
-    dimension: str = Field(min_length=1)
-    subtype: str = Field(min_length=1)
+    dimension: str = Field(min_length=1, max_length=50)
+    subtype: str = Field(min_length=1, max_length=100)
     source_text: Optional[str] = None
     draft_text: Optional[str] = None
     comments: Optional[str] = None
     severity: Optional[int] = Field(default=None, ge=1, le=5)
-    detector: Optional[str] = None
+    detector: Optional[str] = Field(default=None, max_length=50)
     evidence: Optional[List[str]] = None
 
     model_config = {"str_strip_whitespace": True}

--- a/models.py
+++ b/models.py
@@ -1034,7 +1034,7 @@ class CardTranslationOut(BaseModel):
 class IssueIn(BaseModel):
     """A single MQM-aligned critique issue."""
 
-    dimension: str = Field(min_length=1, max_length=50)
+    dimension: Literal["accuracy", "terminology", "linguistic_conventions"]
     subtype: str = Field(min_length=1, max_length=100)
     source_text: Optional[str] = None
     draft_text: Optional[str] = None

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -5114,31 +5114,32 @@ def test_add_critique_issues_missing_fields(client, regular_token1):
 def test_add_critique_issues_invalid_severity(
     client, regular_token1, test_assessment_id
 ):
-    """Severity outside 1-5 is rejected."""
+    """Severity outside 1-5 is rejected (0 and 6 both fail; 1 and 5 succeed)."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "JHN 1:1"
     )
 
-    critique_data = {
-        "agent_translation_id": translation_id,
-        "issues": [
-            {
-                "dimension": "accuracy",
-                "subtype": "omission",
-                "source_text": "test",
-                "comments": "test",
-                "severity": 10,
-            }
-        ],
-    }
+    def post(severity):
+        return client.post(
+            f"{prefix}/agent/critique",
+            json={
+                "agent_translation_id": translation_id,
+                "issues": [
+                    {
+                        "dimension": "accuracy",
+                        "subtype": "omission",
+                        "source_text": "test",
+                        "severity": severity,
+                    }
+                ],
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
 
-    response = client.post(
-        f"{prefix}/agent/critique",
-        json=critique_data,
-        headers={"Authorization": f"Bearer {regular_token1}"},
-    )
-
-    assert response.status_code == 422
+    assert post(0).status_code == 422
+    assert post(10).status_code == 422
+    assert post(1).status_code == 200
+    assert post(5).status_code == 200
 
 
 def test_add_critique_issues_missing_dimension_or_subtype(
@@ -5451,6 +5452,75 @@ def test_get_critique_issues_ordered(client, regular_token1, test_assessment_id)
     assert test_issues[1]["severity"] == 3
     assert test_issues[2]["chapter"] == 2
     assert test_issues[2]["verse"] == 1
+
+
+def test_get_critique_issues_null_severity_sorts_last(
+    client, regular_token1, test_assessment_id
+):
+    """Null severity must sort *after* numeric severities within a verse."""
+    t = _create_translation(client, regular_token1, test_assessment_id, "OBA 1:1")
+    _create_critique(
+        client,
+        regular_token1,
+        t,
+        issues=[
+            {
+                "dimension": "accuracy",
+                "subtype": "mistranslation",
+                "source_text": "no-sev-marker",
+                "draft_text": "x",
+                "severity": None,
+            },
+            _omission_issue("with-sev-marker", severity=2),
+        ],
+    )
+
+    response = client.get(
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&book=OBA",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+
+    assert response.status_code == 200
+    oba = [
+        d
+        for d in response.json()
+        if d["source_text"] in {"no-sev-marker", "with-sev-marker"}
+    ]
+    assert len(oba) == 2
+    assert oba[0]["source_text"] == "with-sev-marker"
+    assert oba[1]["source_text"] == "no-sev-marker"
+
+
+def test_get_critique_issues_min_severity_excludes_null_severity(
+    client, regular_token1, test_assessment_id
+):
+    """min_severity uses `severity >= N` which excludes NULL rows in SQL."""
+    t = _create_translation(client, regular_token1, test_assessment_id, "NAM 1:1")
+    _create_critique(
+        client,
+        regular_token1,
+        t,
+        issues=[
+            {
+                "dimension": "accuracy",
+                "subtype": "mistranslation",
+                "source_text": "nam-null-sev",
+                "draft_text": "x",
+                "severity": None,
+            },
+            _omission_issue("nam-sev-3", severity=3),
+        ],
+    )
+
+    response = client.get(
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&book=NAM&min_severity=1",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200
+    nam = [
+        d for d in response.json() if d["source_text"] in {"nam-null-sev", "nam-sev-3"}
+    ]
+    assert {row["source_text"] for row in nam} == {"nam-sev-3"}
 
 
 def test_get_critique_issues_empty_results(client, regular_token1, test_assessment_id):

--- a/test/test_agent_routes/test_agent_routes.py
+++ b/test/test_agent_routes/test_agent_routes.py
@@ -4843,17 +4843,13 @@ def _create_translation(client, token, assessment_id, vref, draft_text="test"):
     return resp.json()["id"]
 
 
-def _create_critique(
-    client, token, translation_id, omissions=None, additions=None, replacements=None
-):
+def _create_critique(client, token, translation_id, issues=None):
     """Helper: create critique issues for a translation and return the response."""
     return client.post(
         f"{prefix}/agent/critique",
         json={
             "agent_translation_id": translation_id,
-            "omissions": omissions or [],
-            "additions": additions or [],
-            "replacements": replacements or [],
+            "issues": issues or [],
         },
         headers={"Authorization": f"Bearer {token}"},
     )
@@ -4869,24 +4865,30 @@ def test_add_critique_issues_success(
 
     critique_data = {
         "agent_translation_id": translation_id,
-        "omissions": [
+        "issues": [
             {
+                "dimension": "accuracy",
+                "subtype": "omission",
                 "source_text": "in the beginning",
                 "comments": "Missing key phrase from source text",
                 "severity": 4,
+                "detector": "llm_accuracy",
+                "evidence": ["span: 'in the beginning'"],
             },
             {
+                "dimension": "accuracy",
+                "subtype": "omission",
                 "source_text": "was the Word",
                 "comments": "Critical theological term missing",
                 "severity": 5,
             },
-        ],
-        "additions": [
             {
+                "dimension": "accuracy",
+                "subtype": "addition",
                 "draft_text": "extra phrase",
                 "comments": "Not present in source",
                 "severity": 2,
-            }
+            },
         ],
     }
 
@@ -4896,37 +4898,38 @@ def test_add_critique_issues_success(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     data = response.json()
 
-    # Should return 3 issues (2 omissions + 1 addition)
     assert len(data) == 3
 
-    # Check first omission
-    omission1 = next((d for d in data if d["source_text"] == "in the beginning"), None)
-    assert omission1 is not None
-    assert omission1["assessment_id"] == test_assessment_id
-    assert omission1["agent_translation_id"] == translation_id
-    assert omission1["vref"] == "JHN 1:1"
-    assert omission1["book"] == "JHN"
-    assert omission1["chapter"] == 1
-    assert omission1["verse"] == 1
-    assert omission1["issue_type"] == "omission"
-    assert omission1["comments"] == "Missing key phrase from source text"
-    assert omission1["severity"] == 4
-    assert omission1["id"] is not None
-    assert omission1["created_at"] is not None
-    assert omission1["draft_text"] is None
+    first = next((d for d in data if d["source_text"] == "in the beginning"), None)
+    assert first is not None
+    assert first["assessment_id"] == test_assessment_id
+    assert first["agent_translation_id"] == translation_id
+    assert first["vref"] == "JHN 1:1"
+    assert first["book"] == "JHN"
+    assert first["chapter"] == 1
+    assert first["verse"] == 1
+    assert first["dimension"] == "accuracy"
+    assert first["subtype"] == "omission"
+    assert first["detector"] == "llm_accuracy"
+    assert first["evidence"] == ["span: 'in the beginning'"]
+    assert first["comments"] == "Missing key phrase from source text"
+    assert first["severity"] == 4
+    assert first["id"] is not None
+    assert first["created_at"] is not None
+    assert first["draft_text"] is None
 
-    # Check second omission
-    omission2 = next((d for d in data if d["source_text"] == "was the Word"), None)
-    assert omission2 is not None
-    assert omission2["severity"] == 5
+    second = next((d for d in data if d["source_text"] == "was the Word"), None)
+    assert second is not None
+    assert second["severity"] == 5
+    assert second["detector"] is None
+    assert second["evidence"] is None
 
-    # Check addition
     addition = next((d for d in data if d["draft_text"] == "extra phrase"), None)
     assert addition is not None
-    assert addition["issue_type"] == "addition"
+    assert addition["subtype"] == "addition"
     assert addition["severity"] == 2
     assert addition["source_text"] is None
 
@@ -4943,7 +4946,7 @@ def test_add_critique_issues_success(
 
 
 def test_add_critique_issues_empty_lists(client, regular_token1, test_assessment_id):
-    """Test adding critique with empty omissions and additions lists."""
+    """Test adding critique with an empty issues list."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "JHN 1:2"
     )
@@ -4955,8 +4958,8 @@ def test_add_critique_issues_empty_lists(client, regular_token1, test_assessment
     assert len(data) == 0  # No issues created
 
 
-def test_add_critique_issues_only_omissions(client, regular_token1, test_assessment_id):
-    """Test adding critique with only omissions."""
+def test_add_critique_issues_terminology(client, regular_token1, test_assessment_id):
+    """Cross-verse terminology issue: evidence carries the related verse refs."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "GEN 1:1"
     )
@@ -4965,20 +4968,32 @@ def test_add_critique_issues_only_omissions(client, regular_token1, test_assessm
         client,
         regular_token1,
         translation_id,
-        omissions=[
-            {"source_text": "God", "comments": "Missing subject", "severity": 5}
+        issues=[
+            {
+                "dimension": "terminology",
+                "subtype": "wrong-key-term",
+                "draft_text": "Lord",
+                "comments": "Should be 'God' to match cross-verse rendering",
+                "severity": 3,
+                "detector": "key_term_lookup",
+                "evidence": ["GEN 1:3", "GEN 1:26"],
+            }
         ],
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     data = response.json()
     assert len(data) == 1
-    assert data[0]["issue_type"] == "omission"
+    assert data[0]["dimension"] == "terminology"
+    assert data[0]["subtype"] == "wrong-key-term"
+    assert data[0]["evidence"] == ["GEN 1:3", "GEN 1:26"]
     assert data[0]["book"] == "GEN"
 
 
-def test_add_critique_issues_only_additions(client, regular_token1, test_assessment_id):
-    """Test adding critique with only additions."""
+def test_add_critique_issues_linguistic_conventions(
+    client, regular_token1, test_assessment_id
+):
+    """Punctuation issue: no source_text/draft_text spans."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "MAT 5:3"
     )
@@ -4987,18 +5002,55 @@ def test_add_critique_issues_only_additions(client, regular_token1, test_assessm
         client,
         regular_token1,
         translation_id,
-        additions=[
-            {"draft_text": "blessed are", "comments": "Redundant phrase", "severity": 1}
+        issues=[
+            {
+                "dimension": "linguistic_conventions",
+                "subtype": "punctuation",
+                "comments": "Missing terminal period",
+                "severity": 1,
+            }
         ],
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     data = response.json()
     assert len(data) == 1
-    assert data[0]["issue_type"] == "addition"
+    assert data[0]["dimension"] == "linguistic_conventions"
+    assert data[0]["subtype"] == "punctuation"
+    assert data[0]["source_text"] is None
+    assert data[0]["draft_text"] is None
     assert data[0]["book"] == "MAT"
     assert data[0]["chapter"] == 5
     assert data[0]["verse"] == 3
+
+
+def test_add_critique_issues_severity_omitted(
+    client, regular_token1, test_assessment_id
+):
+    """Severity is nullable: passing None must be preserved, not coerced."""
+    translation_id = _create_translation(
+        client, regular_token1, test_assessment_id, "MAT 1:1"
+    )
+
+    response = _create_critique(
+        client,
+        regular_token1,
+        translation_id,
+        issues=[
+            {
+                "dimension": "accuracy",
+                "subtype": "mistranslation",
+                "source_text": "abc",
+                "draft_text": "xyz",
+                "severity": None,
+            }
+        ],
+    )
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["severity"] is None
 
 
 def test_add_critique_issues_nonexistent_translation(
@@ -5009,7 +5061,15 @@ def test_add_critique_issues_nonexistent_translation(
         client,
         regular_token1,
         999999,
-        omissions=[{"source_text": "test", "comments": "test", "severity": 1}],
+        issues=[
+            {
+                "dimension": "accuracy",
+                "subtype": "omission",
+                "source_text": "test",
+                "comments": "test",
+                "severity": 1,
+            }
+        ],
     )
 
     assert response.status_code == 404
@@ -5024,8 +5084,7 @@ def test_add_critique_issues_unauthorized(client, test_assessment_id, regular_to
 
     critique_data = {
         "agent_translation_id": translation_id,
-        "omissions": [],
-        "additions": [],
+        "issues": [],
     }
 
     response = client.post(
@@ -5039,7 +5098,7 @@ def test_add_critique_issues_unauthorized(client, test_assessment_id, regular_to
 def test_add_critique_issues_missing_fields(client, regular_token1):
     """Test that missing required fields are rejected."""
     critique_data = {
-        "omissions": [],
+        "issues": [],
         # Missing agent_translation_id
     }
 
@@ -5055,21 +5114,22 @@ def test_add_critique_issues_missing_fields(client, regular_token1):
 def test_add_critique_issues_invalid_severity(
     client, regular_token1, test_assessment_id
 ):
-    """Test that invalid severity values are rejected."""
+    """Severity outside 1-5 is rejected."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "JHN 1:1"
     )
 
     critique_data = {
         "agent_translation_id": translation_id,
-        "omissions": [
+        "issues": [
             {
+                "dimension": "accuracy",
+                "subtype": "omission",
                 "source_text": "test",
                 "comments": "test",
-                "severity": 10,  # Invalid (should be 0-5)
+                "severity": 10,
             }
         ],
-        "additions": [],
     }
 
     response = client.post(
@@ -5078,6 +5138,31 @@ def test_add_critique_issues_invalid_severity(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
+    assert response.status_code == 422
+
+
+def test_add_critique_issues_missing_dimension_or_subtype(
+    client, regular_token1, test_assessment_id
+):
+    """dimension and subtype are required."""
+    translation_id = _create_translation(
+        client, regular_token1, test_assessment_id, "JHN 1:1"
+    )
+
+    response = _create_critique(
+        client,
+        regular_token1,
+        translation_id,
+        issues=[{"subtype": "omission", "severity": 1}],
+    )
+    assert response.status_code == 422
+
+    response = _create_critique(
+        client,
+        regular_token1,
+        translation_id,
+        issues=[{"dimension": "accuracy", "severity": 1}],
+    )
     assert response.status_code == 422
 
 
@@ -5093,7 +5178,15 @@ def test_add_critique_issues_nullable_comments(
         client,
         regular_token1,
         translation_id,
-        omissions=[{"source_text": "test phrase", "comments": None, "severity": 3}],
+        issues=[
+            {
+                "dimension": "accuracy",
+                "subtype": "omission",
+                "source_text": "test phrase",
+                "comments": None,
+                "severity": 3,
+            }
+        ],
     )
 
     assert response.status_code == 200
@@ -5104,23 +5197,49 @@ def test_add_critique_issues_nullable_comments(
     assert data[0]["severity"] == 3
 
 
+def _omission_issue(source_text, severity=3, comments="missing"):
+    return {
+        "dimension": "accuracy",
+        "subtype": "omission",
+        "source_text": source_text,
+        "comments": comments,
+        "severity": severity,
+    }
+
+
+def _addition_issue(draft_text, severity=2, comments="added"):
+    return {
+        "dimension": "accuracy",
+        "subtype": "addition",
+        "draft_text": draft_text,
+        "comments": comments,
+        "severity": severity,
+    }
+
+
+def _mistranslation_issue(
+    source_text, draft_text, severity=4, comments="mistranslated"
+):
+    return {
+        "dimension": "accuracy",
+        "subtype": "mistranslation",
+        "source_text": source_text,
+        "draft_text": draft_text,
+        "comments": comments,
+        "severity": severity,
+    }
+
+
 def test_get_critique_issues_by_assessment(client, regular_token1, test_assessment_id):
     """Test getting all critique issues for an assessment."""
-    # Add some test data
     t1 = _create_translation(client, regular_token1, test_assessment_id, "JHN 1:1")
     _create_critique(
-        client,
-        regular_token1,
-        t1,
-        omissions=[{"source_text": "word", "comments": "missing", "severity": 4}],
+        client, regular_token1, t1, issues=[_omission_issue("word", severity=4)]
     )
 
     t2 = _create_translation(client, regular_token1, test_assessment_id, "JHN 1:2")
     _create_critique(
-        client,
-        regular_token1,
-        t2,
-        omissions=[{"source_text": "light", "comments": "missing", "severity": 3}],
+        client, regular_token1, t2, issues=[_omission_issue("light", severity=3)]
     )
 
     # Get all issues for assessment
@@ -5139,21 +5258,14 @@ def test_get_critique_issues_by_vref(client, regular_token1, test_assessment_id)
     """Test filtering critique issues by specific vref."""
     t1 = _create_translation(client, regular_token1, test_assessment_id, "JHN 3:16")
     _create_critique(
-        client,
-        regular_token1,
-        t1,
-        omissions=[{"source_text": "world", "comments": "missing", "severity": 5}],
+        client, regular_token1, t1, issues=[_omission_issue("world", severity=5)]
     )
 
     t2 = _create_translation(client, regular_token1, test_assessment_id, "JHN 3:17")
     _create_critique(
-        client,
-        regular_token1,
-        t2,
-        omissions=[{"source_text": "condemn", "comments": "missing", "severity": 4}],
+        client, regular_token1, t2, issues=[_omission_issue("condemn", severity=4)]
     )
 
-    # Filter by specific vref
     response = client.get(
         f"{prefix}/agent/critique?assessment_id={test_assessment_id}&vref=JHN 3:16",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -5169,21 +5281,14 @@ def test_get_critique_issues_by_book(client, regular_token1, test_assessment_id)
     """Test filtering critique issues by book."""
     t1 = _create_translation(client, regular_token1, test_assessment_id, "ROM 1:1")
     _create_critique(
-        client,
-        regular_token1,
-        t1,
-        omissions=[{"source_text": "Paul", "comments": "missing", "severity": 3}],
+        client, regular_token1, t1, issues=[_omission_issue("Paul", severity=3)]
     )
 
     t2 = _create_translation(client, regular_token1, test_assessment_id, "ROM 1:2")
     _create_critique(
-        client,
-        regular_token1,
-        t2,
-        omissions=[{"source_text": "gospel", "comments": "missing", "severity": 4}],
+        client, regular_token1, t2, issues=[_omission_issue("gospel", severity=4)]
     )
 
-    # Filter by book
     response = client.get(
         f"{prefix}/agent/critique?assessment_id={test_assessment_id}&book=ROM",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -5195,38 +5300,57 @@ def test_get_critique_issues_by_book(client, regular_token1, test_assessment_id)
     assert all(issue["book"] == "ROM" for issue in data)
 
 
-def test_get_critique_issues_by_issue_type(client, regular_token1, test_assessment_id):
-    """Test filtering critique issues by issue type."""
+def test_get_critique_issues_by_dimension(client, regular_token1, test_assessment_id):
+    """Filter by MQM dimension."""
     t1 = _create_translation(client, regular_token1, test_assessment_id, "EPH 1:1")
     _create_critique(
         client,
         regular_token1,
         t1,
-        omissions=[{"source_text": "grace", "comments": "missing", "severity": 3}],
-        additions=[{"draft_text": "extra", "comments": "added", "severity": 2}],
+        issues=[
+            _omission_issue("grace", severity=3),
+            {
+                "dimension": "terminology",
+                "subtype": "wrong-key-term",
+                "draft_text": "Lord",
+                "severity": 2,
+            },
+        ],
     )
 
-    # Filter by omissions only
     response = client.get(
-        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&issue_type=omission",
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&dimension=terminology",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
-
     assert response.status_code == 200
     data = response.json()
-    omissions = [d for d in data if d["vref"] == "EPH 1:1"]
-    assert all(issue["issue_type"] == "omission" for issue in omissions)
+    eph_issues = [d for d in data if d["vref"] == "EPH 1:1"]
+    assert eph_issues
+    assert all(issue["dimension"] == "terminology" for issue in eph_issues)
 
-    # Filter by additions only
-    response = client.get(
-        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&issue_type=addition",
-        headers={"Authorization": f"Bearer {regular_token1}"},
+
+def test_get_critique_issues_by_subtype(client, regular_token1, test_assessment_id):
+    """Filter by MQM subtype."""
+    t1 = _create_translation(client, regular_token1, test_assessment_id, "EPH 2:1")
+    _create_critique(
+        client,
+        regular_token1,
+        t1,
+        issues=[
+            _omission_issue("grace", severity=3),
+            _addition_issue("extra", severity=2),
+        ],
     )
 
+    response = client.get(
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&subtype=omission",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
     assert response.status_code == 200
     data = response.json()
-    additions = [d for d in data if d["vref"] == "EPH 1:1"]
-    assert all(issue["issue_type"] == "addition" for issue in additions)
+    eph_issues = [d for d in data if d["vref"] == "EPH 2:1"]
+    assert eph_issues
+    assert all(issue["subtype"] == "omission" for issue in eph_issues)
 
 
 def test_get_critique_issues_by_min_severity(
@@ -5238,13 +5362,12 @@ def test_get_critique_issues_by_min_severity(
         client,
         regular_token1,
         t1,
-        omissions=[
-            {"source_text": "low", "comments": "low severity", "severity": 1},
-            {"source_text": "high", "comments": "high severity", "severity": 5},
+        issues=[
+            _omission_issue("low", severity=1),
+            _omission_issue("high", severity=5),
         ],
     )
 
-    # Filter by min_severity=4
     response = client.get(
         f"{prefix}/agent/critique?assessment_id={test_assessment_id}&min_severity=4",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -5261,24 +5384,21 @@ def test_get_critique_issues_by_min_severity(
 def test_get_critique_issues_combined_filters(
     client, regular_token1, test_assessment_id
 ):
-    """Test combining multiple filters."""
+    """Combine book, subtype and min_severity filters."""
     t1 = _create_translation(client, regular_token1, test_assessment_id, "COL 1:1")
     _create_critique(
         client,
         regular_token1,
         t1,
-        omissions=[
-            {"source_text": "match", "comments": "should match", "severity": 5},
-            {"source_text": "nomatch", "comments": "wrong severity", "severity": 2},
-        ],
-        additions=[
-            {"draft_text": "wrong_type", "comments": "wrong type", "severity": 5},
+        issues=[
+            _omission_issue("match", severity=5),
+            _omission_issue("nomatch", severity=2),
+            _addition_issue("wrong_type", severity=5),
         ],
     )
 
-    # Filter by book, issue_type, and min_severity
     response = client.get(
-        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&book=COL&issue_type=omission&min_severity=4",
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&book=COL&subtype=omission&min_severity=4",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -5286,7 +5406,7 @@ def test_get_critique_issues_combined_filters(
     data = response.json()
     col_issues = [d for d in data if d["vref"] == "COL 1:1"]
     assert all(issue["book"] == "COL" for issue in col_issues)
-    assert all(issue["issue_type"] == "omission" for issue in col_issues)
+    assert all(issue["subtype"] == "omission" for issue in col_issues)
     assert all(issue["severity"] >= 4 for issue in col_issues)
     assert any(issue["source_text"] == "match" for issue in col_issues)
     assert not any(issue["source_text"] == "nomatch" for issue in col_issues)
@@ -5297,26 +5417,17 @@ def test_get_critique_issues_ordered(client, regular_token1, test_assessment_id)
     """Test that results are ordered by book, chapter, verse, severity."""
     t1 = _create_translation(client, regular_token1, test_assessment_id, "JHN 2:1")
     _create_critique(
-        client,
-        regular_token1,
-        t1,
-        omissions=[{"source_text": "low", "comments": "test", "severity": 1}],
+        client, regular_token1, t1, issues=[_omission_issue("low", severity=1)]
     )
 
     t2 = _create_translation(client, regular_token1, test_assessment_id, "JHN 1:3")
     _create_critique(
-        client,
-        regular_token1,
-        t2,
-        omissions=[{"source_text": "high", "comments": "test", "severity": 5}],
+        client, regular_token1, t2, issues=[_omission_issue("high", severity=5)]
     )
 
     t3 = _create_translation(client, regular_token1, test_assessment_id, "JHN 1:3")
     _create_critique(
-        client,
-        regular_token1,
-        t3,
-        omissions=[{"source_text": "med", "comments": "test", "severity": 3}],
+        client, regular_token1, t3, issues=[_omission_issue("med", severity=3)]
     )
 
     response = client.get(
@@ -5356,17 +5467,17 @@ def test_get_critique_issues_empty_results(client, regular_token1, test_assessme
     assert len(rev_issues) == 0
 
 
-def test_get_critique_issues_invalid_issue_type(
+def test_get_critique_issues_unknown_dimension_returns_empty(
     client, regular_token1, test_assessment_id
 ):
-    """Test that invalid issue_type is rejected."""
+    """Unknown dimension is accepted (no enum validation) and yields no rows."""
     response = client.get(
-        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&issue_type=invalid",
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&dimension=bogus",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
-    assert response.status_code == 400
-    assert "issue_type must be" in response.json()["detail"]
+    assert response.status_code == 200
+    assert response.json() == []
 
 
 def test_get_critique_issues_invalid_severity(
@@ -5379,7 +5490,7 @@ def test_get_critique_issues_invalid_severity(
     )
 
     assert response.status_code == 400
-    assert "min_severity must be between 0 and 5" in response.json()["detail"]
+    assert "min_severity must be between 1 and 5" in response.json()["detail"]
 
 
 def test_get_critique_issues_missing_assessment_id(client, regular_token1):
@@ -5422,10 +5533,9 @@ def test_get_critique_issues_by_revision_reference_ids(
         client,
         regular_token1,
         t1,
-        omissions=[{"source_text": "test", "comments": "test comment", "severity": 3}],
+        issues=[_omission_issue("revref-marker-text", severity=3)],
     )
 
-    # Get using revision_id and reference_id
     response = client.get(
         f"{prefix}/agent/critique?revision_id={test_revision_id}&reference_id={test_revision_id_2}",
         headers={"Authorization": f"Bearer {regular_token1}"},
@@ -5434,10 +5544,12 @@ def test_get_critique_issues_by_revision_reference_ids(
     assert response.status_code == 200
     data = response.json()
     assert isinstance(data, list)
-    # Filter to our test data
-    test_issues = [d for d in data if d["vref"] == "MAT 1:1"]
-    assert len(test_issues) > 0
-    assert test_issues[0]["issue_type"] == "omission"
+    marker = next(
+        (d for d in data if d.get("source_text") == "revref-marker-text"), None
+    )
+    assert marker is not None
+    assert marker["vref"] == "MAT 1:1"
+    assert marker["subtype"] == "omission"
 
 
 def test_get_critique_issues_missing_both_id_types(client, regular_token1):
@@ -5525,9 +5637,7 @@ def test_get_critique_issues_all_assessments_true(
         client,
         regular_token1,
         t1,
-        omissions=[
-            {"source_text": "first assessment", "comments": "test 1", "severity": 3}
-        ],
+        issues=[_omission_issue("first assessment", severity=3, comments="test 1")],
     )
 
     t2 = _create_translation(client, regular_token1, assessment2.id, "PHM 1:2")
@@ -5535,9 +5645,7 @@ def test_get_critique_issues_all_assessments_true(
         client,
         regular_token1,
         t2,
-        omissions=[
-            {"source_text": "second assessment", "comments": "test 2", "severity": 4}
-        ],
+        issues=[_omission_issue("second assessment", severity=4, comments="test 2")],
     )
 
     # Get using revision_id and reference_id with all_assessments=True (default)
@@ -5604,9 +5712,7 @@ def test_get_critique_issues_all_assessments_false(
         client,
         regular_token1,
         t1,
-        omissions=[
-            {"source_text": "older assessment", "comments": "old test", "severity": 2}
-        ],
+        issues=[_omission_issue("older assessment", severity=2, comments="old test")],
     )
 
     t2 = _create_translation(client, regular_token1, newer_assessment.id, "TIT 1:2")
@@ -5614,9 +5720,7 @@ def test_get_critique_issues_all_assessments_false(
         client,
         regular_token1,
         t2,
-        omissions=[
-            {"source_text": "newer assessment", "comments": "new test", "severity": 5}
-        ],
+        issues=[_omission_issue("newer assessment", severity=5, comments="new test")],
     )
 
     # Get using revision_id and reference_id with all_assessments=False
@@ -5679,7 +5783,7 @@ def test_get_critique_issues_all_assessments_explicit_true(
         client,
         regular_token1,
         t1,
-        omissions=[{"source_text": "assessment one", "comments": "a1", "severity": 1}],
+        issues=[_omission_issue("assessment one", severity=1, comments="a1")],
     )
 
     t2 = _create_translation(client, regular_token1, assessment2.id, "JUD 1:2")
@@ -5687,7 +5791,7 @@ def test_get_critique_issues_all_assessments_explicit_true(
         client,
         regular_token1,
         t2,
-        omissions=[{"source_text": "assessment two", "comments": "a2", "severity": 2}],
+        issues=[_omission_issue("assessment two", severity=2, comments="a2")],
     )
 
     # Explicitly set all_assessments=True
@@ -5719,13 +5823,13 @@ def test_get_critique_issues_filter_by_translation_id(
         client,
         regular_token1,
         t1,
-        omissions=[{"source_text": "t1 issue", "comments": "from t1", "severity": 3}],
+        issues=[_omission_issue("t1 issue", severity=3, comments="from t1")],
     )
     _create_critique(
         client,
         regular_token1,
         t2,
-        omissions=[{"source_text": "t2 issue", "comments": "from t2", "severity": 4}],
+        issues=[_omission_issue("t2 issue", severity=4, comments="from t2")],
     )
 
     # Filter by first translation
@@ -5751,7 +5855,7 @@ def test_critique_response_includes_translation_id(
         client,
         regular_token1,
         t1,
-        omissions=[{"source_text": "check field", "comments": "verify", "severity": 2}],
+        issues=[_omission_issue("check field", severity=2, comments="verify")],
     )
 
     assert response.status_code == 200
@@ -5760,11 +5864,11 @@ def test_critique_response_includes_translation_id(
     assert data[0]["agent_translation_id"] == t1
 
 
-# ── replacement issue tests ──────────────────────────────────────────
+# ── mistranslation / multi-issue / unconstrained-field tests ─────────
 
 
-def test_add_replacement_issues(client, regular_token1, test_assessment_id):
-    """Test creating replacement issues with both source_text and draft_text."""
+def test_add_mistranslation_issue(client, regular_token1, test_assessment_id):
+    """Mistranslation: both source_text and draft_text populated."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "GEN 1:2"
     )
@@ -5773,28 +5877,25 @@ def test_add_replacement_issues(client, regular_token1, test_assessment_id):
         client,
         regular_token1,
         translation_id,
-        replacements=[
-            {
-                "source_text": "love",
-                "draft_text": "like",
-                "comments": "Incorrect translation of key term",
-                "severity": 4,
-            }
+        issues=[
+            _mistranslation_issue(
+                "love", "like", severity=4, comments="Incorrect translation of key term"
+            )
         ],
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     data = response.json()
     assert len(data) == 1
-    assert data[0]["issue_type"] == "replacement"
+    assert data[0]["subtype"] == "mistranslation"
     assert data[0]["source_text"] == "love"
     assert data[0]["draft_text"] == "like"
     assert data[0]["comments"] == "Incorrect translation of key term"
     assert data[0]["severity"] == 4
 
 
-def test_add_all_three_issue_types(client, regular_token1, test_assessment_id):
-    """Test creating all three issue types in one request."""
+def test_add_mixed_issues_one_request(client, regular_token1, test_assessment_id):
+    """All three accuracy subtypes plus a terminology one in a single request."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "GEN 1:3"
     )
@@ -5803,37 +5904,55 @@ def test_add_all_three_issue_types(client, regular_token1, test_assessment_id):
         client,
         regular_token1,
         translation_id,
-        omissions=[{"source_text": "omitted phrase", "severity": 3}],
-        additions=[{"draft_text": "added phrase", "severity": 2}],
-        replacements=[
-            {"source_text": "original", "draft_text": "wrong", "severity": 4}
+        issues=[
+            _omission_issue("omitted phrase", severity=3),
+            _addition_issue("added phrase", severity=2),
+            _mistranslation_issue("original", "wrong", severity=4),
+            {
+                "dimension": "terminology",
+                "subtype": "wrong-key-term",
+                "draft_text": "Lord",
+                "severity": 3,
+                "evidence": ["GEN 1:1"],
+            },
         ],
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 200, response.text
     data = response.json()
-    assert len(data) == 3
+    assert len(data) == 4
 
-    omission = next((d for d in data if d["issue_type"] == "omission"), None)
+    omission = next(
+        (
+            d
+            for d in data
+            if d["subtype"] == "omission" and d["dimension"] == "accuracy"
+        ),
+        None,
+    )
     assert omission is not None
     assert omission["source_text"] == "omitted phrase"
     assert omission["draft_text"] is None
 
-    addition = next((d for d in data if d["issue_type"] == "addition"), None)
+    addition = next((d for d in data if d["subtype"] == "addition"), None)
     assert addition is not None
     assert addition["draft_text"] == "added phrase"
     assert addition["source_text"] is None
 
-    replacement = next((d for d in data if d["issue_type"] == "replacement"), None)
-    assert replacement is not None
-    assert replacement["source_text"] == "original"
-    assert replacement["draft_text"] == "wrong"
+    mistr = next((d for d in data if d["subtype"] == "mistranslation"), None)
+    assert mistr is not None
+    assert mistr["source_text"] == "original"
+    assert mistr["draft_text"] == "wrong"
+
+    term = next((d for d in data if d["dimension"] == "terminology"), None)
+    assert term is not None
+    assert term["evidence"] == ["GEN 1:1"]
 
 
-def test_get_critique_issues_filter_by_replacement(
+def test_get_critique_issues_filter_by_mistranslation(
     client, regular_token1, test_assessment_id
 ):
-    """Test filtering GET by issue_type=replacement."""
+    """Filter GET by subtype=mistranslation."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "GEN 1:4"
     )
@@ -5842,12 +5961,14 @@ def test_get_critique_issues_filter_by_replacement(
         client,
         regular_token1,
         translation_id,
-        omissions=[{"source_text": "source only", "severity": 2}],
-        replacements=[{"source_text": "src", "draft_text": "dst", "severity": 3}],
+        issues=[
+            _omission_issue("source only", severity=2),
+            _mistranslation_issue("src", "dst", severity=3),
+        ],
     )
 
     response = client.get(
-        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&issue_type=replacement",
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}&subtype=mistranslation",
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
 
@@ -5855,15 +5976,13 @@ def test_get_critique_issues_filter_by_replacement(
     data = response.json()
     gen14 = [d for d in data if d["vref"] == "GEN 1:4"]
     assert len(gen14) == 1
-    assert gen14[0]["issue_type"] == "replacement"
+    assert gen14[0]["subtype"] == "mistranslation"
     assert gen14[0]["source_text"] == "src"
     assert gen14[0]["draft_text"] == "dst"
 
 
-def test_omission_missing_source_text_returns_422(
-    client, regular_token1, test_assessment_id
-):
-    """Verify omission missing source_text is rejected."""
+def test_add_issue_without_any_text_spans(client, regular_token1, test_assessment_id):
+    """An issue with neither source_text nor draft_text is allowed (e.g., punctuation)."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "GEN 1:5"
     )
@@ -5872,64 +5991,21 @@ def test_omission_missing_source_text_returns_422(
         client,
         regular_token1,
         translation_id,
-        omissions=[{"comments": "no source_text", "severity": 2}],
+        issues=[
+            {
+                "dimension": "linguistic_conventions",
+                "subtype": "punctuation",
+                "comments": "spans not required",
+                "severity": 2,
+            }
+        ],
     )
 
-    assert response.status_code == 422
-
-
-def test_addition_missing_draft_text_returns_422(
-    client, regular_token1, test_assessment_id
-):
-    """Verify addition missing draft_text is rejected."""
-    translation_id = _create_translation(
-        client, regular_token1, test_assessment_id, "GEN 1:6"
-    )
-
-    response = _create_critique(
-        client,
-        regular_token1,
-        translation_id,
-        additions=[{"comments": "no draft_text", "severity": 2}],
-    )
-
-    assert response.status_code == 422
-
-
-def test_replacement_missing_source_text_returns_422(
-    client, regular_token1, test_assessment_id
-):
-    """Verify replacement missing source_text is rejected."""
-    translation_id = _create_translation(
-        client, regular_token1, test_assessment_id, "GEN 1:7"
-    )
-
-    response = _create_critique(
-        client,
-        regular_token1,
-        translation_id,
-        replacements=[{"draft_text": "only draft", "severity": 2}],
-    )
-
-    assert response.status_code == 422
-
-
-def test_replacement_missing_draft_text_returns_422(
-    client, regular_token1, test_assessment_id
-):
-    """Verify replacement missing draft_text is rejected."""
-    translation_id = _create_translation(
-        client, regular_token1, test_assessment_id, "GEN 1:8"
-    )
-
-    response = _create_critique(
-        client,
-        regular_token1,
-        translation_id,
-        replacements=[{"source_text": "only source", "severity": 2}],
-    )
-
-    assert response.status_code == 422
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["source_text"] is None
+    assert data[0]["draft_text"] is None
 
 
 # ── last_user_edit tests ──────────────────────────────────────────────

--- a/test/test_agent_routes/test_critique_resolution.py
+++ b/test/test_agent_routes/test_critique_resolution.py
@@ -20,20 +20,37 @@ def _create_translation(client, token, assessment_id, vref, draft_text="test"):
     return resp.json()["id"]
 
 
-def _create_critique(
-    client, token, translation_id, omissions=None, additions=None, replacements=None
-):
+def _create_critique(client, token, translation_id, issues=None):
     """Helper: create critique issues for a translation and return the response."""
     return client.post(
         f"{prefix}/agent/critique",
         json={
             "agent_translation_id": translation_id,
-            "omissions": omissions or [],
-            "additions": additions or [],
-            "replacements": replacements or [],
+            "issues": issues or [],
         },
         headers={"Authorization": f"Bearer {token}"},
     )
+
+
+def _omission_issue(source_text, severity=3, comments=None):
+    return {
+        "dimension": "accuracy",
+        "subtype": "omission",
+        "source_text": source_text,
+        "comments": comments,
+        "severity": severity,
+    }
+
+
+def _mistranslation_issue(source_text, draft_text, severity=4, comments=None):
+    return {
+        "dimension": "accuracy",
+        "subtype": "mistranslation",
+        "source_text": source_text,
+        "draft_text": draft_text,
+        "comments": comments,
+        "severity": severity,
+    }
 
 
 def test_resolve_critique_issue_success(client, regular_token1, test_assessment_id):
@@ -47,7 +64,7 @@ def test_resolve_critique_issue_success(client, regular_token1, test_assessment_
         client,
         regular_token1,
         translation_id,
-        omissions=[{"source_text": "word", "comments": "missing word", "severity": 4}],
+        issues=[_omission_issue("word", severity=4, comments="missing word")],
     )
     assert create_response.status_code == 200
     created_issues = create_response.json()
@@ -84,7 +101,7 @@ def test_unresolve_critique_issue_success(client, regular_token1, test_assessmen
         client,
         regular_token1,
         translation_id,
-        omissions=[{"source_text": "made", "comments": "missing made", "severity": 3}],
+        issues=[_omission_issue("made", severity=3, comments="missing made")],
     )
     issue_id = create_response.json()[0]["id"]
 
@@ -125,21 +142,15 @@ def test_get_critique_issues_filter_by_resolved(
         client,
         regular_token1,
         t1,
-        omissions=[
-            {
-                "source_text": "unresolved",
-                "comments": "this stays unresolved",
-                "severity": 2,
-            }
+        issues=[
+            _omission_issue("unresolved", severity=2, comments="this stays unresolved")
         ],
     )
     resolved_response = _create_critique(
         client,
         regular_token1,
         t2,
-        omissions=[
-            {"source_text": "resolved", "comments": "this gets resolved", "severity": 3}
-        ],
+        issues=[_omission_issue("resolved", severity=3, comments="this gets resolved")],
     )
 
     assert unresolved_response.status_code == 200
@@ -181,8 +192,10 @@ def test_get_critique_issues_filter_by_resolved(
     assert all(not issue["is_resolved"] for issue in unresolved_issues)
 
 
-def test_resolve_replacement_issue_success(client, regular_token1, test_assessment_id):
-    """Test that replacement issues can be resolved just like omissions."""
+def test_resolve_mistranslation_issue_success(
+    client, regular_token1, test_assessment_id
+):
+    """Mistranslation issues can be resolved just like omissions."""
     translation_id = _create_translation(
         client, regular_token1, test_assessment_id, "JHN 1:4"
     )
@@ -191,13 +204,8 @@ def test_resolve_replacement_issue_success(client, regular_token1, test_assessme
         client,
         regular_token1,
         translation_id,
-        replacements=[
-            {
-                "source_text": "love",
-                "draft_text": "like",
-                "comments": "wrong term",
-                "severity": 4,
-            }
+        issues=[
+            _mistranslation_issue("love", "like", severity=4, comments="wrong term")
         ],
     )
     assert create_response.status_code == 200
@@ -214,7 +222,8 @@ def test_resolve_replacement_issue_success(client, regular_token1, test_assessme
     resolved = resolve_response.json()
     assert resolved["is_resolved"] is True
     assert resolved["resolution_notes"] == "Fixed translation to use 'love'"
-    assert resolved["issue_type"] == "replacement"
+    assert resolved["dimension"] == "accuracy"
+    assert resolved["subtype"] == "mistranslation"
     assert resolved["source_text"] == "love"
     assert resolved["draft_text"] == "like"
 


### PR DESCRIPTION
## Summary

- Replaces the three flat critique buckets (omission / addition / replacement) with a unified, MQM-aligned `Issue` that can express the accuracy, terminology, and linguistic-conventions dimensions our benchmark grades against.
- `POST /v3/agent/critique` now takes a single `issues` array of `{dimension, subtype, source_text?, draft_text?, comments?, severity?, detector?, evidence?}` — no back-compat.
- `GET /v3/agent/critique` `issue_type` filter is replaced with optional `dimension` and `subtype` filters; `min_severity` range narrows to 1–5.
- `agent_critique_issue` table: drops `issue_type` (+ index + the text-fields CHECK constraint); adds `dimension`, `subtype`, `detector`, `evidence` (JSONB); makes `severity` nullable so the agent can pass through `None` when the model omits it.
- Migration `e8a3f1c2d790` deletes existing rows — there is no defensible mapping onto the MQM taxonomy.

Coordinates with aqua-assessments `feat/critique-mqm-reorg` and the aqua-django-app consumer changes; the three repos must deploy in sync because they share the dev/prod Postgres.

Fixes #793

## Test plan

- [x] `alembic upgrade head` applies cleanly on dev DB
- [x] `pytest test/test_agent_routes/test_agent_routes.py -k critique` — 36 passed
- [x] `pytest test/test_agent_routes/test_critique_resolution.py` — 6 passed
- [x] Full `pytest test/test_agent_routes/` — 431 passed
- [ ] Verify aqua-assessments and aqua-django-app rollouts land together
- [ ] Smoke-check `/v3/agent/critique` POST/GET in dev after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)