### PR TITLE
Make new check-linting command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,15 @@ push-release:
 
 linting:
 	@echo "Running linting"
+	@black . --exclude '/(venv|\.venv|alembic)/'
+	@echo "Black passed"
+	@isort . --skip venv --skip .venv --skip ./alembic --profile black
+	@echo "Isort passed"
+	@flake8 . --exclude='venv,.venv,./alembic,**/v1/**,**/v2/**' --ignore=E501,W503,E203,E228,E226
+	@echo "Linting passed"
+
+check-linting:
+	@echo "Running linting"
 	@black --check . --exclude '/(venv|\.venv|alembic)/'
 	@echo "Black passed"
 	@isort --check . --skip venv --skip .venv --skip ./alembic --profile black


### PR DESCRIPTION
Currently, this repo (`aqua-api`) runs check-only for `make linting`, while `aero-api` reformats in-place. This PR separates linting into an automatic linting reformatting command and a check-only linting command. The same is done in `aero-api`.