### PR TITLE
Add POST /v3/tfidf_result/by_text + by_texts (encode text → TF-IDF neighbors)

### DIFF
--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -105,7 +105,9 @@ async def _rank_against_corpus(
 ) -> List:
     """Return top-`limit` (id, vref, similarity) rows for a single query vector.
 
-    SVD output is L2-normalized, so inner product equals cosine similarity.
+    Ranks by inner product against the stored corpus vectors — the same score
+    `by_vector`/`by_vectors` use (corpus vectors are the raw SVD output, so the
+    query must be too; `_encode_texts` honours that).
 
     Exclusion (leakage guard) is pushed into the WHERE clause so `limit` rows
     survive after dropping — same approach as the vref-keyed GET endpoint.
@@ -122,8 +124,11 @@ async def _rank_against_corpus(
     conditions = [TfidfPcaVector.assessment_id == assessment_id]
     if exclude_vref:
         if exclude_book:
+            # Exact book match (token before the first space) rather than a
+            # LIKE pattern, so a `_`/`%` in caller-supplied exclude_vref can't
+            # act as a SQL wildcard.
             book = exclude_vref.split(" ", 1)[0]
-            conditions.append(~TfidfPcaVector.vref.like(f"{book} %"))
+            conditions.append(func.split_part(TfidfPcaVector.vref, " ", 1) != book)
         else:
             conditions.append(TfidfPcaVector.vref != exclude_vref)
 

--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -46,6 +46,8 @@ from models import (
     TfidfArtifactsPullResponse,
     TfidfArtifactsPushRequest,
     TfidfArtifactsPushResponse,
+    TfidfByTextRequest,
+    TfidfByTextsRequest,
     TfidfByVectorRequest,
     TfidfByVectorsRequest,
     TfidfByVectorsResponse,
@@ -98,10 +100,17 @@ async def _rank_against_corpus(
     assessment_id: int,
     query_vector: List[float],
     limit: int,
+    exclude_vref: str | None = None,
+    exclude_book: bool = False,
 ) -> List:
     """Return top-`limit` (id, vref, similarity) rows for a single query vector.
 
     SVD output is L2-normalized, so inner product equals cosine similarity.
+
+    Exclusion (leakage guard) is pushed into the WHERE clause so `limit` rows
+    survive after dropping — same approach as the vref-keyed GET endpoint.
+    When `exclude_book` is set, all verses in `exclude_vref`'s book are dropped
+    (book = the token before the first space); otherwise only the exact verse.
     """
     similarity_expr = cast(
         text(
@@ -110,9 +119,17 @@ async def _rank_against_corpus(
         Float,
     ).label("cosine_similarity")
 
+    conditions = [TfidfPcaVector.assessment_id == assessment_id]
+    if exclude_vref:
+        if exclude_book:
+            book = exclude_vref.split(" ", 1)[0]
+            conditions.append(~TfidfPcaVector.vref.like(f"{book} %"))
+        else:
+            conditions.append(TfidfPcaVector.vref != exclude_vref)
+
     query = (
         select(TfidfPcaVector.id, TfidfPcaVector.vref, similarity_expr)
-        .where(TfidfPcaVector.assessment_id == assessment_id)
+        .where(*conditions)
         .order_by(similarity_expr.desc())
         .limit(limit)
     )
@@ -142,9 +159,13 @@ async def _score_against_corpus(
     query_vector: List[float],
     limit: int,
     reference_id: int | None,
+    exclude_vref: str | None = None,
+    exclude_book: bool = False,
 ) -> List[TfidfResult]:
     """Rank corpus verses by similarity, then hydrate with revision/reference text."""
-    rows = await _rank_against_corpus(db, assessment.id, query_vector, limit)
+    rows = await _rank_against_corpus(
+        db, assessment.id, query_vector, limit, exclude_vref, exclude_book
+    )
     vrefs = [row.vref for row in rows]
 
     revision_texts = await _fetch_verse_texts(db, assessment.revision_id, vrefs)
@@ -1105,6 +1126,116 @@ async def pull_tfidf_artifacts(
 
 
 # ---------------------------------------------------------------------------
+# Server-side text encoding (TF-IDF → SVD-300), for the by_text endpoints.
+# Ports the encode chain from aqua-assessments' tfidf service so callers can
+# pass raw text instead of a pre-computed vector.
+# ---------------------------------------------------------------------------
+
+# Rehydrating the SVD components matrix + building the two vectorizers is the
+# only real per-request cost (~100-200ms). Cache the rebuilt encoder per
+# assessment, keyed alongside the artifact run's created_at so a re-push
+# (which bumps created_at) transparently invalidates the stale entry. No lock:
+# concurrent writers store identical objects, and nothing iterates the dict.
+_ENCODER_CACHE: Dict[int, tuple] = {}
+
+
+def _rehydrate_encoder(word, char, svd) -> tuple:
+    """Rebuild (word_vec, char_vec, svd) from stored artifact values.
+
+    `word`/`char` are (vocabulary, idf, params) tuples; `svd` is
+    (components_npy_bytes, n_components). Pure CPU work — call via
+    asyncio.to_thread. sklearn is imported lazily so workers that never hit
+    this path don't pay the import cost at startup.
+    """
+    from sklearn.decomposition import TruncatedSVD
+    from sklearn.feature_extraction.text import TfidfVectorizer
+
+    def _vectorizer(vocabulary, idf, params):
+        vec = TfidfVectorizer(
+            analyzer=params["analyzer"],
+            ngram_range=tuple(params["ngram_range"]),
+            lowercase=params["lowercase"],
+            max_df=params["max_df"],
+            min_df=params["min_df"],
+            vocabulary=vocabulary,
+        )
+        # The idf_ setter builds the internal TfidfTransformer/_idf_diag that
+        # transform() needs (vocabulary alone isn't enough).
+        vec.idf_ = np.asarray(idf, dtype=float)
+        return vec
+
+    word_vec = _vectorizer(*word)
+    char_vec = _vectorizer(*char)
+
+    components_npy, n_components = svd
+    components = np.load(io.BytesIO(components_npy), allow_pickle=False)
+    truncated = TruncatedSVD(n_components=n_components)
+    truncated.components_ = components
+    return word_vec, char_vec, truncated
+
+
+def _encode_texts(encoder: tuple, texts: List[str]) -> List[List[float]]:
+    """Encode raw texts into the 300-dim SVD space the corpus vectors live in.
+
+    Mirrors aqua-assessments' `_encode_and_query`: word + char TF-IDF, L2-norm
+    of the horizontally-stacked sparse matrix, then SVD projection.
+    """
+    from scipy.sparse import hstack
+    from sklearn.preprocessing import normalize
+
+    word_vec, char_vec, svd = encoder
+    Xw = word_vec.transform(texts)
+    Xc = char_vec.transform(texts)
+    X = normalize(hstack([Xw, Xc]), norm="l2", axis=1)
+    return svd.transform(X).astype(float).tolist()
+
+
+async def _get_encoder(db: AsyncSession, assessment_id: int) -> tuple:
+    """Load (and cache) the rehydrated encoder for an assessment.
+
+    404s if the assessment has no TF-IDF artifacts (run/vectorizers/svd).
+    """
+    run = await db.scalar(
+        select(TfidfArtifactRun).where(TfidfArtifactRun.assessment_id == assessment_id)
+    )
+    if run is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No TF-IDF artifacts found for assessment {assessment_id}",
+        )
+
+    cached = _ENCODER_CACHE.get(assessment_id)
+    if cached is not None and cached[0] == run.created_at:
+        return cached[1]
+
+    vectorizer_rows = (
+        await db.scalars(
+            select(TfidfVectorizerArtifact).where(
+                TfidfVectorizerArtifact.assessment_id == assessment_id
+            )
+        )
+    ).all()
+    by_kind = {v.kind: v for v in vectorizer_rows}
+    svd = await db.scalar(
+        select(TfidfSvd).where(TfidfSvd.assessment_id == assessment_id)
+    )
+    if "word" not in by_kind or "char" not in by_kind or svd is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Incomplete TF-IDF artifacts for assessment {assessment_id}",
+        )
+
+    encoder = await asyncio.to_thread(
+        _rehydrate_encoder,
+        (by_kind["word"].vocabulary, by_kind["word"].idf, by_kind["word"].params),
+        (by_kind["char"].vocabulary, by_kind["char"].idf, by_kind["char"].params),
+        (svd.components_npy, svd.n_components),
+    )
+    _ENCODER_CACHE[assessment_id] = (run.created_at, encoder)
+    return encoder
+
+
+# ---------------------------------------------------------------------------
 # POST — similarity by arbitrary vector
 # ---------------------------------------------------------------------------
 
@@ -1272,6 +1403,149 @@ async def get_tfidf_result_by_vectors(
             "limit": body.limit,
             "reference_id": body.reference_id,
             "batch_size": len(body.vectors),
+            "duration_s": duration,
+        },
+    )
+
+    return TfidfByVectorsResponse(results=results)
+
+
+# ---------------------------------------------------------------------------
+# POST — similarity by raw text (server-side encode)
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/tfidf_result/by_text",
+    response_model=Dict[str, Union[List[TfidfResult], int]],
+)
+async def get_tfidf_result_by_text(
+    body: TfidfByTextRequest,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Nearest-neighbour corpus verses to an arbitrary piece of text.
+
+    Encodes `text` into the assessment's 300-dim TF-IDF/SVD space server-side
+    (the step callers previously did out-of-band), then ranks it against the
+    corpus exactly like /tfidf_result/by_vector. `exclude_vref`/`exclude_book`
+    drop the query verse (or its whole book) from the neighbours.
+    """
+    request_start = time.perf_counter()
+
+    assessment = await _resolve_assessment_for_by_vector(
+        body.assessment_id, current_user, db
+    )
+    encoder = await _get_encoder(db, body.assessment_id)
+    vector = (await asyncio.to_thread(_encode_texts, encoder, [body.text]))[0]
+
+    results = await _score_against_corpus(
+        db,
+        assessment,
+        vector,
+        body.limit,
+        body.reference_id,
+        body.exclude_vref,
+        body.exclude_book,
+    )
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"get_tfidf_result_by_text completed in {duration}s",
+        extra={
+            "method": "POST",
+            "path": "/tfidf_result/by_text",
+            "assessment_id": body.assessment_id,
+            "limit": body.limit,
+            "reference_id": body.reference_id,
+            "results_returned": len(results),
+            "duration_s": duration,
+        },
+    )
+
+    return {"results": results, "total_count": len(results)}
+
+
+@router.post(
+    "/tfidf_result/by_texts",
+    response_model=TfidfByVectorsResponse,
+)
+async def get_tfidf_result_by_texts(
+    body: TfidfByTextsRequest,
+    current_user: UserModel = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Batch companion to /tfidf_result/by_text — one neighbour set per text.
+
+    `exclude_vrefs[i]` (if provided) applies to `texts[i]`; `exclude_book`
+    applies to all of them.
+    """
+    request_start = time.perf_counter()
+
+    assessment = await _resolve_assessment_for_by_vector(
+        body.assessment_id, current_user, db
+    )
+
+    total_results = len(body.texts) * body.limit
+    if total_results > TFIDF_MAX_BATCH_RESULTS:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"len(texts) * limit must not exceed {TFIDF_MAX_BATCH_RESULTS}; "
+                f"got {len(body.texts)} * {body.limit} = {total_results}"
+            ),
+        )
+
+    encoder = await _get_encoder(db, body.assessment_id)
+    vectors = await asyncio.to_thread(_encode_texts, encoder, body.texts)
+
+    # Rank each vector sequentially (AsyncSession can't run concurrent
+    # statements), then hydrate text once across the union of vrefs — keeping
+    # the query count at N+2 rather than 3N. Mirrors /tfidf_result/by_vectors.
+    ranked: List[List] = []
+    all_vrefs: set = set()
+    for i, vec in enumerate(vectors):
+        exclude_vref = body.exclude_vrefs[i] if body.exclude_vrefs else None
+        rows = await _rank_against_corpus(
+            db,
+            body.assessment_id,
+            vec,
+            body.limit,
+            exclude_vref,
+            body.exclude_book,
+        )
+        ranked.append(rows)
+        all_vrefs.update(r.vref for r in rows)
+
+    vrefs_list = list(all_vrefs)
+    revision_texts = await _fetch_verse_texts(db, assessment.revision_id, vrefs_list)
+    reference_texts = await _fetch_verse_texts(db, body.reference_id, vrefs_list)
+
+    results = [
+        [
+            TfidfResult(
+                id=row.id,
+                vref=row.vref,
+                similarity=float(row.cosine_similarity),
+                assessment_id=assessment.id,
+                revision_text=revision_texts.get(row.vref),
+                reference_text=reference_texts.get(row.vref),
+            )
+            for row in rows
+        ]
+        for rows in ranked
+    ]
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"get_tfidf_result_by_texts completed in {duration}s",
+        extra={
+            "method": "POST",
+            "path": "/tfidf_result/by_texts",
+            "assessment_id": body.assessment_id,
+            "limit": body.limit,
+            "reference_id": body.reference_id,
+            "batch_size": len(body.texts),
             "duration_s": duration,
         },
     )

--- a/assessment_routes/v3/tfidf_artifact_routes.py
+++ b/assessment_routes/v3/tfidf_artifact_routes.py
@@ -1143,6 +1143,12 @@ async def pull_tfidf_artifacts(
 # concurrent writers store identical objects, and nothing iterates the dict.
 _ENCODER_CACHE: Dict[int, tuple] = {}
 
+# Cap on cached encoders per worker. Each entry holds two vectorizers plus a
+# 300×n_features components matrix, so an unbounded cache could accumulate one
+# (potentially large) encoder per assessment ever queried. FIFO-evict the
+# oldest once full — encoders are cheap to rebuild on the next request.
+_ENCODER_CACHE_MAXSIZE = 32
+
 
 def _rehydrate_encoder(word, char, svd) -> tuple:
     """Rebuild (word_vec, char_vec, svd) from stored artifact values.
@@ -1236,6 +1242,12 @@ async def _get_encoder(db: AsyncSession, assessment_id: int) -> tuple:
         (by_kind["char"].vocabulary, by_kind["char"].idf, by_kind["char"].params),
         (svd.components_npy, svd.n_components),
     )
+    if (
+        assessment_id not in _ENCODER_CACHE
+        and len(_ENCODER_CACHE) >= _ENCODER_CACHE_MAXSIZE
+    ):
+        # Evict the oldest entry (dicts preserve insertion order).
+        _ENCODER_CACHE.pop(next(iter(_ENCODER_CACHE)), None)
     _ENCODER_CACHE[assessment_id] = (run.created_at, encoder)
     return encoder
 

--- a/models.py
+++ b/models.py
@@ -1673,6 +1673,38 @@ class TfidfByVectorsResponse(BaseModel):
     results: List[List[TfidfResult]]
 
 
+class TfidfByTextRequest(BaseModel):
+    assessment_id: int
+    text: str
+    limit: int = Field(default=10, ge=1, le=500)
+    reference_id: Optional[int] = Field(default=None, ge=1)
+    # Drop the result whose vref matches exclude_vref (leakage guard). When
+    # exclude_book is True, drop all results in exclude_vref's book instead.
+    exclude_vref: Optional[str] = None
+    exclude_book: bool = False
+
+
+class TfidfByTextsRequest(BaseModel):
+    assessment_id: int
+    texts: List[str] = Field(..., min_length=1, max_length=TFIDF_MAX_BATCH_VECTORS)
+    limit: int = Field(default=10, ge=1, le=500)
+    reference_id: Optional[int] = Field(default=None, ge=1)
+    # Per-text exclusion: exclude_vrefs[i] applies to texts[i]. Either omit it
+    # or pass a same-length list as texts.
+    exclude_vrefs: Optional[List[str]] = None
+    exclude_book: bool = False
+
+    @model_validator(mode="after")
+    def _exclude_vrefs_length(self) -> "TfidfByTextsRequest":
+        if self.exclude_vrefs is not None and len(self.exclude_vrefs) != len(
+            self.texts
+        ):
+            raise ValueError(
+                "exclude_vrefs must be the same length as texts when provided"
+            )
+        return self
+
+
 # --- Assessment Results Push/Delete models ---
 
 

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@ import math
 import re
 import unicodedata
 from enum import Enum
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import (
     BaseModel,
@@ -1673,9 +1673,15 @@ class TfidfByVectorsResponse(BaseModel):
     results: List[List[TfidfResult]]
 
 
+# Upper bound on a single text to encode. A verse is well under this; the cap
+# just stops a pathological multi-MB string from driving a huge transform on a
+# worker thread.
+TFIDF_MAX_TEXT_CHARS = 10_000
+
+
 class TfidfByTextRequest(BaseModel):
     assessment_id: int
-    text: str
+    text: str = Field(..., min_length=1, max_length=TFIDF_MAX_TEXT_CHARS)
     limit: int = Field(default=10, ge=1, le=500)
     reference_id: Optional[int] = Field(default=None, ge=1)
     # Drop the result whose vref matches exclude_vref (leakage guard). When
@@ -1683,10 +1689,18 @@ class TfidfByTextRequest(BaseModel):
     exclude_vref: Optional[str] = None
     exclude_book: bool = False
 
+    @model_validator(mode="after")
+    def _exclude_book_needs_vref(self) -> "TfidfByTextRequest":
+        if self.exclude_book and not self.exclude_vref:
+            raise ValueError("exclude_book=True requires exclude_vref")
+        return self
+
 
 class TfidfByTextsRequest(BaseModel):
     assessment_id: int
-    texts: List[str] = Field(..., min_length=1, max_length=TFIDF_MAX_BATCH_VECTORS)
+    texts: List[
+        Annotated[str, Field(min_length=1, max_length=TFIDF_MAX_TEXT_CHARS)]
+    ] = Field(..., min_length=1, max_length=TFIDF_MAX_BATCH_VECTORS)
     limit: int = Field(default=10, ge=1, le=500)
     reference_id: Optional[int] = Field(default=None, ge=1)
     # Per-text exclusion: exclude_vrefs[i] applies to texts[i]. Either omit it
@@ -1695,13 +1709,15 @@ class TfidfByTextsRequest(BaseModel):
     exclude_book: bool = False
 
     @model_validator(mode="after")
-    def _exclude_vrefs_length(self) -> "TfidfByTextsRequest":
+    def _validate_exclusions(self) -> "TfidfByTextsRequest":
         if self.exclude_vrefs is not None and len(self.exclude_vrefs) != len(
             self.texts
         ):
             raise ValueError(
                 "exclude_vrefs must be the same length as texts when provided"
             )
+        if self.exclude_book and not self.exclude_vrefs:
+            raise ValueError("exclude_book=True requires exclude_vrefs")
         return self
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -90,6 +90,8 @@ requests==2.31.0
 requests-toolbelt==0.9.1
 rsa==4.9
 s3transfer==0.5.2
+scikit-learn==1.6.1
+scipy==1.13.1
 six==1.16.0
 sniffio==1.3.0
 SQLAlchemy==1.4.36

--- a/test/test_assessment_routes/test_tfidf_by_text.py
+++ b/test/test_assessment_routes/test_tfidf_by_text.py
@@ -220,7 +220,7 @@ def test_by_text_self_match_round_trip(
     assert data["total_count"] == 10
     top = data["results"][0]
     assert top["vref"] == vref
-    assert top["similarity"] == pytest.approx(1.0, abs=1e-3)
+    assert top["similarity"] == pytest.approx(1.0, abs=1e-4)
     # revision_text hydrated from the corpus revision.
     assert top["revision_text"] == f"src {vref}"
     sims = [r["similarity"] for r in data["results"]]
@@ -375,7 +375,7 @@ def test_by_texts_one_list_per_text(client, regular_token1, encoded_tfidf_assess
     results = resp.json()["results"]
     assert len(results) == len(texts)
     assert [rs[0]["vref"] for rs in results] == expected
-    assert all(rs[0]["similarity"] == pytest.approx(1.0, abs=1e-3) for rs in results)
+    assert all(rs[0]["similarity"] == pytest.approx(1.0, abs=1e-4) for rs in results)
 
 
 def test_by_texts_per_text_exclude_vrefs(
@@ -464,3 +464,96 @@ def test_by_texts_unauthorized(client, regular_token2, encoded_tfidf_assessment)
         headers={"Authorization": f"Bearer {regular_token2}"},
     )
     assert resp.status_code == 403
+
+
+def test_by_texts_no_auth(client, encoded_tfidf_assessment):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "texts": ["alpha beta"],
+            "limit": 3,
+        },
+    )
+    assert resp.status_code == 401
+
+
+def test_by_texts_exclude_book_drops_whole_book(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    """exclude_book on the batch path filters per-text using exclude_vrefs[i]."""
+    assessment_id = encoded_tfidf_assessment["assessment_id"]
+    # idx 250 → EXO, idx 3 → GEN.
+    idxs = [250, 3]
+    texts = [encoded_tfidf_assessment["corpus"][i] for i in idxs]
+    vrefs = [encoded_tfidf_assessment["vrefs"][i] for i in idxs]
+    assert vrefs[0].startswith("EXO ") and vrefs[1].startswith("GEN ")
+
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={
+            "assessment_id": assessment_id,
+            "texts": texts,
+            "limit": 20,
+            "exclude_vrefs": vrefs,
+            "exclude_book": True,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    results = resp.json()["results"]
+    # texts[0] excludes EXO; texts[1] excludes GEN.
+    assert all(not r["vref"].startswith("EXO ") for r in results[0])
+    assert all(not r["vref"].startswith("GEN ") for r in results[1])
+
+
+# ---------------------------------------------------------------------------
+# Request-model validation
+# ---------------------------------------------------------------------------
+
+
+def test_by_text_empty_text_rejected(client, regular_token1, encoded_tfidf_assessment):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "text": "",
+            "limit": 3,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
+
+
+def test_by_text_exclude_book_without_vref_rejected(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "text": "alpha beta",
+            "limit": 3,
+            "exclude_book": True,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
+    assert "exclude_book" in str(resp.json()["detail"])
+
+
+def test_by_texts_exclude_book_without_vrefs_rejected(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "texts": ["alpha beta"],
+            "limit": 3,
+            "exclude_book": True,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
+    assert "exclude_book" in str(resp.json()["detail"])

--- a/test/test_assessment_routes/test_tfidf_by_text.py
+++ b/test/test_assessment_routes/test_tfidf_by_text.py
@@ -1,0 +1,466 @@
+"""Tests for POST /v3/tfidf_result/by_text and /v3/tfidf_result/by_texts.
+
+These exercise the server-side encode path: a real TfidfVectorizer (word +
+char) + TruncatedSVD is fitted on a synthetic corpus, the corpus vectors are
+seeded into tfidf_pca_vector, and the fitted encoder is stored via the
+artifact push endpoint. The endpoints then re-encode raw text and must
+reproduce the stored vectors (self-match ≈ 1.0) and honour the exclusion
+semantics.
+"""
+
+import base64
+import io
+
+import numpy as np
+import pytest
+from scipy.sparse import hstack
+from sklearn.decomposition import TruncatedSVD
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.preprocessing import normalize
+
+from database.models import Assessment, TfidfPcaVector, VerseReference, VerseText
+
+prefix = "v3"
+
+# n_samples == n_components so the corpus spans an at-most-300-dim subspace and
+# 300 SVD components capture all of it — each stored vector keeps unit norm, so
+# a self-match's inner product is ≈ 1.0 (criterion 2). 200 from GEN, 100 from
+# EXO (real vrefs, since tfidf_pca_vector.vref is FK'd to verse_reference) so
+# exclude_book has something to remove.
+_N_GEN = 200
+_N_EXO = 100
+_N_DOCS = _N_GEN + _N_EXO
+_VOCAB = [
+    "alpha",
+    "beta",
+    "gamma",
+    "delta",
+    "epsilon",
+    "zeta",
+    "eta",
+    "theta",
+    "iota",
+    "kappa",
+    "lambda",
+    "mu",
+    "nu",
+    "xi",
+    "omicron",
+    "pi",
+    "rho",
+    "sigma",
+    "tau",
+    "upsilon",
+    "phi",
+    "chi",
+    "psi",
+    "omega",
+]
+
+
+def _real_vrefs(db) -> list:
+    """Fetch real GEN/EXO vrefs (tfidf_pca_vector.vref is FK'd to
+    verse_reference). The first _N_EXO results below index 200 are EXO."""
+    gen = [
+        r[0]
+        for r in db.query(VerseReference.full_verse_id)
+        .filter(VerseReference.full_verse_id.like("GEN %"))
+        .limit(_N_GEN)
+        .all()
+    ]
+    exo = [
+        r[0]
+        for r in db.query(VerseReference.full_verse_id)
+        .filter(VerseReference.full_verse_id.like("EXO %"))
+        .limit(_N_EXO)
+        .all()
+    ]
+    return gen + exo
+
+
+def _vectorizer_payload(vec: TfidfVectorizer, analyzer: str, ngram_range) -> dict:
+    return {
+        "vocabulary": {k: int(v) for k, v in vec.vocabulary_.items()},
+        "idf": vec.idf_.tolist(),
+        "params": {
+            "analyzer": analyzer,
+            "ngram_range": list(ngram_range),
+            "lowercase": True,
+            "max_df": 1.0,
+            "min_df": 1,
+        },
+    }
+
+
+def _components_b64(svd: TruncatedSVD) -> str:
+    buf = io.BytesIO()
+    np.save(buf, svd.components_.astype(np.float32), allow_pickle=False)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+@pytest.fixture(scope="module")
+def encoded_tfidf_assessment(
+    client,
+    regular_token1,
+    test_db_session,
+    test_revision_id,
+    test_revision_id_2,
+):
+    """Fit a real encoder, seed the corpus, push the artifacts. Returns a dict
+    with assessment_id, the ordered corpus texts, and their vrefs."""
+    rng = np.random.default_rng(0)
+
+    corpus = []
+    for _ in range(_N_DOCS):
+        n = int(rng.integers(5, 12))
+        corpus.append(" ".join(rng.choice(_VOCAB, size=n)))
+    vrefs = _real_vrefs(test_db_session)
+
+    word = TfidfVectorizer(
+        analyzer="word", ngram_range=(1, 2), lowercase=True, max_df=1.0, min_df=1
+    )
+    char = TfidfVectorizer(
+        analyzer="char_wb", ngram_range=(3, 6), lowercase=True, max_df=1.0, min_df=1
+    )
+    Xw = word.fit_transform(corpus)
+    Xc = char.fit_transform(corpus)
+    X = normalize(hstack([Xw, Xc]), norm="l2", axis=1)
+    n_features = Xw.shape[1] + Xc.shape[1]
+
+    svd = TruncatedSVD(n_components=300)
+    Xr = svd.fit_transform(X)
+
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="tfidf",
+        status="running",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+    assessment_id = assessment.id
+
+    # Seed the corpus vectors exactly as aqua-assessments would (raw SVD
+    # output, no post-normalization).
+    for vref, vec in zip(vrefs, Xr):
+        test_db_session.add(
+            TfidfPcaVector(assessment_id=assessment_id, vref=vref, vector=vec.tolist())
+        )
+    test_db_session.commit()
+
+    # Seed revision/reference text only for the vrefs the tests assert on,
+    # guarding against rows other fixtures may already have for these
+    # revisions (verse_reference is unique per revision).
+    def _seed_text(revision_id, vref, text):
+        existing = (
+            test_db_session.query(VerseText)
+            .filter(
+                VerseText.revision_id == revision_id,
+                VerseText.verse_reference == vref,
+            )
+            .first()
+        )
+        if existing is None:
+            test_db_session.add(
+                VerseText(text=text, revision_id=revision_id, verse_reference=vref)
+            )
+        else:
+            existing.text = text
+
+    for vref in (vrefs[5], vrefs[12]):
+        _seed_text(test_revision_id, vref, f"src {vref}")
+        _seed_text(test_revision_id_2, vref, f"ref {vref}")
+    test_db_session.commit()
+
+    body = {
+        "n_components": 300,
+        "n_corpus_vrefs": _N_DOCS,
+        "sklearn_version": "1.6.1",
+        "word_vectorizer": _vectorizer_payload(word, "word", (1, 2)),
+        "char_vectorizer": _vectorizer_payload(char, "char_wb", (3, 6)),
+        "svd": {
+            "n_components": 300,
+            "n_features": n_features,
+            "dtype": "float32",
+            "components_b64": _components_b64(svd),
+        },
+    }
+    resp = client.post(
+        f"{prefix}/assessment/{assessment_id}/tfidf-artifacts",
+        json=body,
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+
+    return {"assessment_id": assessment_id, "corpus": corpus, "vrefs": vrefs}
+
+
+# ---------------------------------------------------------------------------
+# by_text
+# ---------------------------------------------------------------------------
+
+
+def test_by_text_self_match_round_trip(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    """A verse's own text encodes back to its stored vector: top hit, sim ≈ 1.0."""
+    assessment_id = encoded_tfidf_assessment["assessment_id"]
+    idx = 5
+    text = encoded_tfidf_assessment["corpus"][idx]
+    vref = encoded_tfidf_assessment["vrefs"][idx]
+
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={"assessment_id": assessment_id, "text": text, "limit": 10},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total_count"] == 10
+    top = data["results"][0]
+    assert top["vref"] == vref
+    assert top["similarity"] == pytest.approx(1.0, abs=1e-3)
+    # revision_text hydrated from the corpus revision.
+    assert top["revision_text"] == f"src {vref}"
+    sims = [r["similarity"] for r in data["results"]]
+    assert sims == sorted(sims, reverse=True)
+
+
+def test_by_text_hydrates_reference_text(
+    client, regular_token1, encoded_tfidf_assessment, test_revision_id_2
+):
+    assessment_id = encoded_tfidf_assessment["assessment_id"]
+    idx = 12
+    text = encoded_tfidf_assessment["corpus"][idx]
+    vref = encoded_tfidf_assessment["vrefs"][idx]
+
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={
+            "assessment_id": assessment_id,
+            "text": text,
+            "limit": 3,
+            "reference_id": test_revision_id_2,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    top = resp.json()["results"][0]
+    assert top["vref"] == vref
+    assert top["reference_text"] == f"ref {vref}"
+
+
+def test_by_text_exclude_vref_drops_only_that_verse(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    """exclude_vref removes the self-match; `limit` other results still return."""
+    assessment_id = encoded_tfidf_assessment["assessment_id"]
+    idx = 7
+    text = encoded_tfidf_assessment["corpus"][idx]
+    vref = encoded_tfidf_assessment["vrefs"][idx]
+
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={
+            "assessment_id": assessment_id,
+            "text": text,
+            "limit": 10,
+            "exclude_vref": vref,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["total_count"] == 10
+    vrefs = [r["vref"] for r in data["results"]]
+    assert vref not in vrefs
+    # A neighbour from the same book is still allowed (default exclude_book=False).
+    assert any(v.startswith("GEN ") for v in vrefs)
+
+
+def test_by_text_exclude_book_drops_whole_book(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    """exclude_book=True removes every result in the query verse's book."""
+    assessment_id = encoded_tfidf_assessment["assessment_id"]
+    # idx 250 → an EXO verse.
+    idx = 250
+    text = encoded_tfidf_assessment["corpus"][idx]
+    vref = encoded_tfidf_assessment["vrefs"][idx]
+    assert vref.startswith("EXO ")
+
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={
+            "assessment_id": assessment_id,
+            "text": text,
+            "limit": 20,
+            "exclude_vref": vref,
+            "exclude_book": True,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    vrefs = [r["vref"] for r in resp.json()["results"]]
+    assert all(not v.startswith("EXO ") for v in vrefs)
+    assert all(v.startswith("GEN ") for v in vrefs)
+
+
+def test_by_text_missing_artifacts_404(
+    client, regular_token1, test_db_session, test_revision_id, test_revision_id_2
+):
+    """A tfidf assessment with no stored artifacts can't encode → 404."""
+    assessment = Assessment(
+        revision_id=test_revision_id,
+        reference_id=test_revision_id_2,
+        type="tfidf",
+        status="running",
+    )
+    test_db_session.add(assessment)
+    test_db_session.commit()
+    test_db_session.refresh(assessment)
+
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={"assessment_id": assessment.id, "text": "alpha beta", "limit": 3},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_by_text_unauthorized(client, regular_token2, encoded_tfidf_assessment):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "text": "alpha beta",
+            "limit": 3,
+        },
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert resp.status_code == 403
+
+
+def test_by_text_no_auth(client, encoded_tfidf_assessment):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_text",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "text": "alpha beta",
+            "limit": 3,
+        },
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# by_texts (batch)
+# ---------------------------------------------------------------------------
+
+
+def test_by_texts_one_list_per_text(client, regular_token1, encoded_tfidf_assessment):
+    """Each input text returns its own verse as the top hit, in input order."""
+    assessment_id = encoded_tfidf_assessment["assessment_id"]
+    idxs = [3, 100, 260]
+    texts = [encoded_tfidf_assessment["corpus"][i] for i in idxs]
+    expected = [encoded_tfidf_assessment["vrefs"][i] for i in idxs]
+
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={"assessment_id": assessment_id, "texts": texts, "limit": 5},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    results = resp.json()["results"]
+    assert len(results) == len(texts)
+    assert [rs[0]["vref"] for rs in results] == expected
+    assert all(rs[0]["similarity"] == pytest.approx(1.0, abs=1e-3) for rs in results)
+
+
+def test_by_texts_per_text_exclude_vrefs(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    """exclude_vrefs[i] drops only texts[i]'s self-match."""
+    assessment_id = encoded_tfidf_assessment["assessment_id"]
+    idxs = [3, 100]
+    texts = [encoded_tfidf_assessment["corpus"][i] for i in idxs]
+    vrefs = [encoded_tfidf_assessment["vrefs"][i] for i in idxs]
+
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={
+            "assessment_id": assessment_id,
+            "texts": texts,
+            "limit": 5,
+            "exclude_vrefs": vrefs,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.text
+    results = resp.json()["results"]
+    for own_vref, rs in zip(vrefs, results):
+        assert own_vref not in [r["vref"] for r in rs]
+
+
+def test_by_texts_exclude_vrefs_length_mismatch_422(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "texts": ["alpha beta", "gamma delta"],
+            "limit": 5,
+            "exclude_vrefs": ["GEN 1:1"],
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
+    assert "exclude_vrefs" in str(resp.json()["detail"])
+
+
+def test_by_texts_combined_cap_rejected(
+    client, regular_token1, encoded_tfidf_assessment
+):
+    """len(texts) * limit above the combined cap is rejected with 422."""
+    from models import TFIDF_MAX_BATCH_RESULTS
+
+    texts = ["alpha beta"] * 400
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "texts": texts,
+            "limit": 100,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
+    assert str(TFIDF_MAX_BATCH_RESULTS) in resp.json()["detail"]
+
+
+def test_by_texts_empty_rejected(client, regular_token1, encoded_tfidf_assessment):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "texts": [],
+            "limit": 3,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
+
+
+def test_by_texts_unauthorized(client, regular_token2, encoded_tfidf_assessment):
+    resp = client.post(
+        f"{prefix}/tfidf_result/by_texts",
+        json={
+            "assessment_id": encoded_tfidf_assessment["assessment_id"],
+            "texts": ["alpha beta"],
+            "limit": 3,
+        },
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert resp.status_code == 403

--- a/test/test_assessment_routes/test_tfidf_by_text.py
+++ b/test/test_assessment_routes/test_tfidf_by_text.py
@@ -60,7 +60,8 @@ _VOCAB = [
 
 def _real_vrefs(db) -> list:
     """Fetch real GEN/EXO vrefs (tfidf_pca_vector.vref is FK'd to
-    verse_reference). The first _N_EXO results below index 200 are EXO."""
+    verse_reference). Returns _N_GEN GEN vrefs (indices 0.._N_GEN-1) followed
+    by _N_EXO EXO vrefs (indices _N_GEN.._N_DOCS-1)."""
     gen = [
         r[0]
         for r in db.query(VerseReference.full_verse_id)
@@ -115,6 +116,10 @@ def encoded_tfidf_assessment(
         n = int(rng.integers(5, 12))
         corpus.append(" ".join(rng.choice(_VOCAB, size=n)))
     vrefs = _real_vrefs(test_db_session)
+    assert len(vrefs) == _N_DOCS, (
+        f"expected {_N_DOCS} seeded vrefs, got {len(vrefs)} — verse_reference "
+        "fixture data may have changed"
+    )
 
     word = TfidfVectorizer(
         analyzer="word", ngram_range=(1, 2), lowercase=True, max_df=1.0, min_df=1


### PR DESCRIPTION
## Summary

Adds two endpoints that encode **raw text** into an assessment's TF-IDF/SVD-300 space server-side and return the nearest corpus verses — closing the gap where neighbors could only be queried by an in-corpus `vref` (`GET /v3/tfidf_result`) or a pre-computed 300-dim `vector` (`POST /v3/tfidf_result/by_vector`). This unblocks the ICL back-translation pipeline, which retrieves neighbors for arbitrary draft-verse text.

- **`POST /v3/tfidf_result/by_text`** — single text → neighbor list. Same response shape as `by_vector`.
- **`POST /v3/tfidf_result/by_texts`** — batch; one neighbor list per input text. Same `len(texts) * limit <= 25000` guard as `by_vectors`.

## Implementation

- Rehydrates the stored `TfidfVectorizer` (word + char) and `TruncatedSVD` directly from the artifact rows (no pickles), then runs the same encode chain aqua-assessments uses (word+char TF-IDF → L2-normalized hstack → SVD-300). Scoring reuses the existing `_score_against_corpus` — no reimplemented similarity.
- Module-level encoder cache keyed by `assessment_id`, invalidated by the artifact run's `created_at` so a re-push transparently refreshes it. CPU-bound rehydrate/encode runs via `asyncio.to_thread`.
- **Leakage guard:** `exclude_vref` drops the exact verse; `exclude_book` drops the whole book (token before the first space). Pushed into the WHERE clause so `limit` rows survive. Batch takes per-text `exclude_vrefs` (same length as `texts`, or omit).
- Adds `scikit-learn==1.6.1` and `scipy==1.13.1` to `requirements.txt` (matching aqua-assessments' sklearn pin so stored artifacts transform identically).

## Test plan

New `test/test_assessment_routes/test_tfidf_by_text.py` fits a real encoder on a synthetic 300-doc corpus (rank ≤ 300 so a self-match reproduces the stored vector at similarity ≈ 1.0) and covers:
- round-trip self-match (top hit, sim ≈ 1.0) with revision/reference text hydration
- `exclude_vref` (exact verse) and `exclude_book` (whole book)
- batch `by_texts` ordering, per-text `exclude_vrefs`, length-mismatch 422, combined-cap 422, empty 422
- missing-artifacts 404, authz (403/401)

`13 passed`; existing tfidf suites (`69 passed`) unaffected. `black --check` / `isort --check` clean.

Fixes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)