### PR TITLE
fix: validate ENVIRONMENT_LOKI at boot; fix invalid default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,10 @@ LOKI_ENABLED=false
 # LOKI_URL=https://loki.example.com/loki/api/v1/push
 # LOKI_AUTH_TOKEN=replace-with-loki-token
 PROJECT_NAME=aqua-api
-ENVIRONMENT_LOKI=local
+# Loki environment label. When LOKI_ENABLED is true this must be one of
+# release / main / development (the values the observability library accepts);
+# an invalid value fails at boot. Ignored while LOKI_ENABLED is false.
+ENVIRONMENT_LOKI=development
 
 # ==========================================================================
 # DEPLOYMENT & TOOLING

--- a/config.py
+++ b/config.py
@@ -27,8 +27,15 @@ wiring in ``app.configure_cors`` rely on.
 from typing import Optional
 
 from dotenv import load_dotenv
-from pydantic import field_validator
+from pydantic import field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Valid values for the Loki ``environment`` label. Mirrors
+# observability_library.log_schema.LokiLoggerLabels.environment
+# (Literal["release", "main", "development"]). Duplicated here on purpose:
+# config must not import observability-library, whose import is optional and
+# guarded in utils.logging_config so a missing/broken install can't crash boot.
+_VALID_LOKI_ENVIRONMENTS = ("release", "main", "development")
 
 # Load .env into os.environ before Settings reads it. Existing environment
 # variables take precedence (python-dotenv's default override=False), matching
@@ -119,7 +126,24 @@ class Settings(BaseSettings):
     loki_url: Optional[str] = None
     loki_auth_token: Optional[str] = None
     project_name: str = "aqua-api"
-    environment_loki: str = "local"
+    environment_loki: str = "development"
+
+    @model_validator(mode="after")
+    def _valid_loki_environment(self):
+        # Only meaningful when Loki shipping is on: an ``ENVIRONMENT_LOKI`` value
+        # outside the library's allowed set makes LokiLoggerLabels(...) raise
+        # inside setup_logger's broad except, which now logs only the exception
+        # *type* (to avoid leaking the auth token/URL) — so the misconfiguration
+        # would be undiagnosable. Fail fast at boot instead, matching the rest of
+        # this module. Left unchecked when Loki is disabled so local runs keep
+        # working regardless of the label value.
+        if self.loki_enabled and self.environment_loki not in _VALID_LOKI_ENVIRONMENTS:
+            raise ValueError(
+                "ENVIRONMENT_LOKI must be one of "
+                f"{_VALID_LOKI_ENVIRONMENTS} when LOKI_ENABLED is true, "
+                f"got {self.environment_loki!r}"
+            )
+        return self
 
 
 # Instantiated once, at import; import this singleton everywhere config is read.

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -143,3 +143,33 @@ def test_invalid_loki_enabled_rejected_at_boot(settings_cls, monkeypatch):
     monkeypatch.setenv("LOKI_ENABLED", "maybe")
     with pytest.raises(ValidationError):
         settings_cls()
+
+
+@pytest.mark.parametrize("env_value", ["release", "main", "development"])
+def test_valid_loki_environment_accepted_when_enabled(
+    settings_cls, monkeypatch, env_value
+):
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv("LOKI_ENABLED", "true")
+    monkeypatch.setenv("ENVIRONMENT_LOKI", env_value)
+    assert settings_cls().environment_loki == env_value
+
+
+def test_invalid_loki_environment_rejected_when_enabled(settings_cls, monkeypatch):
+    """An ENVIRONMENT_LOKI outside the library's allowed set fails at boot when
+    Loki is on, rather than being swallowed by setup_logger's broad except (which
+    logs only the exception type, making the misconfiguration undiagnosable)."""
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv("LOKI_ENABLED", "true")
+    monkeypatch.setenv("ENVIRONMENT_LOKI", "local")
+    with pytest.raises(ValidationError, match="ENVIRONMENT_LOKI"):
+        settings_cls()
+
+
+def test_invalid_loki_environment_ignored_when_disabled(settings_cls, monkeypatch):
+    """With Loki off, the label value is never sent, so a non-canonical value
+    (including the old 'local' default) must not block boot for local dev."""
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv("LOKI_ENABLED", "false")
+    monkeypatch.setenv("ENVIRONMENT_LOKI", "local")
+    assert settings_cls().environment_loki == "local"


### PR DESCRIPTION
## Summary

Surfaced during the #850 (main → release) promotion review. The Loki `environment` label must be one of `release` / `main` / `development` — the `Literal` accepted by `observability_library.log_schema.LokiLoggerLabels.environment`. But `config.py` defaulted `ENVIRONMENT_LOKI` to `"local"` and accepted any string.

Consequence: if someone sets `LOKI_ENABLED=true` without a valid `ENVIRONMENT_LOKI` (e.g. locally or via docker-compose, whose default is `docker`), `LokiLoggerLabels(...)` raises a `ValidationError` inside `setup_logger`'s broad `except`, which — correctly, to avoid leaking the auth token/URL — logs only `type(e).__name__`. The misconfiguration is silently swallowed and undiagnosable from logs.

**Production is unaffected** (prod sets `ENVIRONMENT_LOKI` to a valid value externally, and no env var names change here). This is a dev-experience / fail-fast-consistency fix.

## Changes

- Default `ENVIRONMENT_LOKI` to a valid value (`development`).
- Add a `model_validator` that fails fast at boot when `LOKI_ENABLED` is true and the label is outside the allowed set — matching the fail-fast philosophy of the rest of `config.py` (empty `AQUA_DB`, malformed pool ints, invalid `LOKI_ENABLED`). Left unchecked when Loki is off, so local runs are unaffected regardless of the label value.
- `config.py` must not import `observability-library` (its import is optional/guarded so a missing install can't crash boot), so the allowed set is mirrored as a local constant with a comment.
- Tests in `test/test_config.py` covering valid / invalid-when-enabled / ignored-when-disabled; updated `.env.example`.

## Test plan

- [x] `pytest test/test_config.py` — 41 pass (4 new, hermetic, no DB).
- [x] black + isort clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)