### PR TITLE
fix: reject empty AQUA_DB at boot; correct SECRET_KEY validation docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,11 @@
 #
 # This file is the authoritative inventory of the environment variables the
 # API reads. Everything under "APPLICATION CONFIGURATION" is loaded and
-# type-validated at boot by config.Settings — a missing *required* variable
-# (AQUA_DB, SECRET_KEY) makes the app fail to start rather than misbehave at
-# runtime. All values below are safe placeholders; never commit real secrets.
+# type-validated at boot by config.Settings. AQUA_DB is required by
+# config.Settings itself; SECRET_KEY is optional there and its non-empty
+# requirement is enforced at import in security_routes/utilities.py. Either way
+# a missing required variable makes the app fail to start rather than misbehave
+# at runtime. All values below are safe placeholders; never commit real secrets.
 
 # ==========================================================================
 # APPLICATION CONFIGURATION  (validated by config.Settings at startup)

--- a/README.md
+++ b/README.md
@@ -69,10 +69,15 @@ cp .env.example .env
 with safe placeholder values and inline documentation. The application
 configuration (database, auth, CORS, Modal, thresholds, and Loki) is loaded
 and type-validated at startup by the typed settings object in
-[`config.py`](config.py) (`config.Settings`), so a missing or malformed
-**required** variable — `AQUA_DB` or `SECRET_KEY` — makes the app fail fast at
-boot instead of surfacing as a subtle runtime bug. See `.env.example` for the
-full set of optional variables and their defaults.
+[`config.py`](config.py) (`config.Settings`). `AQUA_DB` is a required field on
+`config.Settings`, so a missing, empty, or malformed value fails validation at
+boot. `SECRET_KEY` is optional on `config.Settings` (so config-only consumers
+like Alembic can import it) and its non-empty requirement is enforced at import
+in [`security_routes/utilities.py`](security_routes/utilities.py) — also
+fail-fast at boot, just in the security layer rather than in `config.Settings`
+itself. Either way, a missing required variable makes the app fail fast at boot
+instead of surfacing as a subtle runtime bug. See `.env.example` for the full
+set of optional variables and their defaults.
 
 ## Swagger
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ with safe placeholder values and inline documentation. The application
 configuration (database, auth, CORS, Modal, thresholds, and Loki) is loaded
 and type-validated at startup by the typed settings object in
 [`config.py`](config.py) (`config.Settings`). `AQUA_DB` is a required field on
-`config.Settings`, so a missing, empty, or malformed value fails validation at
-boot. `SECRET_KEY` is optional on `config.Settings` (so config-only consumers
+`config.Settings`, so a missing or empty value fails validation at boot (the
+value's shape as a DB URL is not checked here — that surfaces when the engine
+connects). `SECRET_KEY` is optional on `config.Settings` (so config-only consumers
 like Alembic can import it) and its non-empty requirement is enforced at import
 in [`security_routes/utilities.py`](security_routes/utilities.py) — also
 fail-fast at boot, just in the security layer rather than in `config.Settings`

--- a/config.py
+++ b/config.py
@@ -27,6 +27,7 @@ wiring in ``app.configure_cors`` rely on.
 from typing import Optional
 
 from dotenv import load_dotenv
+from pydantic import field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Load .env into os.environ before Settings reads it. Existing environment
@@ -47,6 +48,17 @@ class Settings(BaseSettings):
     # Required: the async SQLAlchemy URL (postgresql+asyncpg://...). A missing
     # value fails validation here, at boot, rather than deep inside a request.
     aqua_db: str
+
+    @field_validator("aqua_db")
+    @classmethod
+    def _aqua_db_nonempty(cls, v: str) -> str:
+        # A required str is satisfied by an explicitly-empty ``AQUA_DB=``, which
+        # would otherwise slip past boot validation and only fail later as an
+        # opaque SQLAlchemy error. Reject empty/whitespace to keep the fail-fast
+        # guarantee (mirrors the SECRET_KEY check in security_routes.utilities).
+        if not v.strip():
+            raise ValueError("AQUA_DB environment variable must not be empty")
+        return v
 
     # "null" forces SQLAlchemy's NullPool (used by the test suite, whose
     # TestClient spawns a fresh event loop per request). Anything else uses the

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,44 @@
+"""Tests for the typed config.Settings boot-time validation.
+
+config.Settings is the fail-fast config layer: a missing or malformed required
+variable must raise at construction (i.e. at application boot) rather than
+surfacing later as an opaque runtime error. AQUA_DB is required, and because a
+required ``str`` field is satisfied by an explicitly-empty ``AQUA_DB=``, the
+non-empty guard is asserted explicitly here.
+"""
+
+import importlib
+
+import pytest
+from pydantic import ValidationError
+
+
+@pytest.fixture
+def fresh_settings(monkeypatch):
+    """Import a fresh config module and return its Settings class.
+
+    config reads os.environ at construction (not via pydantic's env_file), so
+    tests set env vars with monkeypatch and construct Settings() directly.
+    """
+    import config
+
+    importlib.reload(config)
+    return config.Settings
+
+
+def test_valid_aqua_db_accepted(fresh_settings, monkeypatch):
+    monkeypatch.setenv("AQUA_DB", "postgresql+asyncpg://u:p@localhost:5432/db")
+    assert fresh_settings().aqua_db.startswith("postgresql+asyncpg://")
+
+
+@pytest.mark.parametrize("value", ["", "   ", "\t\n"])
+def test_empty_aqua_db_rejected_at_boot(fresh_settings, monkeypatch, value):
+    monkeypatch.setenv("AQUA_DB", value)
+    with pytest.raises(ValidationError, match="AQUA_DB"):
+        fresh_settings()
+
+
+def test_missing_aqua_db_rejected_at_boot(fresh_settings, monkeypatch):
+    monkeypatch.delenv("AQUA_DB", raising=False)
+    with pytest.raises(ValidationError):
+        fresh_settings()

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,44 +1,46 @@
 """Tests for the typed config.Settings boot-time validation.
 
-config.Settings is the fail-fast config layer: a missing or malformed required
+config.Settings is the fail-fast config layer: a missing or empty required
 variable must raise at construction (i.e. at application boot) rather than
 surfacing later as an opaque runtime error. AQUA_DB is required, and because a
 required ``str`` field is satisfied by an explicitly-empty ``AQUA_DB=``, the
 non-empty guard is asserted explicitly here.
 """
 
-import importlib
-
 import pytest
 from pydantic import ValidationError
 
 
 @pytest.fixture
-def fresh_settings(monkeypatch):
-    """Import a fresh config module and return its Settings class.
+def settings_cls(monkeypatch):
+    """Return the config.Settings class for construction under a patched env.
 
     config reads os.environ at construction (not via pydantic's env_file), so
-    tests set env vars with monkeypatch and construct Settings() directly.
+    tests set env vars with monkeypatch and construct Settings() directly. We
+    deliberately do NOT reload the config module: reloading re-runs its
+    module-level ``settings = Settings()`` against the ambient environment,
+    which makes these tests fail at setup on any machine without AQUA_DB set
+    (e.g. a fresh clone with no .env). Constructing our own instances keeps the
+    tests hermetic and self-contained.
     """
     import config
 
-    importlib.reload(config)
     return config.Settings
 
 
-def test_valid_aqua_db_accepted(fresh_settings, monkeypatch):
+def test_valid_aqua_db_accepted(settings_cls, monkeypatch):
     monkeypatch.setenv("AQUA_DB", "postgresql+asyncpg://u:p@localhost:5432/db")
-    assert fresh_settings().aqua_db.startswith("postgresql+asyncpg://")
+    assert settings_cls().aqua_db.startswith("postgresql+asyncpg://")
 
 
 @pytest.mark.parametrize("value", ["", "   ", "\t\n"])
-def test_empty_aqua_db_rejected_at_boot(fresh_settings, monkeypatch, value):
+def test_empty_aqua_db_rejected_at_boot(settings_cls, monkeypatch, value):
     monkeypatch.setenv("AQUA_DB", value)
     with pytest.raises(ValidationError, match="AQUA_DB"):
-        fresh_settings()
+        settings_cls()
 
 
-def test_missing_aqua_db_rejected_at_boot(fresh_settings, monkeypatch):
+def test_missing_aqua_db_rejected_at_boot(settings_cls, monkeypatch):
     monkeypatch.delenv("AQUA_DB", raising=False)
     with pytest.raises(ValidationError):
-        fresh_settings()
+        settings_cls()


### PR DESCRIPTION
## What & why

Follow-up to Copilot's review on #850, tightening the fail-fast config work from #847. All three findings were legitimate; none blocked the promotion, so they're addressed here against `main`.

## Changes

- **`config.py` — reject empty `AQUA_DB` at boot.** `aqua_db: str` is required, but pydantic treats an explicitly-set empty string (`AQUA_DB=`) as a valid `str`, so it passed boot validation and only failed later as an opaque SQLAlchemy error — contradicting the fail-fast goal. Adds a `field_validator` rejecting empty/whitespace. This mirrors the existing non-empty `SECRET_KEY` guard in `security_routes/utilities.py`, so the two required vars now behave consistently.

- **`README.md` / `.env.example` — correct where `SECRET_KEY` validation lives.** Both docs said `config.Settings` type-validates the required vars "`AQUA_DB` or `SECRET_KEY`". But `secret_key` is intentionally `Optional[str] = None` on `config.Settings` (so config-only consumers like Alembic can import it), and its non-empty requirement is enforced at import in `security_routes/utilities.py`. Reworded to reflect that split. Both checks are still fail-fast at boot — only the *location* of the `SECRET_KEY` check was mis-stated.

- **`test/test_config.py` (new)** — pins the `AQUA_DB` contract: valid URL accepted; empty / whitespace / missing all raise `ValidationError` at construction.

## Test plan

- [x] `pytest test/test_config.py` — 5 passed (valid, empty, whitespace×2, missing).
- [x] Manual: `Settings()` with `AQUA_DB='   '` raises; with a real URL succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
