### PR TITLE
chore: #850 promotion-review follow-ups (dead deps, config tests, log redaction)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,6 @@ asyncpg==0.27.0
 attrs==23.2.0
 bcrypt==4.1.2
 black==23.12.1
-boto3==1.21.31
-botocore==1.24.46
 certifi==2023.11.17
 cffi==1.16.0
 charset-normalizer==2.1.1
@@ -88,7 +86,6 @@ pyzmq==25.1.2
 requests==2.31.0
 requests-toolbelt==0.9.1
 rsa==4.9
-s3transfer==0.5.2
 scikit-learn==1.6.1
 scipy==1.13.1
 six==1.16.0

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -44,3 +44,65 @@ def test_missing_aqua_db_rejected_at_boot(settings_cls, monkeypatch):
     monkeypatch.delenv("AQUA_DB", raising=False)
     with pytest.raises(ValidationError):
         settings_cls()
+
+
+# A valid AQUA_DB so the required-field check passes and the tests below can
+# exercise coercion of the *other* fields.
+_VALID_DB = "postgresql+asyncpg://u:p@localhost:5432/db"
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "AQUA_DB_POOL_SIZE",
+        "AQUA_DB_MAX_OVERFLOW",
+        "AQUA_DB_POOL_TIMEOUT",
+        "AQUA_DB_POOL_RECYCLE",
+    ],
+)
+def test_non_numeric_pool_config_rejected_at_boot(settings_cls, monkeypatch, env_name):
+    """Non-numeric pool config fails fast at Settings() construction.
+
+    These int fields replaced the hand-rolled ``_env_int()`` helper removed from
+    database.dependencies; pydantic must reject a malformed value at boot (the
+    same fail-fast contract AQUA_DB has) rather than letting it surface as an
+    opaque error when the engine is built.
+    """
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv(env_name, "notanumber")
+    with pytest.raises(ValidationError, match=env_name.lower()):
+        settings_cls()
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("true", True),
+        ("True", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("false", False),
+        ("False", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+    ],
+)
+def test_loki_enabled_bool_coercion(settings_cls, monkeypatch, raw, expected):
+    """LOKI_ENABLED is a real bool, parsed from the usual truthy/falsy spellings.
+
+    This is the whole point of the typed field: it avoids the
+    ``bool(os.getenv("LOKI_ENABLED"))`` footgun (cf. #712) where any non-empty
+    string — including "false" — was truthy.
+    """
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv("LOKI_ENABLED", raw)
+    assert settings_cls().loki_enabled is expected
+
+
+def test_invalid_loki_enabled_rejected_at_boot(settings_cls, monkeypatch):
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv("LOKI_ENABLED", "maybe")
+    with pytest.raises(ValidationError):
+        settings_cls()

--- a/utils/logging_config.py
+++ b/utils/logging_config.py
@@ -135,8 +135,13 @@ def setup_logger(
 
             logger.addHandler(loki_handler)
         except Exception as e:
-            # Fail gracefully if Loki is unavailable
-            logger.warning(f"Failed to initialize Loki handler: {e}")
+            # Fail gracefully if Loki is unavailable. Log the exception *type*
+            # rather than its str(): the message originates in the private
+            # observability-library and could embed the Loki auth token or URL
+            # (e.g. an auth/URL-validation error that echoes its input), which
+            # would then land in plaintext in console logs. The type name is
+            # enough to diagnose without risking credential exposure.
+            logger.warning("Failed to initialize Loki handler: %s", type(e).__name__)
 
     return logger
 


### PR DESCRIPTION
## Summary

Follow-ups surfaced by the release-readiness review of **PR #850** (`main` → `release`). These are the low-risk, code-only items; they land on `main` so they ride the next promotion. The **critical** finding from that review — the prod Loki deploy gap — is intentionally **not** here (it's held pending confirmation of `LOKI_ENABLED` in the prod App Runner env).

## Changes

- **Remove dead `boto3`/`botocore`/`s3transfer`** from `requirements.txt`. Their only consumer was the v1/v2 `key_fetch.py` API-key auth path removed in #711/#846; no application code imports them (grep-confirmed repo-wide). Drops unused AWS-SDK attack surface (transitive CVEs) with zero functional change. (`jmespath` left in place conservatively — tiny, pure-Python, and not clearly boto-exclusive.)
- **`test/test_config.py`** — cover pydantic coercion the typed config (#836) introduced but didn't yet test:
  - Non-numeric integer pool config (`AQUA_DB_POOL_SIZE`, `_MAX_OVERFLOW`, `_POOL_TIMEOUT`, `_POOL_RECYCLE`) now asserted to fail fast at `Settings()` construction, matching `AQUA_DB`'s fail-fast contract (replaces the removed hand-rolled `_env_int()` helper).
  - `LOKI_ENABLED` bool coercion across the truthy/falsy spellings plus an invalid value — the exact `bool(os.getenv(...))` truthiness footgun (cf. #712) the typed field exists to fix.
- **`utils/logging_config.py`** — log the Loki-handler-init exception *type* (`type(e).__name__`) rather than its `str()`. The message originates in the private observability-library and could embed the Loki auth token/URL; this keeps it diagnosable without risking credential exposure in plaintext console logs.

## Test plan

- [x] `pytest test/test_config.py` — 20 passed (5 existing + 15 new)
- [x] `pytest test/test_logging_config.py` — 4 passed
- [x] `black --check`, `isort --check --profile black`, `flake8` (repo rules) — clean
- [x] `import app` + `import utils.logging_config` — OK
- [x] Grep-confirmed no `boto3`/`botocore`/`s3transfer`/`jmespath` imports anywhere in the repo

## Deferred (tracked separately, not in this PR)

- 🔴 **Prod Loki deploy gap** — Dockerfile installs only `requirements.txt`, which no longer contains the observability library; held pending prod `LOKI_ENABLED` check.
- Keep-alive margin tuning; root-level test files not run by CI; dead sync engine in `database/database.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)