### PR TITLE
fix: install observability-library in Docker image so prod keeps Loki logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,13 @@
 FROM python:3.11
 
 COPY requirements.txt requirements-observability.txt ./
-# RUN apt update
 
 # Install the observability superset so the deployed image includes the Loki
 # handler (observability-library) that ships logs when LOKI_ENABLED=true.
 # requirements-observability.txt `-r`'s the base requirements, so this installs
 # everything. Contributors without the extra still build from requirements.txt
 # directly; only the deployed image needs the observability dependency.
-RUN pip install -r requirements-observability.txt && \
-    rm -rf var/lin/apt/lists/*
+RUN pip install -r requirements-observability.txt
 
 RUN mkdir /app
 COPY *.py /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 FROM python:3.11
 
-COPY requirements.txt .
+COPY requirements.txt requirements-observability.txt ./
 # RUN apt update
 
-RUN pip install -r requirements.txt && \
+# Install the observability superset so the deployed image includes the Loki
+# handler (observability-library) that ships logs when LOKI_ENABLED=true.
+# requirements-observability.txt `-r`'s the base requirements, so this installs
+# everything. Contributors without the extra still build from requirements.txt
+# directly; only the deployed image needs the observability dependency.
+RUN pip install -r requirements-observability.txt && \
     rm -rf var/lin/apt/lists/*
 
 RUN mkdir /app


### PR DESCRIPTION
## Summary

Completes the **critical finding** from the PR #850 promotion review: the deployed image silently lost Loki log shipping.

#849 made `observability-library` an optional import and moved it out of the mandatory `requirements.txt` into `requirements-observability.txt` (so a plain build succeeds without it). But the **Dockerfile installs only `requirements.txt`**, so the deployed image no longer contains the Loki handler. With `LOKI_ENABLED=true`, `utils/logging_config.py` falls to the "library unavailable → warn once → console" path and Loki shipping silently stops — and the Grafana dashboard (sourced from Loki) goes dark. That was an unintended side effect of an import-hygiene change; #849 explicitly claimed to *preserve* behavior when Loki is enabled + installed.

## Change

- `Dockerfile`: `COPY` both requirements files and `pip install -r requirements-observability.txt` (a superset that `-r`'s the base). Restores the pre-#849 deploy behavior.

The dev/contributor path is unaffected — local builds still use `requirements.txt` directly; only the deployed image pulls the observability dependency.

## Why this is low-risk

- **Restores prior state:** the *exact* combination (base `requirements.txt` + `observability-library@v0.1.0`) was installed in the image before #849 and built/deployed successfully. This reinstates it.
- **No dependency conflict:** `observability-library` declares one dependency, `aiohttp>=3.8.0`, already satisfied by the pinned `aiohttp==3.8.3`; `requires-python >=3.10` matches the `python:3.11` base. No new transitive deps.
- **Public repo:** `sil-ai/observability-library` is public and the `v0.1.0` tag resolves anonymously, so the credential-free `docker build` in CI (`make build-actions`) can clone it — as it did before #849.
- **CI validates it:** `pr.yml` runs `make build-actions`, so this PR's own CI performs the real image build with the observability install.

## Deploy note

This restores Loki shipping **only if the prod App Runner service has `LOKI_ENABLED=true`**. If prod does *not* use Loki, this change is a harmless (the extra dep is installed but unused) — but in that case the better call is to keep it out and decommission the Grafana dashboard. Confirm `LOKI_ENABLED` on the prod service.

## Test plan

- [x] `observability-library` deps inspected: only `aiohttp>=3.8.0`, satisfied by base `aiohttp==3.8.3`; `requires-python >=3.10` ✓
- [x] Repo public; `v0.1.0` tag resolves with no credentials
- [ ] CI `make build-actions` builds the image with the observability install (authoritative)

## Relationship to other PRs

- Follows the PR #850 promotion review (this is the "critical" item that was held pending the prod `LOKI_ENABLED` check).
- Independent of #852 (the other review follow-ups: dead deps, config tests, log redaction). Both target `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)