### PR TITLE
Add critique span suggestions + whole-verse translation alternatives (#811)

### DIFF
--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -112,6 +112,16 @@ def sanitize_text(text: Optional[str]) -> Optional[str]:
     return text.strip()
 
 
+def sanitize_alternatives(alternatives):
+    """Sanitize a list of SuggestionItem alternatives into JSONB-ready dicts."""
+    if alternatives is None:
+        return None
+    return [
+        {"text": sanitize_text(a.text), "note": sanitize_text(a.note)}
+        for a in alternatives
+    ]
+
+
 @router.post("/agent/word-alignment", response_model=AgentWordAlignmentOut)
 async def add_word_alignment(
     alignment: AgentWordAlignmentIn,
@@ -440,6 +450,7 @@ async def add_critique_issues(
                 if issue_in.evidence is not None
                 else None
             )
+            suggestions = sanitize_alternatives(issue_in.suggestions)
             issue = AgentCritiqueIssue(
                 assessment_id=assessment_id,
                 agent_translation_id=critique.agent_translation_id,
@@ -455,6 +466,7 @@ async def add_critique_issues(
                 comments=sanitize_text(issue_in.comments),
                 severity=issue_in.severity,
                 evidence=evidence,
+                suggestions=suggestions,
             )
             db.add(issue)
             created_issues.append(issue)
@@ -3726,6 +3738,7 @@ async def add_agent_translation(
         hyper_literal = sanitize_text(translation.hyper_literal_translation)
         literal = sanitize_text(translation.literal_translation)
         english = sanitize_text(translation.english_translation)
+        alternatives = sanitize_alternatives(translation.alternatives)
 
         # Create the translation record
         agent_translation = AgentTranslation(
@@ -3739,6 +3752,7 @@ async def add_agent_translation(
             hyper_literal_translation=hyper_literal,
             literal_translation=literal,
             english_translation=english,
+            alternatives=alternatives,
         )
 
         db.add(agent_translation)
@@ -3874,6 +3888,7 @@ async def add_agent_translations_bulk(
                 ),
                 literal_translation=sanitize_text(trans.literal_translation),
                 english_translation=sanitize_text(trans.english_translation),
+                alternatives=sanitize_alternatives(trans.alternatives),
             )
             for trans in request.translations
         ]

--- a/agent_routes/v3/agent_routes.py
+++ b/agent_routes/v3/agent_routes.py
@@ -112,13 +112,17 @@ def sanitize_text(text: Optional[str]) -> Optional[str]:
     return text.strip()
 
 
-def sanitize_alternatives(alternatives):
-    """Sanitize a list of SuggestionItem alternatives into JSONB-ready dicts."""
-    if alternatives is None:
+def sanitize_suggestion_items(items):
+    """Sanitize a list of SuggestionItem (suggestions/alternatives) into JSONB-ready dicts.
+
+    An empty or absent list is normalized to None so "none provided" and
+    "explicitly empty" persist identically (NULL).
+    """
+    if not items:
         return None
     return [
-        {"text": sanitize_text(a.text), "note": sanitize_text(a.note)}
-        for a in alternatives
+        {"text": sanitize_text(item.text), "note": sanitize_text(item.note)}
+        for item in items
     ]
 
 
@@ -450,7 +454,7 @@ async def add_critique_issues(
                 if issue_in.evidence is not None
                 else None
             )
-            suggestions = sanitize_alternatives(issue_in.suggestions)
+            suggestions = sanitize_suggestion_items(issue_in.suggestions)
             issue = AgentCritiqueIssue(
                 assessment_id=assessment_id,
                 agent_translation_id=critique.agent_translation_id,
@@ -3738,7 +3742,7 @@ async def add_agent_translation(
         hyper_literal = sanitize_text(translation.hyper_literal_translation)
         literal = sanitize_text(translation.literal_translation)
         english = sanitize_text(translation.english_translation)
-        alternatives = sanitize_alternatives(translation.alternatives)
+        alternatives = sanitize_suggestion_items(translation.alternatives)
 
         # Create the translation record
         agent_translation = AgentTranslation(
@@ -3888,7 +3892,7 @@ async def add_agent_translations_bulk(
                 ),
                 literal_translation=sanitize_text(trans.literal_translation),
                 english_translation=sanitize_text(trans.english_translation),
-                alternatives=sanitize_alternatives(trans.alternatives),
+                alternatives=sanitize_suggestion_items(trans.alternatives),
             )
             for trans in request.translations
         ]

--- a/alembic/migrations/versions/a1c2e3f4b5d6_add_suggestions_and_alternatives.py
+++ b/alembic/migrations/versions/a1c2e3f4b5d6_add_suggestions_and_alternatives.py
@@ -1,0 +1,43 @@
+"""Add span-level suggestions to critique issues + whole-verse alternatives to translations
+
+Revision ID: a1c2e3f4b5d6
+Revises: d4f7b1e9c3a2
+Create Date: 2026-06-24
+
+Adds two optional JSONB columns (aqua-api#811):
+- ``agent_critique_issue.suggestions`` -- list of {text, note?} proposed
+  replacements for the issue's ``draft_text`` span (anchoring inherited from
+  ``draft_text``/``source_text``; no offsets).
+- ``agent_translations.alternatives`` -- list of {text, note?} whole-verse
+  alternative renderings, independent of any specific critique.
+
+Both are nullable and default NULL; existing rows are unaffected.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+from alembic import op
+
+revision: str = "a1c2e3f4b5d6"
+down_revision: Union[str, None] = "d4f7b1e9c3a2"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "agent_critique_issue",
+        sa.Column("suggestions", JSONB(), nullable=True),
+    )
+    op.add_column(
+        "agent_translations",
+        sa.Column("alternatives", JSONB(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("agent_translations", "alternatives")
+    op.drop_column("agent_critique_issue", "suggestions")

--- a/database/models.py
+++ b/database/models.py
@@ -784,6 +784,7 @@ class AgentCritiqueIssue(Base):
     comments = Column(Text, nullable=True)
     severity = Column(Integer, nullable=True)  # 1..5, NULL when the agent omits it
     evidence = Column(JSONB, nullable=True)  # list[str]
+    suggestions = Column(JSONB, nullable=True)  # list[{text, note?}]
 
     # Resolution tracking
     is_resolved = Column(Boolean, default=False, nullable=False)
@@ -839,6 +840,7 @@ class AgentTranslation(Base):
     hyper_literal_translation = Column(Text, nullable=True)
     literal_translation = Column(Text, nullable=True)
     english_translation = Column(Text, nullable=True)
+    alternatives = Column(JSONB, nullable=True)  # list[{text, note?}]
     created_at = Column(TIMESTAMP, default=func.now())
 
     assessment = relationship("Assessment")

--- a/models.py
+++ b/models.py
@@ -1031,6 +1031,15 @@ class CardTranslationOut(BaseModel):
     examples: List[CardTranslationExampleOut] = []
 
 
+class SuggestionItem(BaseModel):
+    """A proposed replacement/rendering, used for span suggestions and whole-verse alternatives."""
+
+    text: str
+    note: Optional[str] = None
+
+    model_config = {"str_strip_whitespace": True}
+
+
 class IssueIn(BaseModel):
     """A single MQM-aligned critique issue."""
 
@@ -1042,6 +1051,7 @@ class IssueIn(BaseModel):
     severity: Optional[int] = Field(default=None, ge=1, le=5)
     detector: Optional[str] = Field(default=None, max_length=50)
     evidence: Optional[List[str]] = None
+    suggestions: Optional[List[SuggestionItem]] = None
 
     model_config = {"str_strip_whitespace": True}
 
@@ -1070,6 +1080,9 @@ class CritiqueStorageRequest(BaseModel):
                         "severity": 4,
                         "detector": "number_diff",
                         "evidence": ["source: 40", "draft: 14"],
+                        "suggestions": [
+                            {"text": "forty days", "note": "match the source number"}
+                        ],
                     }
                 ],
             }
@@ -1095,6 +1108,7 @@ class CritiqueIssueOut(BaseModel):
     severity: Optional[int] = None
     detector: Optional[str] = None
     evidence: Optional[List[str]] = None
+    suggestions: Optional[List[SuggestionItem]] = None
     is_resolved: bool = False
     resolved_by_id: Optional[int] = None
     resolved_at: Optional[datetime.datetime] = None
@@ -1119,6 +1133,9 @@ class CritiqueIssueOut(BaseModel):
                 "severity": 4,
                 "detector": "number_diff",
                 "evidence": ["source: 40", "draft: 14"],
+                "suggestions": [
+                    {"text": "forty days", "note": "match the source number"}
+                ],
                 "is_resolved": False,
                 "resolved_by_id": None,
                 "resolved_at": None,
@@ -1173,6 +1190,7 @@ class AgentTranslationIn(BaseModel):
     hyper_literal_translation: Optional[str] = None
     literal_translation: Optional[str] = None
     english_translation: Optional[str] = None
+    alternatives: Optional[List[SuggestionItem]] = None
 
     model_config = {
         "json_schema_extra": {
@@ -1182,6 +1200,12 @@ class AgentTranslationIn(BaseModel):
                 "hyper_literal_translation": "And beginning there-was with Word",
                 "literal_translation": "In the beginning was the Word",
                 "english_translation": "In the beginning was the Word",
+                "alternatives": [
+                    {
+                        "text": "In the beginning the Word already existed",
+                        "note": "smoother English phrasing",
+                    }
+                ],
             }
         }
     }
@@ -1196,6 +1220,7 @@ class AgentTranslationStorageRequest(BaseModel):
     hyper_literal_translation: Optional[str] = None
     literal_translation: Optional[str] = None
     english_translation: Optional[str] = None
+    alternatives: Optional[List[SuggestionItem]] = None
 
     model_config = {
         "json_schema_extra": {
@@ -1206,6 +1231,12 @@ class AgentTranslationStorageRequest(BaseModel):
                 "hyper_literal_translation": "And beginning there-was with Word",
                 "literal_translation": "In the beginning was the Word",
                 "english_translation": "In the beginning was the Word",
+                "alternatives": [
+                    {
+                        "text": "In the beginning the Word already existed",
+                        "note": "smoother English phrasing",
+                    }
+                ],
             }
         }
     }
@@ -1254,6 +1285,7 @@ class AgentTranslationOut(BaseModel):
     hyper_literal_translation: Optional[str] = None
     literal_translation: Optional[str] = None
     english_translation: Optional[str] = None
+    alternatives: Optional[List[SuggestionItem]] = None
     created_at: Optional[datetime.datetime] = None
 
     model_config = {
@@ -1270,6 +1302,12 @@ class AgentTranslationOut(BaseModel):
                 "hyper_literal_translation": "And beginning there-was with Word",
                 "literal_translation": "In the beginning was the Word",
                 "english_translation": "In the beginning was the Word",
+                "alternatives": [
+                    {
+                        "text": "In the beginning the Word already existed",
+                        "note": "smoother English phrasing",
+                    }
+                ],
                 "created_at": "2024-06-01T12:00:00",
             }
         },

--- a/models.py
+++ b/models.py
@@ -1034,7 +1034,7 @@ class CardTranslationOut(BaseModel):
 class SuggestionItem(BaseModel):
     """A proposed replacement/rendering, used for span suggestions and whole-verse alternatives."""
 
-    text: str
+    text: str = Field(min_length=1)
     note: Optional[str] = None
 
     model_config = {"str_strip_whitespace": True}
@@ -1258,6 +1258,12 @@ class AgentTranslationBulkRequest(BaseModel):
                         "draft_text": "Na mwanzo kulikuwa na Neno",
                         "hyper_literal_translation": "And beginning there-was with Word",
                         "literal_translation": "In the beginning was the Word",
+                        "alternatives": [
+                            {
+                                "text": "In the beginning the Word already existed",
+                                "note": "smoother English phrasing",
+                            }
+                        ],
                     },
                     {
                         "vref": "JHN 1:2",

--- a/test/test_agent_routes/test_suggestions_alternatives.py
+++ b/test/test_agent_routes/test_suggestions_alternatives.py
@@ -76,7 +76,18 @@ def test_critique_suggestions_optional(client, regular_token1, test_assessment_i
         headers={"Authorization": f"Bearer {regular_token1}"},
     )
     assert resp.status_code == 200
+    issue_id = resp.json()[0]["id"]
     assert resp.json()[0]["suggestions"] is None
+
+    # NULL also round-trips through GET as null (not [] or a missing key).
+    get_resp = client.get(
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}"
+        f"&agent_translation_id={translation_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert get_resp.status_code == 200
+    fetched = next(i for i in get_resp.json() if i["id"] == issue_id)
+    assert fetched["suggestions"] is None
 
 
 def test_translation_alternatives_round_trip(
@@ -111,6 +122,117 @@ def test_translation_alternatives_optional(client, regular_token1, test_assessme
     """Omitting alternatives leaves the field NULL (backward compatible)."""
     created = _create_translation(client, regular_token1, test_assessment_id, "EXO 1:2")
     assert created["alternatives"] is None
+
+    get_resp = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&vref=EXO 1:2",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert get_resp.status_code == 200
+    fetched = next(t for t in get_resp.json() if t["id"] == created["id"])
+    assert fetched["alternatives"] is None
+
+
+def test_critique_multiple_issues_each_keep_own_suggestions(
+    client, regular_token1, test_assessment_id
+):
+    """Each issue in a multi-issue POST keeps its own suggestions (no cross-bleed)."""
+    translation_id = _create_translation(
+        client, regular_token1, test_assessment_id, "JHN 3:18"
+    )["id"]
+    issues = [
+        {
+            "dimension": "accuracy",
+            "subtype": "omission",
+            "source_text": "first",
+            "suggestions": [{"text": "A"}],
+        },
+        {
+            "dimension": "accuracy",
+            "subtype": "mistranslation",
+            "source_text": "second",
+            "draft_text": "x",
+            "suggestions": [{"text": "B"}, {"text": "C", "note": "alt"}],
+        },
+    ]
+    resp = client.post(
+        f"{prefix}/agent/critique",
+        json={"agent_translation_id": translation_id, "issues": issues},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.json()
+    by_source = {i["source_text"]: i for i in resp.json()}
+    assert by_source["first"]["suggestions"] == [{"text": "A", "note": None}]
+    assert by_source["second"]["suggestions"] == [
+        {"text": "B", "note": None},
+        {"text": "C", "note": "alt"},
+    ]
+
+
+def test_suggestion_text_control_chars_sanitized(
+    client, regular_token1, test_assessment_id
+):
+    """Control characters in suggestion text/note are stripped like other text fields."""
+    translation_id = _create_translation(
+        client, regular_token1, test_assessment_id, "JHN 3:19"
+    )["id"]
+    issue = {
+        "dimension": "accuracy",
+        "subtype": "mistranslation",
+        "source_text": "s",
+        "draft_text": "d",
+        "suggestions": [{"text": "foo\nbar\tbaz", "note": "line\rnote"}],
+    }
+    resp = client.post(
+        f"{prefix}/agent/critique",
+        json={"agent_translation_id": translation_id, "issues": [issue]},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.json()
+    assert resp.json()[0]["suggestions"] == [
+        {"text": "foo bar baz", "note": "line note"}
+    ]
+
+
+def test_empty_list_normalized_to_null(client, regular_token1, test_assessment_id):
+    """An explicit empty list persists as NULL for both alternatives and suggestions."""
+    created = _create_translation(
+        client, regular_token1, test_assessment_id, "EXO 1:3", alternatives=[]
+    )
+    assert created["alternatives"] is None
+
+    translation_id = created["id"]
+    issue = {
+        "dimension": "accuracy",
+        "subtype": "omission",
+        "source_text": "s",
+        "suggestions": [],
+    }
+    resp = client.post(
+        f"{prefix}/agent/critique",
+        json={"agent_translation_id": translation_id, "issues": [issue]},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()[0]["suggestions"] is None
+
+
+def test_blank_suggestion_text_rejected(client, regular_token1, test_assessment_id):
+    """A whitespace-only suggestion text is rejected with 422 (min_length)."""
+    translation_id = _create_translation(
+        client, regular_token1, test_assessment_id, "JHN 3:20"
+    )["id"]
+    issue = {
+        "dimension": "accuracy",
+        "subtype": "omission",
+        "source_text": "s",
+        "suggestions": [{"text": "   "}],
+    }
+    resp = client.post(
+        f"{prefix}/agent/critique",
+        json={"agent_translation_id": translation_id, "issues": [issue]},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 422
 
 
 def test_bulk_translations_alternatives(client, regular_token1, test_assessment_id):

--- a/test/test_agent_routes/test_suggestions_alternatives.py
+++ b/test/test_agent_routes/test_suggestions_alternatives.py
@@ -1,0 +1,136 @@
+"""Tests for span-level critique suggestions and whole-verse translation alternatives (aqua-api#811)."""
+
+prefix = "v3"
+
+
+def _create_translation(client, token, assessment_id, vref, alternatives=None):
+    body = {"assessment_id": assessment_id, "vref": vref, "draft_text": "test"}
+    if alternatives is not None:
+        body["alternatives"] = alternatives
+    resp = client.post(
+        f"{prefix}/agent/translation",
+        json=body,
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert resp.status_code == 200, f"Failed to create translation: {resp.json()}"
+    return resp.json()
+
+
+def test_critique_suggestions_round_trip(client, regular_token1, test_assessment_id):
+    """suggestions posted on a critique issue are persisted and returned on GET."""
+    translation_id = _create_translation(
+        client, regular_token1, test_assessment_id, "JHN 3:16"
+    )["id"]
+
+    issue = {
+        "dimension": "accuracy",
+        "subtype": "mistranslation/sense",
+        "source_text": "went",
+        "draft_text": "кӧчкелен",
+        "comments": "overstates the motion",
+        "severity": 3,
+        "suggestions": [
+            {"text": "келген", "note": "neutral 'came/went'"},
+            {"text": "барган"},
+        ],
+    }
+    post_resp = client.post(
+        f"{prefix}/agent/critique",
+        json={"agent_translation_id": translation_id, "issues": [issue]},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert post_resp.status_code == 200, post_resp.json()
+    created = post_resp.json()[0]
+    assert created["suggestions"] == [
+        {"text": "келген", "note": "neutral 'came/went'"},
+        {"text": "барган", "note": None},
+    ]
+
+    get_resp = client.get(
+        f"{prefix}/agent/critique?assessment_id={test_assessment_id}"
+        f"&agent_translation_id={translation_id}",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert get_resp.status_code == 200
+    fetched = next(i for i in get_resp.json() if i["id"] == created["id"])
+    assert fetched["suggestions"] == [
+        {"text": "келген", "note": "neutral 'came/went'"},
+        {"text": "барган", "note": None},
+    ]
+
+
+def test_critique_suggestions_optional(client, regular_token1, test_assessment_id):
+    """Omitting suggestions leaves the field NULL (backward compatible)."""
+    translation_id = _create_translation(
+        client, regular_token1, test_assessment_id, "JHN 3:17"
+    )["id"]
+    issue = {
+        "dimension": "accuracy",
+        "subtype": "omission",
+        "source_text": "world",
+        "severity": 2,
+    }
+    resp = client.post(
+        f"{prefix}/agent/critique",
+        json={"agent_translation_id": translation_id, "issues": [issue]},
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()[0]["suggestions"] is None
+
+
+def test_translation_alternatives_round_trip(
+    client, regular_token1, test_assessment_id
+):
+    """alternatives posted on a single translation are persisted and returned on GET."""
+    alternatives = [
+        {"text": "These are the names of Israel's sons.", "note": "smoother phrasing"},
+        {"text": "The names of Israel's sons are these."},
+    ]
+    created = _create_translation(
+        client, regular_token1, test_assessment_id, "EXO 1:1", alternatives=alternatives
+    )
+    assert created["alternatives"] == [
+        {"text": "These are the names of Israel's sons.", "note": "smoother phrasing"},
+        {"text": "The names of Israel's sons are these.", "note": None},
+    ]
+
+    get_resp = client.get(
+        f"{prefix}/agent/translations?assessment_id={test_assessment_id}&vref=EXO 1:1",
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert get_resp.status_code == 200
+    fetched = next(t for t in get_resp.json() if t["id"] == created["id"])
+    assert fetched["alternatives"] == [
+        {"text": "These are the names of Israel's sons.", "note": "smoother phrasing"},
+        {"text": "The names of Israel's sons are these.", "note": None},
+    ]
+
+
+def test_translation_alternatives_optional(client, regular_token1, test_assessment_id):
+    """Omitting alternatives leaves the field NULL (backward compatible)."""
+    created = _create_translation(client, regular_token1, test_assessment_id, "EXO 1:2")
+    assert created["alternatives"] is None
+
+
+def test_bulk_translations_alternatives(client, regular_token1, test_assessment_id):
+    """alternatives flow through the bulk translations endpoint."""
+    resp = client.post(
+        f"{prefix}/agent/translations",
+        json={
+            "assessment_id": test_assessment_id,
+            "translations": [
+                {
+                    "vref": "EXO 2:1",
+                    "draft_text": "a",
+                    "alternatives": [{"text": "alt-a", "note": "n"}],
+                },
+                {"vref": "EXO 2:2", "draft_text": "b"},
+            ],
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert resp.status_code == 200, resp.json()
+    by_vref = {t["vref"]: t for t in resp.json()}
+    assert by_vref["EXO 2:1"]["alternatives"] == [{"text": "alt-a", "note": "n"}]
+    assert by_vref["EXO 2:2"]["alternatives"] is None


### PR DESCRIPTION
## Summary

Adds two optional, backward-compatible additions to the agent storage/retrieval contract (aqua-api is the storage layer; generation is a downstream runner task tracked in sil-ai/aqua-assessments#394):

- **`agent_critique_issue.suggestions`** — per-issue proposed replacements for the critique's `draft_text` span. Anchoring is inherited from `draft_text`/`source_text` (no offsets).
- **`agent_translations.alternatives`** — whole-verse alternative renderings, independent of any specific critique.

Both are a new shared `SuggestionItem` model (`{text: str, note?: str}`), `Optional`/NULL by default. Existing storers and consumers are unaffected — no version bump.

### Changes
- `models.py`: `SuggestionItem`; `suggestions` on `IssueIn`/`CritiqueIssueOut`; `alternatives` on `AgentTranslationIn`/`AgentTranslationStorageRequest`/`AgentTranslationOut`
- `database/models.py`: `AgentCritiqueIssue.suggestions` + `AgentTranslation.alternatives` JSONB columns (mirroring `evidence`)
- `agent_routes/v3/agent_routes.py`: `sanitize_alternatives()` helper; persistence in `POST /agent/critique`, `POST /agent/translation`, bulk `POST /agent/translations`. GETs flow through via `from_attributes`.
- Alembic migration `a1c2e3f4b5d6` (single head onto `d4f7b1e9c3a2`)

Fixes #811

## Test plan
- New `test/test_agent_routes/test_suggestions_alternatives.py` — round-trip + optional/NULL + bulk (5 tests)
- Full suite: 44/44 pass (5 new + 39 existing critique/translation tests, no regressions)
- `black` + `isort` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Axg1bkpi4CAzcTxx5wiV74