### PR TITLE
feat: add GET /averageresult endpoint (#254)

### DIFF
--- a/assessment_routes/v3/results_query_routes.py
+++ b/assessment_routes/v3/results_query_routes.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import Float, Text, case, cast, func, text
+from sqlalchemy import Float, Text, case, cast, func, literal, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql import select
@@ -36,7 +36,10 @@ from models import AlignmentMatch, MultipleResult, NgramResult
 from models import Result_v2 as Result
 from models import TextLengthsResult, TfidfResult, WordAlignment
 from security_routes.auth_routes import get_current_user
-from security_routes.utilities import is_user_authorized_for_assessment
+from security_routes.utilities import (
+    get_authorized_revision_ids,
+    is_user_authorized_for_assessment,
+)
 from utils.logging_config import setup_logger
 from utils.verse_range_utils import merge_verse_ranges
 
@@ -236,6 +239,106 @@ async def build_results_query(
         base_query,
         final_count_query,
     )
+
+
+async def build_average_results_query(
+    assessment_ids: List[int],
+    assessment_type: str,
+    book: Optional[str],
+    chapter: Optional[int],
+    verse: Optional[int],
+    page: Optional[int],
+    page_size: Optional[int],
+    aggregate: Optional[aggType],
+    reverse: Optional[bool],
+) -> Tuple:
+    """Build the averaged-results query for ``/averageresult``.
+
+    Mirrors ``build_results_query`` but averages ``score`` across *all*
+    the supplied ``assessment_ids`` (the deduplicated set of assessments
+    for one revision + type) instead of a single assessment. Because
+    every assessment writes at most one result row per verse, grouping by
+    the vref/aggregation columns without grouping on ``assessment_id``
+    yields the mean score across the reference texts for each vref.
+    """
+    base_query = select(AssessmentResult).where(
+        AssessmentResult.assessment_id.in_(assessment_ids)
+    )
+
+    if book is not None:
+        base_query = base_query.where(func.upper(AssessmentResult.book) == book.upper())
+    if chapter is not None:
+        base_query = base_query.where(AssessmentResult.chapter == chapter)
+    if verse is not None:
+        base_query = base_query.where(AssessmentResult.verse == verse)
+
+    # Mirror /result's missing-words handling: for these types only the
+    # non-null source rows are meaningful unless the caller asks for the
+    # reverse view.
+    only_non_null = (
+        assessment_type in ["question-answering", "word-tests"] and not reverse
+    )
+    if only_non_null:
+        base_query = base_query.where(AssessmentResult.source.isnot(None))
+
+    subquery = base_query.subquery()
+
+    if aggregate == aggType.chapter:
+        group_by_columns = ["book", "chapter"]
+    elif aggregate == aggType.book:
+        group_by_columns = ["book"]
+    elif aggregate == aggType.text:
+        group_by_columns = []
+    else:
+        group_by_columns = ["book", "chapter", "verse"]
+
+    # For text-level aggregation there are no grouping columns — every row
+    # collapses into a single average. We still GROUP BY (rather than emit a
+    # bare aggregate) so that an empty input yields zero rows instead of one
+    # all-NULL row that would fail Result validation. A plain constant is
+    # rejected by Postgres ("non-integer constant in GROUP BY"), so group by a
+    # scalar subquery, which is a valid single-group expression.
+    if group_by_columns:
+        main_group_by = [getattr(subquery.c, col) for col in group_by_columns]
+        count_group_by = [getattr(AssessmentResult, col) for col in group_by_columns]
+    else:
+        main_group_by = [select(literal(1)).scalar_subquery()]
+        count_group_by = [select(literal(1)).scalar_subquery()]
+
+    base_query = (
+        select(
+            func.min(subquery.c.id).label("id"),
+            *[getattr(subquery.c, col) for col in group_by_columns],
+            func.avg(subquery.c.score).label("score"),
+            func.bool_or(subquery.c.flag).label("flag"),
+            func.bool_or(subquery.c.hide).label("hide"),
+        )
+        .group_by(*main_group_by)
+        .order_by("id")
+    )
+    if page is not None and page_size is not None:
+        base_query = base_query.offset((page - 1) * page_size).limit(page_size)
+
+    count_query = (
+        select(func.count())
+        .select_from(AssessmentResult)
+        .where(AssessmentResult.assessment_id.in_(assessment_ids))
+    )
+    if book is not None:
+        count_query = count_query.where(
+            func.upper(AssessmentResult.book) == book.upper()
+        )
+    if chapter is not None:
+        count_query = count_query.where(AssessmentResult.chapter == chapter)
+    if verse is not None:
+        count_query = count_query.where(AssessmentResult.verse == verse)
+    if only_non_null:
+        count_query = count_query.where(AssessmentResult.source.isnot(None))
+
+    count_subquery = count_query.group_by(*count_group_by).subquery()
+    final_count_query = select(func.count()).select_from(count_subquery)
+
+    return base_query, final_count_query
 
 
 # Process-local memoization of `ngrams_table` total counts, keyed by
@@ -735,6 +838,213 @@ async def get_result(
             "page": page,
             "page_size": page_size,
             "aggregate": aggregate.value if aggregate else None,
+            "total_count": total_count,
+            "results_returned": len(result_list),
+            "duration_s": duration,
+        },
+    )
+
+    return {"results": result_list, "total_count": total_count}
+
+
+@router.get(
+    "/averageresult",
+    response_model=Dict[str, Union[List[Result], int]],
+)
+async def get_average_result(
+    revision_id: int,
+    assessment_type: str,
+    book: Optional[str] = None,
+    chapter: Optional[int] = None,
+    verse: Optional[int] = None,
+    page: Optional[int] = None,
+    page_size: Optional[int] = None,
+    aggregate: Optional[aggType] = None,
+    include_text: bool = False,
+    reverse: Optional[bool] = False,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+):
+    """
+    Returns the average assessment result for a revision, averaged across every
+    reference text it has been assessed against for the given assessment type.
+
+    All finished assessments for ``revision_id`` of type ``assessment_type`` are
+    collected (each has a different ``reference_id``); where the same reference
+    has been assessed more than once only the most recent assessment is used.
+    The scores are then averaged, preserving the ``vref`` dimension so a single
+    average score is returned per verse (or per aggregation group), exactly as
+    ``GET /result`` returns per-verse scores for a single assessment.
+
+    Parameters
+    ----------
+    revision_id : int
+        The ID of the revision to average results for.
+    assessment_type : str
+        The assessment type to average (e.g. "word-alignment").
+    book : str, optional
+        Restrict results to one book.
+    chapter : int, optional
+        Restrict results to one chapter. If set, book must also be set.
+    verse : int, optional
+        Restrict results to one verse. If set, book and chapter must also be set.
+    page : int, optional
+        The page of results to return. If set, page_size must also be set.
+    page_size : int, optional
+        The number of results to return per page. If set, page must also be set.
+    aggregate : str, optional
+        If set to "chapter"/"book"/"text", results are aggregated to that level.
+        Otherwise results are returned at the verse level.
+    include_text : bool, optional
+        If true, include the revision's verse text for each result. Only valid
+        for verse-level results (i.e. when aggregate is not set).
+    reverse : bool, optional
+        For question-answering / word-tests assessments, include the null-source
+        rows as well (matching the /result endpoint's behaviour).
+
+    Returns
+    -------
+    Dict[str, Union[List[Result], int]]
+        A dictionary containing the list of averaged results and the total count.
+    """
+    request_start = time.perf_counter()
+
+    await validate_parameters(book, chapter, verse, aggregate, page, page_size)
+
+    if include_text and aggregate is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "include_text and aggregate cannot both be set. Text can only be "
+                "included for verse-level results."
+            ),
+        )
+
+    # The user must be able to see the revision itself. References they are
+    # not authorised for are simply excluded from the average below, so no
+    # score is ever leaked for a reference the user cannot access.
+    authorized_revision_ids = await get_authorized_revision_ids(current_user.id, db)
+    if revision_id not in authorized_revision_ids:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="User not authorized to see this revision",
+        )
+
+    # Discover the assessments for this revision + type, keeping only the most
+    # recent assessment per reference (DISTINCT ON reference_id, newest first).
+    candidate_assessments = (
+        await db.execute(
+            select(Assessment.id, Assessment.reference_id)
+            .where(
+                Assessment.revision_id == revision_id,
+                Assessment.type == assessment_type,
+                Assessment.status == "finished",
+                Assessment.deleted.is_not(True),
+            )
+            .order_by(
+                Assessment.reference_id,
+                Assessment.end_time.desc().nullslast(),
+                Assessment.id.desc(),
+            )
+            .distinct(Assessment.reference_id)
+        )
+    ).all()
+
+    assessment_ids = [
+        row.id
+        for row in candidate_assessments
+        if row.reference_id is None or row.reference_id in authorized_revision_ids
+    ]
+
+    if not assessment_ids:
+        duration = round(time.perf_counter() - request_start, 2)
+        logger.info(
+            f"get_average_result completed in {duration}s (no assessments)",
+            extra={
+                "method": "GET",
+                "path": "/averageresult",
+                "revision_id": revision_id,
+                "assessment_type": assessment_type,
+                "total_count": 0,
+                "results_returned": 0,
+                "duration_s": duration,
+            },
+        )
+        return {"results": [], "total_count": 0}
+
+    query, count_query = await build_average_results_query(
+        assessment_ids,
+        assessment_type,
+        book,
+        chapter,
+        verse,
+        page,
+        page_size,
+        aggregate,
+        reverse,
+    )
+
+    result_data, total_count = await execute_query(query, count_query, db)
+
+    result_list = []
+    for row in result_data:
+        if aggregate == aggType.chapter:
+            vref = f"{row.book} {row.chapter}"
+        elif aggregate == aggType.book:
+            vref = f"{row.book}"
+        elif aggregate == aggType.text:
+            vref = None
+        else:
+            # Verse level. chapter/verse are nullable, so append them only
+            # when present — degrade gracefully like /result rather than
+            # emitting "GEN None:None".
+            vref = f"{row.book}"
+            if row.chapter is not None:
+                vref += f" {row.chapter}"
+                if row.verse is not None:
+                    vref += f":{row.verse}"
+
+        result_obj = Result(
+            id=row.id if hasattr(row, "id") else None,
+            assessment_id=None,
+            vref=vref,
+            score=row.score if hasattr(row, "score") else None,
+            flag=row.flag if hasattr(row, "flag") else None,
+            hide=row.hide if hasattr(row, "hide") else None,
+        )
+        result_list.append(result_obj)
+
+    # Optionally attach the revision's verse text for each verse-level result.
+    if include_text and result_list:
+        vrefs = [r.vref for r in result_list if r.vref is not None]
+        text_by_vref: Dict[str, Optional[str]] = {}
+        if vrefs:
+            text_rows = await db.execute(
+                select(VerseText.verse_reference, VerseText.text).where(
+                    VerseText.revision_id == revision_id,
+                    VerseText.verse_reference.in_(vrefs),
+                )
+            )
+            text_by_vref = {row.verse_reference: row.text for row in text_rows.all()}
+        for result_obj in result_list:
+            result_obj.revision_text = text_by_vref.get(result_obj.vref)
+
+    duration = round(time.perf_counter() - request_start, 2)
+    logger.info(
+        f"get_average_result completed in {duration}s",
+        extra={
+            "method": "GET",
+            "path": "/averageresult",
+            "revision_id": revision_id,
+            "assessment_type": assessment_type,
+            "assessments_averaged": len(assessment_ids),
+            "book": book,
+            "chapter": chapter,
+            "verse": verse,
+            "page": page,
+            "page_size": page_size,
+            "aggregate": aggregate.value if aggregate else None,
+            "include_text": include_text,
             "total_count": total_count,
             "results_returned": len(result_list),
             "duration_s": duration,

--- a/test/test_assessment_routes/test_results_query_routes.py
+++ b/test/test_assessment_routes/test_results_query_routes.py
@@ -2548,3 +2548,396 @@ def test_textalignmentmatches_use_eflomal_false_is_fastalign(
     sources = {row["source_word"] for row in response.json()["results"]}
     assert "alpha" in sources
     assert "beta" not in sources
+
+
+# ----- /v3/averageresult --------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class AverageResultDataset:
+    """IDs created by the `average_result_dataset` fixture.
+
+    One revision assessed (type "word-alignment") against three references:
+    two the test user can access (ref_a, ref_b) and one they cannot (ref_c).
+    ref_a carries two assessments so the dedup-by-reference (most recent wins)
+    behaviour can be verified. Scores are chosen so the expected averages are
+    exact, and the "wrong" values on the excluded assessments (the stale ref_a
+    assessment and the unauthorized ref_c assessment) differ from the winners
+    so any leak changes the average.
+    """
+
+    revision_id: int
+    ref_a_id: int
+    ref_b_id: int
+    ref_c_id: int
+    unauth_reference_id: int  # ref_c: revision the test user cannot access
+    # An authorized revision with a finished assessment that wrote zero result
+    # rows — exercises the empty-set paths (esp. text aggregation).
+    empty_results_revision_id: int
+
+
+@pytest.fixture(scope="module")
+def average_result_dataset(test_db_session):
+    user = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group = test_db_session.query(Group).first()
+
+    def _version(name, abbr):
+        return BibleVersion(
+            name=name,
+            iso_language="eng",
+            iso_script="Latn",
+            abbreviation=abbr,
+            owner_id=user.id if user else None,
+        )
+
+    v_rev = _version("avg_res_revision", "avg-rev")
+    v_ref_a = _version("avg_res_reference_a", "avg-ra")
+    v_ref_b = _version("avg_res_reference_b", "avg-rb")
+    v_ref_c = _version("avg_res_reference_c", "avg-rc")
+    v_empty = _version("avg_res_empty", "avg-empty")
+    test_db_session.add_all([v_rev, v_ref_a, v_ref_b, v_ref_c, v_empty])
+    test_db_session.flush()
+
+    # Grant the test user's group access to the revision, refs A and B, and the
+    # empty-results revision; ref C is deliberately left inaccessible.
+    for v in (v_rev, v_ref_a, v_ref_b, v_empty):
+        test_db_session.add(
+            BibleVersionAccess(bible_version_id=v.id, group_id=group.id)
+        )
+
+    def _revision(version_id, d):
+        return BibleRevision(date=d, bible_version_id=version_id, published=False)
+
+    r_rev = _revision(v_rev.id, date(2023, 1, 1))
+    r_ref_a = _revision(v_ref_a.id, date(2023, 1, 2))
+    r_ref_b = _revision(v_ref_b.id, date(2023, 1, 3))
+    r_ref_c = _revision(v_ref_c.id, date(2023, 1, 4))
+    r_empty = _revision(v_empty.id, date(2023, 1, 5))
+    test_db_session.add_all([r_rev, r_ref_a, r_ref_b, r_ref_c, r_empty])
+    test_db_session.flush()
+
+    def _assessment(reference_id, end_time):
+        return Assessment(
+            revision_id=r_rev.id,
+            reference_id=reference_id,
+            type="word-alignment",
+            status="finished",
+            end_time=end_time,
+        )
+
+    # ref_a assessed twice: the newer one (2024-06) is the winner; the older
+    # one (2024-01) carries stale scores that must be excluded by dedup.
+    a_ref_a_new = _assessment(r_ref_a.id, datetime(2024, 6, 1))
+    a_ref_a_old = _assessment(r_ref_a.id, datetime(2024, 1, 1))
+    a_ref_b = _assessment(r_ref_b.id, datetime(2024, 3, 1))
+    a_ref_c = _assessment(r_ref_c.id, datetime(2024, 5, 1))
+    # A finished assessment for the empty-results revision, with NO result rows.
+    a_empty = Assessment(
+        revision_id=r_empty.id,
+        reference_id=r_ref_a.id,
+        type="word-alignment",
+        status="finished",
+        end_time=datetime(2024, 2, 1),
+    )
+    test_db_session.add_all([a_ref_a_new, a_ref_a_old, a_ref_b, a_ref_c, a_empty])
+    test_db_session.flush()
+
+    def _result(assessment_id, book, chapter, verse, score):
+        return AssessmentResult(
+            assessment_id=assessment_id,
+            vref=None,
+            score=score,
+            book=book,
+            chapter=chapter,
+            verse=verse,
+            flag=False,
+            note=None,
+            source=None,
+            target=None,
+            hide=False,
+        )
+
+    test_db_session.add_all(
+        [
+            # Winner for ref_a
+            _result(a_ref_a_new.id, "GEN", 1, 1, 0.4),
+            _result(a_ref_a_new.id, "GEN", 1, 2, 0.6),
+            _result(a_ref_a_new.id, "EXO", 1, 1, 0.2),
+            # Stale ref_a (must be excluded by dedup) — deliberately 0.9 so any
+            # leak would inflate the averages.
+            _result(a_ref_a_old.id, "GEN", 1, 1, 0.9),
+            _result(a_ref_a_old.id, "GEN", 1, 2, 0.9),
+            _result(a_ref_a_old.id, "EXO", 1, 1, 0.9),
+            # ref_b
+            _result(a_ref_b.id, "GEN", 1, 1, 0.6),
+            _result(a_ref_b.id, "GEN", 1, 2, 0.8),
+            _result(a_ref_b.id, "EXO", 1, 1, 0.4),
+            # ref_c (must be excluded by authorization) — deliberately 0.0 so
+            # any leak would deflate the averages.
+            _result(a_ref_c.id, "GEN", 1, 1, 0.0),
+            _result(a_ref_c.id, "GEN", 1, 2, 0.0),
+            _result(a_ref_c.id, "EXO", 1, 1, 0.0),
+        ]
+    )
+
+    # Revision verse text for the include_text path.
+    test_db_session.add_all(
+        [
+            VerseText(
+                revision_id=r_rev.id,
+                verse_reference="GEN 1:1",
+                text="in the beginning",
+                book="GEN",
+                chapter=1,
+                verse=1,
+            ),
+            VerseText(
+                revision_id=r_rev.id,
+                verse_reference="GEN 1:2",
+                text="and the earth",
+                book="GEN",
+                chapter=1,
+                verse=2,
+            ),
+        ]
+    )
+    test_db_session.commit()
+
+    return AverageResultDataset(
+        revision_id=r_rev.id,
+        ref_a_id=r_ref_a.id,
+        ref_b_id=r_ref_b.id,
+        ref_c_id=r_ref_c.id,
+        unauth_reference_id=r_ref_c.id,
+        empty_results_revision_id=r_empty.id,
+    )
+
+
+def _avg_by_vref(response):
+    return {r["vref"]: r["score"] for r in response.json()["results"]}
+
+
+def test_averageresult_verse_level_averages_across_references(
+    client, regular_token1, average_result_dataset
+):
+    """Averages across the (deduplicated, authorized) references, per vref.
+
+    GEN 1:1 = mean(0.4, 0.6) = 0.5, GEN 1:2 = mean(0.6, 0.8) = 0.7,
+    EXO 1:1 = mean(0.2, 0.4) = 0.3. The stale ref_a assessment (0.9s) and the
+    unauthorized ref_c assessment (0.0s) are both excluded — any leak from
+    either would shift these averages.
+    """
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total_count"] == 3
+    scores = _avg_by_vref(response)
+    assert scores["GEN 1:1"] == pytest.approx(0.5)
+    assert scores["GEN 1:2"] == pytest.approx(0.7)
+    assert scores["EXO 1:1"] == pytest.approx(0.3)
+
+
+def test_averageresult_book_filter(client, regular_token1, average_result_dataset):
+    """book filter restricts to that book; matching is case-insensitive."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+            "book": "gen",  # lowercase to exercise case-insensitive match
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total_count"] == 2
+    scores = _avg_by_vref(response)
+    assert set(scores) == {"GEN 1:1", "GEN 1:2"}
+
+
+def test_averageresult_book_aggregation(client, regular_token1, average_result_dataset):
+    """aggregate=book collapses each book to a single averaged row."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+            "aggregate": "book",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    scores = _avg_by_vref(response)
+    # GEN: mean(0.4, 0.6, 0.6, 0.8) = 0.6 ; EXO: mean(0.2, 0.4) = 0.3
+    assert scores["GEN"] == pytest.approx(0.6)
+    assert scores["EXO"] == pytest.approx(0.3)
+
+
+def test_averageresult_text_aggregation(client, regular_token1, average_result_dataset):
+    """aggregate=text returns one row averaging every included result."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+            "aggregate": "text",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["total_count"] == 1
+    assert len(body["results"]) == 1
+    result = body["results"][0]
+    assert result["vref"] is None
+    # mean(0.4, 0.6, 0.2, 0.6, 0.8, 0.4) = 3.0 / 6 = 0.5
+    assert result["score"] == pytest.approx(0.5)
+
+
+def test_averageresult_pagination(client, regular_token1, average_result_dataset):
+    """Pagination returns page slices while total_count reflects the full set."""
+    page1 = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+            "page": 1,
+            "page_size": 2,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    page2 = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+            "page": 2,
+            "page_size": 2,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert page1.status_code == 200 and page2.status_code == 200
+    assert page1.json()["total_count"] == 3
+    assert page2.json()["total_count"] == 3
+    assert len(page1.json()["results"]) == 2
+    assert len(page2.json()["results"]) == 1
+    # No overlap between pages.
+    page1_vrefs = {r["vref"] for r in page1.json()["results"]}
+    page2_vrefs = {r["vref"] for r in page2.json()["results"]}
+    assert page1_vrefs.isdisjoint(page2_vrefs)
+
+
+def test_averageresult_include_text(client, regular_token1, average_result_dataset):
+    """include_text attaches the revision's verse text to each verse-level row."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+            "book": "GEN",
+            "include_text": True,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    texts = {r["vref"]: r["revision_text"] for r in response.json()["results"]}
+    assert texts["GEN 1:1"] == "in the beginning"
+    assert texts["GEN 1:2"] == "and the earth"
+
+
+def test_averageresult_include_text_with_aggregate_is_rejected(
+    client, regular_token1, average_result_dataset
+):
+    """include_text only makes sense at verse level, so it 400s with aggregate."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+            "aggregate": "book",
+            "include_text": True,
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 400
+    assert "include_text" in response.json()["detail"]
+
+
+def test_averageresult_unauthorized_revision(
+    client, regular_token2, average_result_dataset
+):
+    """A user without access to the revision gets 403."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "word-alignment",
+        },
+        headers={"Authorization": f"Bearer {regular_token2}"},
+    )
+    assert response.status_code == 403
+
+
+def test_averageresult_no_matching_assessments_returns_empty(
+    client, regular_token1, average_result_dataset
+):
+    """An authorized revision with no assessments of the type yields an empty
+    set (200), not a 404."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.revision_id,
+            "assessment_type": "no-such-type",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["results"] == []
+    assert body["total_count"] == 0
+
+
+def test_averageresult_text_aggregation_empty_results(
+    client, regular_token1, average_result_dataset
+):
+    """A finished assessment that wrote no result rows must not 500 under text
+    aggregation — the collapsed single group should yield zero rows, not one
+    all-NULL row that fails Result validation."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.empty_results_revision_id,
+            "assessment_type": "word-alignment",
+            "aggregate": "text",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["results"] == []
+    assert body["total_count"] == 0
+
+
+def test_averageresult_verse_level_empty_results(
+    client, regular_token1, average_result_dataset
+):
+    """Verse-level averaging over an assessment with no result rows is empty."""
+    response = client.get(
+        "/v3/averageresult",
+        params={
+            "revision_id": average_result_dataset.empty_results_revision_id,
+            "assessment_type": "word-alignment",
+        },
+        headers={"Authorization": f"Bearer {regular_token1}"},
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["results"] == []
+    assert body["total_count"] == 0


### PR DESCRIPTION
## What & why

Closes #254.

Adds a new `GET /averageresult` endpoint that returns the **average assessment result for a revision, averaged across every reference text it has been assessed against** for a given assessment type. The result preserves the `vref` dimension — one average score per verse — just like `GET /result` returns per-verse scores for a single assessment.

## How it works

Given `revision_id` and `assessment_type`:

1. **Discover** all `finished` (non-deleted) assessments for that revision + type (each has a different `reference_id`).
2. **Deduplicate** by `reference_id`, keeping only the most recent per reference — `DISTINCT ON (reference_id)` ordered by `end_time DESC NULLS LAST, id DESC` (the same recency pattern used in `search_routes.py`).
3. **Average** `AssessmentResult.score` across the selected assessments, grouped by the vref / aggregation columns.

## Parameters (parity with `/result`)

- `book` / `chapter` / `verse` filtering (book match is case-insensitive)
- `aggregate` = `chapter` / `book` / `text`
- `page` / `page_size` pagination
- `include_text` — attach the revision's verse text to each verse-level result (rejected with 400 alongside `aggregate`, since it's verse-level only)
- `reverse` — include null-source rows for `question-answering` / `word-tests`, matching `/result`

Registered under both `/v3` and `/latest`.

## Authorization

- 403 if the caller can't access the revision.
- References the caller isn't authorized for are **excluded from the average**, so no score is ever averaged in for a reference they can't see. Uses the existing `get_authorized_revision_ids` helper (one query) rather than N per-assessment auth checks.

## Notable edge cases handled

- **Empty result sets**: a finished assessment that wrote zero result rows returns `{"results": [], "total_count": 0}` (200), including under `aggregate=text` — which groups by a scalar subquery so an empty input yields zero rows rather than one all-NULL row that would fail `Result` validation (500).
- Verse-level `vref` composition guards nullable `chapter`/`verse` instead of emitting `"GEN None:None"`.

## Tests

11 new tests in `test/test_assessment_routes/test_results_query_routes.py` covering: averaging across references, dedup (most-recent-wins, with a stale-score trap), authorization filtering (unauthorized-reference trap + 403), book filtering, book/text aggregation, pagination, `include_text`, the `include_text`+`aggregate` 400, no-matching-assessments, and the empty-results text/verse paths.

Full `test_results_query_routes.py` module passes locally (59 passed). The endpoint diff was code-reviewed; the review's critical finding (text-aggregation empty-set 500) is fixed and has a dedicated regression test.

## Note

Issue #254 is marked **closed** on GitHub and predates the v4 refactor (an older `/averageresults` existed on the pre-v4 `master`). This PR reimplements it for the current v3/latest codebase per the issue's spec. Re-confirm the endpoint is still wanted before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)