### PR TITLE
fix: remove duplicate assessment_id declaration on AssessmentResult

### DIFF
--- a/database/models.py
+++ b/database/models.py
@@ -245,7 +245,6 @@ class AssessmentResult(Base):
     chapter = Column(Integer)
     verse = Column(Integer)
 
-    assessment_id = Column(Integer, ForeignKey("assessment.id"))
     assessment = relationship("Assessment", back_populates="results")
 
     __table_args__ = (


### PR DESCRIPTION
## Summary
- `AssessmentResult` in `database/models.py` declared `assessment_id = Column(Integer, ForeignKey("assessment.id"))` twice (once in natural field order, once again right before the `assessment` relationship). SQLAlchemy silently kept the second, dead-code duplicate.
- Removes the duplicate declaration. This is declaration-only — the column definition is unchanged, so there is no schema change and no Alembic migration.

Closes #841

## Test plan
- [x] `assessment_id` appears exactly once on `AssessmentResult.__table__.columns`
- [x] `alembic upgrade head` runs cleanly against a fresh pgvector DB
- [x] Full assessment_result-touching test suite passes: `test/test_assessment_routes/test_results_query_routes.py`, `test/test_assessment_routes/test_results_push_routes.py`, `test/test_train_routes/test_train_routes.py` (159 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)