### PR TITLE
Add bulk DELETE /v3/affixes-by-version/{version_id} (#796)

### DIFF
--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -176,6 +176,10 @@ async def delete_affixes_by_version(
         stamped_result = await db.execute(
             delete(LanguageAffix).where(LanguageAffix.target_version_id == version_id)
         )
+        # Migration e2ad1ed4a64a dropped all NULL-target rows, so this
+        # branch usually deletes nothing — but POST/PUT /affixes without a
+        # revision_id can still create NULL-stamped rows, and the GET
+        # soft-union would resurface them, so it is not dead code.
         iso_keyed_result = await db.execute(
             delete(LanguageAffix).where(
                 LanguageAffix.iso_639_3 == iso,

--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -28,6 +28,7 @@ from models import (
     AffixOut,
     AffixPatch,
     AffixReplaceResponse,
+    BulkAffixDeleteResponse,
 )
 from security_routes.auth_routes import get_current_user
 from security_routes.utilities import is_user_authorized_for_bible_version
@@ -117,6 +118,104 @@ async def get_affixes_by_version(
         total=len(rows),
         affixes=[AffixOut.model_validate(a) for a in rows],
     )
+
+
+@router.delete(
+    "/affixes-by-version/{version_id}",
+    response_model=BulkAffixDeleteResponse,
+)
+async def delete_affixes_by_version(
+    version_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """Wipe every affix the GET soft-union would return for ``version_id``.
+
+    Deletes (atomically, in one transaction):
+    - rows version-stamped to ``version_id`` (``target_version_id == version_id``)
+    - legacy iso-keyed rows (``target_version_id IS NULL``) that share the
+      version's ISO — the same rows ``GET /affixes-by-version/{version_id}``
+      surfaces via its soft union.
+
+    Rows stamped to other versions of the same ISO are left intact, so other
+    versions' soft-union reads stay consistent.
+
+    This is the affix analog of ``DELETE /v3/agent/lexeme-card`` (#703) and
+    lets ``build_mode="rebuild"`` clear affixes the same way it clears cards.
+    The existing ``DELETE /v3/tokenizer/training-artifacts/{version_id}``
+    already removes version-stamped affixes as a side effect, but it leaves
+    iso-keyed legacy rows behind and is awkward as the primary surface for
+    affix-only cleanups.
+
+    Status codes:
+    - 200: returns row counts deleted (zeros if nothing existed — idempotent)
+    - 403: caller is not authorized for this version — also returned for
+      non-existent version_ids when the caller is a regular user, so
+      unauthorized callers can't enumerate valid versions (matches the GET)
+    - 404: admin caller requesting a version_id that doesn't exist
+    """
+    request_start = time.perf_counter()
+
+    if not await is_user_authorized_for_bible_version(current_user.id, version_id, db):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User not authorized to access this bible_version",
+        )
+
+    version_lookup = await db.execute(
+        select(BibleVersion.iso_language).where(BibleVersion.id == version_id)
+    )
+    iso = version_lookup.scalar_one_or_none()
+    if iso is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No bible_version with id {version_id}",
+        )
+
+    try:
+        stamped_result = await db.execute(
+            delete(LanguageAffix).where(LanguageAffix.target_version_id == version_id)
+        )
+        iso_keyed_result = await db.execute(
+            delete(LanguageAffix).where(
+                LanguageAffix.iso_639_3 == iso,
+                LanguageAffix.target_version_id.is_(None),
+            )
+        )
+        await db.commit()
+    except SQLAlchemyError as e:
+        await db.rollback()
+        logger.error("Failed to bulk-delete affixes", exc_info=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Database error: {e}",
+        ) from e
+
+    stamped_count = stamped_result.rowcount or 0
+    iso_keyed_count = iso_keyed_result.rowcount or 0
+    response = BulkAffixDeleteResponse(
+        target_version_id=version_id,
+        iso_639_3=iso,
+        version_stamped_deleted=stamped_count,
+        iso_keyed_deleted=iso_keyed_count,
+        total_deleted=stamped_count + iso_keyed_count,
+    )
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"delete_affixes_by_version completed in {duration}s",
+        extra={
+            "method": "DELETE",
+            "path": "/affixes-by-version/{version_id}",
+            "version_id": version_id,
+            "iso": iso,
+            "version_stamped_deleted": stamped_count,
+            "iso_keyed_deleted": iso_keyed_count,
+            "total_deleted": response.total_deleted,
+            "duration_s": duration,
+        },
+    )
+    return response
 
 
 @router.get("/affixes", response_model=AffixListOut)

--- a/models.py
+++ b/models.py
@@ -1819,6 +1819,24 @@ class BulkLexemeCardDeleteResponse(BaseModel):
     card_translations_deleted: int
 
 
+class BulkAffixDeleteResponse(BaseModel):
+    """Row counts deleted by DELETE /v3/affixes-by-version/{version_id}.
+
+    Mirrors the soft-union semantics of ``GET /v3/affixes-by-version``:
+    deletes both rows version-stamped to ``version_id`` and legacy
+    iso-keyed rows (``target_version_id IS NULL``) that share the
+    version's ISO. Rows stamped to other versions of the same ISO are
+    left intact. Counts are split so callers can see what came from
+    each bucket.
+    """
+
+    target_version_id: int
+    iso_639_3: str
+    version_stamped_deleted: int
+    iso_keyed_deleted: int
+    total_deleted: int
+
+
 class TokenizerRunOut(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/test/test_agent_routes/test_training_artifacts_routes.py
+++ b/test/test_agent_routes/test_training_artifacts_routes.py
@@ -957,3 +957,250 @@ def test_delete_training_artifacts_cascades_to_word_morpheme_index(
     ), "WordMorphemeIndex rows should cascade-delete with the morpheme"
 
     _cleanup(db_session, version_id, iso)
+
+
+# ---- DELETE /affixes-by-version/{version_id} (issue #796) ------------------
+
+
+def test_delete_affixes_by_version_clears_stamped_and_iso_keyed_rows(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id_2,
+    db_session,
+):
+    """The DELETE mirrors the GET soft-union: version-stamped rows AND
+    legacy iso-keyed (NULL target) rows both go, while rows stamped to
+    other versions of the same ISO survive. Counts are split by bucket."""
+    version_id = _resolve_version_id(db_session, test_revision_id)
+    iso = _resolve_iso(db_session, version_id)
+    _cleanup(db_session, version_id, iso, extra_version_ids=(test_version_id_2,))
+
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.flush()
+    db_session.add_all(
+        [
+            LanguageAffix(
+                iso_639_3=iso,
+                form="v1-",
+                position="prefix",
+                gloss="versioned-1",
+                target_version_id=version_id,
+            ),
+            LanguageAffix(
+                iso_639_3=iso,
+                form="-v2",
+                position="suffix",
+                gloss="versioned-2",
+                target_version_id=version_id,
+            ),
+            LanguageAffix(
+                iso_639_3=iso,
+                form="-leg",
+                position="suffix",
+                gloss="legacy-null",
+                target_version_id=None,
+            ),
+            LanguageAffix(
+                iso_639_3=iso,
+                form="other-",
+                position="prefix",
+                gloss="other-version",
+                target_version_id=test_version_id_2,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    resp = client.delete(
+        f"/{prefix}/affixes-by-version/{version_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == {
+        "target_version_id": version_id,
+        "iso_639_3": iso,
+        "version_stamped_deleted": 2,
+        "iso_keyed_deleted": 1,
+        "total_deleted": 3,
+    }
+
+    db_session.expire_all()
+    remaining = {
+        row.form
+        for row in db_session.query(LanguageAffix).filter(
+            LanguageAffix.iso_639_3 == iso
+        )
+    }
+    assert remaining == {"other-"}
+
+    resp = client.get(
+        f"/{prefix}/affixes-by-version/{version_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+    _cleanup(db_session, version_id, iso, extra_version_ids=(test_version_id_2,))
+
+
+def test_delete_affixes_by_version_idempotent_when_nothing_exists(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Rebuild semantics are 'ensure nothing exists' — zero counts on an
+    empty target, and zero counts again on a repeat call."""
+    version_id = _resolve_version_id(db_session, test_revision_id)
+    iso = _resolve_iso(db_session, version_id)
+    _cleanup(db_session, version_id, iso)
+
+    for _ in range(2):
+        resp = client.delete(
+            f"/{prefix}/affixes-by-version/{version_id}",
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == {
+            "target_version_id": version_id,
+            "iso_639_3": iso,
+            "version_stamped_deleted": 0,
+            "iso_keyed_deleted": 0,
+            "total_deleted": 0,
+        }
+
+
+def test_delete_affixes_by_version_preserves_other_isos(
+    client, regular_token1, test_revision_id, db_session
+):
+    """Legacy NULL-target rows belonging to a different ISO are outside
+    this version's soft-union and must survive the wipe."""
+    version_id = _resolve_version_id(db_session, test_revision_id)
+    iso = _resolve_iso(db_session, version_id)
+    other_iso = "swh" if iso != "swh" else "eng"
+    _cleanup(db_session, version_id, iso)
+    db_session.query(LanguageAffix).filter(
+        LanguageAffix.iso_639_3 == other_iso
+    ).delete()
+    db_session.query(LanguageProfile).filter(
+        LanguageProfile.iso_639_3 == other_iso
+    ).delete()
+    db_session.commit()
+
+    db_session.add_all(
+        [
+            LanguageProfile(iso_639_3=iso, name="English"),
+            LanguageProfile(iso_639_3=other_iso, name="Swahili"),
+        ]
+    )
+    db_session.flush()
+    db_session.add_all(
+        [
+            LanguageAffix(
+                iso_639_3=iso,
+                form="mine-",
+                position="prefix",
+                gloss="goes",
+                target_version_id=version_id,
+            ),
+            LanguageAffix(
+                iso_639_3=other_iso,
+                form="-stays",
+                position="suffix",
+                gloss="other-iso-legacy",
+                target_version_id=None,
+            ),
+        ]
+    )
+    db_session.commit()
+
+    resp = client.delete(
+        f"/{prefix}/affixes-by-version/{version_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total_deleted"] == 1
+
+    db_session.expire_all()
+    assert (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == other_iso)
+        .count()
+        == 1
+    ), "Legacy rows of an unrelated ISO must not be deleted"
+
+    db_session.query(LanguageAffix).filter(
+        LanguageAffix.iso_639_3 == other_iso
+    ).delete()
+    db_session.query(LanguageProfile).filter(
+        LanguageProfile.iso_639_3 == other_iso
+    ).delete()
+    db_session.commit()
+    _cleanup(db_session, version_id, iso)
+
+
+def test_delete_affixes_by_version_403_when_user_lacks_version_access(
+    client, regular_token2, test_revision_id, db_session
+):
+    version_id = _resolve_version_id(db_session, test_revision_id)
+    resp = client.delete(
+        f"/{prefix}/affixes-by-version/{version_id}",
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+def test_delete_affixes_by_version_403_when_version_unknown(
+    client, regular_token1, db_session
+):
+    resp = client.delete(
+        f"/{prefix}/affixes-by-version/999999999",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 403, resp.text
+
+
+def test_delete_affixes_by_version_admin_gets_404_for_unknown_version(
+    client, admin_token, db_session
+):
+    resp = client.delete(
+        f"/{prefix}/affixes-by-version/999999999",
+        headers={"Authorization": f"Bearer {admin_token}"},
+    )
+    assert resp.status_code == 404, resp.text
+
+
+def test_delete_affixes_by_version_without_token(client, test_revision_id, db_session):
+    version_id = _resolve_version_id(db_session, test_revision_id)
+    resp = client.delete(f"/{prefix}/affixes-by-version/{version_id}")
+    assert resp.status_code == 401
+
+
+def test_delete_affixes_by_version_latest_alias(
+    client, regular_token1, test_revision_id, db_session
+):
+    """The affix router is mounted under both /v3 and /latest — the
+    rebuild path in aqua-assessments calls /latest, so pin the alias."""
+    version_id = _resolve_version_id(db_session, test_revision_id)
+    iso = _resolve_iso(db_session, version_id)
+    _cleanup(db_session, version_id, iso)
+
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.flush()
+    db_session.add(
+        LanguageAffix(
+            iso_639_3=iso,
+            form="alias-",
+            position="prefix",
+            gloss="via-latest",
+            target_version_id=version_id,
+        )
+    )
+    db_session.commit()
+
+    resp = client.delete(
+        f"/latest/affixes-by-version/{version_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["total_deleted"] == 1
+
+    _cleanup(db_session, version_id, iso)

--- a/test/test_agent_routes/test_training_artifacts_routes.py
+++ b/test/test_agent_routes/test_training_artifacts_routes.py
@@ -1201,6 +1201,12 @@ def test_delete_affixes_by_version_latest_alias(
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert resp.status_code == 200, resp.text
-    assert resp.json()["total_deleted"] == 1
+    assert resp.json() == {
+        "target_version_id": version_id,
+        "iso_639_3": iso,
+        "version_stamped_deleted": 1,
+        "iso_keyed_deleted": 0,
+        "total_deleted": 1,
+    }
 
     _cleanup(db_session, version_id, iso)


### PR DESCRIPTION
## Summary

- Add `DELETE /v3/affixes-by-version/{version_id}` (and the `/latest/` alias via the existing router mounts) — the affix analog of the bulk lexeme-card DELETE (#703), so `build_mode="rebuild"` in aqua-assessments can clear a version's affix inventory before re-extraction.
- The DELETE mirrors the GET soft-union: atomically removes rows version-stamped to `version_id` **plus** legacy iso-keyed rows (`target_version_id IS NULL`) sharing the version's ISO. Rows stamped to other versions of the same ISO are untouched.
- Response (`BulkAffixDeleteResponse`) splits counts by bucket: `version_stamped_deleted`, `iso_keyed_deleted`, `total_deleted`.
- Auth/status semantics match the sibling rebuild endpoints: 200 with counts (idempotent zeros), 403 for unauthorized callers including unknown version_ids (no enumeration), 404 for admins on missing versions, 401 unauthenticated.

Fixes #796

## Test plan

- [x] `test_delete_affixes_by_version_clears_stamped_and_iso_keyed_rows` — soft-union wipe with per-bucket counts; other-version rows survive; follow-up GET returns empty
- [x] `test_delete_affixes_by_version_idempotent_when_nothing_exists` — zero counts, twice
- [x] `test_delete_affixes_by_version_preserves_other_isos` — legacy rows of an unrelated ISO survive
- [x] `test_delete_affixes_by_version_403_when_user_lacks_version_access` / `..._403_when_version_unknown` — no enumeration for regular users
- [x] `test_delete_affixes_by_version_admin_gets_404_for_unknown_version`
- [x] `test_delete_affixes_by_version_without_token` — 401
- [x] `test_delete_affixes_by_version_latest_alias` — pins the `/latest` mount and full response shape
- [x] Full `test/test_agent_routes/` suite passes locally (441 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)