### PR TITLE
Version-scope language_affixes writes (#798)

### DIFF
--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -46,6 +46,42 @@ def _normalize(value: str) -> str:
     return unicodedata.normalize("NFC", value).strip()
 
 
+async def _resolve_version_and_validate_iso(db, revision_id, payload_iso):
+    """Resolve ``target_version_id`` from ``revision_id`` and reject any
+    mismatch between the revision's version ISO and ``payload_iso``.
+
+    Returns the resolved ``target_version_id``. Raises 422 if the revision
+    is unknown or its version's ISO doesn't match ``payload_iso``. The
+    cross-check is important under version-scoped writes (#798): without
+    it a caller could write a row whose ``iso_639_3`` belongs to one
+    language but whose ``target_version_id`` belongs to another, leaving
+    the row invisible to both ``GET /affixes-by-version`` (filters by
+    version's iso) and any sensible iso-only listing.
+    """
+    lookup = await db.execute(
+        select(BibleRevision.bible_version_id, BibleVersion.iso_language)
+        .join(BibleVersion, BibleRevision.bible_version_id == BibleVersion.id)
+        .where(BibleRevision.id == revision_id)
+    )
+    row = lookup.first()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=f"Unknown revision_id {revision_id}",
+        )
+    target_version_id, version_iso = row
+    if version_iso != payload_iso:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"iso_639_3 {payload_iso!r} does not match the ISO "
+                f"({version_iso!r}) of the version that owns "
+                f"revision_id {revision_id}"
+            ),
+        )
+    return target_version_id
+
+
 @router.get("/affixes-by-version/{version_id}", response_model=AffixListOut)
 async def get_affixes_by_version(
     version_id: int,
@@ -323,17 +359,9 @@ async def commit_affixes(
 
     target_version_id: Optional[int] = None
     if payload.revision_id is not None:
-        revision_lookup = await db.execute(
-            select(BibleRevision.bible_version_id).where(
-                BibleRevision.id == payload.revision_id
-            )
+        target_version_id = await _resolve_version_and_validate_iso(
+            db, payload.revision_id, iso
         )
-        target_version_id = revision_lookup.scalar_one_or_none()
-        if target_version_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Unknown revision_id {payload.revision_id}",
-            )
 
     n_new = 0
     n_updated = 0
@@ -565,17 +593,9 @@ async def replace_affixes(
 
     target_version_id: Optional[int] = None
     if payload.revision_id is not None:
-        revision_lookup = await db.execute(
-            select(BibleRevision.bible_version_id).where(
-                BibleRevision.id == payload.revision_id
-            )
+        target_version_id = await _resolve_version_and_validate_iso(
+            db, payload.revision_id, iso
         )
-        target_version_id = revision_lookup.scalar_one_or_none()
-        if target_version_id is None:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                detail=f"Unknown revision_id {payload.revision_id}",
-            )
 
     try:
         # Version-scope the replace: deleting only rows in the current
@@ -744,6 +764,8 @@ async def patch_affix(
         # being patched, mirroring the version-scoped unique indexes
         # (#798): collisions only matter within the same target_version_id
         # (or within the legacy NULL bucket for the same ISO).
+        # For stamped rows, target_version_id uniquely implies the ISO,
+        # so the iso filter is omitted; for NULL rows it is required.
         if affix.target_version_id is None:
             scope_clause = and_(
                 LanguageAffix.iso_639_3 == affix.iso_639_3,

--- a/agent_routes/v3/affix_routes.py
+++ b/agent_routes/v3/affix_routes.py
@@ -273,10 +273,17 @@ async def commit_affixes(
     db: AsyncSession = Depends(get_db),
     current_user: UserModel = Depends(get_current_user),
 ):
-    """Bulk upsert of language affixes, keyed on (iso, form, position).
+    """Bulk upsert of language affixes, scoped to the payload's revision.
+
+    With ``revision_id`` set (the canonical agent path), conflicts are
+    detected against rows stamped to the same ``target_version_id``;
+    rows owned by other versions of the same ISO are untouched (#798).
+    Without a ``revision_id``, conflicts are detected against the legacy
+    ``target_version_id IS NULL`` bucket only.
 
     Same gloss → idempotent upsert of examples/n_runs/source_model.
-    Different gloss for an existing (form, position) → **409** with body:
+    Different gloss for an existing (form, position) within the scope →
+    **409** with body:
 
         {"detail": {"message": ..., "conflicts": [
             {"form", "position", "submitted_gloss",
@@ -362,8 +369,10 @@ async def commit_affixes(
                 }
 
             # Look up existing rows for the (form, position) tuples in the
-            # payload. One OR-of-ANDs clause per tuple is fine at the
-            # ~10-30 affix scale the comment specifies.
+            # payload, scoped to the same target_version_id so a write for
+            # one version doesn't 409 against another version's rows (#798).
+            # When the payload has no revision_id, scope to the legacy
+            # target_version_id IS NULL bucket.
             existing_map: dict[tuple[str, str], dict] = {}
             if incoming:
                 clauses = [
@@ -373,6 +382,13 @@ async def commit_affixes(
                     )
                     for (f, p) in incoming.keys()
                 ]
+                if target_version_id is not None:
+                    scope_clause = LanguageAffix.target_version_id == target_version_id
+                else:
+                    scope_clause = and_(
+                        LanguageAffix.iso_639_3 == iso,
+                        LanguageAffix.target_version_id.is_(None),
+                    )
                 existing_result = await db.execute(
                     select(
                         LanguageAffix.id,
@@ -383,7 +399,7 @@ async def commit_affixes(
                         LanguageAffix.n_runs,
                         LanguageAffix.source_model,
                     ).where(
-                        LanguageAffix.iso_639_3 == iso,
+                        scope_clause,
                         or_(*clauses),
                     )
                 )
@@ -467,16 +483,21 @@ async def commit_affixes(
                     "source_model": stmt.excluded.source_model,
                     "updated_at": func.now(),
                 }
-                # First-writer-wins for target_version_id: only stamp it on
-                # rows where it's currently NULL (Phase 1 backfill semantics).
+                # Conflict target tracks the partial unique that owns this
+                # bucket: (target_version_id, form, position) for stamped
+                # rows, (iso, form, position) for legacy NULL rows (#798).
                 if target_version_id is not None:
-                    set_values["target_version_id"] = func.coalesce(
-                        LanguageAffix.target_version_id, stmt.excluded.target_version_id
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["target_version_id", "form", "position"],
+                        index_where=LanguageAffix.target_version_id.isnot(None),
+                        set_=set_values,
                     )
-                stmt = stmt.on_conflict_do_update(
-                    index_elements=["iso_639_3", "form", "position"],
-                    set_=set_values,
-                )
+                else:
+                    stmt = stmt.on_conflict_do_update(
+                        index_elements=["iso_639_3", "form", "position"],
+                        index_where=LanguageAffix.target_version_id.is_(None),
+                        set_=set_values,
+                    )
                 await db.execute(stmt)
 
         await db.commit()
@@ -557,11 +578,16 @@ async def replace_affixes(
             )
 
     try:
-        del_filter = LanguageAffix.iso_639_3 == iso
-        if payload.revision_id is not None:
+        # Version-scope the replace: deleting only rows in the current
+        # write bucket avoids wiping affixes that belong to other versions
+        # of the same ISO (#798). When the caller omits revision_id we
+        # operate on the legacy target_version_id IS NULL bucket only.
+        if target_version_id is not None:
+            del_filter = LanguageAffix.target_version_id == target_version_id
+        else:
             del_filter = and_(
-                del_filter,
-                LanguageAffix.first_seen_revision_id == payload.revision_id,
+                LanguageAffix.iso_639_3 == iso,
+                LanguageAffix.target_version_id.is_(None),
             )
         result = await db.execute(delete(LanguageAffix).where(del_filter))
         n_deleted = result.rowcount
@@ -608,10 +634,12 @@ async def replace_affixes(
                 for (form, position), fields in incoming.items()
             ]
             stmt = pg_insert(LanguageAffix).values(rows)
-            # PUT is "replace": if the scoped delete left a row from another
-            # scope with the same (form, position), authoritatively overwrite
-            # gloss too. This is the one path that may change an existing
-            # row's gloss without an explicit PATCH.
+            # PUT is "replace within scope": if the scoped delete raced
+            # with a concurrent writer and left a row in this bucket,
+            # authoritatively overwrite gloss too. This is the one path
+            # that may change an existing row's gloss without an explicit
+            # PATCH. Conflict target matches the partial unique for the
+            # current write bucket (#798).
             replace_set = {
                 "gloss": stmt.excluded.gloss,
                 "examples": stmt.excluded.examples,
@@ -620,14 +648,18 @@ async def replace_affixes(
                 "first_seen_revision_id": stmt.excluded.first_seen_revision_id,
                 "updated_at": func.now(),
             }
-            # PUT overwrites target_version_id authoritatively when caller
-            # supplies a revision; otherwise preserve any prior stamp.
             if target_version_id is not None:
-                replace_set["target_version_id"] = stmt.excluded.target_version_id
-            stmt = stmt.on_conflict_do_update(
-                index_elements=["iso_639_3", "form", "position"],
-                set_=replace_set,
-            )
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["target_version_id", "form", "position"],
+                    index_where=LanguageAffix.target_version_id.isnot(None),
+                    set_=replace_set,
+                )
+            else:
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["iso_639_3", "form", "position"],
+                    index_where=LanguageAffix.target_version_id.is_(None),
+                    set_=replace_set,
+                )
             await db.execute(stmt)
             n_inserted = len(rows)
 
@@ -708,9 +740,20 @@ async def patch_affix(
     )
 
     if (new_form, new_position) != (affix.form, affix.position):
+        # Scope the duplicate check to the same write bucket as the row
+        # being patched, mirroring the version-scoped unique indexes
+        # (#798): collisions only matter within the same target_version_id
+        # (or within the legacy NULL bucket for the same ISO).
+        if affix.target_version_id is None:
+            scope_clause = and_(
+                LanguageAffix.iso_639_3 == affix.iso_639_3,
+                LanguageAffix.target_version_id.is_(None),
+            )
+        else:
+            scope_clause = LanguageAffix.target_version_id == affix.target_version_id
         dup_result = await db.execute(
             select(LanguageAffix.id).where(
-                LanguageAffix.iso_639_3 == affix.iso_639_3,
+                scope_clause,
                 LanguageAffix.form == new_form,
                 LanguageAffix.position == new_position,
                 LanguageAffix.id != affix.id,

--- a/alembic/migrations/versions/d4f7b1e9c3a2_version_scope_affix_unique.py
+++ b/alembic/migrations/versions/d4f7b1e9c3a2_version_scope_affix_unique.py
@@ -90,6 +90,38 @@ def downgrade() -> None:
         "ux_language_affixes_version_form_position",
         table_name="language_affixes",
     )
+    # The new write semantics deliberately allow a stamped row and a
+    # legacy NULL row to coexist at the same (iso, form, position) -- see
+    # test_put_affixes_scoped_to_revision_leaves_legacy_null_row_intact.
+    # Restoring the non-partial iso-keyed unique would fail on any such
+    # pair. Drop the NULL-stamped row in those cases (it is reproducible
+    # by re-running the agent without revision_id, and migration
+    # e2ad1ed4a64a already established the precedent of deleting NULL
+    # legacy data).
+    op.execute(
+        """
+        DELETE FROM language_affixes
+        WHERE target_version_id IS NULL
+          AND (iso_639_3, form, position) IN (
+              SELECT iso_639_3, form, position
+              FROM language_affixes
+              WHERE target_version_id IS NOT NULL
+          )
+        """
+    )
+    # If two stamped rows from different versions share (iso, form,
+    # position), the iso-keyed unique can only be restored by dropping
+    # all but one. Keep the lowest-id row and delete the others.
+    op.execute(
+        """
+        DELETE FROM language_affixes a
+        USING language_affixes b
+        WHERE a.iso_639_3 = b.iso_639_3
+          AND a.form = b.form
+          AND a.position = b.position
+          AND a.id > b.id
+        """
+    )
     op.create_index(
         "ux_language_affixes_version_form_position_gloss",
         "language_affixes",

--- a/alembic/migrations/versions/d4f7b1e9c3a2_version_scope_affix_unique.py
+++ b/alembic/migrations/versions/d4f7b1e9c3a2_version_scope_affix_unique.py
@@ -45,6 +45,7 @@ Downgrade restores the old iso-keyed unique. The old
 downgrade -- it was effectively a no-op given the iso-keyed unique
 already covered (form, position) uniqueness per language.
 """
+
 from typing import Sequence, Union
 
 from alembic import op

--- a/alembic/migrations/versions/d4f7b1e9c3a2_version_scope_affix_unique.py
+++ b/alembic/migrations/versions/d4f7b1e9c3a2_version_scope_affix_unique.py
@@ -40,10 +40,12 @@ Existing data already satisfies both partial indexes: after
 which implies at most one row per ``(target_version_id, form, position)``
 too.
 
-Downgrade restores the old iso-keyed unique. The old
-``ux_language_affixes_version_form_position_gloss`` is not restored on
-downgrade -- it was effectively a no-op given the iso-keyed unique
-already covered (form, position) uniqueness per language.
+Downgrade restores the iso-keyed unique and the legacy 4-column
+``ux_language_affixes_version_form_position_gloss`` index, after deduping
+rows the new partial uniques deliberately allowed to coexist (NULL+stamped
+at the same ``(iso, form, position)``; multiple stamped versions sharing
+``(iso, form, position)``). That dedup is lossy by design -- the rows it
+drops are reproducible by re-running the agent.
 """
 
 from typing import Sequence, Union

--- a/alembic/migrations/versions/d4f7b1e9c3a2_version_scope_affix_unique.py
+++ b/alembic/migrations/versions/d4f7b1e9c3a2_version_scope_affix_unique.py
@@ -1,0 +1,103 @@
+"""Scope language_affixes uniqueness per target_version_id
+
+Revision ID: d4f7b1e9c3a2
+Revises: e8a3f1c2d790
+Create Date: 2026-06-10
+
+Background
+----------
+Reads (#693 -- ``GET /affixes-by-version``) and bulk DELETE (#797 --
+``DELETE /affixes-by-version``) are already version-scoped, but the
+write/conflict path was still iso-scoped: the unique index
+``ux_language_affixes_iso_form_position`` was on
+``(iso_639_3, form, position)``. So a ``POST /v3/affixes`` for one
+``target_version_id`` would 409 against rows owned by *another* version
+of the same ISO, and the patch-fallback path silently mutated the other
+version's rows.
+
+This migration version-scopes the write path, mirroring lexeme cards'
+``(LOWER(target_lemma), source_language_iso, target_version_id)``.
+
+What changes
+------------
+- Drop ``ux_language_affixes_iso_form_position``
+  (was ``(iso_639_3, form, position)`` unique, all rows).
+- Drop ``ux_language_affixes_version_form_position_gloss``
+  (was ``(target_version_id, form, position, gloss)`` unique).
+  Polysemy is rejected at the API layer (#c4f2a8e9b1d7), so the gloss
+  column in this composite no longer serves a real purpose. The new
+  ``ux_language_affixes_version_form_position`` replaces it.
+- Add ``ux_language_affixes_version_form_position``: partial unique on
+  ``(target_version_id, form, position) WHERE target_version_id IS NOT NULL``.
+- Add ``ux_language_affixes_iso_form_position_legacy``: partial unique on
+  ``(iso_639_3, form, position) WHERE target_version_id IS NULL``.
+  Migration ``e2ad1ed4a64a`` deleted all NULL-stamped legacy rows, but
+  the API still allows NULL-stamped writes (POST/PUT without
+  ``revision_id``), so this partial keeps the legacy bucket's uniqueness.
+
+Existing data already satisfies both partial indexes: after
+``c4f2a8e9b1d7``, there is at most one row per ``(iso, form, position)``,
+which implies at most one row per ``(target_version_id, form, position)``
+too.
+
+Downgrade restores the old iso-keyed unique. The old
+``ux_language_affixes_version_form_position_gloss`` is not restored on
+downgrade -- it was effectively a no-op given the iso-keyed unique
+already covered (form, position) uniqueness per language.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "d4f7b1e9c3a2"
+down_revision: Union[str, None] = "e8a3f1c2d790"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index(
+        "ux_language_affixes_iso_form_position",
+        table_name="language_affixes",
+    )
+    op.drop_index(
+        "ux_language_affixes_version_form_position_gloss",
+        table_name="language_affixes",
+    )
+    op.create_index(
+        "ux_language_affixes_version_form_position",
+        "language_affixes",
+        ["target_version_id", "form", "position"],
+        unique=True,
+        postgresql_where="target_version_id IS NOT NULL",
+    )
+    op.create_index(
+        "ux_language_affixes_iso_form_position_legacy",
+        "language_affixes",
+        ["iso_639_3", "form", "position"],
+        unique=True,
+        postgresql_where="target_version_id IS NULL",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ux_language_affixes_iso_form_position_legacy",
+        table_name="language_affixes",
+    )
+    op.drop_index(
+        "ux_language_affixes_version_form_position",
+        table_name="language_affixes",
+    )
+    op.create_index(
+        "ux_language_affixes_version_form_position_gloss",
+        "language_affixes",
+        ["target_version_id", "form", "position", "gloss"],
+        unique=True,
+    )
+    op.create_index(
+        "ux_language_affixes_iso_form_position",
+        "language_affixes",
+        ["iso_639_3", "form", "position"],
+        unique=True,
+    )

--- a/database/models.py
+++ b/database/models.py
@@ -21,7 +21,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import backref, relationship
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, text
 
 Base = declarative_base()
 
@@ -1130,19 +1130,20 @@ class LanguageAffix(Base):
         ),
         CheckConstraint("n_runs >= 1", name="ck_language_affixes_n_runs_min_1"),
         Index(
-            "ux_language_affixes_iso_form_position",
+            "ux_language_affixes_version_form_position",
+            "target_version_id",
+            "form",
+            "position",
+            unique=True,
+            postgresql_where=text("target_version_id IS NOT NULL"),
+        ),
+        Index(
+            "ux_language_affixes_iso_form_position_legacy",
             "iso_639_3",
             "form",
             "position",
             unique=True,
-        ),
-        Index(
-            "ux_language_affixes_version_form_position_gloss",
-            "target_version_id",
-            "form",
-            "position",
-            "gloss",
-            unique=True,
+            postgresql_where=text("target_version_id IS NULL"),
         ),
         Index("ix_language_affixes_iso", "iso_639_3"),
         Index("ix_language_affixes_iso_position", "iso_639_3", "position"),

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -877,11 +877,7 @@ def test_affixes_put_replace_is_version_scoped(
     assert body["n_deleted"] == 0
     assert body["n_inserted"] == 1
 
-    rows = (
-        db_session.query(LanguageAffix)
-        .filter(LanguageAffix.iso_639_3 == iso)
-        .all()
-    )
+    rows = db_session.query(LanguageAffix).filter(LanguageAffix.iso_639_3 == iso).all()
     by_version = {r.target_version_id: r.form for r in rows}
     assert by_version == {test_version_id_2: "preserve-", test_version_id: "fresh-"}
 

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -1,6 +1,8 @@
 """Tests for language affix storage API endpoints."""
 
-from database.models import LanguageAffix, LanguageProfile
+from datetime import date
+
+from database.models import BibleRevision, BibleVersion, LanguageAffix, LanguageProfile
 
 prefix = "v3"
 
@@ -17,6 +19,42 @@ def _cleanup(db_session):
 
 def _seed_profile(db_session):
     db_session.add(LanguageProfile(iso_639_3=TEST_ISO, name="Swahili"))
+    db_session.commit()
+
+
+def _resolve_iso(db_session, version_id):
+    return (
+        db_session.query(BibleVersion.iso_language)
+        .filter(BibleVersion.id == version_id)
+        .scalar()
+    )
+
+
+def _revision_for_version(db_session, version_id):
+    """Return any revision id belonging to ``version_id``, creating one if needed."""
+    rev = (
+        db_session.query(BibleRevision)
+        .filter(BibleRevision.bible_version_id == version_id)
+        .order_by(BibleRevision.id)
+        .first()
+    )
+    if rev is not None:
+        return rev.id
+    new_rev = BibleRevision(
+        date=date.today(),
+        bible_version_id=version_id,
+        published=False,
+        machine_translation=True,
+    )
+    db_session.add(new_rev)
+    db_session.commit()
+    db_session.refresh(new_rev)
+    return new_rev.id
+
+
+def _cleanup_version_scoped(db_session, iso, *version_ids):
+    db_session.query(LanguageAffix).filter(LanguageAffix.iso_639_3 == iso).delete()
+    db_session.query(LanguageProfile).filter(LanguageProfile.iso_639_3 == iso).delete()
     db_session.commit()
 
 
@@ -547,6 +585,9 @@ def test_affixes_nfc_normalization_dedupes(client, regular_token1, db_session):
 def test_affixes_first_seen_revision_preserved_on_upsert(
     client, regular_token1, test_revision_id, db_session
 ):
+    """An upsert within the same target_version_id bucket must not clobber
+    ``first_seen_revision_id`` on the existing row — the column is
+    intentionally omitted from the ON CONFLICT update set."""
     _cleanup(db_session)
     _seed_profile(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
@@ -561,12 +602,13 @@ def test_affixes_first_seen_revision_preserved_on_upsert(
         headers=headers,
     )
 
-    # Second commit with a different revision_id — should not clobber
-    # first_seen_revision_id.
+    # Second commit in the same version bucket with new examples — the
+    # upsert must preserve first_seen_revision_id.
     resp = client.post(
         f"/{prefix}/affixes",
         json={
             "iso_639_3": TEST_ISO,
+            "revision_id": test_revision_id,
             "affixes": [
                 {
                     "form": "akha-",
@@ -612,6 +654,293 @@ def test_affixes_source_model_change_counts_as_updated(
 
     resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
     assert resp.json()["affixes"][0]["source_model"] == "model-b"
+
+
+# ---- Version-scoped write semantics (#798) ---------------------------------
+
+
+def test_affixes_post_same_form_position_across_versions_no_409(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+    db_session,
+):
+    """A POST scoped to version A must not 409 against another version's
+    stamped rows for the same (form, position). The agent's rebuild flow
+    relies on this — see #798.
+    """
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
+
+    revision_v1 = test_revision_id
+    revision_v2 = _revision_for_version(db_session, test_version_id_2)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_v1,
+            "affixes": [
+                {"form": "ku-", "position": "prefix", "gloss": "v1-gloss"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Same (form, position) under a different version with a *different*
+    # gloss — previously triggered a 409 due to the iso-keyed unique.
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_v2,
+            "affixes": [
+                {"form": "ku-", "position": "prefix", "gloss": "v2-gloss"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["n_affixes_new"] == 1
+
+    rows = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == iso)
+        .order_by(LanguageAffix.target_version_id)
+        .all()
+    )
+    by_version = {r.target_version_id: r.gloss for r in rows}
+    assert by_version == {test_version_id: "v1-gloss", test_version_id_2: "v2-gloss"}
+
+    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+
+
+def test_affixes_post_does_not_mutate_other_versions_rows(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+    db_session,
+):
+    """A POST scoped to version A must not overwrite version B's stored
+    fields, even when the upsert matches (form, position). Reproduces the
+    cross-version contamination described in #798.
+    """
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
+
+    revision_v1 = test_revision_id
+    revision_v2 = _revision_for_version(db_session, test_version_id_2)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_v2,
+            "source_model": "model-v2",
+            "affixes": [
+                {
+                    "form": "-le",
+                    "position": "suffix",
+                    "gloss": "v2-perfect",
+                    "examples": ["v2-ex"],
+                    "n_runs": 7,
+                },
+            ],
+        },
+        headers=headers,
+    )
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_v1,
+            "source_model": "model-v1",
+            "affixes": [
+                {
+                    "form": "-le",
+                    "position": "suffix",
+                    "gloss": "v1-perfect",
+                    "examples": ["v1-ex"],
+                    "n_runs": 1,
+                },
+            ],
+        },
+        headers=headers,
+    )
+
+    v2_row = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.target_version_id == test_version_id_2)
+        .one()
+    )
+    db_session.refresh(v2_row)
+    assert v2_row.gloss == "v2-perfect"
+    assert v2_row.examples == ["v2-ex"]
+    assert v2_row.n_runs == 7
+    assert v2_row.source_model == "model-v2"
+
+    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+
+
+def test_affixes_post_same_version_same_form_position_still_409s(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    db_session,
+):
+    """Within a single ``target_version_id`` the (form, position) gloss
+    conflict is still detected and returns 409 (#798 only relaxes
+    cross-version conflicts).
+    """
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso, test_version_id)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
+
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+    payload = {
+        "iso_639_3": iso,
+        "revision_id": test_revision_id,
+        "affixes": [{"form": "wa-", "position": "prefix", "gloss": "first"}],
+    }
+    resp = client.post(f"/{prefix}/affixes", json=payload, headers=headers)
+    assert resp.status_code == 200
+
+    payload["affixes"] = [{"form": "wa-", "position": "prefix", "gloss": "second"}]
+    resp = client.post(f"/{prefix}/affixes", json=payload, headers=headers)
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["conflicts"][0]["existing_gloss"] == "first"
+    assert detail["conflicts"][0]["submitted_gloss"] == "second"
+
+    _cleanup_version_scoped(db_session, iso, test_version_id)
+
+
+def test_affixes_put_replace_is_version_scoped(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+    db_session,
+):
+    """PUT replace-all for version A must not delete rows owned by
+    version B. Replaces the previous iso-wide delete (#798)."""
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
+
+    revision_v1 = test_revision_id
+    revision_v2 = _revision_for_version(db_session, test_version_id_2)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_v2,
+            "affixes": [
+                {"form": "preserve-", "position": "prefix", "gloss": "v2-keeps"},
+            ],
+        },
+        headers=headers,
+    )
+
+    resp = client.put(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_v1,
+            "affixes": [
+                {"form": "fresh-", "position": "prefix", "gloss": "v1-only"},
+            ],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # n_deleted counts only v1's rows (zero — nothing existed yet there).
+    assert body["n_deleted"] == 0
+    assert body["n_inserted"] == 1
+
+    rows = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == iso)
+        .all()
+    )
+    by_version = {r.target_version_id: r.form for r in rows}
+    assert by_version == {test_version_id_2: "preserve-", test_version_id: "fresh-"}
+
+    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+
+
+def test_affixes_patch_only_collides_within_same_version(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+    db_session,
+):
+    """PATCHing an affix's (form, position) into one used by a *different*
+    version must succeed — the duplicate check is version-scoped (#798)."""
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
+
+    revision_v1 = test_revision_id
+    revision_v2 = _revision_for_version(db_session, test_version_id_2)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_v2,
+            "affixes": [{"form": "shared-", "position": "prefix", "gloss": "v2"}],
+        },
+        headers=headers,
+    )
+    client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_v1,
+            "affixes": [{"form": "unique-", "position": "prefix", "gloss": "v1"}],
+        },
+        headers=headers,
+    )
+
+    v1_row_id = (
+        db_session.query(LanguageAffix.id)
+        .filter(LanguageAffix.target_version_id == test_version_id)
+        .scalar()
+    )
+    # Renaming v1's row to v2's (form, position) is allowed — they live in
+    # different version buckets.
+    resp = client.patch(
+        f"/{prefix}/affixes/{v1_row_id}",
+        json={"form": "shared-"},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
     _cleanup(db_session)
 
 
@@ -919,9 +1248,13 @@ def test_put_affixes_duplicate_in_payload_rejected(client, regular_token1, db_se
     _cleanup(db_session)
 
 
-def test_put_affixes_scoped_delete_handles_conflict_with_other_revision(
+def test_put_affixes_scoped_to_revision_leaves_legacy_null_row_intact(
     client, regular_token1, test_revision_id, db_session
 ):
+    """Under version-scoped writes (#798), a stamped PUT only deletes
+    rows in its own bucket. A pre-existing legacy NULL-stamped row at
+    the same (form, position) is left in place rather than being
+    clobbered by the PUT's authoritative replace."""
     _cleanup(db_session)
     _seed_profile(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
@@ -955,11 +1288,18 @@ def test_put_affixes_scoped_delete_handles_conflict_with_other_revision(
     )
     assert resp.status_code == 200
 
-    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
-    data = resp.json()
-    assert data["total"] == 1
-    assert data["affixes"][0]["examples"] == ["akhatenda"]
-    assert data["affixes"][0]["first_seen_revision_id"] == test_revision_id
+    rows = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .order_by(LanguageAffix.target_version_id.nulls_first())
+        .all()
+    )
+    assert len(rows) == 2
+    legacy_row, stamped_row = rows
+    assert legacy_row.target_version_id is None
+    assert stamped_row.target_version_id is not None
+    assert stamped_row.examples == ["akhatenda"]
+    assert stamped_row.first_seen_revision_id == test_revision_id
     _cleanup(db_session)
 
 
@@ -1242,12 +1582,12 @@ def test_patch_affix_n_runs_null_ignored(client, regular_token1, db_session):
     _cleanup(db_session)
 
 
-def test_put_affixes_overwrites_gloss_on_cross_revision_collision(
+def test_put_affixes_stamped_does_not_overwrite_legacy_null_gloss(
     client, regular_token1, test_revision_id, db_session
 ):
-    """PUT scoped to rev2 overwrites the gloss of an unscoped row at the same
-    (form, position) — authoritative replace under the new
-    (iso, form, position) unique key."""
+    """A stamped PUT must not overwrite the gloss of a legacy
+    target_version_id IS NULL row at the same (form, position): the two
+    rows live in separate write buckets under #798."""
     _cleanup(db_session)
     _seed_profile(db_session)
     headers = {"Authorization": f"Bearer {regular_token1}"}
@@ -1276,10 +1616,15 @@ def test_put_affixes_overwrites_gloss_on_cross_revision_collision(
     )
     assert resp.status_code == 200
 
-    listing = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers).json()
-    assert listing["total"] == 1
-    assert listing["affixes"][0]["gloss"] == "perfective"
-    assert listing["affixes"][0]["first_seen_revision_id"] == test_revision_id
+    rows = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .all()
+    )
+    glosses_by_target = {r.target_version_id: r.gloss for r in rows}
+    assert glosses_by_target[None] == "past"
+    stamped_gloss = next(v for k, v in glosses_by_target.items() if k is not None)
+    assert stamped_gloss == "perfective"
     _cleanup(db_session)
 
 

--- a/test/test_agent_routes/test_affix_routes.py
+++ b/test/test_agent_routes/test_affix_routes.py
@@ -52,7 +52,7 @@ def _revision_for_version(db_session, version_id):
     return new_rev.id
 
 
-def _cleanup_version_scoped(db_session, iso, *version_ids):
+def _cleanup_version_scoped(db_session, iso):
     db_session.query(LanguageAffix).filter(LanguageAffix.iso_639_3 == iso).delete()
     db_session.query(LanguageProfile).filter(LanguageProfile.iso_639_3 == iso).delete()
     db_session.commit()
@@ -349,15 +349,19 @@ def test_affixes_additive_preserves_absent_rows(client, regular_token1, db_sessi
     _cleanup(db_session)
 
 
-def test_affixes_with_revision_id(client, regular_token1, test_revision_id, db_session):
-    _cleanup(db_session)
-    _seed_profile(db_session)
+def test_affixes_with_revision_id(
+    client, regular_token1, test_revision_id, test_version_id, db_session
+):
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     resp = client.post(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "revision_id": test_revision_id,
             "affixes": [
                 {"form": "akha-", "position": "prefix", "gloss": "past"},
@@ -367,9 +371,36 @@ def test_affixes_with_revision_id(client, regular_token1, test_revision_id, db_s
     )
     assert resp.status_code == 200
 
-    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    resp = client.get(f"/{prefix}/affixes?iso={iso}", headers=headers)
     assert resp.json()["affixes"][0]["first_seen_revision_id"] == test_revision_id
-    _cleanup(db_session)
+    _cleanup_version_scoped(db_session, iso)
+
+
+def test_affixes_post_iso_revision_mismatch_returns_422(
+    client, regular_token1, test_revision_id, test_version_id, db_session
+):
+    """POST with a payload iso that disagrees with the revision's version
+    iso is rejected (#798 — version-scoped writes need the cross-check
+    so the row's iso and target_version_id stay consistent)."""
+    version_iso = _resolve_iso(db_session, test_version_id)
+    wrong_iso = "swh" if version_iso != "swh" else "ngq"
+    _cleanup_version_scoped(db_session, wrong_iso)
+    db_session.add(LanguageProfile(iso_639_3=wrong_iso, name=wrong_iso))
+    db_session.commit()
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": wrong_iso,
+            "revision_id": test_revision_id,
+            "affixes": [{"form": "ba-", "position": "prefix", "gloss": "x"}],
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 422, resp.text
+    assert "does not match" in resp.json()["detail"]
+    _cleanup_version_scoped(db_session, wrong_iso)
 
 
 def test_affixes_get_missing_profile(client, regular_token1, db_session):
@@ -583,32 +614,41 @@ def test_affixes_nfc_normalization_dedupes(client, regular_token1, db_session):
 
 
 def test_affixes_first_seen_revision_preserved_on_upsert(
-    client, regular_token1, test_revision_id, db_session
+    client,
+    regular_token1,
+    test_revision_id,
+    test_revision_id_2,
+    test_version_id,
+    db_session,
 ):
     """An upsert within the same target_version_id bucket must not clobber
     ``first_seen_revision_id`` on the existing row — the column is
-    intentionally omitted from the ON CONFLICT update set."""
-    _cleanup(db_session)
-    _seed_profile(db_session)
+    intentionally omitted from the ON CONFLICT update set. Uses two
+    distinct revisions of the same version to exercise the "later
+    revision must not overwrite the first-seen stamp" path."""
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     client.post(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "revision_id": test_revision_id,
             "affixes": [{"form": "akha-", "position": "prefix", "gloss": "past"}],
         },
         headers=headers,
     )
 
-    # Second commit in the same version bucket with new examples — the
-    # upsert must preserve first_seen_revision_id.
+    # Second commit, different revision of the same version — the upsert
+    # must preserve the original first_seen_revision_id.
     resp = client.post(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
-            "revision_id": test_revision_id,
+            "iso_639_3": iso,
+            "revision_id": test_revision_id_2,
             "affixes": [
                 {
                     "form": "akha-",
@@ -622,13 +662,9 @@ def test_affixes_first_seen_revision_preserved_on_upsert(
     )
     assert resp.status_code == 200
 
-    row = (
-        db_session.query(LanguageAffix)
-        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
-        .one()
-    )
+    row = db_session.query(LanguageAffix).filter(LanguageAffix.iso_639_3 == iso).one()
     assert row.first_seen_revision_id == test_revision_id
-    _cleanup(db_session)
+    _cleanup_version_scoped(db_session, iso)
 
 
 def test_affixes_source_model_change_counts_as_updated(
@@ -672,7 +708,7 @@ def test_affixes_post_same_form_position_across_versions_no_409(
     relies on this — see #798.
     """
     iso = _resolve_iso(db_session, test_version_id)
-    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    _cleanup_version_scoped(db_session, iso)
     db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
     db_session.commit()
 
@@ -715,10 +751,13 @@ def test_affixes_post_same_form_position_across_versions_no_409(
         .order_by(LanguageAffix.target_version_id)
         .all()
     )
+    # Both rows land in stamped buckets — guards against a regression that
+    # accidentally routes one of them into the legacy NULL bucket.
+    assert all(r.target_version_id is not None for r in rows)
     by_version = {r.target_version_id: r.gloss for r in rows}
     assert by_version == {test_version_id: "v1-gloss", test_version_id_2: "v2-gloss"}
 
-    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    _cleanup_version_scoped(db_session, iso)
 
 
 def test_affixes_post_does_not_mutate_other_versions_rows(
@@ -734,7 +773,7 @@ def test_affixes_post_does_not_mutate_other_versions_rows(
     cross-version contamination described in #798.
     """
     iso = _resolve_iso(db_session, test_version_id)
-    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    _cleanup_version_scoped(db_session, iso)
     db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
     db_session.commit()
 
@@ -791,7 +830,7 @@ def test_affixes_post_does_not_mutate_other_versions_rows(
     assert v2_row.n_runs == 7
     assert v2_row.source_model == "model-v2"
 
-    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    _cleanup_version_scoped(db_session, iso)
 
 
 def test_affixes_post_same_version_same_form_position_still_409s(
@@ -806,7 +845,7 @@ def test_affixes_post_same_version_same_form_position_still_409s(
     cross-version conflicts).
     """
     iso = _resolve_iso(db_session, test_version_id)
-    _cleanup_version_scoped(db_session, iso, test_version_id)
+    _cleanup_version_scoped(db_session, iso)
     db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
     db_session.commit()
 
@@ -826,7 +865,7 @@ def test_affixes_post_same_version_same_form_position_still_409s(
     assert detail["conflicts"][0]["existing_gloss"] == "first"
     assert detail["conflicts"][0]["submitted_gloss"] == "second"
 
-    _cleanup_version_scoped(db_session, iso, test_version_id)
+    _cleanup_version_scoped(db_session, iso)
 
 
 def test_affixes_put_replace_is_version_scoped(
@@ -840,7 +879,7 @@ def test_affixes_put_replace_is_version_scoped(
     """PUT replace-all for version A must not delete rows owned by
     version B. Replaces the previous iso-wide delete (#798)."""
     iso = _resolve_iso(db_session, test_version_id)
-    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    _cleanup_version_scoped(db_session, iso)
     db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
     db_session.commit()
 
@@ -881,7 +920,7 @@ def test_affixes_put_replace_is_version_scoped(
     by_version = {r.target_version_id: r.form for r in rows}
     assert by_version == {test_version_id_2: "preserve-", test_version_id: "fresh-"}
 
-    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    _cleanup_version_scoped(db_session, iso)
 
 
 def test_affixes_patch_only_collides_within_same_version(
@@ -895,7 +934,7 @@ def test_affixes_patch_only_collides_within_same_version(
     """PATCHing an affix's (form, position) into one used by a *different*
     version must succeed — the duplicate check is version-scoped (#798)."""
     iso = _resolve_iso(db_session, test_version_id)
-    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    _cleanup_version_scoped(db_session, iso)
     db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
     db_session.commit()
 
@@ -936,8 +975,101 @@ def test_affixes_patch_only_collides_within_same_version(
     )
     assert resp.status_code == 200, resp.text
 
-    _cleanup_version_scoped(db_session, iso, test_version_id, test_version_id_2)
+    _cleanup_version_scoped(db_session, iso)
     _cleanup(db_session)
+
+
+def test_affixes_rebuild_does_not_409_against_other_versions_rows(
+    client,
+    regular_token1,
+    test_revision_id,
+    test_version_id,
+    test_version_id_2,
+    db_session,
+):
+    """Reproduces the production scenario from issue #798's ``acw`` log:
+    version B holds rows; version A is being rebuilt (DELETE then POST)
+    and re-extracts overlapping (form, position) entries. Under the old
+    iso-scoped unique, this 409'd against version B's rows and the
+    agent's patch-fallback silently mutated them. Under version-scoping
+    the POST must return 200 with no conflicts."""
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
+
+    revision_a = test_revision_id
+    revision_b = _revision_for_version(db_session, test_version_id_2)
+    headers = {"Authorization": f"Bearer {regular_token1}"}
+
+    # Seed version B with rows that share (form, position) with what A
+    # will produce, but with deliberately divergent glosses/examples so
+    # any cross-version mutation would be visible afterwards.
+    overlapping = [
+        {
+            "form": "ku-",
+            "position": "prefix",
+            "gloss": "b-gloss",
+            "examples": ["b-ex"],
+            "n_runs": 5,
+        },
+        {
+            "form": "-ile",
+            "position": "suffix",
+            "gloss": "b-gloss-2",
+            "examples": ["b-ex-2"],
+            "n_runs": 3,
+        },
+    ]
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={
+            "iso_639_3": iso,
+            "revision_id": revision_b,
+            "affixes": overlapping,
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+
+    # Simulate A's clean-slate rebuild: bulk DELETE then re-POST.
+    resp = client.delete(
+        f"/{prefix}/affixes-by-version/{test_version_id}", headers=headers
+    )
+    assert resp.status_code == 200, resp.text
+
+    a_rows = [
+        {"form": "ku-", "position": "prefix", "gloss": "a-gloss"},
+        {"form": "-ile", "position": "suffix", "gloss": "a-gloss-2"},
+    ]
+    resp = client.post(
+        f"/{prefix}/affixes",
+        json={"iso_639_3": iso, "revision_id": revision_a, "affixes": a_rows},
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["n_affixes_new"] == 2
+    assert body["n_affixes_updated"] == 0
+
+    # Version B's rows are untouched (glosses, examples, n_runs preserved).
+    b_rows = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.target_version_id == test_version_id_2)
+        .order_by(LanguageAffix.form)
+        .all()
+    )
+    db_session.expire_all()
+    b_rows = (
+        db_session.query(LanguageAffix)
+        .filter(LanguageAffix.target_version_id == test_version_id_2)
+        .order_by(LanguageAffix.form)
+        .all()
+    )
+    glosses = {r.form: r.gloss for r in b_rows}
+    assert glosses == {"-ile": "b-gloss-2", "ku-": "b-gloss"}
+
+    _cleanup_version_scoped(db_session, iso)
 
 
 def test_affixes_updated_at_refreshed_on_upsert(client, regular_token1, db_session):
@@ -1119,16 +1251,18 @@ def test_put_affixes_no_prior_rows(client, regular_token1, db_session):
 
 
 def test_put_affixes_scoped_by_revision(
-    client, regular_token1, test_revision_id, db_session
+    client, regular_token1, test_revision_id, test_version_id, db_session
 ):
-    _cleanup(db_session)
-    _seed_profile(db_session)
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     client.post(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "revision_id": test_revision_id,
             "affixes": [
                 {"form": "akha-", "position": "prefix", "gloss": "past"},
@@ -1139,7 +1273,7 @@ def test_put_affixes_scoped_by_revision(
     client.post(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "affixes": [
                 {"form": "-ile", "position": "suffix", "gloss": "perfect"},
             ],
@@ -1150,7 +1284,7 @@ def test_put_affixes_scoped_by_revision(
     resp = client.put(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "revision_id": test_revision_id,
             "affixes": [
                 {"form": "wa-", "position": "prefix", "gloss": "plural"},
@@ -1163,9 +1297,10 @@ def test_put_affixes_scoped_by_revision(
     assert body["n_deleted"] == 1
     assert body["n_inserted"] == 1
 
-    resp = client.get(f"/{prefix}/affixes?iso={TEST_ISO}", headers=headers)
+    resp = client.get(f"/{prefix}/affixes?iso={iso}", headers=headers)
     forms = {a["form"] for a in resp.json()["affixes"]}
     assert forms == {"-ile", "wa-"}
+    _cleanup_version_scoped(db_session, iso)
     _cleanup(db_session)
 
 
@@ -1245,20 +1380,22 @@ def test_put_affixes_duplicate_in_payload_rejected(client, regular_token1, db_se
 
 
 def test_put_affixes_scoped_to_revision_leaves_legacy_null_row_intact(
-    client, regular_token1, test_revision_id, db_session
+    client, regular_token1, test_revision_id, test_version_id, db_session
 ):
     """Under version-scoped writes (#798), a stamped PUT only deletes
     rows in its own bucket. A pre-existing legacy NULL-stamped row at
     the same (form, position) is left in place rather than being
     clobbered by the PUT's authoritative replace."""
-    _cleanup(db_session)
-    _seed_profile(db_session)
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     client.post(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "affixes": [
                 {"form": "akha-", "position": "prefix", "gloss": "past"},
             ],
@@ -1269,7 +1406,7 @@ def test_put_affixes_scoped_to_revision_leaves_legacy_null_row_intact(
     resp = client.put(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "revision_id": test_revision_id,
             "affixes": [
                 {
@@ -1286,7 +1423,7 @@ def test_put_affixes_scoped_to_revision_leaves_legacy_null_row_intact(
 
     rows = (
         db_session.query(LanguageAffix)
-        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
+        .filter(LanguageAffix.iso_639_3 == iso)
         .order_by(LanguageAffix.target_version_id.nulls_first())
         .all()
     )
@@ -1296,7 +1433,7 @@ def test_put_affixes_scoped_to_revision_leaves_legacy_null_row_intact(
     assert stamped_row.target_version_id is not None
     assert stamped_row.examples == ["akhatenda"]
     assert stamped_row.first_seen_revision_id == test_revision_id
-    _cleanup(db_session)
+    _cleanup_version_scoped(db_session, iso)
 
 
 # ── GET /affixes exposes id ─────────────────────────────────────────
@@ -1579,19 +1716,21 @@ def test_patch_affix_n_runs_null_ignored(client, regular_token1, db_session):
 
 
 def test_put_affixes_stamped_does_not_overwrite_legacy_null_gloss(
-    client, regular_token1, test_revision_id, db_session
+    client, regular_token1, test_revision_id, test_version_id, db_session
 ):
     """A stamped PUT must not overwrite the gloss of a legacy
     target_version_id IS NULL row at the same (form, position): the two
     rows live in separate write buckets under #798."""
-    _cleanup(db_session)
-    _seed_profile(db_session)
+    iso = _resolve_iso(db_session, test_version_id)
+    _cleanup_version_scoped(db_session, iso)
+    db_session.add(LanguageProfile(iso_639_3=iso, name="English"))
+    db_session.commit()
     headers = {"Authorization": f"Bearer {regular_token1}"}
 
     client.post(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "affixes": [
                 {"form": "akha-", "position": "prefix", "gloss": "past"},
             ],
@@ -1602,7 +1741,7 @@ def test_put_affixes_stamped_does_not_overwrite_legacy_null_gloss(
     resp = client.put(
         f"/{prefix}/affixes",
         json={
-            "iso_639_3": TEST_ISO,
+            "iso_639_3": iso,
             "revision_id": test_revision_id,
             "affixes": [
                 {"form": "akha-", "position": "prefix", "gloss": "perfective"},
@@ -1612,16 +1751,12 @@ def test_put_affixes_stamped_does_not_overwrite_legacy_null_gloss(
     )
     assert resp.status_code == 200
 
-    rows = (
-        db_session.query(LanguageAffix)
-        .filter(LanguageAffix.iso_639_3 == TEST_ISO)
-        .all()
-    )
+    rows = db_session.query(LanguageAffix).filter(LanguageAffix.iso_639_3 == iso).all()
     glosses_by_target = {r.target_version_id: r.gloss for r in rows}
     assert glosses_by_target[None] == "past"
     stamped_gloss = next(v for k, v in glosses_by_target.items() if k is not None)
     assert stamped_gloss == "perfective"
-    _cleanup(db_session)
+    _cleanup_version_scoped(db_session, iso)
 
 
 def test_patch_affix_null_form_position_gloss_ignored(


### PR DESCRIPTION
## Summary

`POST` / `PUT` / `PATCH /v3/affixes` were detecting conflicts at the `(iso, form, position)` level, so a write for one version 409'd against — and the agent's patch-fallback silently overwrote — affixes owned by *other* versions of the same ISO. Reads (#693) and bulk DELETE (#797) were already version-scoped; this completes the version-keying migration (#687) for the write path.

- Migration `d4f7b1e9c3a2`: replaces `ux_language_affixes_iso_form_position` with two partial uniques — `(target_version_id, form, position) WHERE target_version_id IS NOT NULL` for stamped rows and `(iso_639_3, form, position) WHERE target_version_id IS NULL` for the legacy bucket. Also drops the now-redundant `ux_language_affixes_version_form_position_gloss`.
- POST `commit_affixes` scopes the conflict lookup and `ON CONFLICT` target to the payload's `target_version_id` (or the NULL legacy bucket).
- PUT `replace_affixes` replaces its iso-wide delete with a per-bucket delete so PUT for version A no longer wipes version B's rows. The redundant `first_seen_revision_id` filter is removed.
- PATCH `/affixes/{id}` duplicate detection is scoped to the row's own bucket.

Fixes #798.

## Test plan
- [x] `pytest test/test_agent_routes/test_affix_routes.py` — 55/55 pass, including new tests for cross-version isolation on POST/PUT/PATCH.
- [x] `pytest test/test_agent_routes/` — 446/446 pass; training-artifacts and tokenizer routes regression-clean.
- [x] Migration applies cleanly against the existing schema; `\d language_affixes` shows the two new partial unique indexes.
- [x] `pre-commit run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)