### PR TITLE
Raise uvicorn keep-alive above App Runner idle timeout to stop sporadic 502s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ ENV PYTHONPATH=/app:$PYTHONPATH
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:8000/health || exit 1
 
-# Keep-alive must outlive the App Runner ingress idle timeout (120s); uvicorn's
-# 5s default races the ingress's connection reuse and yields sporadic 502s.
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "8", "--timeout-keep-alive", "120"]
+# Keep-alive must exceed the App Runner ingress idle timeout (120s) with margin;
+# uvicorn's 5s default races the ingress's connection reuse and yields sporadic 502s.
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "8", "--timeout-keep-alive", "130"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ ENV PYTHONPATH=/app:$PYTHONPATH
 HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
     CMD curl -fsS http://localhost:8000/health || exit 1
 
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "8"]
+# Keep-alive must outlive the App Runner ingress idle timeout (120s); uvicorn's
+# 5s default races the ingress's connection reuse and yields sporadic 502s.
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "8", "--timeout-keep-alive", "120"]


### PR DESCRIPTION
## Summary

- Adds `--timeout-keep-alive 130` to the uvicorn CMD so uvicorn holds idle keep-alive connections longer than the App Runner ingress does (~120s idle timeout, plus margin since the two timers are not synchronized).
- Fixes sporadic instant `502 Bad Gateway` responses generated at the App Runner ingress: uvicorn's default 5s keep-alive closes idle connections that the ingress then tries to reuse, killing the request before it ever reaches the app (no application log).

## Evidence

- **2026-07-14 ~15:16:45 UTC** — 11 `POST /v3/tfidf_result/by_texts` requests from an aqua-agent run 502'd within ~250ms against dev (`cp3by92k8p`), trace `f929838134bda552dacb468928fb0d86`. The app logged only 200s (~200ms each) in the same seconds, zero errors.
- **2026-07-13 ~15:23 UTC** — same signature against prod (`tmv9bz5v4q`), 6 requests, trace `2eb60ac702a612f815459b94e73cb953`.
- The failing requests reused connections after a ~3.5s client-side pause while fresh connections succeeded in the same second — the classic keep-alive reaper race.

Agent-side hardening (retry on transient 5xx instead of silently zeroing examples) is tracked in sil-ai/aqua-assessments#405.

## Test plan

- [ ] CI green
- [ ] After deploy to dev, re-run an agent tfidf scoring pass and confirm no `by_texts ... 502` lines in aqua-agent logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ET7RQ97YnhizBkmdkWYDbi

## Review follow-up (not in this PR)

- Consider `--limit-concurrency` as a backstop now that idle connections linger longer; needs a value reconciled with App Runner per-instance max concurrency, and returns 503s when hit — deliberate tuning, not a quick add.
