### PR TITLE
chore(v4): remove dead DB sync-engine scaffolding (#848) + confirm dead route packages (#839)

### DIFF
--- a/database/database.py
+++ b/database/database.py
@@ -1,23 +1,13 @@
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
-
-from config import settings
+# NOTE: The application does all DB access through the async stack
+# (`create_async_engine` / `AsyncSession`, see `database/dependencies.py`).
+# This module intentionally exposes only `Base` for the ORM metadata, which
+# Alembic imports in `alembic/migrations/env.py`.
+#
+# A sync `create_engine(settings.aqua_db)` scaffold (`engine`, `db_session`,
+# `init_db`) used to live here but was dead code: `settings.aqua_db` is an
+# async URL (`postgresql+asyncpg://…`), so the sync engine would have raised on
+# first connect, and nothing ever connected through it. Removed to drop the
+# footgun (see issue #848).
 from database.models import Base
 
-# AQUA_DB is a required setting, validated when `config` is imported, so it is
-# guaranteed to be present (non-empty) here.
-DATABASE_URL = settings.aqua_db
-
-engine = create_engine(DATABASE_URL)
-db_session = scoped_session(
-    sessionmaker(autocommit=False, autoflush=False, bind=engine)
-)
-
-
-Base.query = db_session.query_property()
-
-
-def init_db():
-    # Import all modules here that might define models so that
-    # they will be registered properly on the metadata.
-    Base.metadata.create_all(bind=engine)
+__all__ = ["Base"]


### PR DESCRIPTION
## Summary

Two related v4 dead-code cleanups (both `D1-easy`, `P3-strategic`).

### #848 — Remove dead sync-engine scaffolding from `database/database.py`
Trimmed `database/database.py` to just the `Base` ORM metadata. Removed:
- `engine = create_engine(settings.aqua_db)`
- `db_session = scoped_session(...)`
- `Base.query = db_session.query_property()`
- `init_db()`

**Why it's safe:** `settings.aqua_db` is an async URL (`postgresql+asyncpg://…`); the sync `create_engine` is lazy and would only raise on first connect — and nothing ever connected through it. `engine`/`db_session`/`init_db` had **zero call sites**. The app does all DB access via the async stack (`create_async_engine` / `AsyncSession`, `database/dependencies.py`). The only importer of `database.database` is `alembic/migrations/env.py`, which imports **only `Base`** (still exported). No behavior change.

### #839 — Unmounted route packages (`inference_routes/`, `review_routes/`)
**Already resolved in version control.** The `.py` sources for both packages were removed by earlier v4 commits:
- `inference_routes/` → renamed to `predict` (`bfe91d7`)
- `review_routes/` results → consolidated into `assessment_routes/` (`c4b2c39`)

Neither package is tracked on this branch or `main`, and neither is imported in `app.py` (verified: zero references repo-wide). Only stale, gitignored `.pyc` artifacts remained in local `__pycache__/` dirs and were cleaned up locally (not part of the diff).

**#486 reconciliation:** #486 references `review_routes/v3/results_routes.py` as if live. That file no longer exists — the `validate_parameters` pagination logic it describes now lives in `assessment_routes/v3/results_query_routes.py`. So #486's file reference is stale; `review_routes/` is genuinely dead. The underlying `page >= 1` validation concern (if still open) applies to the new location and is out of scope here.

## Verification
- `import database.database` → exposes only `Base`; `engine`/`db_session`/`init_db` gone.
- `import app` succeeds; `from database.database import Base` (Alembic path) succeeds.
- `pytest test/test_security_routes/test_auth_routes.py` → **4 passed** (exercises the session fixtures).

Closes #848
Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)