### PR TITLE
Accept missing per-part Content-Type as octet-stream on /v3/revision

### DIFF
--- a/bible_routes/v3/revision_routes.py
+++ b/bible_routes/v3/revision_routes.py
@@ -213,7 +213,10 @@ async def upload_revision(
     # DoS where an authenticated user uploads a huge body to exhaust workers.
     # Strip any media-type parameters (e.g. "text/plain; charset=utf-8") so
     # well-formed clients that include a charset aren't falsely rejected.
-    raw_content_type = file.content_type or ""
+    # Treat a missing/empty per-part Content-Type as application/octet-stream:
+    # generic HTTP clients (e.g. requests' 2-tuple file form) omit it entirely,
+    # and #767's intent was for those uploads to succeed.
+    raw_content_type = file.content_type or "application/octet-stream"
     media_type = raw_content_type.split(";", 1)[0].strip().lower()
     if media_type not in ALLOWED_CONTENT_TYPES:
         raise HTTPException(

--- a/bible_routes/v3/revision_routes.py
+++ b/bible_routes/v3/revision_routes.py
@@ -29,9 +29,11 @@ MAX_UPLOAD_BYTES = 50 * 1024 * 1024
 # Read in 1MB chunks when streaming to enforce the cap without loading the
 # whole file at once.
 UPLOAD_READ_CHUNK_BYTES = 1024 * 1024
-# Most HTTP clients send plain text as "text/plain"; curl / generic clients
-# fall back to "application/octet-stream". Anything else (images, archives,
-# HTML, etc.) is rejected with 415.
+# Most HTTP clients send plain text as "text/plain"; curl sends
+# "application/octet-stream" explicitly, and some clients (e.g. requests'
+# 2-tuple file form / urllib3) emit no per-part Content-Type at all — that
+# missing case is defaulted to "application/octet-stream" below. Anything
+# else (images, archives, HTML, etc.) is rejected with 415.
 ALLOWED_CONTENT_TYPES = {"text/plain", "application/octet-stream"}
 
 

--- a/test/test_bible_routes/test_revision_routes.py
+++ b/test/test_bible_routes/test_revision_routes.py
@@ -581,10 +581,14 @@ def test_upload_revision_accepts_missing_content_type(
 
     boundary = "----testboundary801"
     body = (
-        f"--{boundary}\r\n"
-        'Content-Disposition: form-data; name="file"; filename="uploadtest.txt"\r\n'
-        "\r\n"
-    ).encode() + file_bytes + f"\r\n--{boundary}--\r\n".encode()
+        (
+            f"--{boundary}\r\n"
+            'Content-Disposition: form-data; name="file"; filename="uploadtest.txt"\r\n'
+            "\r\n"
+        ).encode()
+        + file_bytes
+        + f"\r\n--{boundary}--\r\n".encode()
+    )
 
     headers = {
         "Authorization": f"Bearer {regular_token1}",

--- a/test/test_bible_routes/test_revision_routes.py
+++ b/test/test_bible_routes/test_revision_routes.py
@@ -565,6 +565,41 @@ def test_upload_revision_accepts_octet_stream(client, regular_token1, db_session
     assert delete_revision(client, regular_token1, revision_id) == 200
 
 
+def test_upload_revision_accepts_missing_content_type(
+    client, regular_token1, db_session
+):
+    """A multipart part with no Content-Type header must be accepted:
+    `requests` (used by aqua-django-app's upload proxy) and other generic
+    HTTP clients omit the per-part Content-Type when files are passed as a
+    `(filename, fileobj)` 2-tuple. The body is hand-crafted here so the
+    "no per-part Content-Type" case is exercised deterministically rather
+    than depending on `httpx`'s mime-guessing behavior."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+
+    test_upload_file = Path("fixtures/uploadtest.txt")
+    file_bytes = test_upload_file.read_bytes()
+
+    boundary = "----testboundary801"
+    body = (
+        f"--{boundary}\r\n"
+        'Content-Disposition: form-data; name="file"; filename="uploadtest.txt"\r\n'
+        "\r\n"
+    ).encode() + file_bytes + f"\r\n--{boundary}--\r\n".encode()
+
+    headers = {
+        "Authorization": f"Bearer {regular_token1}",
+        "Content-Type": f"multipart/form-data; boundary={boundary}",
+    }
+    test_revision = {"version_id": version_id, "name": "No Content-Type Revision"}
+    response = client.post(
+        f"{prefix}/revision", params=test_revision, content=body, headers=headers
+    )
+
+    assert response.status_code == 200, response.text
+    revision_id = response.json()["id"]
+    assert delete_revision(client, regular_token1, revision_id) == 200
+
+
 @pytest.mark.asyncio
 async def test_read_upload_with_limit_streams_oversize_when_size_unknown():
     """When the client doesn't advertise a size (file.size is None), the


### PR DESCRIPTION
## Summary

- Default a missing/empty per-part `Content-Type` to `application/octet-stream` *before* the allowlist check on `POST /v3/revision`, so generic HTTP clients (e.g. `requests` 2-tuple file uploads, which `urllib3` emits with no per-part Content-Type) stop 415'ing.
- Add a regression test that hand-crafts a multipart body with no `Content-Type` header on the file part and asserts a 200.
- Behavior for known-bad content-types (e.g. `image/png`) is unchanged — still 415. The 50 MB chunked-streaming cap from #767 / #726 is unchanged.

## Why

The allowlist added in #767 over-rejected: `file.content_type or ""` made an empty per-part Content-Type fall through to the allowlist check as `""`, which is not in `{text/plain, application/octet-stream}` → 415. That contradicts #767's stated intent ("generic-client uploads still succeed") and broke all revision uploads on staging via aqua-django-app's upload proxy (sil-ai/aqua-django-app#391).

The actual DoS mitigation from #726 is the 50 MB cap with chunked streaming read, which is independent of the allowlist. The allowlist remains as defense-in-depth and still rejects clearly-wrong types.

Fixes #801. Refs #726, #767.

## Test plan

- [x] `test_upload_revision_accepts_missing_content_type` — multipart part with no `Content-Type` returns 200 (currently 415).
- [x] All 17 tests in `test_revision_routes.py` pass, including the existing `test_upload_revision_rejects_disallowed_content_type` (image/png still 415) and `test_upload_revision_rejects_oversized_file` (50 MB cap still enforced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)