### PR TITLE
fix: treat blank DB-pool env vars as unset in typed config

### DIFF
--- a/config.py
+++ b/config.py
@@ -69,6 +69,26 @@ class Settings(BaseSettings):
     aqua_db_pool_timeout: int = 10
     aqua_db_pool_recycle: int = 1800
 
+    @field_validator(
+        "aqua_db_pool_size",
+        "aqua_db_max_overflow",
+        "aqua_db_pool_timeout",
+        "aqua_db_pool_recycle",
+        mode="before",
+    )
+    @classmethod
+    def _blank_pool_var_to_default(cls, v, info):
+        # docker-compose wires these as ``AQUA_DB_POOL_SIZE=${AQUA_DB_POOL_SIZE:-}``,
+        # i.e. present-but-blank means "use the app default". The pre-#847
+        # ``_env_int`` helper honored that (empty string => default); pydantic's
+        # int parsing does not — a present ``""`` raises int_parsing at boot. Map a
+        # blank/whitespace value back to the field's declared default to restore
+        # that behavior. Everything else (valid ints, and non-blank garbage that
+        # must still fail fast) falls through to pydantic's normal coercion.
+        if isinstance(v, str) and v.strip() == "":
+            return cls.model_fields[info.field_name].default
+        return v
+
     # --- Auth -----------------------------------------------------------
     # Optional at this layer so that importing config never fails for consumers
     # that don't need JWT signing (notably Alembic, which imports

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,6 +14,15 @@ os.environ["AQUA_DB_POOLCLASS"] = "null"
 # setdefault so we never override a real value the environment provides.
 os.environ.setdefault("SECRET_KEY", "test-secret-key-not-for-production")
 
+# config.Settings (imported transitively via `from app import app` below)
+# requires AQUA_DB at construction, which runs at collection time — before any
+# test fixture. Provide the standard local test DB so a bare environment (fresh
+# clone, no .env, AQUA_DB unset) can still collect; setdefault means a real
+# AQUA_DB already exported by the shell/CI (e.g. `make test`) always wins.
+os.environ.setdefault(
+    "AQUA_DB", "postgresql+asyncpg://dbuser:dbpassword@localhost:5432/dbname"
+)
+
 from datetime import date  # noqa: E402
 
 import bcrypt  # noqa: E402

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -74,6 +74,43 @@ def test_non_numeric_pool_config_rejected_at_boot(settings_cls, monkeypatch, env
         settings_cls()
 
 
+# (env var, field name, declared default) for the four pooled int settings.
+_POOL_FIELDS = [
+    ("AQUA_DB_POOL_SIZE", "aqua_db_pool_size", 2),
+    ("AQUA_DB_MAX_OVERFLOW", "aqua_db_max_overflow", 3),
+    ("AQUA_DB_POOL_TIMEOUT", "aqua_db_pool_timeout", 10),
+    ("AQUA_DB_POOL_RECYCLE", "aqua_db_pool_recycle", 1800),
+]
+
+
+@pytest.mark.parametrize("env_name,field_name,default", _POOL_FIELDS)
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+def test_blank_pool_config_falls_back_to_default(
+    settings_cls, monkeypatch, env_name, field_name, default, blank
+):
+    """A present-but-blank pool var uses the field default, not a crash.
+
+    docker-compose wires these as ``AQUA_DB_POOL_SIZE=${AQUA_DB_POOL_SIZE:-}``,
+    so an unset host var reaches the process as an empty string meaning "use the
+    default". The pre-#847 ``_env_int`` helper honored this; typed pydantic ints
+    do not (a present ``""`` raises int_parsing at boot). The blank->default
+    validator restores that behavior; whitespace is treated the same as empty.
+    """
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv(env_name, blank)
+    assert getattr(settings_cls(), field_name) == default
+
+
+@pytest.mark.parametrize("env_name,field_name,default", _POOL_FIELDS)
+def test_valid_pool_config_coerced_to_int(
+    settings_cls, monkeypatch, env_name, field_name, default
+):
+    """A valid integer string is still coerced normally (blank fallback aside)."""
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv(env_name, "7")
+    assert getattr(settings_cls(), field_name) == 7
+
+
 @pytest.mark.parametrize(
     "raw,expected",
     [


### PR DESCRIPTION
## Regression

The typed-config migration (#847, on `main`) introduced a boot-time crash: setting any of the four DB-pool env vars to an **empty string** now fails with a pydantic `ValidationError`, where the previous code treated a blank value as "use the default."

`docker-compose.yml` wires these vars blank by default:

```yaml
- AQUA_DB_POOL_SIZE=${AQUA_DB_POOL_SIZE:-}
```

(and the same for `AQUA_DB_MAX_OVERFLOW`, `AQUA_DB_POOL_TIMEOUT`, `AQUA_DB_POOL_RECYCLE`). On `release`, `database/dependencies.py` read these through an `_env_int` helper that deliberately treated empty string as "unset" and returned the default. #847 replaced that helper with typed pydantic `int` fields in `config.py` (`aqua_db_pool_size: int = 2`, etc.). Pydantic falls back to a field default **only when the env var is entirely absent** — a present-but-empty `""` is treated as a malformed int:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Settings
aqua_db_pool_size
  Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='']
```

Because `config.py` builds `settings = Settings()` at module import, `docker compose up api` now crashes at boot.

## Fix

Fixed at the **config layer**, where it is environment-agnostic — a `field_validator(..., mode="before")` over the four int pool fields maps an empty-or-whitespace string to the field's declared default, and lets everything else fall through to pydantic's normal coercion.

`docker-compose.yml` is intentionally left unchanged: the blank-means-default convention is deliberate and other deploy environments may rely on it, so the fix belongs at the layer that is environment-agnostic.

Behavior restored to parity with `release`:

| Input | Result |
|---|---|
| blank `""` / whitespace `"   "` | field default (**regression fixed**) |
| valid int string `"7"` | `7` (unchanged) |
| non-blank garbage `"notanumber"` | still raises at boot (fail-fast preserved) |
| var entirely absent | field default (unchanged) |

## Tests

Extended `test/test_config.py` with parametrized cases across all four pool fields: blank, whitespace, and valid-int, alongside the existing non-numeric fail-fast case. Tests are hermetic (construct `Settings()` under a monkeypatched env). `pytest test/test_config.py` → 36 passed.

## Test-collection robustness (`test/conftest.py`)

Also seeds an `AQUA_DB` fallback via `os.environ.setdefault(...)` in `test/conftest.py`, mirroring the existing `SECRET_KEY` fallback. `config.Settings` requires `AQUA_DB` at import, and `conftest.py` imports the app (`from app import app`) at collection time — so on a bare environment (fresh clone, no `.env`, `AQUA_DB` unset) collection fails before any fixture runs. This keeps the whole suite collectable with no ambient env; a real `AQUA_DB` already exported by the shell/CI (e.g. `make test`) still wins.

This folds in the fix for the test-hermeticity comments Copilot raised on #850 (`test/test_config.py`, `test/test_logging_config.py`): per-file seeding wouldn't actually help there, since conftest's app import fails first — one `setdefault` at the collection entry point covers every test file.

## Scope

Code-only — **no schema change and no Alembic migration**. Touches `config.py`, `test/conftest.py`, and `test/test_config.py`. The pool-var change is specifically a local-compose dev-flow regression (the deployed App Runner services set concrete integer values, not empty strings), but still a real bug. Restores parity with `release`; no deploy-time change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
