### PR TITLE
Migrate critique rows instead of deleting them

### DIFF
--- a/alembic/migrations/versions/e8a3f1c2d790_critique_mqm_unified_issue.py
+++ b/alembic/migrations/versions/e8a3f1c2d790_critique_mqm_unified_issue.py
@@ -8,8 +8,13 @@ Drops issue_type / its index / the text-fields CHECK constraint.  Adds
 dimension, subtype, detector (String) and evidence (JSONB).  Makes severity
 nullable.  Adds indices on dimension and subtype.
 
-This is an intentional **breaking change**; existing rows are deleted as
-there is no defensible mapping from the old buckets to the MQM taxonomy.
+Existing rows are preserved by mapping the legacy issue_type onto the new
+MQM taxonomy:
+    omission    -> dimension='accuracy', subtype='omission'
+    addition    -> dimension='accuracy', subtype='addition'
+    replacement -> dimension='accuracy', subtype='mistranslation'
+
+detector and evidence stay NULL for legacy rows.
 """
 
 from typing import Sequence, Union
@@ -25,24 +30,34 @@ branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 
 
-def upgrade() -> None:
-    # Existing rows cannot be mapped onto the MQM taxonomy — drop them rather
-    # than carry stale data forward under bogus dimension/subtype values.
-    op.execute("DELETE FROM agent_critique_issue")
+_FORWARD_MAP_SQL = """
+    UPDATE agent_critique_issue
+    SET dimension = 'accuracy',
+        subtype = CASE issue_type
+            WHEN 'omission'    THEN 'omission'
+            WHEN 'addition'    THEN 'addition'
+            WHEN 'replacement' THEN 'mistranslation'
+        END
+"""
 
+
+def upgrade() -> None:
+    # 1. Drop the legacy CHECK constraint that ties issue_type to the
+    #    source_text/draft_text NULL pattern.  It no longer applies once we
+    #    drop issue_type, and the new schema permits any combination
+    #    (e.g. punctuation issues with no spans).
     op.drop_constraint(
         "ck_critique_issue_text_fields", "agent_critique_issue", type_="check"
     )
-    op.drop_index("ix_agent_critique_issue_type", table_name="agent_critique_issue")
-    op.drop_column("agent_critique_issue", "issue_type")
 
+    # 2. Add new columns nullable so we can backfill before applying NOT NULL.
     op.add_column(
         "agent_critique_issue",
-        sa.Column("dimension", sa.String(length=50), nullable=False),
+        sa.Column("dimension", sa.String(length=50), nullable=True),
     )
     op.add_column(
         "agent_critique_issue",
-        sa.Column("subtype", sa.String(length=100), nullable=False),
+        sa.Column("subtype", sa.String(length=100), nullable=True),
     )
     op.add_column(
         "agent_critique_issue",
@@ -53,6 +68,47 @@ def upgrade() -> None:
         sa.Column("evidence", JSONB(), nullable=True),
     )
 
+    # 3. Backfill from issue_type.  All three legacy buckets are accuracy
+    #    issues under the MQM taxonomy.
+    op.execute(_FORWARD_MAP_SQL)
+
+    # 4. Sanity check: no row should be left unmapped.  If the table held
+    #    something other than the three documented issue_types we want to
+    #    abort loudly rather than ship NULL dimensions.
+    conn = op.get_bind()
+    unmapped = conn.execute(
+        sa.text(
+            "SELECT count(*) FROM agent_critique_issue "
+            "WHERE dimension IS NULL OR subtype IS NULL"
+        )
+    ).scalar()
+    if unmapped:
+        raise RuntimeError(
+            f"{unmapped} rows in agent_critique_issue could not be mapped "
+            "from issue_type to (dimension, subtype). Inspect the table for "
+            "unexpected issue_type values before re-running."
+        )
+
+    # 5. Enforce NOT NULL now that all rows are populated.
+    op.alter_column(
+        "agent_critique_issue",
+        "dimension",
+        existing_type=sa.String(length=50),
+        nullable=False,
+    )
+    op.alter_column(
+        "agent_critique_issue",
+        "subtype",
+        existing_type=sa.String(length=100),
+        nullable=False,
+    )
+
+    # 6. Drop the legacy column and its index.
+    op.drop_index("ix_agent_critique_issue_type", table_name="agent_critique_issue")
+    op.drop_column("agent_critique_issue", "issue_type")
+
+    # 7. Relax severity — the agent now passes through NULL when the model
+    #    omits it (we deliberately do not coerce to 0 or 1).
     op.alter_column(
         "agent_critique_issue",
         "severity",
@@ -60,6 +116,7 @@ def upgrade() -> None:
         nullable=True,
     )
 
+    # 8. New indices for the new filter columns.
     op.create_index(
         "ix_agent_critique_issue_dimension",
         "agent_critique_issue",
@@ -73,13 +130,38 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute("DELETE FROM agent_critique_issue")
+    # Downgrade is best-effort: any row whose (dimension, subtype) pair is
+    # outside the three legacy accuracy buckets cannot round-trip into the
+    # old schema without inventing data.  Abort rather than silently mis-label
+    # such rows.
+    conn = op.get_bind()
+    unmappable = conn.execute(
+        sa.text(
+            """
+            SELECT count(*) FROM agent_critique_issue
+            WHERE NOT (
+                dimension = 'accuracy'
+                AND subtype IN ('omission', 'addition', 'mistranslation')
+            )
+            """
+        )
+    ).scalar()
+    if unmappable:
+        raise RuntimeError(
+            f"Cannot downgrade: {unmappable} rows use a (dimension, subtype) "
+            "pair that has no legacy issue_type equivalent. Remove or remap "
+            "those rows before downgrading."
+        )
 
     op.drop_index("ix_agent_critique_issue_subtype", table_name="agent_critique_issue")
     op.drop_index(
         "ix_agent_critique_issue_dimension", table_name="agent_critique_issue"
     )
 
+    # severity must go back to NOT NULL.  Backfill any NULL severity rows to
+    # 3 (mid-scale) before tightening — the old API treated severity as
+    # required so callers cannot have meant "unknown" via NULL there.
+    op.execute("UPDATE agent_critique_issue SET severity = 3 WHERE severity IS NULL")
     op.alter_column(
         "agent_critique_issue",
         "severity",
@@ -87,14 +169,9 @@ def downgrade() -> None:
         nullable=False,
     )
 
-    op.drop_column("agent_critique_issue", "evidence")
-    op.drop_column("agent_critique_issue", "detector")
-    op.drop_column("agent_critique_issue", "subtype")
-    op.drop_column("agent_critique_issue", "dimension")
-
-    # server_default lets the NOT NULL column be added safely even if a row
-    # were inserted between the DELETE above and this ADD COLUMN (defence in
-    # depth — the DELETE should have left the table empty).
+    # server_default lets the NOT NULL column be added safely; we clear it
+    # again immediately after the backfill so new inserts must supply a
+    # value, matching the original schema.
     op.add_column(
         "agent_critique_issue",
         sa.Column(
@@ -104,7 +181,23 @@ def downgrade() -> None:
             server_default="omission",
         ),
     )
+    op.execute(
+        """
+        UPDATE agent_critique_issue
+        SET issue_type = CASE subtype
+            WHEN 'omission'       THEN 'omission'
+            WHEN 'addition'       THEN 'addition'
+            WHEN 'mistranslation' THEN 'replacement'
+        END
+        """
+    )
     op.alter_column("agent_critique_issue", "issue_type", server_default=None)
+
+    op.drop_column("agent_critique_issue", "evidence")
+    op.drop_column("agent_critique_issue", "detector")
+    op.drop_column("agent_critique_issue", "subtype")
+    op.drop_column("agent_critique_issue", "dimension")
+
     op.create_index(
         "ix_agent_critique_issue_type", "agent_critique_issue", ["issue_type"]
     )

--- a/alembic/migrations/versions/e8a3f1c2d790_critique_mqm_unified_issue.py
+++ b/alembic/migrations/versions/e8a3f1c2d790_critique_mqm_unified_issue.py
@@ -14,7 +14,23 @@ MQM taxonomy:
     addition    -> dimension='accuracy', subtype='addition'
     replacement -> dimension='accuracy', subtype='mistranslation'
 
-detector and evidence stay NULL for legacy rows.
+detector and evidence stay NULL for legacy rows (truthful provenance — these
+issues predate detector tagging).
+
+Caveat on `replacement -> mistranslation`: the legacy taxonomy did not
+distinguish term-consistency failures (which MQM puts under
+`dimension=terminology`) from generic semantic mistranslations.  Mapping
+everything to `accuracy/mistranslation` is the most defensible default —
+the underlying `source_text` and `draft_text` are preserved, so a later
+re-classification job can split this bucket without data loss.
+
+Operator note: this migration is content-mutable under a stable revision
+ID.  Any environment that previously applied the delete-based draft of
+e8a3f1c2d790 against non-empty data has already lost those rows — alembic
+will consider it up-to-date and the backfill below will not re-fire.  As
+of merge time the only environments at e8a3f1c2d790 were dev + CI
+(ephemeral, empty); prod and other long-lived envs are still on
+91243bb07389 and will receive the backfill.
 """
 
 from typing import Sequence, Union
@@ -37,6 +53,7 @@ _FORWARD_MAP_SQL = """
             WHEN 'omission'    THEN 'omission'
             WHEN 'addition'    THEN 'addition'
             WHEN 'replacement' THEN 'mistranslation'
+            ELSE NULL
         END
 """
 
@@ -83,11 +100,15 @@ def upgrade() -> None:
         )
     ).scalar()
     if unmapped:
-        raise RuntimeError(
+        msg = (
             f"{unmapped} rows in agent_critique_issue could not be mapped "
             "from issue_type to (dimension, subtype). Inspect the table for "
             "unexpected issue_type values before re-running."
         )
+        # Print before raising so the operator sees the message above the
+        # traceback noise alembic emits for any migration exception.
+        print(f"\nMIGRATION ABORT: {msg}\n")
+        raise RuntimeError(msg)
 
     # 5. Enforce NOT NULL now that all rows are populated.
     op.alter_column(
@@ -147,11 +168,13 @@ def downgrade() -> None:
         )
     ).scalar()
     if unmappable:
-        raise RuntimeError(
+        msg = (
             f"Cannot downgrade: {unmappable} rows use a (dimension, subtype) "
             "pair that has no legacy issue_type equivalent. Remove or remap "
             "those rows before downgrading."
         )
+        print(f"\nMIGRATION ABORT: {msg}\n")
+        raise RuntimeError(msg)
 
     op.drop_index("ix_agent_critique_issue_subtype", table_name="agent_critique_issue")
     op.drop_index(
@@ -159,8 +182,10 @@ def downgrade() -> None:
     )
 
     # severity must go back to NOT NULL.  Backfill any NULL severity rows to
-    # 3 (mid-scale) before tightening — the old API treated severity as
-    # required so callers cannot have meant "unknown" via NULL there.
+    # 3 (mid-point of the 1..5 scale) before tightening — the old API treated
+    # severity as required, so callers can never have meant "unknown" via
+    # NULL there.  This is a one-way lossy coercion documented for operators
+    # reading the downgrade output.
     op.execute("UPDATE agent_critique_issue SET severity = 3 WHERE severity IS NULL")
     op.alter_column(
         "agent_critique_issue",
@@ -181,6 +206,10 @@ def downgrade() -> None:
             server_default="omission",
         ),
     )
+    # The unmappable pre-flight check above guarantees every subtype is one of
+    # the three legacy buckets; the explicit `ELSE NULL` makes that contract
+    # visible and ensures any future drift surfaces as a NOT NULL violation
+    # on the column rather than getting silently fixed by `server_default`.
     op.execute(
         """
         UPDATE agent_critique_issue
@@ -188,6 +217,7 @@ def downgrade() -> None:
             WHEN 'omission'       THEN 'omission'
             WHEN 'addition'       THEN 'addition'
             WHEN 'mistranslation' THEN 'replacement'
+            ELSE NULL
         END
         """
     )


### PR DESCRIPTION
## Summary

Follow-up to #794. The MQM migration in main currently does `DELETE FROM agent_critique_issue`, which would drop 7,185 rows of real critique data when applied to prod. On inspection, the three legacy buckets map cleanly onto the MQM taxonomy, so we should preserve them:

- `omission` → `dimension=accuracy, subtype=omission`
- `addition` → `dimension=accuracy, subtype=addition`
- `replacement` → `dimension=accuracy, subtype=mistranslation`

`detector` and `evidence` stay `NULL` for legacy rows — that's the honest provenance, since these issues predate detector tagging.

### Changes

- Upgrade adds the new columns nullable, runs the backfill UPDATE, asserts every row was mapped, then applies NOT NULL and drops `issue_type` + index + the legacy CHECK constraint.
- Downgrade reverses the mapping for the three legacy subtypes and aborts with a clear `RuntimeError` for any `(dimension, subtype)` pair that has no `issue_type` equivalent (e.g. terminology, linguistic_conventions). Silent mis-labelling on downgrade would corrupt analytics worse than failing loudly.
- Same revision ID (`e8a3f1c2d790`); dev DBs that already applied the previous version are unaffected (no rows to map there).

## Test plan

- [x] Seeded dev DB with one row per legacy bucket; `alembic upgrade head` produced the expected `(dimension, subtype, severity)` tuples.
- [x] `alembic downgrade -1` reversed cleanly back to the original `issue_type` rows.
- [x] Inserted an unmappable `terminology/wrong-key-term` row, ran `alembic downgrade -1`, got the documented `RuntimeError` instead of silent data corruption.
- [x] Full `pytest test/test_agent_routes/` — 433 passed.
- [ ] Apply on prod after PR merge (replaces 7,185-row deletion with backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)