### PR TITLE
Add per-version transcribed_audio flag, auto-apply to agent-critique (#815)

### DIFF
--- a/alembic/migrations/versions/b7c4d2e9f1a3_add_transcribed_audio_to_bible_version.py
+++ b/alembic/migrations/versions/b7c4d2e9f1a3_add_transcribed_audio_to_bible_version.py
@@ -1,0 +1,45 @@
+"""Add transcribed_audio to bible_version
+
+Revision ID: b7c4d2e9f1a3
+Revises: a1c2e3f4b5d6
+Create Date: 2026-06-26
+
+Background
+----------
+The agent-critique assessment honors an optional ``transcribed_audio`` flag
+(#811 / #813) telling the agent the draft is a transcription of recorded
+audio. Whether a version's revisions are ASR transcriptions is really a
+property of the version, so this migration promotes it to a column on
+``bible_version`` (#815). The assessment endpoint auto-applies it to
+agent-critique runs for revisions of the version.
+
+``server_default="false"`` makes the migration zero-downtime: existing rows
+get ``false`` on read, preserving today's behavior (flag off everywhere).
+
+Downgrade drops the column. No data backfill is needed.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b7c4d2e9f1a3"
+down_revision = "a1c2e3f4b5d6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "bible_version",
+        sa.Column(
+            "transcribed_audio",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("bible_version", "transcribed_audio")

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -20,7 +20,7 @@ from sqlalchemy.orm import aliased
 
 from assessment_routes.v3.alignment_filters import eflomal_method_clause
 from database.dependencies import get_db
-from database.models import Assessment, BibleRevision, BibleVersionAccess
+from database.models import Assessment, BibleRevision, BibleVersion, BibleVersionAccess
 from database.models import UserDB as UserModel
 from database.models import UserGroup
 
@@ -509,6 +509,47 @@ async def add_assessment(
         reference.bible_version_id if reference is not None else None
     )
 
+    # For agent-critique, default the transcribed_audio flag from the version
+    # being assessed (the draft/target) unless the request set it explicitly via
+    # extra_kwargs. The flag tells the agent the draft is an ASR transcription
+    # (#811/#813); promoting it to the version (#815) lets it be set once and
+    # applied to every assessment of that version's revisions.
+    is_transcribed = False
+    if a.type == "agent-critique":
+        injected_transcribed = a.kwargs.get("transcribed_audio") if a.kwargs else None
+        # The dedup filter below uses JSONB containment (strictly typed), so a
+        # truthy-but-non-bool injected value would silently bypass it. Reject it.
+        if injected_transcribed is not None and not isinstance(
+            injected_transcribed, bool
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail="transcribed_audio must be a boolean.",
+            )
+        # An explicit extra_kwargs value wins over the version default.
+        if injected_transcribed is not None:
+            is_transcribed = injected_transcribed
+        else:
+            version = await db.get(BibleVersion, target_version_id)
+            is_transcribed = bool(version and version.transcribed_audio)
+        # Fold the resolved flag into kwargs so it reaches Modal, the create-time
+        # dedup check, and the read endpoints. Stored as {"transcribed_audio":
+        # true} when on; on an explicit opt-out we strip any injected flag so the
+        # row reads as off and dedup stays correct.
+        if is_transcribed:
+            combined_kwargs = dict(a.kwargs or {})
+            combined_kwargs["transcribed_audio"] = True
+            try:
+                combined_kwargs = AssessmentIn.validate_kwargs(combined_kwargs)
+            except ValueError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+            a.kwargs = combined_kwargs
+            parsed_kwargs = combined_kwargs
+        elif a.kwargs and "transcribed_audio" in a.kwargs:
+            stripped = {k: v for k, v in a.kwargs.items() if k != "transcribed_audio"}
+            a.kwargs = stripped or None
+            parsed_kwargs = a.kwargs
+
     # Check for already-completed assessment (force=true bypasses this)
     if not force:
         completed_stmt = (
@@ -557,6 +598,20 @@ async def add_assessment(
                     ~Assessment.kwargs.has_key("last_vref"),
                 )
             )
+        # Distinguish agent-critique runs by the transcribed_audio flag so a
+        # transcribed run and a plain one dedup as separate assessments.
+        if a.type == "agent-critique":
+            if is_transcribed:
+                completed_stmt = completed_stmt.where(
+                    Assessment.kwargs.op("@>")({"transcribed_audio": True})
+                )
+            else:
+                completed_stmt = completed_stmt.where(
+                    or_(
+                        Assessment.kwargs.is_(None),
+                        ~Assessment.kwargs.has_key("transcribed_audio"),
+                    )
+                )
         result = await db.execute(completed_stmt)
         existing = result.scalars().first()
         if existing is not None:

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -531,7 +531,7 @@ async def add_assessment(
             is_transcribed = injected_transcribed
         else:
             version = await db.get(BibleVersion, target_version_id)
-            is_transcribed = bool(version and version.transcribed_audio)
+            is_transcribed = version.transcribed_audio if version else False
         # Fold the resolved flag into kwargs so it reaches Modal, the create-time
         # dedup check, and the read endpoints. Stored as {"transcribed_audio":
         # true} when on; on an explicit opt-out we strip any injected flag so the
@@ -600,6 +600,8 @@ async def add_assessment(
             )
         # Distinguish agent-critique runs by the transcribed_audio flag so a
         # transcribed run and a plain one dedup as separate assessments.
+        # `is_transcribed` is resolved above (from the version default or an
+        # explicit extra_kwargs override) before the version-id derivation.
         if a.type == "agent-critique":
             if is_transcribed:
                 completed_stmt = completed_stmt.where(

--- a/assessment_routes/v3/assessment_routes.py
+++ b/assessment_routes/v3/assessment_routes.py
@@ -600,8 +600,9 @@ async def add_assessment(
             )
         # Distinguish agent-critique runs by the transcribed_audio flag so a
         # transcribed run and a plain one dedup as separate assessments.
-        # `is_transcribed` is resolved above (from the version default or an
-        # explicit extra_kwargs override) before the version-id derivation.
+        # `is_transcribed` is resolved above, just after the version-id
+        # derivation (the target version id is needed to load the version flag),
+        # from the version default or an explicit extra_kwargs override.
         if a.type == "agent-critique":
             if is_transcribed:
                 completed_stmt = completed_stmt.where(

--- a/bible_routes/v3/version_routes.py
+++ b/bible_routes/v3/version_routes.py
@@ -125,6 +125,9 @@ async def add_version(
     Description: Whether the version is machine translated.
     - is_reference: bool
     Description: Whether the version is a reference version.
+    - transcribed_audio: bool
+    Description: Whether the version's revisions are transcriptions of recorded
+    audio (ASR). Auto-applied to agent-critique assessments. Defaults to false.
     - add_to_groups: List[int] (required)
     Description: The IDs of the groups to add the version to.
     At least one group must be specified.
@@ -151,6 +154,7 @@ async def add_version(
         machine_translation=v.machineTranslation,
         owner_id=current_user.id,
         is_reference=v.is_reference,
+        transcribed_audio=v.transcribed_audio,
     )
 
     db.add(new_version)
@@ -250,6 +254,9 @@ async def modify_version(
     Description: Whether the version is machine translated.
     - is_reference: bool
     Description: Whether the version is a reference version.
+    - transcribed_audio: bool
+    Description: Whether the version's revisions are transcriptions of recorded
+    audio (ASR). Auto-applied to agent-critique assessments. Defaults to false.
     - add_to_groups: Optional[List[int]]
     Description: The IDs of the groups to add the version to,
     the version will only be added to this groups, not to all tha groups of the user as usual.

--- a/database/models.py
+++ b/database/models.py
@@ -316,6 +316,9 @@ class BibleVersion(Base):
     )
     machine_translation = Column(Boolean)
     is_reference = Column(Boolean)
+    transcribed_audio = Column(
+        Boolean, nullable=False, server_default="false", default=False
+    )
     deleted = Column(Boolean, default=False)
     deletedAt = Column(TIMESTAMP, default=None)
     owner_id = Column(Integer, ForeignKey("users.id"), nullable=True, default=None)

--- a/models.py
+++ b/models.py
@@ -26,7 +26,7 @@ class VersionUpdate(BaseModel):
     forwardTranslation: Union[int, None] = None
     backTranslation: Union[int, None] = None
     machineTranslation: bool = False
-    transcribed_audio: Optional[bool] = None
+    transcribed_audio: bool = False
     add_to_groups: Optional[List[int]] = None
     remove_from_groups: Optional[List[int]] = None
 

--- a/models.py
+++ b/models.py
@@ -56,7 +56,7 @@ class VersionIn(BaseModel):
     backTranslation: Optional[int] = None
     machineTranslation: Optional[bool] = False
     is_reference: Optional[bool] = False
-    transcribed_audio: Optional[bool] = False
+    transcribed_audio: bool = False
     add_to_groups: List[int]
 
     model_config = {

--- a/models.py
+++ b/models.py
@@ -26,6 +26,7 @@ class VersionUpdate(BaseModel):
     forwardTranslation: Union[int, None] = None
     backTranslation: Union[int, None] = None
     machineTranslation: bool = False
+    transcribed_audio: Optional[bool] = None
     add_to_groups: Optional[List[int]] = None
     remove_from_groups: Optional[List[int]] = None
 
@@ -55,6 +56,7 @@ class VersionIn(BaseModel):
     backTranslation: Optional[int] = None
     machineTranslation: Optional[bool] = False
     is_reference: Optional[bool] = False
+    transcribed_audio: Optional[bool] = False
     add_to_groups: List[int]
 
     model_config = {
@@ -98,6 +100,7 @@ class VersionOut_v3(BaseModel):
     owner_id: Union[int, None] = None
     group_ids: List[int] = []
     is_reference: bool = False
+    transcribed_audio: bool = False
     deleted: bool = False
 
     @field_validator("deleted", mode="before")

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1858,6 +1858,127 @@ def test_agent_critique_derives_version_ids(
         assert kwargs["target_version_id"] == target_version_id
 
 
+# --- per-version transcribed_audio default (#815) ---
+
+
+def _set_version_transcribed(test_db_session, version_id, value):
+    from database.models import BibleVersion as BibleVersionModel
+
+    version = test_db_session.query(BibleVersionModel).filter_by(id=version_id).one()
+    version.transcribed_audio = value
+    test_db_session.commit()
+
+
+def test_agent_critique_inherits_version_transcribed_audio(
+    client, regular_token1, db_session, test_db_session
+):
+    """When the draft's version has transcribed_audio=true, an agent-critique
+    auto-applies the flag into the assessment kwargs and forwards it."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+    _set_version_transcribed(test_db_session, target_version_id, True)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "agent-critique",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()[0]["kwargs"] == {"transcribed_audio": True}
+        assert mock_runner.await_args.args[0].kwargs == {"transcribed_audio": True}
+
+
+def test_agent_critique_version_not_transcribed_no_flag(
+    client, regular_token1, db_session, test_db_session
+):
+    """A version with the default (false) flag leaves agent-critique kwargs
+    unchanged (None)."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "agent-critique",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()[0]["kwargs"] is None
+
+
+def test_agent_critique_explicit_false_overrides_version_true(
+    client, regular_token1, db_session, test_db_session
+):
+    """An explicit transcribed_audio=false in extra_kwargs wins over a version
+    whose flag is true — the stored kwargs read as off (None)."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+    _set_version_transcribed(test_db_session, target_version_id, True)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "agent-critique",
+                "extra_kwargs": '{"transcribed_audio": false}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()[0]["kwargs"] is None
+
+
+def test_non_agent_critique_ignores_version_transcribed_audio(
+    client, regular_token1, db_session, test_db_session
+):
+    """The version flag is only consulted for agent-critique; other assessment
+    types ignore it."""
+    version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, version_id)
+    _set_version_transcribed(test_db_session, version_id, True)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "type": "sentence-length",
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()[0]["kwargs"] is None
+
+
 def test_no_reference_assessment_derives_target_only(
     client, regular_token1, db_session, test_db_session
 ):

--- a/test/test_assessment_routes/test_assessment_routes.py
+++ b/test/test_assessment_routes/test_assessment_routes.py
@@ -1979,6 +1979,134 @@ def test_non_agent_critique_ignores_version_transcribed_audio(
         assert response.json()[0]["kwargs"] is None
 
 
+def test_agent_critique_explicit_true_on_non_transcribed_version(
+    client, regular_token1, db_session, test_db_session
+):
+    """An explicit transcribed_audio=true in extra_kwargs turns the flag on even
+    when the version default is false."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        response = client.post(
+            f"{prefix}/assessment",
+            params={
+                "revision_id": revision_id,
+                "reference_id": reference_id,
+                "type": "agent-critique",
+                "extra_kwargs": '{"transcribed_audio": true}',
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200, response.text
+        assert response.json()[0]["kwargs"] == {"transcribed_audio": True}
+
+
+def test_agent_critique_non_bool_transcribed_audio_returns_400(
+    client, regular_token1, db_session, test_db_session
+):
+    """A truthy-but-non-bool transcribed_audio in extra_kwargs is rejected with
+    400 so it can't silently bypass the JSONB-strict dedup filter."""
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+        for bad_value in ('"true"', "1", "0"):
+            response = client.post(
+                f"{prefix}/assessment",
+                params={
+                    "revision_id": revision_id,
+                    "reference_id": reference_id,
+                    "type": "agent-critique",
+                    "extra_kwargs": '{"transcribed_audio": ' + bad_value + "}",
+                },
+                headers={"Authorization": f"Bearer {regular_token1}"},
+            )
+            assert response.status_code == 400, (bad_value, response.text)
+            assert "transcribed_audio" in response.json()["detail"]
+        assert mock_runner.await_count == 0
+
+
+def test_agent_critique_transcribed_version_dedup(
+    client, regular_token1, db_session, test_db_session
+):
+    """The auto-applied flag participates in dedup: a transcribed run blocks its
+    own duplicate (in-progress and completed), but a plain run (version toggled
+    off) on the same revision/reference is a distinct bucket."""
+    from datetime import datetime
+
+    target_version_id = create_bible_version(client, regular_token1, db_session)
+    source_version_id = create_bible_version(client, regular_token1, db_session)
+    revision_id = upload_revision(client, regular_token1, target_version_id)
+    reference_id = upload_revision(client, regular_token1, source_version_id)
+    _set_version_transcribed(test_db_session, target_version_id, True)
+
+    params = {
+        "revision_id": revision_id,
+        "reference_id": reference_id,
+        "type": "agent-critique",
+    }
+
+    with patch(
+        f"assessment_routes.{prefix}.assessment_routes.call_assessment_runner"
+    ) as mock_runner:
+        mock_runner.return_value = None
+
+        first = client.post(
+            f"{prefix}/assessment",
+            params=params,
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert first.status_code == 200, first.text
+        first_id = first.json()[0]["id"]
+        assert first.json()[0]["kwargs"] == {"transcribed_audio": True}
+
+        # In-progress duplicate of the transcribed run is blocked.
+        in_progress_dup = client.post(
+            f"{prefix}/assessment",
+            params=params,
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert in_progress_dup.status_code == 409
+
+        finished = (
+            db_session.query(Assessment).filter(Assessment.id == first_id).first()
+        )
+        finished.status = "finished"
+        finished.end_time = datetime.now()
+        db_session.commit()
+
+        # Completed duplicate of the transcribed run is blocked.
+        completed_dup = client.post(
+            f"{prefix}/assessment",
+            params=params,
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert completed_dup.status_code == 409
+        assert str(first_id) in completed_dup.json()["detail"]
+
+        # Toggle the version off: a plain run is a distinct bucket and is allowed
+        # despite the finished transcribed assessment.
+        _set_version_transcribed(test_db_session, target_version_id, False)
+        plain = client.post(
+            f"{prefix}/assessment",
+            params=params,
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert plain.status_code == 200, plain.text
+        assert plain.json()[0]["kwargs"] is None
+
+
 def test_no_reference_assessment_derives_target_only(
     client, regular_token1, db_session, test_db_session
 ):
@@ -2247,6 +2375,12 @@ def test_assess_dup_lock_key_is_stable_and_distinct_per_quadruple():
     assert k1 != _assess_dup_lock_key(
         1, 2, "word-alignment", _canonicalize_kwargs({"use_eflomal": True})
     ), "different kwargs must yield a different key"
+    k_critique = _assess_dup_lock_key(
+        1, 2, "agent-critique", _canonicalize_kwargs(None)
+    )
+    assert k_critique != _assess_dup_lock_key(
+        1, 2, "agent-critique", _canonicalize_kwargs({"transcribed_audio": True})
+    ), "transcribed_audio must yield a different key from the unflagged run"
 
     # reference_id=None vs. reference_id absent should be the same — and
     # both should differ from any concrete int reference.

--- a/test/test_bible_routes/test_version_routes.py
+++ b/test/test_bible_routes/test_version_routes.py
@@ -568,6 +568,77 @@ class TestIncludeDeleted:
         assert by_id[legacy_id]["deleted"] is False
 
 
+class TestTranscribedAudioFlag:
+    def test_create_version_with_transcribed_audio(
+        self, client, regular_token1, db_session
+    ):
+        group_1 = db_session.query(Group).filter_by(name="Group1").first()
+        headers = {"Authorization": f"Bearer {regular_token1}"}
+        params = {
+            **new_version_data,
+            "abbreviation": "TAV",
+            "transcribed_audio": True,
+            "add_to_groups": [group_1.id],
+        }
+        resp = client.post(f"{prefix}/version", json=params, headers=headers)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["transcribed_audio"] is True
+        row = (
+            db_session.query(BibleVersionModel).filter_by(id=resp.json()["id"]).first()
+        )
+        assert row.transcribed_audio is True
+
+    def test_create_version_defaults_transcribed_audio_false(
+        self, client, regular_token1, db_session
+    ):
+        group_1 = db_session.query(Group).filter_by(name="Group1").first()
+        headers = {"Authorization": f"Bearer {regular_token1}"}
+        params = {
+            **new_version_data,
+            "abbreviation": "TAV2",
+            "add_to_groups": [group_1.id],
+        }
+        resp = client.post(f"{prefix}/version", json=params, headers=headers)
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["transcribed_audio"] is False
+        row = (
+            db_session.query(BibleVersionModel).filter_by(id=resp.json()["id"]).first()
+        )
+        assert row.transcribed_audio is False
+
+    def test_update_version_transcribed_audio(self, client, regular_token1, db_session):
+        group_1 = db_session.query(Group).filter_by(name="Group1").first()
+        headers = {"Authorization": f"Bearer {regular_token1}"}
+        params = {
+            **new_version_data,
+            "abbreviation": "TAV3",
+            "add_to_groups": [group_1.id],
+        }
+        version_id = client.post(
+            f"{prefix}/version", json=params, headers=headers
+        ).json()["id"]
+
+        on = client.put(
+            f"{prefix}/version",
+            json={"id": version_id, "transcribed_audio": True},
+            headers=headers,
+        )
+        assert on.status_code == 200, on.text
+        db_session.expire_all()
+        row = db_session.query(BibleVersionModel).filter_by(id=version_id).first()
+        assert row.transcribed_audio is True
+
+        off = client.put(
+            f"{prefix}/version",
+            json={"id": version_id, "transcribed_audio": False},
+            headers=headers,
+        )
+        assert off.status_code == 200, off.text
+        db_session.expire_all()
+        row = db_session.query(BibleVersionModel).filter_by(id=version_id).first()
+        assert row.transcribed_audio is False
+
+
 class TestVersionValidation:
     def test_create_version_without_add_to_groups(self, client, regular_token1):
         """Test that creating a version without add_to_groups fails with 422."""


### PR DESCRIPTION
## Summary

Promotes the `transcribed_audio` flag (added per-assessment in #813/#814) to a property of the **version**, so it can be set once and applied automatically to that version's agent-critique assessments.

- **Schema:** new `transcribed_audio` boolean column on `bible_version` (default `false`, zero-downtime `server_default`) + Alembic migration `b7c4d2e9f1a3`.
- **Version API:** settable on `POST /v3/version`, updatable on `PUT /v3/version`, returned in `VersionOut_v3`.
- **Assessment integration:** when an **agent-critique** assessment is started, `transcribed_audio` defaults from the draft revision's version flag and is folded into the assessment `kwargs` (the runner already forwards non-reserved kwargs to `assess()`). An explicit `extra_kwargs` value **overrides** the version default. The completed-assessment dedup query filters on the flag so transcribed and plain runs dedup independently.

Scope: only the draft (revision-under-assessment) version's flag is consulted; only meaningful for `agent-critique`; default `false` → no behavior change for existing versions.

## Test plan

- Version routes: create with flag, default-false, update on/off (`test_version_routes.py`).
- Assessment auto-apply: inherits version flag into kwargs; version-false leaves kwargs unchanged; explicit `extra_kwargs` false overrides version true; non-agent-critique ignores the flag (`test_assessment_routes.py`).
- Full `test_version_routes.py`, `test_assessment_routes.py`, and `test_bible_routes/` suites pass.

## Notes

- This overlaps `add_assessment` with PR #814 (typed query param + dedup filter). It is built on `main` and stands alone (the kwargs→`assess()` forwarding already exists on main). When #814 merges, the two will reconcile in `add_assessment`.

Fixes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)