### PR TITLE
test: add v3 OpenAPI contract snapshot guard (#756)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,14 @@ test: linting localdb-up
 	pytest test
 	make down
 
+# Rewrite the committed v3 OpenAPI contract baseline that
+# test/test_openapi_contract.py guards. Run after an INTENTIONAL v3 change
+# and commit the resulting snapshot diff (see issue #756, epic #842). No DB
+# required — generating the schema does not touch the database.
+regen-openapi-snapshot:
+	@export PYTHONPATH=${PWD} && \
+	python scripts/regen_openapi_snapshot.py
+
 
 push-branch:
 	docker push ${REGISTRY}/${IMAGENAME}:latest

--- a/scripts/regen_openapi_snapshot.py
+++ b/scripts/regen_openapi_snapshot.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python
+"""Regenerate the committed v3 OpenAPI contract snapshot.
+
+This is the v3 freeze guard's write side (issue #756, epic #842). The
+companion test ``test/test_openapi_contract.py`` compares the live
+``GET /openapi.json`` output against ``test/snapshots/openapi_v3.json`` and
+never writes it; running this script is the *only* sanctioned way to update
+that baseline. Regenerate → commit, and the snapshot diff is the reviewable
+record of every intentional change to the frozen v3 wire contract.
+
+Usage (no arguments, no flags — running it is the whole interface):
+
+    python scripts/regen_openapi_snapshot.py
+    # or, for discoverability alongside `make test`:
+    make regen-openapi-snapshot
+
+The test and this script share ``get_openapi_response`` and ``dump_schema``
+below so the two can never disagree about *what* the contract is or *how* it
+is serialized on disk.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+# Running `python scripts/regen_openapi_snapshot.py` puts this file's directory
+# (scripts/) on sys.path[0], not the repo root, so `from app import app` would
+# fail. Put the repo root first so the app package imports the same way it does
+# under `pytest test` (which runs with PYTHONPATH=<repo root>). Importing this
+# module from the test is a no-op here, since the root is already on the path.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+# The endpoint every real client fetches; snapshot exactly what it serves.
+OPENAPI_PATH = "/openapi.json"
+
+# Committed baseline. Kept next to the test that reads it.
+SNAPSHOT_PATH = REPO_ROOT / "test" / "snapshots" / "openapi_v3.json"
+
+
+def get_openapi_response(client=None):
+    """Return the raw ``GET /openapi.json`` response.
+
+    This is the single fetch path shared by the contract test and this regen
+    script, so both snapshot exactly what the running app serves (the custom
+    ``app.py::my_schema`` output cached on ``app.openapi_schema`` at import).
+
+    Pass an existing ``TestClient`` — the test hands in its module-scoped
+    ``client`` fixture — or omit it to build a throwaway client, which is the
+    script's path when run standalone.
+    """
+    if client is None:
+        # Imported lazily so importing this module (e.g. from the test, which
+        # already has the app loaded via conftest) does not build a second app.
+        from fastapi.testclient import TestClient
+
+        from app import app
+
+        client = TestClient(app)
+    return client.get(OPENAPI_PATH)
+
+
+def dump_schema(schema) -> str:
+    """Serialize ``schema`` exactly as it is stored in the baseline file.
+
+    ``sort_keys=True`` makes the on-disk order deterministic (so unrelated
+    dict-ordering churn never shows up in diffs) and ``indent=2`` keeps the
+    snapshot reviewable line-by-line in PRs. The trailing newline makes the
+    regenerate → commit round-trip byte-clean under end-of-file fixers.
+    """
+    return json.dumps(schema, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> None:
+    resp = get_openapi_response()
+    resp.raise_for_status()
+    schema = resp.json()
+
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    SNAPSHOT_PATH.write_text(dump_schema(schema), encoding="utf-8")
+
+    rel = SNAPSHOT_PATH.relative_to(REPO_ROOT)
+    print(f"Wrote v3 OpenAPI contract snapshot to {rel}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/regen_openapi_snapshot.py
+++ b/scripts/regen_openapi_snapshot.py
@@ -20,17 +20,32 @@ is serialized on disk.
 """
 
 import json
+import os
 import sys
 from pathlib import Path
 
 # Running `python scripts/regen_openapi_snapshot.py` puts this file's directory
-# (scripts/) on sys.path[0], not the repo root, so `from app import app` would
-# fail. Put the repo root first so the app package imports the same way it does
-# under `pytest test` (which runs with PYTHONPATH=<repo root>). Importing this
-# module from the test is a no-op here, since the root is already on the path.
+# (scripts/) on sys.path, not the repo root, so `from app import app` can't
+# resolve. Add the repo root as an import fallback. The `not in` guard keeps
+# this a no-op under `pytest test` (which already has the repo root on sys.path
+# via PYTHONPATH=<repo root>), so importing this module during collection never
+# reorders the test session's import precedence.
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
+    sys.path.append(str(REPO_ROOT))
+
+# Importing `app` pulls in config.Settings and security_routes.utilities, which
+# require AQUA_DB and SECRET_KEY at import time and fail fast when either is
+# absent. Generating the OpenAPI schema never opens a DB connection or signs a
+# token, so any syntactically valid values work: provide the same dummy defaults
+# conftest.py uses so this script runs out of the box on a fresh clone or in CI,
+# where the gitignored .env that supplies these locally does not exist.
+# setdefault means a real value already in the environment always wins.
+os.environ.setdefault(
+    "AQUA_DB", "postgresql+asyncpg://dbuser:dbpassword@localhost:5432/dbname"
+)
+os.environ.setdefault("SECRET_KEY", "regen-openapi-snapshot-not-for-production")
+os.environ.setdefault("AQUA_DB_POOLCLASS", "null")
 
 # The endpoint every real client fetches; snapshot exactly what it serves.
 OPENAPI_PATH = "/openapi.json"

--- a/scripts/regen_openapi_snapshot.py
+++ b/scripts/regen_openapi_snapshot.py
@@ -27,31 +27,42 @@ from pathlib import Path
 # Running `python scripts/regen_openapi_snapshot.py` puts this file's directory
 # (scripts/) on sys.path, not the repo root, so `from app import app` can't
 # resolve. Add the repo root as an import fallback. The `not in` guard keeps
-# this a no-op under `pytest test` (which already has the repo root on sys.path
-# via PYTHONPATH=<repo root>), so importing this module during collection never
-# reorders the test session's import precedence.
+# derived below.
 REPO_ROOT = Path(__file__).resolve().parent.parent
-if str(REPO_ROOT) not in sys.path:
-    sys.path.append(str(REPO_ROOT))
-
-# Importing `app` pulls in config.Settings and security_routes.utilities, which
-# require AQUA_DB and SECRET_KEY at import time and fail fast when either is
-# absent. Generating the OpenAPI schema never opens a DB connection or signs a
-# token, so any syntactically valid values work: provide the same dummy defaults
-# conftest.py uses so this script runs out of the box on a fresh clone or in CI,
-# where the gitignored .env that supplies these locally does not exist.
-# setdefault means a real value already in the environment always wins.
-os.environ.setdefault(
-    "AQUA_DB", "postgresql+asyncpg://dbuser:dbpassword@localhost:5432/dbname"
-)
-os.environ.setdefault("SECRET_KEY", "regen-openapi-snapshot-not-for-production")
-os.environ.setdefault("AQUA_DB_POOLCLASS", "null")
 
 # The endpoint every real client fetches; snapshot exactly what it serves.
 OPENAPI_PATH = "/openapi.json"
 
 # Committed baseline. Kept next to the test that reads it.
 SNAPSHOT_PATH = REPO_ROOT / "test" / "snapshots" / "openapi_v3.json"
+
+
+def _prepare_standalone_import() -> None:
+    """Make ``from app import app`` succeed when this script runs on its own.
+
+    Only the standalone path needs this: running ``python scripts/...`` puts
+    scripts/ (not the repo root) on ``sys.path``, and importing ``app`` pulls in
+    ``config.Settings`` and ``security_routes.utilities``, which require AQUA_DB
+    and SECRET_KEY at import time and fail fast when either is absent. The
+    gitignored .env supplies those locally but not on a fresh clone or in CI.
+
+    This is deliberately *not* run at module import: the contract test imports
+    this module (for the shared helpers) but passes its own client, so it never
+    hits this path. Keeping the ``sys.path`` / ``os.environ`` mutation out of
+    import means importing this module has no side effects that could reorder
+    the test session's import precedence or leak env defaults into other tests.
+
+    Generating the schema opens no DB connection and signs no token, so the
+    dummy values below never matter to the output; ``setdefault`` lets a real
+    value already in the environment win.
+    """
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.append(str(REPO_ROOT))
+    os.environ.setdefault(
+        "AQUA_DB", "postgresql+asyncpg://dbuser:dbpassword@localhost:5432/dbname"
+    )
+    os.environ.setdefault("SECRET_KEY", "regen-openapi-snapshot-not-for-production")
+    os.environ.setdefault("AQUA_DB_POOLCLASS", "null")
 
 
 def get_openapi_response(client=None):
@@ -66,8 +77,11 @@ def get_openapi_response(client=None):
     script's path when run standalone.
     """
     if client is None:
-        # Imported lazily so importing this module (e.g. from the test, which
-        # already has the app loaded via conftest) does not build a second app.
+        # Standalone path: prepare sys.path / env, then import lazily so that
+        # merely importing this module (e.g. from the test, which already has
+        # the app loaded via conftest) does not build a second app.
+        _prepare_standalone_import()
+
         from fastapi.testclient import TestClient
 
         from app import app

--- a/test/snapshots/openapi_v3.json
+++ b/test/snapshots/openapi_v3.json
@@ -1,0 +1,26021 @@
+{
+  "components": {
+    "schemas": {
+      "AffixCommitRequest": {
+        "properties": {
+          "affixes": {
+            "items": {
+              "$ref": "#/components/schemas/AffixIn"
+            },
+            "title": "Affixes",
+            "type": "array"
+          },
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "revision_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Id"
+          },
+          "source_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Model"
+          }
+        },
+        "required": [
+          "iso_639_3"
+        ],
+        "title": "AffixCommitRequest",
+        "type": "object"
+      },
+      "AffixCommitResponse": {
+        "properties": {
+          "n_affixes_new": {
+            "title": "N Affixes New",
+            "type": "integer"
+          },
+          "n_affixes_unchanged": {
+            "title": "N Affixes Unchanged",
+            "type": "integer"
+          },
+          "n_affixes_updated": {
+            "title": "N Affixes Updated",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "n_affixes_new",
+          "n_affixes_updated",
+          "n_affixes_unchanged"
+        ],
+        "title": "AffixCommitResponse",
+        "type": "object"
+      },
+      "AffixIn": {
+        "properties": {
+          "examples": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Examples"
+          },
+          "form": {
+            "minLength": 1,
+            "title": "Form",
+            "type": "string"
+          },
+          "gloss": {
+            "minLength": 1,
+            "title": "Gloss",
+            "type": "string"
+          },
+          "n_runs": {
+            "default": 1,
+            "maximum": 32767.0,
+            "minimum": 1.0,
+            "title": "N Runs",
+            "type": "integer"
+          },
+          "position": {
+            "enum": [
+              "prefix",
+              "suffix",
+              "infix"
+            ],
+            "title": "Position",
+            "type": "string"
+          }
+        },
+        "required": [
+          "form",
+          "position",
+          "gloss"
+        ],
+        "title": "AffixIn",
+        "type": "object"
+      },
+      "AffixListOut": {
+        "properties": {
+          "affixes": {
+            "items": {
+              "$ref": "#/components/schemas/AffixOut"
+            },
+            "title": "Affixes",
+            "type": "array"
+          },
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "iso_639_3",
+          "total",
+          "affixes"
+        ],
+        "title": "AffixListOut",
+        "type": "object"
+      },
+      "AffixOut": {
+        "properties": {
+          "examples": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Examples"
+          },
+          "first_seen_revision_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Seen Revision Id"
+          },
+          "form": {
+            "title": "Form",
+            "type": "string"
+          },
+          "gloss": {
+            "title": "Gloss",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "n_runs": {
+            "default": 1,
+            "maximum": 32767.0,
+            "minimum": 1.0,
+            "title": "N Runs",
+            "type": "integer"
+          },
+          "position": {
+            "enum": [
+              "prefix",
+              "suffix",
+              "infix"
+            ],
+            "title": "Position",
+            "type": "string"
+          },
+          "source_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Model"
+          }
+        },
+        "required": [
+          "id",
+          "form",
+          "position",
+          "gloss"
+        ],
+        "title": "AffixOut",
+        "type": "object"
+      },
+      "AffixPatch": {
+        "description": "Partial update model for language affixes \u2014 all fields optional.",
+        "properties": {
+          "examples": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Examples"
+          },
+          "form": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Form"
+          },
+          "gloss": {
+            "anyOf": [
+              {
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Gloss"
+          },
+          "n_runs": {
+            "anyOf": [
+              {
+                "maximum": 32767.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N Runs"
+          },
+          "position": {
+            "anyOf": [
+              {
+                "enum": [
+                  "prefix",
+                  "suffix",
+                  "infix"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position"
+          },
+          "source_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Model"
+          }
+        },
+        "title": "AffixPatch",
+        "type": "object"
+      },
+      "AffixReplaceResponse": {
+        "properties": {
+          "n_deleted": {
+            "title": "N Deleted",
+            "type": "integer"
+          },
+          "n_inserted": {
+            "title": "N Inserted",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "n_deleted",
+          "n_inserted"
+        ],
+        "title": "AffixReplaceResponse",
+        "type": "object"
+      },
+      "AgentTranslationBulkRequest": {
+        "description": "Request to store multiple translations in bulk.",
+        "example": {
+          "assessment_id": 123,
+          "translations": [
+            {
+              "alternatives": [
+                {
+                  "note": "smoother English phrasing",
+                  "text": "In the beginning the Word already existed"
+                }
+              ],
+              "draft_text": "Na mwanzo kulikuwa na Neno",
+              "hyper_literal_translation": "And beginning there-was with Word",
+              "literal_translation": "In the beginning was the Word",
+              "vref": "JHN 1:1"
+            },
+            {
+              "draft_text": "Huyu alikuwa mwanzoni na Mungu",
+              "hyper_literal_translation": "This-one he-was beginning with God",
+              "literal_translation": "He was in the beginning with God",
+              "vref": "JHN 1:2"
+            }
+          ]
+        },
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "translations": {
+            "items": {
+              "$ref": "#/components/schemas/AgentTranslationIn"
+            },
+            "title": "Translations",
+            "type": "array"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "translations"
+        ],
+        "title": "AgentTranslationBulkRequest",
+        "type": "object"
+      },
+      "AgentTranslationIn": {
+        "description": "Single translation input for storage.",
+        "example": {
+          "alternatives": [
+            {
+              "note": "smoother English phrasing",
+              "text": "In the beginning the Word already existed"
+            }
+          ],
+          "draft_text": "Na mwanzo kulikuwa na Neno",
+          "english_translation": "In the beginning was the Word",
+          "hyper_literal_translation": "And beginning there-was with Word",
+          "literal_translation": "In the beginning was the Word",
+          "vref": "JHN 1:1"
+        },
+        "properties": {
+          "alternatives": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SuggestionItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alternatives"
+          },
+          "draft_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Text"
+          },
+          "english_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "English Translation"
+          },
+          "hyper_literal_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hyper Literal Translation"
+          },
+          "literal_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Literal Translation"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vref"
+        ],
+        "title": "AgentTranslationIn",
+        "type": "object"
+      },
+      "AgentTranslationOut": {
+        "description": "Response model for agent translation.",
+        "example": {
+          "alternatives": [
+            {
+              "note": "smoother English phrasing",
+              "text": "In the beginning the Word already existed"
+            }
+          ],
+          "assessment_id": 123,
+          "created_at": "2024-06-01T12:00:00",
+          "draft_text": "Na mwanzo kulikuwa na Neno",
+          "english_translation": "In the beginning was the Word",
+          "hyper_literal_translation": "And beginning there-was with Word",
+          "id": 1,
+          "literal_translation": "In the beginning was the Word",
+          "reference_version_id": 789,
+          "revision_id": 456,
+          "script": "Latn",
+          "version": 1,
+          "vref": "JHN 1:1"
+        },
+        "properties": {
+          "alternatives": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SuggestionItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alternatives"
+          },
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "draft_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Text"
+          },
+          "english_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "English Translation"
+          },
+          "hyper_literal_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hyper Literal Translation"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "literal_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Literal Translation"
+          },
+          "reference_version_id": {
+            "title": "Reference Version Id",
+            "type": "integer"
+          },
+          "revision_id": {
+            "title": "Revision Id",
+            "type": "integer"
+          },
+          "script": {
+            "title": "Script",
+            "type": "string"
+          },
+          "version": {
+            "title": "Version",
+            "type": "integer"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "assessment_id",
+          "revision_id",
+          "reference_version_id",
+          "script",
+          "vref",
+          "version"
+        ],
+        "title": "AgentTranslationOut",
+        "type": "object"
+      },
+      "AgentTranslationStorageRequest": {
+        "description": "Request to store a single translation.",
+        "example": {
+          "alternatives": [
+            {
+              "note": "smoother English phrasing",
+              "text": "In the beginning the Word already existed"
+            }
+          ],
+          "assessment_id": 123,
+          "draft_text": "Na mwanzo kulikuwa na Neno",
+          "english_translation": "In the beginning was the Word",
+          "hyper_literal_translation": "And beginning there-was with Word",
+          "literal_translation": "In the beginning was the Word",
+          "vref": "JHN 1:1"
+        },
+        "properties": {
+          "alternatives": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SuggestionItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alternatives"
+          },
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "draft_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Text"
+          },
+          "english_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "English Translation"
+          },
+          "hyper_literal_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Hyper Literal Translation"
+          },
+          "literal_translation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Literal Translation"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "vref"
+        ],
+        "title": "AgentTranslationStorageRequest",
+        "type": "object"
+      },
+      "AgentWordAlignmentBulkItem": {
+        "properties": {
+          "is_human_verified": {
+            "default": false,
+            "title": "Is Human Verified",
+            "type": "boolean"
+          },
+          "score": {
+            "default": 0.0,
+            "title": "Score",
+            "type": "number"
+          },
+          "source_word": {
+            "title": "Source Word",
+            "type": "string"
+          },
+          "target_word": {
+            "title": "Target Word",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_word",
+          "target_word"
+        ],
+        "title": "AgentWordAlignmentBulkItem",
+        "type": "object"
+      },
+      "AgentWordAlignmentBulkRequest": {
+        "properties": {
+          "alignments": {
+            "items": {
+              "$ref": "#/components/schemas/AgentWordAlignmentBulkItem"
+            },
+            "title": "Alignments",
+            "type": "array"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "source_version_id",
+          "target_version_id",
+          "alignments"
+        ],
+        "title": "AgentWordAlignmentBulkRequest",
+        "type": "object"
+      },
+      "AgentWordAlignmentIn": {
+        "example": {
+          "is_human_verified": false,
+          "score": 0.95,
+          "source_version_id": 1,
+          "source_word": "love",
+          "target_version_id": 2,
+          "target_word": "amor"
+        },
+        "properties": {
+          "is_human_verified": {
+            "default": false,
+            "title": "Is Human Verified",
+            "type": "boolean"
+          },
+          "score": {
+            "default": 0.0,
+            "title": "Score",
+            "type": "number"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "source_word": {
+            "title": "Source Word",
+            "type": "string"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          },
+          "target_word": {
+            "title": "Target Word",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_word",
+          "target_word",
+          "source_version_id",
+          "target_version_id"
+        ],
+        "title": "AgentWordAlignmentIn",
+        "type": "object"
+      },
+      "AgentWordAlignmentOut": {
+        "example": {
+          "created_at": "2024-06-01T12:00:00",
+          "id": 1,
+          "is_human_verified": false,
+          "last_updated": "2024-06-01T12:00:00",
+          "score": 0.95,
+          "source_version_id": 1,
+          "source_word": "love",
+          "target_version_id": 2,
+          "target_word": "amor"
+        },
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_human_verified": {
+            "title": "Is Human Verified",
+            "type": "boolean"
+          },
+          "last_updated": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Updated"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "source_word": {
+            "title": "Source Word",
+            "type": "string"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          },
+          "target_word": {
+            "title": "Target Word",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "source_word",
+          "target_word",
+          "source_version_id",
+          "target_version_id",
+          "score",
+          "is_human_verified"
+        ],
+        "title": "AgentWordAlignmentOut",
+        "type": "object"
+      },
+      "AlignmentMatch": {
+        "properties": {
+          "probability": {
+            "title": "Probability",
+            "type": "number"
+          },
+          "rank": {
+            "title": "Rank",
+            "type": "integer"
+          },
+          "source_word": {
+            "title": "Source Word",
+            "type": "string"
+          },
+          "strength_confidence": {
+            "title": "Strength Confidence",
+            "type": "number"
+          },
+          "strength_margin_mass": {
+            "title": "Strength Margin Mass",
+            "type": "number"
+          },
+          "strength_mass": {
+            "title": "Strength Mass",
+            "type": "number"
+          },
+          "support_hits": {
+            "title": "Support Hits",
+            "type": "integer"
+          },
+          "support_mass": {
+            "title": "Support Mass",
+            "type": "number"
+          },
+          "target_word": {
+            "title": "Target Word",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_word",
+          "target_word",
+          "rank",
+          "probability",
+          "support_mass",
+          "support_hits",
+          "strength_mass",
+          "strength_margin_mass",
+          "strength_confidence"
+        ],
+        "title": "AlignmentMatch",
+        "type": "object"
+      },
+      "AlignmentScoreItem": {
+        "properties": {
+          "flag": {
+            "default": false,
+            "title": "Flag",
+            "type": "boolean"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vref",
+          "score"
+        ],
+        "title": "AlignmentScoreItem",
+        "type": "object"
+      },
+      "AlignmentScoreType": {
+        "enum": [
+          "top",
+          "threshold"
+        ],
+        "title": "AlignmentScoreType",
+        "type": "string"
+      },
+      "AssessmentOut": {
+        "example": {
+          "attempt_count": 0,
+          "end_time": "2024-06-01T12:00:00",
+          "id": 1,
+          "owner_id": 1,
+          "reference_id": 1,
+          "requested_time": "2024-06-01T12:00:00",
+          "revision_id": 1,
+          "start_time": "2024-06-01T12:00:00",
+          "status": "finished",
+          "type": "word-alignment"
+        },
+        "properties": {
+          "attempt_count": {
+            "default": 0,
+            "title": "Attempt Count",
+            "type": "integer"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_training": {
+            "default": false,
+            "title": "Is Training",
+            "type": "boolean"
+          },
+          "kwargs": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Kwargs"
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Id"
+          },
+          "percent_complete": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Percent Complete"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          },
+          "requested_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requested Time"
+          },
+          "revision_id": {
+            "title": "Revision Id",
+            "type": "integer"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "status_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Detail"
+          },
+          "type": {
+            "$ref": "#/components/schemas/AssessmentType"
+          }
+        },
+        "required": [
+          "id",
+          "revision_id",
+          "type"
+        ],
+        "title": "AssessmentOut",
+        "type": "object"
+      },
+      "AssessmentResultItem": {
+        "properties": {
+          "flag": {
+            "default": false,
+            "title": "Flag",
+            "type": "boolean"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "target": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vref",
+          "score"
+        ],
+        "title": "AssessmentResultItem",
+        "type": "object"
+      },
+      "AssessmentStatus": {
+        "enum": [
+          "queued",
+          "running",
+          "finished",
+          "failed"
+        ],
+        "title": "AssessmentStatus",
+        "type": "string"
+      },
+      "AssessmentStatusUpdate": {
+        "properties": {
+          "percent_complete": {
+            "anyOf": [
+              {
+                "maximum": 100.0,
+                "minimum": 0.0,
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Percent Complete"
+          },
+          "status": {
+            "$ref": "#/components/schemas/AssessmentStatus"
+          },
+          "status_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Detail"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "AssessmentStatusUpdate",
+        "type": "object"
+      },
+      "AssessmentType": {
+        "enum": [
+          "word-alignment",
+          "sentence-length",
+          "semantic-similarity",
+          "ngrams",
+          "tfidf",
+          "text-lengths",
+          "agent-critique"
+        ],
+        "title": "AssessmentType",
+        "type": "string"
+      },
+      "Body_change_password_latest_change_password_post": {
+        "properties": {
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Secret"
+          },
+          "grant_type": {
+            "anyOf": [
+              {
+                "pattern": "password",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          },
+          "scope": {
+            "default": "",
+            "title": "Scope",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_change_password_latest_change_password_post",
+        "type": "object"
+      },
+      "Body_create_user_latest_users_post": {
+        "properties": {
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Secret"
+          },
+          "grant_type": {
+            "anyOf": [
+              {
+                "pattern": "password",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          },
+          "scope": {
+            "default": "",
+            "title": "Scope",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_create_user_latest_users_post",
+        "type": "object"
+      },
+      "Body_login_for_access_token_latest_token_post": {
+        "properties": {
+          "client_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Id"
+          },
+          "client_secret": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Client Secret"
+          },
+          "grant_type": {
+            "anyOf": [
+              {
+                "pattern": "password",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grant Type"
+          },
+          "password": {
+            "title": "Password",
+            "type": "string"
+          },
+          "scope": {
+            "default": "",
+            "title": "Scope",
+            "type": "string"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ],
+        "title": "Body_login_for_access_token_latest_token_post",
+        "type": "object"
+      },
+      "Body_upload_revision_latest_revision_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_revision_latest_revision_post",
+        "type": "object"
+      },
+      "Body_upload_revision_v3_revision_post": {
+        "properties": {
+          "file": {
+            "format": "binary",
+            "title": "File",
+            "type": "string"
+          }
+        },
+        "required": [
+          "file"
+        ],
+        "title": "Body_upload_revision_v3_revision_post",
+        "type": "object"
+      },
+      "BulkAffixDeleteResponse": {
+        "description": "Row counts deleted by DELETE /v3/affixes-by-version/{version_id}.\n\nMirrors the soft-union semantics of ``GET /v3/affixes-by-version``:\ndeletes both rows version-stamped to ``version_id`` and legacy\niso-keyed rows (``target_version_id IS NULL``) that share the\nversion's ISO. Rows stamped to other versions of the same ISO are\nleft intact. Counts are split so callers can see what came from\neach bucket.",
+        "properties": {
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "iso_keyed_deleted": {
+            "title": "Iso Keyed Deleted",
+            "type": "integer"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          },
+          "total_deleted": {
+            "title": "Total Deleted",
+            "type": "integer"
+          },
+          "version_stamped_deleted": {
+            "title": "Version Stamped Deleted",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "target_version_id",
+          "iso_639_3",
+          "version_stamped_deleted",
+          "iso_keyed_deleted",
+          "total_deleted"
+        ],
+        "title": "BulkAffixDeleteResponse",
+        "type": "object"
+      },
+      "BulkLexemeCardDeleteResponse": {
+        "description": "Row counts deleted by DELETE /v3/agent/lexeme-card?target_version_id=X.\n\nWipes every lexeme card for the given target_version_id regardless of\nsource_version_id (cards built under different pivots all go), plus\ncascades to examples and card_translations.",
+        "properties": {
+          "card_translations_deleted": {
+            "title": "Card Translations Deleted",
+            "type": "integer"
+          },
+          "examples_deleted": {
+            "title": "Examples Deleted",
+            "type": "integer"
+          },
+          "lexeme_cards_deleted": {
+            "title": "Lexeme Cards Deleted",
+            "type": "integer"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "target_version_id",
+          "lexeme_cards_deleted",
+          "examples_deleted",
+          "card_translations_deleted"
+        ],
+        "title": "BulkLexemeCardDeleteResponse",
+        "type": "object"
+      },
+      "CardTranslationExampleIn": {
+        "properties": {
+          "example_id": {
+            "title": "Example Id",
+            "type": "integer"
+          },
+          "source_text": {
+            "title": "Source Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "example_id",
+          "source_text"
+        ],
+        "title": "CardTranslationExampleIn",
+        "type": "object"
+      },
+      "CardTranslationExampleOut": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "example_id": {
+            "title": "Example Id",
+            "type": "integer"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "source_text": {
+            "title": "Source Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "example_id",
+          "source_text"
+        ],
+        "title": "CardTranslationExampleOut",
+        "type": "object"
+      },
+      "CardTranslationIn": {
+        "description": "Write-side payload for a single (card, target_language) translation overlay.",
+        "example": {
+          "build_version": "spa-v1",
+          "examples": [
+            {
+              "example_id": 12345,
+              "source_text": "nos salv\u00f3 al renovarnos al nacer de nuevo"
+            }
+          ],
+          "language_iso": "spa",
+          "parent_build_version": "v1",
+          "senses": [
+            {
+              "definition": "camino, ruta, sendero"
+            }
+          ],
+          "source_lemma": "camino",
+          "source_surface_forms": [
+            "camino",
+            "caminos"
+          ]
+        },
+        "properties": {
+          "build_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Build Version"
+          },
+          "examples": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CardTranslationExampleIn"
+            },
+            "title": "Examples",
+            "type": "array"
+          },
+          "language_iso": {
+            "maxLength": 3,
+            "minLength": 3,
+            "title": "Language Iso",
+            "type": "string"
+          },
+          "parent_build_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Build Version"
+          },
+          "senses": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Senses"
+          },
+          "source_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Lemma"
+          },
+          "source_surface_forms": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Surface Forms"
+          }
+        },
+        "required": [
+          "language_iso"
+        ],
+        "title": "CardTranslationIn",
+        "type": "object"
+      },
+      "CardTranslationOut": {
+        "description": "Read-side shape of a stored translation overlay.",
+        "properties": {
+          "build_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Build Version"
+          },
+          "card_id": {
+            "title": "Card Id",
+            "type": "integer"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "examples": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CardTranslationExampleOut"
+            },
+            "title": "Examples",
+            "type": "array"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "language_iso": {
+            "title": "Language Iso",
+            "type": "string"
+          },
+          "last_updated": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Updated"
+          },
+          "last_user_edit": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last User Edit"
+          },
+          "parent_build_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Build Version"
+          },
+          "senses": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Senses"
+          },
+          "source_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Lemma"
+          },
+          "source_surface_forms": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Surface Forms"
+          }
+        },
+        "required": [
+          "id",
+          "card_id",
+          "language_iso"
+        ],
+        "title": "CardTranslationOut",
+        "type": "object"
+      },
+      "CooccurrenceItem": {
+        "properties": {
+          "co_occurrence_count": {
+            "title": "Co Occurrence Count",
+            "type": "integer"
+          },
+          "example_words": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Example Words",
+            "type": "array"
+          },
+          "morpheme": {
+            "title": "Morpheme",
+            "type": "string"
+          },
+          "morpheme_class": {
+            "title": "Morpheme Class",
+            "type": "string"
+          },
+          "typical_position": {
+            "title": "Typical Position",
+            "type": "string"
+          }
+        },
+        "required": [
+          "morpheme",
+          "morpheme_class",
+          "co_occurrence_count",
+          "example_words",
+          "typical_position"
+        ],
+        "title": "CooccurrenceItem",
+        "type": "object"
+      },
+      "CooccurrenceResponse": {
+        "properties": {
+          "cooccurrences": {
+            "items": {
+              "$ref": "#/components/schemas/CooccurrenceItem"
+            },
+            "title": "Cooccurrences",
+            "type": "array"
+          },
+          "is_truncated": {
+            "default": false,
+            "title": "Is Truncated",
+            "type": "boolean"
+          },
+          "morpheme": {
+            "title": "Morpheme",
+            "type": "string"
+          },
+          "total_words_containing": {
+            "title": "Total Words Containing",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "morpheme",
+          "total_words_containing",
+          "cooccurrences"
+        ],
+        "title": "CooccurrenceResponse",
+        "type": "object"
+      },
+      "CritiqueIssueOut": {
+        "description": "Individual critique issue for output.",
+        "example": {
+          "agent_translation_id": 1,
+          "assessment_id": 123,
+          "book": "JHN",
+          "chapter": 1,
+          "comments": "Number mistranslated",
+          "created_at": "2024-06-01T12:00:00",
+          "detector": "number_diff",
+          "dimension": "accuracy",
+          "draft_text": "fourteen days",
+          "evidence": [
+            "source: 40",
+            "draft: 14"
+          ],
+          "id": 1,
+          "is_resolved": false,
+          "severity": 4,
+          "source_text": "forty days",
+          "subtype": "mistranslation/hallucination-numbers",
+          "suggestions": [
+            {
+              "note": "match the source number",
+              "text": "forty days"
+            }
+          ],
+          "verse": 1,
+          "vref": "JHN 1:1"
+        },
+        "properties": {
+          "agent_translation_id": {
+            "title": "Agent Translation Id",
+            "type": "integer"
+          },
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "book": {
+            "title": "Book",
+            "type": "string"
+          },
+          "chapter": {
+            "title": "Chapter",
+            "type": "integer"
+          },
+          "comments": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comments"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "detector": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector"
+          },
+          "dimension": {
+            "title": "Dimension",
+            "type": "string"
+          },
+          "draft_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Text"
+          },
+          "evidence": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_resolved": {
+            "default": false,
+            "title": "Is Resolved",
+            "type": "boolean"
+          },
+          "resolution_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolution Notes"
+          },
+          "resolved_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved At"
+          },
+          "resolved_by_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Resolved By Id"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity"
+          },
+          "source_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Text"
+          },
+          "subtype": {
+            "title": "Subtype",
+            "type": "string"
+          },
+          "suggestions": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SuggestionItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggestions"
+          },
+          "verse": {
+            "title": "Verse",
+            "type": "integer"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "assessment_id",
+          "agent_translation_id",
+          "vref",
+          "book",
+          "chapter",
+          "verse",
+          "dimension",
+          "subtype"
+        ],
+        "title": "CritiqueIssueOut",
+        "type": "object"
+      },
+      "CritiqueIssueResolutionRequest": {
+        "description": "Request to resolve a critique issue.",
+        "example": {
+          "resolution_notes": "Issue was addressed by updating the translation in the revision."
+        },
+        "properties": {
+          "resolution_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional notes about how the issue was resolved",
+            "title": "Resolution Notes"
+          }
+        },
+        "title": "CritiqueIssueResolutionRequest",
+        "type": "object"
+      },
+      "CritiqueStorageRequest": {
+        "description": "Request to store MQM-aligned critique issues for a verse.\n\nThe critique is linked to a specific agent translation by agent_translation_id.\nThe assessment_id and vref are derived from the referenced translation.",
+        "example": {
+          "agent_translation_id": 1,
+          "issues": [
+            {
+              "comments": "Number mistranslated",
+              "detector": "number_diff",
+              "dimension": "accuracy",
+              "draft_text": "fourteen days",
+              "evidence": [
+                "source: 40",
+                "draft: 14"
+              ],
+              "severity": 4,
+              "source_text": "forty days",
+              "subtype": "mistranslation/hallucination-numbers",
+              "suggestions": [
+                {
+                  "note": "match the source number",
+                  "text": "forty days"
+                }
+              ]
+            }
+          ]
+        },
+        "properties": {
+          "agent_translation_id": {
+            "title": "Agent Translation Id",
+            "type": "integer"
+          },
+          "issues": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/IssueIn"
+            },
+            "title": "Issues",
+            "type": "array"
+          }
+        },
+        "required": [
+          "agent_translation_id"
+        ],
+        "title": "CritiqueStorageRequest",
+        "type": "object"
+      },
+      "DeleteRequest": {
+        "properties": {
+          "ids": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ids"
+        ],
+        "title": "DeleteRequest",
+        "type": "object"
+      },
+      "DeleteResponse": {
+        "properties": {
+          "deleted": {
+            "title": "Deleted",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "deleted"
+        ],
+        "title": "DeleteResponse",
+        "type": "object"
+      },
+      "EflomalAssessmentOut": {
+        "description": "Push response \u2014 summary only, not the 470K+ data rows.",
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "num_alignment_links": {
+            "title": "Num Alignment Links",
+            "type": "integer"
+          },
+          "num_dictionary_entries": {
+            "title": "Num Dictionary Entries",
+            "type": "integer"
+          },
+          "num_missing_words": {
+            "title": "Num Missing Words",
+            "type": "integer"
+          },
+          "num_verse_pairs": {
+            "title": "Num Verse Pairs",
+            "type": "integer"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "assessment_id",
+          "source_version_id",
+          "target_version_id",
+          "num_verse_pairs",
+          "num_alignment_links",
+          "num_dictionary_entries",
+          "num_missing_words"
+        ],
+        "title": "EflomalAssessmentOut",
+        "type": "object"
+      },
+      "EflomalBpeModels": {
+        "description": "SentencePiece BPE models (serialized protobuf), one per direction.",
+        "properties": {
+          "source_model_b64": {
+            "title": "Source Model B64",
+            "type": "string"
+          },
+          "target_model_b64": {
+            "title": "Target Model B64",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_model_b64",
+          "target_model_b64"
+        ],
+        "title": "EflomalBpeModels",
+        "type": "object"
+      },
+      "EflomalDictionaryItem": {
+        "description": "Dictionary entry. Words in original form (case preserved).",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "probability": {
+            "title": "Probability",
+            "type": "number"
+          },
+          "source_word": {
+            "title": "Source Word",
+            "type": "string"
+          },
+          "target_word": {
+            "title": "Target Word",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_word",
+          "target_word",
+          "count",
+          "probability"
+        ],
+        "title": "EflomalDictionaryItem",
+        "type": "object"
+      },
+      "EflomalPriorItem": {
+        "description": "LEX prior row: one BPE token pair with a Dirichlet-prior alpha.",
+        "properties": {
+          "alpha": {
+            "maximum": 0.95,
+            "minimum": 0.5,
+            "title": "Alpha",
+            "type": "number"
+          },
+          "source_bpe": {
+            "title": "Source Bpe",
+            "type": "string"
+          },
+          "target_bpe": {
+            "title": "Target Bpe",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_bpe",
+          "target_bpe",
+          "alpha"
+        ],
+        "title": "EflomalPriorItem",
+        "type": "object"
+      },
+      "EflomalResultsPullResponse": {
+        "description": "Full eflomal training artifacts for inference consumption.\n\nReplaces Modal's load_artifacts() \u2014 all data needed to run realtime_assess()\nis returned in a single response for the caller to load and cache.",
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "bpe_models": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EflomalBpeModels"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "num_alignment_links": {
+            "title": "Num Alignment Links",
+            "type": "integer"
+          },
+          "num_dictionary_entries": {
+            "title": "Num Dictionary Entries",
+            "type": "integer"
+          },
+          "num_missing_words": {
+            "title": "Num Missing Words",
+            "type": "integer"
+          },
+          "num_verse_pairs": {
+            "title": "Num Verse Pairs",
+            "type": "integer"
+          },
+          "priors": {
+            "items": {
+              "$ref": "#/components/schemas/EflomalPriorItem"
+            },
+            "title": "Priors",
+            "type": "array"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          },
+          "reverse_dict": {
+            "additionalProperties": {
+              "items": {
+                "$ref": "#/components/schemas/EflomalReverseDictSource"
+              },
+              "type": "array"
+            },
+            "title": "Reverse Dict",
+            "type": "object"
+          },
+          "revision_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Id"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          },
+          "target_word_counts": {
+            "items": {
+              "$ref": "#/components/schemas/EflomalTargetWordCountItem"
+            },
+            "title": "Target Word Counts",
+            "type": "array"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "source_version_id",
+          "target_version_id",
+          "num_verse_pairs",
+          "num_alignment_links",
+          "num_dictionary_entries",
+          "num_missing_words",
+          "target_word_counts"
+        ],
+        "title": "EflomalResultsPullResponse",
+        "type": "object"
+      },
+      "EflomalResultsPushRequest": {
+        "description": "Create the eflomal_assessment metadata row (no bulk data).\n\nAfter this call succeeds, push dictionary, target-word-counts,\npriors, and BPE models via their own endpoints, then PATCH the\nassessment status to 'finished'.",
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "num_alignment_links": {
+            "title": "Num Alignment Links",
+            "type": "integer"
+          },
+          "num_dictionary_entries": {
+            "title": "Num Dictionary Entries",
+            "type": "integer"
+          },
+          "num_missing_words": {
+            "title": "Num Missing Words",
+            "type": "integer"
+          },
+          "num_verse_pairs": {
+            "title": "Num Verse Pairs",
+            "type": "integer"
+          },
+          "source_version_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Version Id"
+          },
+          "target_version_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Version Id"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "num_verse_pairs",
+          "num_alignment_links",
+          "num_dictionary_entries",
+          "num_missing_words"
+        ],
+        "title": "EflomalResultsPushRequest",
+        "type": "object"
+      },
+      "EflomalReverseDictSource": {
+        "description": "One source-word candidate in a reverse_dict entry.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "count"
+        ],
+        "title": "EflomalReverseDictSource",
+        "type": "object"
+      },
+      "EflomalTargetWordCountItem": {
+        "description": "Target word frequency. Word in normalized form.",
+        "properties": {
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "word": {
+            "title": "Word",
+            "type": "string"
+          }
+        },
+        "required": [
+          "word",
+          "count"
+        ],
+        "title": "EflomalTargetWordCountItem",
+        "type": "object"
+      },
+      "Group": {
+        "properties": {
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "Group",
+        "type": "object"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "title": "Detail",
+            "type": "array"
+          }
+        },
+        "title": "HTTPValidationError",
+        "type": "object"
+      },
+      "IncludeVerses": {
+        "enum": [
+          "all",
+          "union",
+          "intersection"
+        ],
+        "title": "IncludeVerses",
+        "type": "string"
+      },
+      "IndexRequest": {
+        "properties": {
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "revision_id": {
+            "title": "Revision Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "iso_639_3",
+          "revision_id"
+        ],
+        "title": "IndexRequest",
+        "type": "object"
+      },
+      "IndexResponse": {
+        "properties": {
+          "unique_morpheme_verse_pairs": {
+            "title": "Unique Morpheme Verse Pairs",
+            "type": "integer"
+          },
+          "verses_indexed": {
+            "title": "Verses Indexed",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "verses_indexed",
+          "unique_morpheme_verse_pairs"
+        ],
+        "title": "IndexResponse",
+        "type": "object"
+      },
+      "InferenceReadiness": {
+        "properties": {
+          "pending_training": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Pending Training",
+            "type": "array"
+          },
+          "ready": {
+            "title": "Ready",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "ready"
+        ],
+        "title": "InferenceReadiness",
+        "type": "object"
+      },
+      "InsertResponse": {
+        "properties": {
+          "ids": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ids"
+        ],
+        "title": "InsertResponse",
+        "type": "object"
+      },
+      "IssueIn": {
+        "description": "A single MQM-aligned critique issue.",
+        "properties": {
+          "comments": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comments"
+          },
+          "detector": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Detector"
+          },
+          "dimension": {
+            "enum": [
+              "accuracy",
+              "terminology",
+              "linguistic_conventions"
+            ],
+            "title": "Dimension",
+            "type": "string"
+          },
+          "draft_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Text"
+          },
+          "evidence": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evidence"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "maximum": 5.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Severity"
+          },
+          "source_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Text"
+          },
+          "subtype": {
+            "maxLength": 100,
+            "minLength": 1,
+            "title": "Subtype",
+            "type": "string"
+          },
+          "suggestions": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SuggestionItem"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Suggestions"
+          }
+        },
+        "required": [
+          "dimension",
+          "subtype"
+        ],
+        "title": "IssueIn",
+        "type": "object"
+      },
+      "Language": {
+        "example": {
+          "iso639": "eng",
+          "name": "English"
+        },
+        "properties": {
+          "iso639": {
+            "title": "Iso639",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "iso639",
+          "name"
+        ],
+        "title": "Language",
+        "type": "object"
+      },
+      "LanguagePivotIn": {
+        "properties": {
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "pivot_iso": {
+            "maxLength": 3,
+            "minLength": 3,
+            "title": "Pivot Iso",
+            "type": "string"
+          },
+          "target_iso": {
+            "maxLength": 3,
+            "minLength": 3,
+            "title": "Target Iso",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_iso",
+          "pivot_iso"
+        ],
+        "title": "LanguagePivotIn",
+        "type": "object"
+      },
+      "LanguagePivotListOut": {
+        "properties": {
+          "mappings": {
+            "items": {
+              "$ref": "#/components/schemas/LanguagePivotOut"
+            },
+            "title": "Mappings",
+            "type": "array"
+          }
+        },
+        "required": [
+          "mappings"
+        ],
+        "title": "LanguagePivotListOut",
+        "type": "object"
+      },
+      "LanguagePivotMissOut": {
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/PivotCandidateOut"
+            },
+            "title": "Candidates",
+            "type": "array"
+          },
+          "hint": {
+            "title": "Hint",
+            "type": "string"
+          },
+          "target_iso": {
+            "title": "Target Iso",
+            "type": "string"
+          }
+        },
+        "required": [
+          "target_iso",
+          "candidates",
+          "hint"
+        ],
+        "title": "LanguagePivotMissOut",
+        "type": "object"
+      },
+      "LanguagePivotOut": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "language_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LanguageProfileOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "pivot_iso": {
+            "title": "Pivot Iso",
+            "type": "string"
+          },
+          "pivot_revision_id": {
+            "title": "Pivot Revision Id",
+            "type": "integer"
+          },
+          "pivot_version_id": {
+            "title": "Pivot Version Id",
+            "type": "integer"
+          },
+          "target_iso": {
+            "title": "Target Iso",
+            "type": "string"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "target_iso",
+          "pivot_iso",
+          "pivot_revision_id",
+          "pivot_version_id"
+        ],
+        "title": "LanguagePivotOut",
+        "type": "object"
+      },
+      "LanguageProfileIn": {
+        "properties": {
+          "autonym": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Autonym"
+          },
+          "branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch"
+          },
+          "common_affixes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Common Affixes"
+          },
+          "family": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Family"
+          },
+          "grammar_sketch": {
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grammar Sketch"
+          },
+          "morphology_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Morphology Notes"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "script": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Script"
+          },
+          "sources": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sources"
+          },
+          "typology_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Typology Summary"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "LanguageProfileIn",
+        "type": "object"
+      },
+      "LanguageProfileOut": {
+        "properties": {
+          "autonym": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Autonym"
+          },
+          "branch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Branch"
+          },
+          "common_affixes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Common Affixes"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "family": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Family"
+          },
+          "grammar_sketch": {
+            "anyOf": [
+              {
+                "maxLength": 65536,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grammar Sketch"
+          },
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "morphology_notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Morphology Notes"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "script": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Script"
+          },
+          "sources": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sources"
+          },
+          "typology_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Typology Summary"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "name",
+          "iso_639_3"
+        ],
+        "title": "LanguageProfileOut",
+        "type": "object"
+      },
+      "LexemeCardIn": {
+        "example": {
+          "alignment_scores": {
+            "love": 0.92,
+            "you": 0.88
+          },
+          "build_version": "agent-20260514T123000Z",
+          "confidence": 0.95,
+          "english_lemma": "love",
+          "examples": [
+            {
+              "source": "I love you",
+              "target": "Te amo"
+            },
+            {
+              "source": "They love music",
+              "target": "Aman la m\u00fasica"
+            }
+          ],
+          "model": "claude-sonnet-4-6",
+          "pos": "verb",
+          "senses": [
+            {
+              "definition": "to feel deep affection",
+              "examples": [
+                "I love you"
+              ]
+            },
+            {
+              "definition": "to enjoy greatly",
+              "examples": [
+                "I love pizza"
+              ]
+            }
+          ],
+          "source_lemma": "love",
+          "source_surface_forms": [
+            "love",
+            "loves",
+            "loved",
+            "loving"
+          ],
+          "source_version_id": 1,
+          "surface_forms": [
+            "amor",
+            "amo",
+            "amas",
+            "ama",
+            "amamos",
+            "anan"
+          ],
+          "target_lemma": "amor",
+          "target_version_id": 2
+        },
+        "properties": {
+          "alignment_scores": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alignment Scores"
+          },
+          "build_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Build Version"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "english_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "English Lemma"
+          },
+          "examples": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Examples"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "pos": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pos"
+          },
+          "senses": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Senses"
+          },
+          "source_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Lemma"
+          },
+          "source_surface_forms": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Surface Forms"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "surface_forms": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surface Forms"
+          },
+          "target_lemma": {
+            "title": "Target Lemma",
+            "type": "string"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "target_lemma",
+          "source_version_id",
+          "target_version_id"
+        ],
+        "title": "LexemeCardIn",
+        "type": "object"
+      },
+      "LexemeCardOut": {
+        "properties": {
+          "alignment_scores": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alignment Scores"
+          },
+          "build_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Build Version"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "english_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "English Lemma"
+          },
+          "examples": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Examples"
+          },
+          "has_translation_overlay": {
+            "default": true,
+            "title": "Has Translation Overlay",
+            "type": "boolean"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "last_updated": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Updated"
+          },
+          "last_user_edit": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last User Edit"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "pos": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pos"
+          },
+          "senses": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Senses"
+          },
+          "source_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Lemma"
+          },
+          "source_surface_forms": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Surface Forms"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "surface_forms": {
+            "anyOf": [
+              {
+                "items": {},
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surface Forms"
+          },
+          "target_lemma": {
+            "title": "Target Lemma",
+            "type": "string"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "target_lemma",
+          "source_version_id",
+          "target_version_id"
+        ],
+        "title": "LexemeCardOut",
+        "type": "object"
+      },
+      "LexemeCardPatch": {
+        "description": "Partial update model for lexeme cards - all fields optional.",
+        "example": {
+          "examples": [
+            {
+              "revision_id": 123,
+              "source": "Example source",
+              "target": "Example target"
+            }
+          ],
+          "surface_forms": [
+            "new_form1",
+            "new_form2"
+          ]
+        },
+        "properties": {
+          "alignment_scores": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "anyOf": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alignment Scores"
+          },
+          "build_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Build Version"
+          },
+          "confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Confidence"
+          },
+          "english_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "English Lemma"
+          },
+          "examples": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Examples"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "pos": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pos"
+          },
+          "senses": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Senses"
+          },
+          "source_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Lemma"
+          },
+          "source_surface_forms": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Surface Forms"
+          },
+          "surface_forms": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Surface Forms"
+          },
+          "target_lemma": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Lemma"
+          }
+        },
+        "title": "LexemeCardPatch",
+        "type": "object"
+      },
+      "ListMode": {
+        "description": "Mode for handling list fields in PATCH operations.",
+        "enum": [
+          "append",
+          "replace",
+          "merge"
+        ],
+        "title": "ListMode",
+        "type": "string"
+      },
+      "MorphemeIn": {
+        "properties": {
+          "morpheme": {
+            "title": "Morpheme",
+            "type": "string"
+          },
+          "morpheme_class": {
+            "enum": [
+              "LEXICAL",
+              "GRAMMATICAL",
+              "BOUND_ROOT",
+              "UNKNOWN"
+            ],
+            "title": "Morpheme Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "morpheme",
+          "morpheme_class"
+        ],
+        "title": "MorphemeIn",
+        "type": "object"
+      },
+      "MorphemeListOut": {
+        "properties": {
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "morphemes": {
+            "items": {
+              "$ref": "#/components/schemas/MorphemeOut"
+            },
+            "title": "Morphemes",
+            "type": "array"
+          },
+          "total": {
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "iso_639_3",
+          "total",
+          "morphemes"
+        ],
+        "title": "MorphemeListOut",
+        "type": "object"
+      },
+      "MorphemeOut": {
+        "properties": {
+          "first_seen_revision_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Seen Revision Id"
+          },
+          "morpheme": {
+            "title": "Morpheme",
+            "type": "string"
+          },
+          "morpheme_class": {
+            "enum": [
+              "LEXICAL",
+              "GRAMMATICAL",
+              "BOUND_ROOT",
+              "UNKNOWN"
+            ],
+            "title": "Morpheme Class",
+            "type": "string"
+          }
+        },
+        "required": [
+          "morpheme",
+          "morpheme_class"
+        ],
+        "title": "MorphemeOut",
+        "type": "object"
+      },
+      "MorphemeSearchResponse": {
+        "properties": {
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "morpheme": {
+            "title": "Morpheme",
+            "type": "string"
+          },
+          "result_count": {
+            "title": "Result Count",
+            "type": "integer"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/MorphemeSearchResult"
+            },
+            "title": "Results",
+            "type": "array"
+          }
+        },
+        "required": [
+          "morpheme",
+          "iso_639_3",
+          "result_count",
+          "results"
+        ],
+        "title": "MorphemeSearchResponse",
+        "type": "object"
+      },
+      "MorphemeSearchResult": {
+        "properties": {
+          "comparison_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comparison Text"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "surface_forms": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Surface Forms",
+            "type": "array"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "verse_reference": {
+            "title": "Verse Reference",
+            "type": "string"
+          }
+        },
+        "required": [
+          "verse_reference",
+          "text",
+          "surface_forms",
+          "count"
+        ],
+        "title": "MorphemeSearchResult",
+        "type": "object"
+      },
+      "MultipleResult": {
+        "properties": {
+          "assessment_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment Id"
+          },
+          "flag": {
+            "default": false,
+            "title": "Flag",
+            "type": "boolean"
+          },
+          "hide": {
+            "default": false,
+            "title": "Hide",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "mean_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Mean Score"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          },
+          "reference_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Text"
+          },
+          "revision_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Id"
+          },
+          "revision_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Text"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "stdev_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stdev Score"
+          },
+          "vref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vref"
+          },
+          "z_score": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Z Score"
+          }
+        },
+        "required": [
+          "score"
+        ],
+        "title": "MultipleResult",
+        "type": "object"
+      },
+      "NgramCorpusBlock": {
+        "properties": {
+          "source_corpus": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NgramCorpusMatches"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "target_corpus": {
+            "$ref": "#/components/schemas/NgramCorpusMatches"
+          }
+        },
+        "title": "NgramCorpusBlock",
+        "type": "object"
+      },
+      "NgramCorpusMatches": {
+        "properties": {
+          "matches": {
+            "items": {
+              "$ref": "#/components/schemas/NgramMatch"
+            },
+            "title": "Matches",
+            "type": "array"
+          }
+        },
+        "title": "NgramCorpusMatches",
+        "type": "object"
+      },
+      "NgramItem": {
+        "properties": {
+          "ngram": {
+            "title": "Ngram",
+            "type": "string"
+          },
+          "ngram_size": {
+            "title": "Ngram Size",
+            "type": "integer"
+          },
+          "vrefs": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50000,
+            "title": "Vrefs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ngram",
+          "ngram_size",
+          "vrefs"
+        ],
+        "title": "NgramItem",
+        "type": "object"
+      },
+      "NgramMatch": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "ngram": {
+            "title": "Ngram",
+            "type": "string"
+          },
+          "ngram_size": {
+            "title": "Ngram Size",
+            "type": "integer"
+          },
+          "verses": {
+            "items": {
+              "$ref": "#/components/schemas/NgramVerseHit"
+            },
+            "title": "Verses",
+            "type": "array"
+          }
+        },
+        "required": [
+          "id",
+          "ngram",
+          "ngram_size"
+        ],
+        "title": "NgramMatch",
+        "type": "object"
+      },
+      "NgramResult": {
+        "properties": {
+          "assessment_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment Id"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "ngram": {
+            "title": "Ngram",
+            "type": "string"
+          },
+          "ngram_size": {
+            "title": "Ngram Size",
+            "type": "integer"
+          },
+          "vrefs": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Vrefs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "ngram",
+          "ngram_size",
+          "vrefs"
+        ],
+        "title": "NgramResult",
+        "type": "object"
+      },
+      "NgramVerseHit": {
+        "properties": {
+          "source_revision_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Revision Text"
+          },
+          "target_revision_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Revision Text"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vref"
+        ],
+        "title": "NgramVerseHit",
+        "type": "object"
+      },
+      "PivotCandidateIn": {
+        "properties": {
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "pivot_iso": {
+            "maxLength": 3,
+            "minLength": 3,
+            "title": "Pivot Iso",
+            "type": "string"
+          },
+          "pivot_revision_id": {
+            "title": "Pivot Revision Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "pivot_iso",
+          "pivot_revision_id"
+        ],
+        "title": "PivotCandidateIn",
+        "type": "object"
+      },
+      "PivotCandidateListOut": {
+        "properties": {
+          "candidates": {
+            "items": {
+              "$ref": "#/components/schemas/PivotCandidateOut"
+            },
+            "title": "Candidates",
+            "type": "array"
+          }
+        },
+        "required": [
+          "candidates"
+        ],
+        "title": "PivotCandidateListOut",
+        "type": "object"
+      },
+      "PivotCandidateOut": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "language_profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LanguageProfileOut"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "notes": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Notes"
+          },
+          "pivot_iso": {
+            "title": "Pivot Iso",
+            "type": "string"
+          },
+          "pivot_revision_id": {
+            "title": "Pivot Revision Id",
+            "type": "integer"
+          },
+          "pivot_version_id": {
+            "title": "Pivot Version Id",
+            "type": "integer"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "pivot_iso",
+          "pivot_revision_id",
+          "pivot_version_id"
+        ],
+        "title": "PivotCandidateOut",
+        "type": "object"
+      },
+      "PredictAppResult": {
+        "properties": {
+          "data": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          },
+          "duration_ms": {
+            "title": "Duration Ms",
+            "type": "integer"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "status": {
+            "enum": [
+              "ok",
+              "error",
+              "not_trained"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "duration_ms"
+        ],
+        "title": "PredictAppResult",
+        "type": "object"
+      },
+      "PredictCritique": {
+        "additionalProperties": true,
+        "description": "The critique payload surfaced per pair on a predict job.\n\nCurrently exposes ``issues`` (the canonical MQM list, see #793).\n``extra=\"allow\"`` keeps any auxiliary keys the agent emits visible to\nconsumers; today there are none documented beyond ``issues``.",
+        "example": {
+          "issues": [
+            {
+              "comments": "Number mistranslated",
+              "detector": "number_diff",
+              "dimension": "accuracy",
+              "draft_text": "fourteen days",
+              "evidence": [
+                "source: 40",
+                "draft: 14"
+              ],
+              "severity": 4,
+              "source_text": "forty days",
+              "subtype": "mistranslation/hallucination-numbers"
+            }
+          ]
+        },
+        "properties": {
+          "issues": {
+            "items": {
+              "$ref": "#/components/schemas/PredictCritiqueIssue"
+            },
+            "title": "Issues",
+            "type": "array"
+          }
+        },
+        "title": "PredictCritique",
+        "type": "object"
+      },
+      "PredictCritiqueIssue": {
+        "additionalProperties": true,
+        "description": "One MQM-aligned critique issue, as surfaced on a predict job's pair.\n\nMirrors the per-issue shape the agent emits and the storage endpoint\naccepts (``POST /v3/agent/critique`` / ``IssueIn``). Extra fields the\nagent may add are preserved on the wire via ``extra=\"allow\"`` rather\nthan dropped, so consumers can rely on the documented fields while\nforward-compat new agent attributes still reach them.\n\nField constraints deliberately diverge from ``IssueIn`` on the read\npath: ``dimension`` is typed as ``str`` (not a ``Literal``), and\n``subtype`` / ``detector`` / ``severity`` carry no length or range\nbounds. Validation here runs over data the agent already wrote into\na stored job result, so any extra-strict typing would convert a\npreviously-200 response into a 500 if the agent ever emits an\nunexpected value (a new MQM dimension added agent-side before\naqua-api, a legacy row predating a tightened constraint, etc.). The\ndocumented values live in each field's ``description`` \u2014 callers\nshould match case-insensitively / by prefix.",
+        "properties": {
+          "comments": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Comments"
+          },
+          "detector": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional tag identifying the automated detector that flagged the issue, e.g. 'number_diff'. Documented length cap of 50 chars is advertised but not enforced.",
+            "maxLength": 50,
+            "title": "Detector"
+          },
+          "dimension": {
+            "description": "MQM dimension. Documented values: 'accuracy', 'terminology', 'linguistic_conventions'. Typed as a plain string on the read path so an unexpected agent value can't 500 the poll endpoint; the documented enum is surfaced via json_schema_extra so Swagger UI still shows the canonical values.",
+            "enum": [
+              "accuracy",
+              "terminology",
+              "linguistic_conventions"
+            ],
+            "title": "Dimension",
+            "type": "string"
+          },
+          "draft_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Draft Text"
+          },
+          "evidence": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional supporting snippets the detector or model attached.",
+            "title": "Evidence"
+          },
+          "severity": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Severity score the agent assigned, typically 1\u20135; null when the model omitted it. Range is advertised via json_schema_extra but not enforced on the read path (see class docstring).",
+            "maximum": 5.0,
+            "minimum": 1.0,
+            "title": "Severity"
+          },
+          "source_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Text"
+          },
+          "subtype": {
+            "description": "Free-form MQM subtype, e.g. 'omission', 'addition', 'mistranslation', 'mistranslation/hallucination-numbers'. Not an enum \u2014 match case-insensitively / by prefix. The documented storage cap of 100 chars is advertised via json_schema_extra without being enforced on the read path.",
+            "maxLength": 100,
+            "title": "Subtype",
+            "type": "string"
+          }
+        },
+        "required": [
+          "dimension",
+          "subtype"
+        ],
+        "title": "PredictCritiqueIssue",
+        "type": "object"
+      },
+      "PredictFanoutResponse": {
+        "properties": {
+          "job": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PredictJobHandle"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pairs": {
+            "items": {
+              "$ref": "#/components/schemas/TextPair"
+            },
+            "title": "Pairs",
+            "type": "array"
+          },
+          "results": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/PredictAppResult"
+            },
+            "title": "Results",
+            "type": "object"
+          }
+        },
+        "required": [
+          "pairs",
+          "results"
+        ],
+        "title": "PredictFanoutResponse",
+        "type": "object"
+      },
+      "PredictInput": {
+        "example": {
+          "apps": [
+            "ngrams",
+            "tfidf",
+            "agent"
+          ],
+          "include_critique": true,
+          "include_translation": true,
+          "pairs": [
+            {
+              "source_text": "In the beginning God created the heavens and the earth.",
+              "target_text": "Hapo mwanzo Mungu aliumba mbingu na dunia.",
+              "vref": "GEN 1:1"
+            }
+          ],
+          "reference_id": 2,
+          "revision_id": 1,
+          "source_version_id": 1,
+          "target_version_id": 2
+        },
+        "properties": {
+          "apps": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Apps"
+          },
+          "assessment_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment Id"
+          },
+          "include_critique": {
+            "default": true,
+            "title": "Include Critique",
+            "type": "boolean"
+          },
+          "include_translation": {
+            "default": true,
+            "title": "Include Translation",
+            "type": "boolean"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "maximum": 10000.0,
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit"
+          },
+          "pairs": {
+            "items": {
+              "$ref": "#/components/schemas/TextPair"
+            },
+            "maxItems": 5000,
+            "minItems": 1,
+            "title": "Pairs",
+            "type": "array"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          },
+          "revision_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Id"
+          },
+          "source_version_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Version Id"
+          },
+          "target_version_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Version Id"
+          }
+        },
+        "required": [
+          "pairs"
+        ],
+        "title": "PredictInput",
+        "type": "object"
+      },
+      "PredictJobHandle": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "includes": {
+            "items": {
+              "enum": [
+                "translation",
+                "critique"
+              ],
+              "type": "string"
+            },
+            "title": "Includes",
+            "type": "array"
+          },
+          "poll_url": {
+            "title": "Poll Url",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "running",
+              "complete",
+              "failed"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "includes",
+          "poll_url"
+        ],
+        "title": "PredictJobHandle",
+        "type": "object"
+      },
+      "PredictJobPair": {
+        "properties": {
+          "critique": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PredictCritique"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "lexeme_cards": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Lexeme Cards"
+          },
+          "source_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Text"
+          },
+          "target_text": {
+            "title": "Target Text",
+            "type": "string"
+          },
+          "translation": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Translation"
+          },
+          "vref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vref"
+          }
+        },
+        "required": [
+          "target_text"
+        ],
+        "title": "PredictJobPair",
+        "type": "object"
+      },
+      "PredictJobStatusResponse": {
+        "properties": {
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "includes": {
+            "items": {
+              "enum": [
+                "translation",
+                "critique"
+              ],
+              "type": "string"
+            },
+            "title": "Includes",
+            "type": "array"
+          },
+          "pairs": {
+            "items": {
+              "$ref": "#/components/schemas/PredictJobPair"
+            },
+            "title": "Pairs",
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "running",
+              "complete",
+              "failed"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "includes",
+          "pairs"
+        ],
+        "title": "PredictJobStatusResponse",
+        "type": "object"
+      },
+      "Result_v2": {
+        "example": {
+          "assessment_id": 1,
+          "flag": false,
+          "hide": false,
+          "id": 1,
+          "score": 0.28,
+          "vref": "GEN 1:1"
+        },
+        "properties": {
+          "assessment_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment Id"
+          },
+          "flag": {
+            "default": false,
+            "title": "Flag",
+            "type": "boolean"
+          },
+          "hide": {
+            "default": false,
+            "title": "Hide",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "reference_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Text"
+          },
+          "revision_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Text"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "target": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target"
+          },
+          "vref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vref"
+          }
+        },
+        "required": [
+          "score"
+        ],
+        "title": "Result_v2",
+        "type": "object"
+      },
+      "RevisionChapters": {
+        "description": "Response model for available chapters in a revision.",
+        "example": {
+          "chapters": {
+            "EXO": [
+              1,
+              2,
+              3
+            ],
+            "GEN": [
+              1,
+              2,
+              3,
+              4,
+              5
+            ]
+          }
+        },
+        "properties": {
+          "chapters": {
+            "additionalProperties": {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            "title": "Chapters",
+            "type": "object"
+          }
+        },
+        "required": [
+          "chapters"
+        ],
+        "title": "RevisionChapters",
+        "type": "object"
+      },
+      "RevisionOut_v3": {
+        "example": {
+          "back_translation_id": 1,
+          "bible_version_id": 1,
+          "date": "2024-06-01",
+          "id": 1,
+          "is_reference": false,
+          "iso_language": "eng",
+          "machineTranslation": false,
+          "name": "June 2024",
+          "published": false,
+          "version_abbreviation": "english_-_king_james_version"
+        },
+        "properties": {
+          "back_translation_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Back Translation Id"
+          },
+          "bible_version_id": {
+            "title": "Bible Version Id",
+            "type": "integer"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_reference": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": false,
+            "title": "Is Reference"
+          },
+          "iso_language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Iso Language"
+          },
+          "machineTranslation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": false,
+            "title": "Machinetranslation"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name"
+          },
+          "published": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": false,
+            "title": "Published"
+          },
+          "version_abbreviation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version Abbreviation"
+          }
+        },
+        "required": [
+          "id",
+          "bible_version_id"
+        ],
+        "title": "RevisionOut_v3",
+        "type": "object"
+      },
+      "Script": {
+        "example": {
+          "iso15924": "Latn",
+          "name": "Latin"
+        },
+        "properties": {
+          "iso15924": {
+            "title": "Iso15924",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "iso15924",
+          "name"
+        ],
+        "title": "Script",
+        "type": "object"
+      },
+      "SemanticSimilarityRequest": {
+        "example": {
+          "source_version_id": 1,
+          "target_version_id": 2,
+          "text1": "Hapo mwanzo Mungu aliumba mbingu na dunia.",
+          "text2": "In the beginning God created the heavens and the earth."
+        },
+        "properties": {
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          },
+          "text1": {
+            "maxLength": 10000,
+            "title": "Text1",
+            "type": "string"
+          },
+          "text2": {
+            "maxLength": 10000,
+            "title": "Text2",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text1",
+          "text2",
+          "source_version_id",
+          "target_version_id"
+        ],
+        "title": "SemanticSimilarityRequest",
+        "type": "object"
+      },
+      "SemanticSimilarityResponse": {
+        "properties": {
+          "score": {
+            "title": "Score",
+            "type": "number"
+          }
+        },
+        "required": [
+          "score"
+        ],
+        "title": "SemanticSimilarityResponse",
+        "type": "object"
+      },
+      "SuggestionItem": {
+        "description": "A proposed replacement/rendering, used for span suggestions and whole-verse alternatives.",
+        "properties": {
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "text": {
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "title": "SuggestionItem",
+        "type": "object"
+      },
+      "TextLengthsInferenceResponse": {
+        "properties": {
+          "char_count_difference": {
+            "title": "Char Count Difference",
+            "type": "integer"
+          },
+          "word_count_difference": {
+            "title": "Word Count Difference",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "word_count_difference",
+          "char_count_difference"
+        ],
+        "title": "TextLengthsInferenceResponse",
+        "type": "object"
+      },
+      "TextLengthsItem": {
+        "properties": {
+          "char_lengths": {
+            "title": "Char Lengths",
+            "type": "number"
+          },
+          "char_lengths_z": {
+            "title": "Char Lengths Z",
+            "type": "number"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          },
+          "word_lengths": {
+            "title": "Word Lengths",
+            "type": "number"
+          },
+          "word_lengths_z": {
+            "title": "Word Lengths Z",
+            "type": "number"
+          }
+        },
+        "required": [
+          "vref",
+          "word_lengths",
+          "char_lengths",
+          "word_lengths_z",
+          "char_lengths_z"
+        ],
+        "title": "TextLengthsItem",
+        "type": "object"
+      },
+      "TextLengthsResult": {
+        "properties": {
+          "assessment_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment Id"
+          },
+          "char_lengths": {
+            "title": "Char Lengths",
+            "type": "number"
+          },
+          "char_lengths_z": {
+            "title": "Char Lengths Z",
+            "type": "number"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "vref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vref"
+          },
+          "vrefs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vrefs"
+          },
+          "word_lengths": {
+            "title": "Word Lengths",
+            "type": "number"
+          },
+          "word_lengths_z": {
+            "title": "Word Lengths Z",
+            "type": "number"
+          }
+        },
+        "required": [
+          "word_lengths",
+          "char_lengths",
+          "word_lengths_z",
+          "char_lengths_z"
+        ],
+        "title": "TextLengthsResult",
+        "type": "object"
+      },
+      "TextPair": {
+        "properties": {
+          "source_text": {
+            "anyOf": [
+              {
+                "maxLength": 10000,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Text"
+          },
+          "target_text": {
+            "maxLength": 10000,
+            "title": "Target Text",
+            "type": "string"
+          },
+          "vref": {
+            "anyOf": [
+              {
+                "maxLength": 50,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vref"
+          }
+        },
+        "required": [
+          "target_text"
+        ],
+        "title": "TextPair",
+        "type": "object"
+      },
+      "TfidfArtifactsAbortRequest": {
+        "properties": {
+          "upload_id": {
+            "title": "Upload Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "upload_id"
+        ],
+        "title": "TfidfArtifactsAbortRequest",
+        "type": "object"
+      },
+      "TfidfArtifactsAbortResponse": {
+        "properties": {
+          "chunks_removed": {
+            "title": "Chunks Removed",
+            "type": "integer"
+          },
+          "upload_id": {
+            "title": "Upload Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "upload_id",
+          "chunks_removed"
+        ],
+        "title": "TfidfArtifactsAbortResponse",
+        "type": "object"
+      },
+      "TfidfArtifactsChunkRequest": {
+        "properties": {
+          "chunk_index": {
+            "minimum": 0.0,
+            "title": "Chunk Index",
+            "type": "integer"
+          },
+          "components_b64": {
+            "title": "Components B64",
+            "type": "string"
+          },
+          "upload_id": {
+            "title": "Upload Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "upload_id",
+          "chunk_index",
+          "components_b64"
+        ],
+        "title": "TfidfArtifactsChunkRequest",
+        "type": "object"
+      },
+      "TfidfArtifactsChunkResponse": {
+        "properties": {
+          "bytes_received": {
+            "title": "Bytes Received",
+            "type": "integer"
+          },
+          "chunk_index": {
+            "title": "Chunk Index",
+            "type": "integer"
+          },
+          "chunks_received": {
+            "title": "Chunks Received",
+            "type": "integer"
+          },
+          "total_chunks": {
+            "title": "Total Chunks",
+            "type": "integer"
+          },
+          "upload_id": {
+            "title": "Upload Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "upload_id",
+          "chunk_index",
+          "bytes_received",
+          "chunks_received",
+          "total_chunks"
+        ],
+        "title": "TfidfArtifactsChunkResponse",
+        "type": "object"
+      },
+      "TfidfArtifactsCommitRequest": {
+        "properties": {
+          "upload_id": {
+            "title": "Upload Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "upload_id"
+        ],
+        "title": "TfidfArtifactsCommitRequest",
+        "type": "object"
+      },
+      "TfidfArtifactsInitRequest": {
+        "properties": {
+          "char_vectorizer": {
+            "$ref": "#/components/schemas/TfidfVectorizerPayload"
+          },
+          "n_components": {
+            "title": "N Components",
+            "type": "integer"
+          },
+          "n_corpus_vrefs": {
+            "title": "N Corpus Vrefs",
+            "type": "integer"
+          },
+          "sklearn_version": {
+            "title": "Sklearn Version",
+            "type": "string"
+          },
+          "source_version_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Version Id"
+          },
+          "svd": {
+            "$ref": "#/components/schemas/TfidfSvdMeta"
+          },
+          "total_chunks": {
+            "maximum": 1024.0,
+            "minimum": 1.0,
+            "title": "Total Chunks",
+            "type": "integer"
+          },
+          "word_vectorizer": {
+            "$ref": "#/components/schemas/TfidfVectorizerPayload"
+          }
+        },
+        "required": [
+          "n_components",
+          "n_corpus_vrefs",
+          "sklearn_version",
+          "word_vectorizer",
+          "char_vectorizer",
+          "svd",
+          "total_chunks"
+        ],
+        "title": "TfidfArtifactsInitRequest",
+        "type": "object"
+      },
+      "TfidfArtifactsInitResponse": {
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "total_chunks": {
+            "title": "Total Chunks",
+            "type": "integer"
+          },
+          "upload_id": {
+            "title": "Upload Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "upload_id",
+          "assessment_id",
+          "total_chunks"
+        ],
+        "title": "TfidfArtifactsInitResponse",
+        "type": "object"
+      },
+      "TfidfArtifactsPullResponse": {
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "char_vectorizer": {
+            "$ref": "#/components/schemas/TfidfVectorizerPayload"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "n_char_features": {
+            "title": "N Char Features",
+            "type": "integer"
+          },
+          "n_components": {
+            "title": "N Components",
+            "type": "integer"
+          },
+          "n_corpus_vrefs": {
+            "title": "N Corpus Vrefs",
+            "type": "integer"
+          },
+          "n_word_features": {
+            "title": "N Word Features",
+            "type": "integer"
+          },
+          "sklearn_version": {
+            "title": "Sklearn Version",
+            "type": "string"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "svd": {
+            "$ref": "#/components/schemas/TfidfSvdPullPayload"
+          },
+          "word_vectorizer": {
+            "$ref": "#/components/schemas/TfidfVectorizerPayload"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "source_version_id",
+          "n_components",
+          "n_word_features",
+          "n_char_features",
+          "n_corpus_vrefs",
+          "sklearn_version",
+          "word_vectorizer",
+          "char_vectorizer",
+          "svd"
+        ],
+        "title": "TfidfArtifactsPullResponse",
+        "type": "object"
+      },
+      "TfidfArtifactsPushRequest": {
+        "properties": {
+          "char_vectorizer": {
+            "$ref": "#/components/schemas/TfidfVectorizerPayload"
+          },
+          "n_components": {
+            "title": "N Components",
+            "type": "integer"
+          },
+          "n_corpus_vrefs": {
+            "title": "N Corpus Vrefs",
+            "type": "integer"
+          },
+          "sklearn_version": {
+            "title": "Sklearn Version",
+            "type": "string"
+          },
+          "source_version_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Version Id"
+          },
+          "svd": {
+            "$ref": "#/components/schemas/TfidfSvdPayload"
+          },
+          "word_vectorizer": {
+            "$ref": "#/components/schemas/TfidfVectorizerPayload"
+          }
+        },
+        "required": [
+          "n_components",
+          "n_corpus_vrefs",
+          "sklearn_version",
+          "word_vectorizer",
+          "char_vectorizer",
+          "svd"
+        ],
+        "title": "TfidfArtifactsPushRequest",
+        "type": "object"
+      },
+      "TfidfArtifactsPushResponse": {
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "components_bytes": {
+            "title": "Components Bytes",
+            "type": "integer"
+          },
+          "n_char_features": {
+            "title": "N Char Features",
+            "type": "integer"
+          },
+          "n_word_features": {
+            "title": "N Word Features",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "n_word_features",
+          "n_char_features",
+          "components_bytes"
+        ],
+        "title": "TfidfArtifactsPushResponse",
+        "type": "object"
+      },
+      "TfidfByTextRequest": {
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "exclude_book": {
+            "default": false,
+            "title": "Exclude Book",
+            "type": "boolean"
+          },
+          "exclude_vref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exclude Vref"
+          },
+          "limit": {
+            "default": 10,
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          },
+          "text": {
+            "maxLength": 10000,
+            "minLength": 1,
+            "title": "Text",
+            "type": "string"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "text"
+        ],
+        "title": "TfidfByTextRequest",
+        "type": "object"
+      },
+      "TfidfByTextsRequest": {
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "exclude_book": {
+            "default": false,
+            "title": "Exclude Book",
+            "type": "boolean"
+          },
+          "exclude_vrefs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exclude Vrefs"
+          },
+          "limit": {
+            "default": 10,
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          },
+          "texts": {
+            "items": {
+              "maxLength": 10000,
+              "minLength": 1,
+              "type": "string"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "title": "Texts",
+            "type": "array"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "texts"
+        ],
+        "title": "TfidfByTextsRequest",
+        "type": "object"
+      },
+      "TfidfByVectorRequest": {
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "limit": {
+            "default": 10,
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          },
+          "vector": {
+            "items": {
+              "type": "number"
+            },
+            "maxItems": 300,
+            "minItems": 300,
+            "title": "Vector",
+            "type": "array"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "vector"
+        ],
+        "title": "TfidfByVectorRequest",
+        "type": "object"
+      },
+      "TfidfByVectorsRequest": {
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "limit": {
+            "default": 10,
+            "maximum": 500.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "reference_id": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Id"
+          },
+          "vectors": {
+            "items": {
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            "maxItems": 500,
+            "minItems": 1,
+            "title": "Vectors",
+            "type": "array"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "vectors"
+        ],
+        "title": "TfidfByVectorsRequest",
+        "type": "object"
+      },
+      "TfidfByVectorsResponse": {
+        "properties": {
+          "results": {
+            "items": {
+              "items": {
+                "$ref": "#/components/schemas/TfidfResult"
+              },
+              "type": "array"
+            },
+            "title": "Results",
+            "type": "array"
+          }
+        },
+        "required": [
+          "results"
+        ],
+        "title": "TfidfByVectorsResponse",
+        "type": "object"
+      },
+      "TfidfNeighbour": {
+        "properties": {
+          "similarity": {
+            "title": "Similarity",
+            "type": "number"
+          },
+          "source_revision_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Revision Text"
+          },
+          "target_revision_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Revision Text"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vref",
+          "similarity"
+        ],
+        "title": "TfidfNeighbour",
+        "type": "object"
+      },
+      "TfidfNeighboursBlock": {
+        "properties": {
+          "source_neighbours": {
+            "items": {
+              "$ref": "#/components/schemas/TfidfNeighbour"
+            },
+            "title": "Source Neighbours",
+            "type": "array"
+          },
+          "target_neighbours": {
+            "items": {
+              "$ref": "#/components/schemas/TfidfNeighbour"
+            },
+            "title": "Target Neighbours",
+            "type": "array"
+          }
+        },
+        "title": "TfidfNeighboursBlock",
+        "type": "object"
+      },
+      "TfidfPcaVectorItem": {
+        "properties": {
+          "vector": {
+            "items": {
+              "type": "number"
+            },
+            "maxItems": 300,
+            "minItems": 300,
+            "title": "Vector",
+            "type": "array"
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "vref",
+          "vector"
+        ],
+        "title": "TfidfPcaVectorItem",
+        "type": "object"
+      },
+      "TfidfResult": {
+        "example": {
+          "assessment_id": 1,
+          "similarity": 0.0835,
+          "vref": "GEN 1:2"
+        },
+        "properties": {
+          "assessment_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment Id"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "reference_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Text"
+          },
+          "revision_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Text"
+          },
+          "similarity": {
+            "title": "Similarity",
+            "type": "number"
+          },
+          "vref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vref"
+          }
+        },
+        "required": [
+          "similarity"
+        ],
+        "title": "TfidfResult",
+        "type": "object"
+      },
+      "TfidfSvdMeta": {
+        "properties": {
+          "dtype": {
+            "default": "float32",
+            "enum": [
+              "float32",
+              "float64"
+            ],
+            "title": "Dtype",
+            "type": "string"
+          },
+          "n_components": {
+            "maximum": 4096.0,
+            "minimum": 1.0,
+            "title": "N Components",
+            "type": "integer"
+          },
+          "n_features": {
+            "maximum": 10000000.0,
+            "minimum": 1.0,
+            "title": "N Features",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "n_components",
+          "n_features"
+        ],
+        "title": "TfidfSvdMeta",
+        "type": "object"
+      },
+      "TfidfSvdPayload": {
+        "properties": {
+          "components_b64": {
+            "title": "Components B64",
+            "type": "string"
+          },
+          "dtype": {
+            "default": "float32",
+            "enum": [
+              "float32",
+              "float64"
+            ],
+            "title": "Dtype",
+            "type": "string"
+          },
+          "n_components": {
+            "maximum": 4096.0,
+            "minimum": 1.0,
+            "title": "N Components",
+            "type": "integer"
+          },
+          "n_features": {
+            "maximum": 10000000.0,
+            "minimum": 1.0,
+            "title": "N Features",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "n_components",
+          "n_features",
+          "components_b64"
+        ],
+        "title": "TfidfSvdPayload",
+        "type": "object"
+      },
+      "TfidfSvdPullPayload": {
+        "properties": {
+          "components_b64": {
+            "title": "Components B64",
+            "type": "string"
+          },
+          "dtype": {
+            "default": "float32",
+            "enum": [
+              "float32",
+              "float64",
+              "float16",
+              "int8"
+            ],
+            "title": "Dtype",
+            "type": "string"
+          },
+          "int8_scale": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Int8 Scale"
+          },
+          "n_components": {
+            "maximum": 4096.0,
+            "minimum": 1.0,
+            "title": "N Components",
+            "type": "integer"
+          },
+          "n_features": {
+            "maximum": 10000000.0,
+            "minimum": 1.0,
+            "title": "N Features",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "n_components",
+          "n_features",
+          "components_b64"
+        ],
+        "title": "TfidfSvdPullPayload",
+        "type": "object"
+      },
+      "TfidfVectorizerPayload": {
+        "properties": {
+          "idf": {
+            "items": {
+              "type": "number"
+            },
+            "title": "Idf",
+            "type": "array"
+          },
+          "params": {
+            "title": "Params",
+            "type": "object"
+          },
+          "vocabulary": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "Vocabulary",
+            "type": "object"
+          }
+        },
+        "required": [
+          "vocabulary",
+          "idf",
+          "params"
+        ],
+        "title": "TfidfVectorizerPayload",
+        "type": "object"
+      },
+      "TimeoutSweepResult": {
+        "properties": {
+          "cutoff": {
+            "format": "date-time",
+            "title": "Cutoff",
+            "type": "string"
+          },
+          "hours": {
+            "title": "Hours",
+            "type": "integer"
+          },
+          "swept_count": {
+            "title": "Swept Count",
+            "type": "integer"
+          },
+          "swept_ids": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Swept Ids",
+            "type": "array"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "swept_count",
+          "swept_ids",
+          "truncated",
+          "cutoff",
+          "hours"
+        ],
+        "title": "TimeoutSweepResult",
+        "type": "object"
+      },
+      "Token": {
+        "properties": {
+          "access_token": {
+            "title": "Access Token",
+            "type": "string"
+          },
+          "token_type": {
+            "title": "Token Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "access_token",
+          "token_type"
+        ],
+        "title": "Token",
+        "type": "object"
+      },
+      "TokenizerRunCommitResponse": {
+        "properties": {
+          "n_class_conflicts": {
+            "title": "N Class Conflicts",
+            "type": "integer"
+          },
+          "n_morphemes_existing": {
+            "title": "N Morphemes Existing",
+            "type": "integer"
+          },
+          "n_morphemes_new": {
+            "title": "N Morphemes New",
+            "type": "integer"
+          },
+          "run_id": {
+            "title": "Run Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "run_id",
+          "n_morphemes_new",
+          "n_morphemes_existing",
+          "n_class_conflicts"
+        ],
+        "title": "TokenizerRunCommitResponse",
+        "type": "object"
+      },
+      "TokenizerRunListOut": {
+        "properties": {
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/TokenizerRunOut"
+            },
+            "title": "Runs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "runs"
+        ],
+        "title": "TokenizerRunListOut",
+        "type": "object"
+      },
+      "TokenizerRunOut": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "n_sample_verses": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N Sample Verses"
+          },
+          "revision_id": {
+            "title": "Revision Id",
+            "type": "integer"
+          },
+          "sample_method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sample Method"
+          },
+          "source_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Model"
+          },
+          "stats_json": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stats Json"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "iso_639_3",
+          "revision_id",
+          "status"
+        ],
+        "title": "TokenizerRunOut",
+        "type": "object"
+      },
+      "TokenizerRunRequest": {
+        "properties": {
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "morphemes": {
+            "items": {
+              "$ref": "#/components/schemas/MorphemeIn"
+            },
+            "title": "Morphemes",
+            "type": "array"
+          },
+          "n_sample_verses": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N Sample Verses"
+          },
+          "profile": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LanguageProfileIn"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "revision_id": {
+            "title": "Revision Id",
+            "type": "integer"
+          },
+          "sample_method": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sample Method"
+          },
+          "source_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Model"
+          },
+          "stats": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stats"
+          }
+        },
+        "required": [
+          "iso_639_3",
+          "revision_id"
+        ],
+        "title": "TokenizerRunRequest",
+        "type": "object"
+      },
+      "TrainingArtifactOut": {
+        "properties": {
+          "created_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "grammar_sketch": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Grammar Sketch"
+          },
+          "iso_639_3": {
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "training_artifacts",
+              "language_profile"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "source_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Model"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          }
+        },
+        "required": [
+          "target_version_id",
+          "iso_639_3",
+          "source"
+        ],
+        "title": "TrainingArtifactOut",
+        "type": "object"
+      },
+      "TrainingArtifactsDeleteResponse": {
+        "description": "Row counts deleted by DELETE /v3/tokenizer/training-artifacts/{version_id}.\n\nThe DELETE only touches rows version-stamped to this version_id;\nlegacy `target_version_id IS NULL` rows and rows stamped to other\nversions of the same ISO are left intact. Lexeme cards are also\nuntouched \u2014 they have their own DELETE endpoint.",
+        "properties": {
+          "affixes_deleted": {
+            "title": "Affixes Deleted",
+            "type": "integer"
+          },
+          "morphemes_deleted": {
+            "title": "Morphemes Deleted",
+            "type": "integer"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          },
+          "training_artifacts_deleted": {
+            "title": "Training Artifacts Deleted",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "target_version_id",
+          "training_artifacts_deleted",
+          "affixes_deleted",
+          "morphemes_deleted"
+        ],
+        "title": "TrainingArtifactsDeleteResponse",
+        "type": "object"
+      },
+      "TrainingJobIn": {
+        "description": "Identify the training pair by version_id (preferred \u2014 latest non-deleted\nrevision is resolved server-side) or by revision_id when a specific\nrevision is required. Exactly one of (version_id, revision_id) must be\nprovided per side.",
+        "example": {
+          "apps": [
+            "word-alignment",
+            "tfidf"
+          ],
+          "options": {
+            "use_eflomal": true
+          },
+          "source_version_id": 1,
+          "target_version_id": 2
+        },
+        "properties": {
+          "apps": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Apps"
+          },
+          "options": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Options"
+          },
+          "source_revision_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Revision Id"
+          },
+          "source_version_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Version Id"
+          },
+          "target_revision_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Revision Id"
+          },
+          "target_version_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Target Version Id"
+          }
+        },
+        "title": "TrainingJobIn",
+        "type": "object"
+      },
+      "TrainingJobOut": {
+        "description": "TrainingJob is metadata only after aqua-api#584 \u2014 status, timing, and\nprogress are sourced from the linked Assessment row when serializing.",
+        "properties": {
+          "assessment_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Assessment Id"
+          },
+          "end_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End Time"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "options": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Options"
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Id"
+          },
+          "percent_complete": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Percent Complete"
+          },
+          "requested_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Requested Time"
+          },
+          "session_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Session Id"
+          },
+          "source_revision_id": {
+            "title": "Source Revision Id",
+            "type": "integer"
+          },
+          "source_version_id": {
+            "title": "Source Version Id",
+            "type": "integer"
+          },
+          "start_time": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Time"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "status_detail": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Detail"
+          },
+          "target_revision_id": {
+            "title": "Target Revision Id",
+            "type": "integer"
+          },
+          "target_version_id": {
+            "title": "Target Version Id",
+            "type": "integer"
+          },
+          "type": {
+            "title": "Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "source_revision_id",
+          "target_revision_id",
+          "source_version_id",
+          "target_version_id"
+        ],
+        "title": "TrainingJobOut",
+        "type": "object"
+      },
+      "TrainingResponse": {
+        "properties": {
+          "inference_readiness": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/InferenceReadiness"
+            },
+            "title": "Inference Readiness",
+            "type": "object"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "training_jobs": {
+            "items": {
+              "$ref": "#/components/schemas/TrainingJobOut"
+            },
+            "title": "Training Jobs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "session_id",
+          "training_jobs",
+          "inference_readiness"
+        ],
+        "title": "TrainingResponse",
+        "type": "object"
+      },
+      "TrainingSessionResultsPage": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/TrainingSessionVrefResults"
+            },
+            "title": "Items",
+            "type": "array"
+          },
+          "page": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page"
+          },
+          "page_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Page Size"
+          },
+          "total_count": {
+            "title": "Total Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "items",
+          "total_count"
+        ],
+        "title": "TrainingSessionResultsPage",
+        "type": "object"
+      },
+      "TrainingSessionResultsResponse": {
+        "properties": {
+          "inference_readiness": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/InferenceReadiness"
+            },
+            "title": "Inference Readiness",
+            "type": "object"
+          },
+          "lexeme_cards_truncated": {
+            "default": false,
+            "title": "Lexeme Cards Truncated",
+            "type": "boolean"
+          },
+          "results": {
+            "$ref": "#/components/schemas/TrainingSessionResultsPage"
+          },
+          "session_id": {
+            "title": "Session Id",
+            "type": "string"
+          },
+          "training_jobs": {
+            "items": {
+              "$ref": "#/components/schemas/TrainingJobOut"
+            },
+            "title": "Training Jobs",
+            "type": "array"
+          }
+        },
+        "required": [
+          "session_id",
+          "training_jobs",
+          "inference_readiness",
+          "results"
+        ],
+        "title": "TrainingSessionResultsResponse",
+        "type": "object"
+      },
+      "TrainingSessionVrefResults": {
+        "properties": {
+          "lexeme_cards": {
+            "items": {
+              "$ref": "#/components/schemas/LexemeCardOut"
+            },
+            "title": "Lexeme Cards",
+            "type": "array"
+          },
+          "ngrams": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/NgramCorpusBlock"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "semantic_similarity": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Result_v2"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tfidf": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TfidfNeighboursBlock"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "vref": {
+            "title": "Vref",
+            "type": "string"
+          },
+          "word_alignment": {
+            "items": {
+              "$ref": "#/components/schemas/WordAlignment"
+            },
+            "title": "Word Alignment",
+            "type": "array"
+          },
+          "word_alignment_score": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Result_v2"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "required": [
+          "vref"
+        ],
+        "title": "TrainingSessionVrefResults",
+        "type": "object"
+      },
+      "User": {
+        "properties": {
+          "email": {
+            "anyOf": [
+              {
+                "format": "email",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "is_admin": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": false,
+            "title": "Is Admin"
+          },
+          "username": {
+            "title": "Username",
+            "type": "string"
+          }
+        },
+        "required": [
+          "username"
+        ],
+        "title": "User",
+        "type": "object"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "title": "Location",
+            "type": "array"
+          },
+          "msg": {
+            "title": "Message",
+            "type": "string"
+          },
+          "type": {
+            "title": "Error Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError",
+        "type": "object"
+      },
+      "VerseText": {
+        "example": {
+          "book": "GEN",
+          "chapter": 1,
+          "first_verse_reference": "GEN 1:1",
+          "revision_id": 1,
+          "text": "In the beginning God created the heaven and the earth.",
+          "verse": 1,
+          "verse_reference": "GEN 1:1",
+          "verse_references": [
+            "GEN 1:1"
+          ]
+        },
+        "properties": {
+          "book": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Book"
+          },
+          "chapter": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Chapter"
+          },
+          "first_verse_reference": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Verse Reference"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "revision_id": {
+            "title": "Revision Id",
+            "type": "integer"
+          },
+          "text": {
+            "title": "Text",
+            "type": "string"
+          },
+          "verse": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verse"
+          },
+          "verse_reference": {
+            "title": "Verse Reference",
+            "type": "string"
+          },
+          "verse_references": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Verse References"
+          }
+        },
+        "required": [
+          "text",
+          "verse_reference",
+          "revision_id"
+        ],
+        "title": "VerseText",
+        "type": "object"
+      },
+      "VersionIn": {
+        "example": {
+          "abbreviation": "english_-_king_james_version",
+          "add_to_groups": [
+            1
+          ],
+          "iso_language": "eng",
+          "iso_script": "Latn",
+          "machineTranslation": false,
+          "name": "English King James Version"
+        },
+        "properties": {
+          "abbreviation": {
+            "title": "Abbreviation",
+            "type": "string"
+          },
+          "add_to_groups": {
+            "items": {
+              "type": "integer"
+            },
+            "title": "Add To Groups",
+            "type": "array"
+          },
+          "backTranslation": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Backtranslation"
+          },
+          "forwardTranslation": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forwardtranslation"
+          },
+          "is_reference": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": false,
+            "title": "Is Reference"
+          },
+          "iso_language": {
+            "title": "Iso Language",
+            "type": "string"
+          },
+          "iso_script": {
+            "title": "Iso Script",
+            "type": "string"
+          },
+          "machineTranslation": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": false,
+            "title": "Machinetranslation"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "rights": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rights"
+          },
+          "transcribed_audio": {
+            "default": false,
+            "title": "Transcribed Audio",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "name",
+          "iso_language",
+          "iso_script",
+          "abbreviation",
+          "add_to_groups"
+        ],
+        "title": "VersionIn",
+        "type": "object"
+      },
+      "VersionOut_v3": {
+        "example": {
+          "abbreviation": "english_-_king_james_version",
+          "deleted": false,
+          "group_ids": [
+            1,
+            2
+          ],
+          "id": 1,
+          "is_reference": false,
+          "iso_language": "eng",
+          "iso_script": "Latn",
+          "machineTranslation": false,
+          "name": "English King James Version",
+          "owner_id": 1
+        },
+        "properties": {
+          "abbreviation": {
+            "title": "Abbreviation",
+            "type": "string"
+          },
+          "back_translation_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Back Translation Id"
+          },
+          "deleted": {
+            "default": false,
+            "title": "Deleted",
+            "type": "boolean"
+          },
+          "forward_translation_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forward Translation Id"
+          },
+          "group_ids": {
+            "default": [],
+            "items": {
+              "type": "integer"
+            },
+            "title": "Group Ids",
+            "type": "array"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "is_reference": {
+            "default": false,
+            "title": "Is Reference",
+            "type": "boolean"
+          },
+          "iso_language": {
+            "title": "Iso Language",
+            "type": "string"
+          },
+          "iso_script": {
+            "title": "Iso Script",
+            "type": "string"
+          },
+          "machineTranslation": {
+            "default": false,
+            "title": "Machinetranslation",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "owner_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Owner Id"
+          },
+          "rights": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rights"
+          },
+          "transcribed_audio": {
+            "default": false,
+            "title": "Transcribed Audio",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "iso_language",
+          "iso_script",
+          "abbreviation"
+        ],
+        "title": "VersionOut_v3",
+        "type": "object"
+      },
+      "VersionUpdate": {
+        "example": {
+          "abbreviation": "english_-_king_james_version",
+          "add_to_groups": [
+            1,
+            2
+          ],
+          "id": 1,
+          "iso_language": "eng",
+          "iso_script": "Latn",
+          "machineTranslation": false,
+          "name": "English King James Version",
+          "remove_from_groups": [
+            3,
+            4
+          ]
+        },
+        "properties": {
+          "abbreviation": {
+            "title": "Abbreviation",
+            "type": "string"
+          },
+          "add_to_groups": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Add To Groups"
+          },
+          "backTranslation": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Backtranslation"
+          },
+          "forwardTranslation": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Forwardtranslation"
+          },
+          "id": {
+            "title": "Id",
+            "type": "integer"
+          },
+          "iso_language": {
+            "title": "Iso Language",
+            "type": "string"
+          },
+          "iso_script": {
+            "title": "Iso Script",
+            "type": "string"
+          },
+          "machineTranslation": {
+            "default": false,
+            "title": "Machinetranslation",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "remove_from_groups": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "integer"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Remove From Groups"
+          },
+          "rights": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rights"
+          },
+          "transcribed_audio": {
+            "default": false,
+            "title": "Transcribed Audio",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id"
+        ],
+        "title": "VersionUpdate",
+        "type": "object"
+      },
+      "WordAlignment": {
+        "properties": {
+          "assessment_id": {
+            "title": "Assessment Id",
+            "type": "integer"
+          },
+          "flag": {
+            "default": false,
+            "title": "Flag",
+            "type": "boolean"
+          },
+          "hide": {
+            "default": false,
+            "title": "Hide",
+            "type": "boolean"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "note": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Note"
+          },
+          "reference_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reference Text"
+          },
+          "revision_text": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Revision Text"
+          },
+          "score": {
+            "title": "Score",
+            "type": "number"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "target": {
+            "title": "Target",
+            "type": "string"
+          },
+          "vref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vref"
+          }
+        },
+        "required": [
+          "assessment_id",
+          "source",
+          "target",
+          "score"
+        ],
+        "title": "WordAlignment",
+        "type": "object"
+      },
+      "WordCount": {
+        "properties": {
+          "count": {
+            "minimum": 1.0,
+            "title": "Count",
+            "type": "integer"
+          },
+          "word": {
+            "title": "Word",
+            "type": "string"
+          }
+        },
+        "required": [
+          "word",
+          "count"
+        ],
+        "title": "WordCount",
+        "type": "object"
+      },
+      "WordIndexRequest": {
+        "properties": {
+          "iso_639_3": {
+            "maxLength": 3,
+            "minLength": 3,
+            "title": "Iso 639 3",
+            "type": "string"
+          },
+          "revision_id": {
+            "title": "Revision Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "iso_639_3",
+          "revision_id"
+        ],
+        "title": "WordIndexRequest",
+        "type": "object"
+      },
+      "WordIndexResponse": {
+        "properties": {
+          "unique_words_indexed": {
+            "title": "Unique Words Indexed",
+            "type": "integer"
+          },
+          "word_morpheme_pairs": {
+            "title": "Word Morpheme Pairs",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "unique_words_indexed",
+          "word_morpheme_pairs"
+        ],
+        "title": "WordIndexResponse",
+        "type": "object"
+      },
+      "aggType": {
+        "enum": [
+          "chapter",
+          "book",
+          "text"
+        ],
+        "title": "aggType",
+        "type": "string"
+      }
+    },
+    "securitySchemes": {
+      "OAuth2PasswordBearer": {
+        "flows": {
+          "password": {
+            "scopes": {},
+            "tokenUrl": "latest/token"
+          }
+        },
+        "type": "oauth2"
+      }
+    }
+  },
+  "info": {
+    "contact": {
+      "email": "mark_woodwardsil.org",
+      "name": "Get Help with this API",
+      "url": "http://ai.sil.org"
+    },
+    "description": "Augmented Quality Assessment API",
+    "license": {
+      "name": "MIT License",
+      "url": "https://opensource.org/license/mit/"
+    },
+    "title": "AQuA API",
+    "version": "0.2.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/": {
+      "get": {
+        "description": "Test docs",
+        "operationId": "read_root__get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Read Root"
+      }
+    },
+    "/health": {
+      "get": {
+        "description": "Liveness probe \u2014 cheap, no external dependencies.",
+        "operationId": "health_health_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Health",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/latest/affixes": {
+      "get": {
+        "operationId": "get_affixes_latest_affixes_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Iso",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "position",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(prefix|suffix|infix)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Position"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Affixes",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Bulk upsert of language affixes, scoped to the payload's revision.\n\nWith ``revision_id`` set (the canonical agent path), conflicts are\ndetected against rows stamped to the same ``target_version_id``;\nrows owned by other versions of the same ISO are untouched (#798).\nWithout a ``revision_id``, conflicts are detected against the legacy\n``target_version_id IS NULL`` bucket only.\n\nSame gloss \u2192 idempotent upsert of examples/n_runs/source_model.\nDifferent gloss for an existing (form, position) within the scope \u2192\n**409** with body:\n\n    {\"detail\": {\"message\": ..., \"conflicts\": [\n        {\"form\", \"position\", \"submitted_gloss\",\n         \"existing_id\", \"existing_gloss\"}, ...\n    ]}}\n\nA single conflict aborts the whole batch \u2014 there are no partial inserts.\nCallers should PATCH /v3/affixes/{existing_id} to update the stored row.\n\nThe SELECT-then-INSERT pattern has a small race window: a concurrent\nwriter can land between the conflict check and the upsert. The\non_conflict_do_update clause omits `gloss` from set_, so a racing\nsame-key insert with a different gloss is silently dropped rather than\noverwriting the stored gloss.",
+        "operationId": "commit_affixes_latest_affixes_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AffixCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixCommitResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Commit Affixes",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "put": {
+        "operationId": "replace_affixes_latest_affixes_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AffixCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixReplaceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Replace Affixes",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/affixes-by-version/{version_id}": {
+      "delete": {
+        "description": "Wipe every affix the GET soft-union would return for ``version_id``.\n\nDeletes (atomically, in one transaction):\n- rows version-stamped to ``version_id`` (``target_version_id == version_id``)\n- legacy iso-keyed rows (``target_version_id IS NULL``) that share the\n  version's ISO \u2014 the same rows ``GET /affixes-by-version/{version_id}``\n  surfaces via its soft union.\n\nRows stamped to other versions of the same ISO are left intact, so other\nversions' soft-union reads stay consistent.\n\nThis is the affix analog of ``DELETE /v3/agent/lexeme-card`` (#703) and\nlets ``build_mode=\"rebuild\"`` clear affixes the same way it clears cards.\nThe existing ``DELETE /v3/tokenizer/training-artifacts/{version_id}``\nalready removes version-stamped affixes as a side effect, but it leaves\niso-keyed legacy rows behind and is awkward as the primary surface for\naffix-only cleanups.\n\nStatus codes:\n- 200: returns row counts deleted (zeros if nothing existed \u2014 idempotent)\n- 403: caller is not authorized for this version \u2014 also returned for\n  non-existent version_ids when the caller is a regular user, so\n  unauthorized callers can't enumerate valid versions (matches the GET)\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "delete_affixes_by_version_latest_affixes_by_version__version_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkAffixDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Affixes By Version",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "get": {
+        "description": "Version-keyed read for language affixes.\n\nReturns the soft union of rows version-stamped for this version\n*and* legacy rows with `target_version_id IS NULL` that share the\nversion's ISO. NULL-stamped rows are treated as \"shared across\nversions of the ISO\" until Phase 5 splits them into per-version\nrows. (Phase 2 of issue #687.)\n\nStatus codes:\n- 200: returns the soft union (may be empty)\n- 403: caller is not authorized for this version \u2014 also returned\n  for non-existent version_ids when the caller is a regular user,\n  so unauthorized callers can't enumerate valid versions\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "get_affixes_by_version_latest_affixes_by_version__version_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "position",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(prefix|suffix|infix)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Position"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Affixes By Version",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/affixes/{affix_id}": {
+      "patch": {
+        "description": "Partial update of a single affix by id.\n\nOnly provided fields are updated; an empty body is a no-op that returns\nthe unchanged row. NFC normalization is applied to `form` and `gloss` by\nPydantic validators; both must be non-empty after strip.\n\nReturns **409** with `{\"detail\": {\"message\", \"existing_id\"}}` if changing\n`form` and/or `position` would collide with another row in the same\nlanguage.",
+        "operationId": "patch_affix_latest_affixes__affix_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "affix_id",
+            "required": true,
+            "schema": {
+              "title": "Affix Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AffixPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Affix",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/critique": {
+      "get": {
+        "description": "Get critique issues filtered by assessment and optionally by other criteria.\n\nQuery Parameters:\n- assessment_id: int (optional) - The assessment ID. Must provide either assessment_id OR (revision_id and reference_id).\n- revision_id: int (optional) - The revision ID. Must be provided with reference_id if not using assessment_id.\n- reference_id: int (optional) - The reference ID. Must be provided with revision_id if not using assessment_id.\n- all_assessments: bool (optional, default=True) - When using revision_id and reference_id, if True returns issues from all assessments between the revision and reference. If False, returns only issues from the latest assessment.\n- agent_translation_id: int (optional) - Filter by specific agent translation ID\n- vref: str (optional) - Filter by specific verse reference (e.g., \"JHN 1:1\")\n- book: str (optional) - Filter by book code (e.g., \"JHN\")\n- dimension: str (optional) - Filter by MQM dimension (e.g., \"accuracy\")\n- subtype: str (optional) - Filter by MQM subtype (e.g., \"wrong-key-term\")\n- min_severity: int (optional) - Minimum severity level (1-5). Issues with\n  severity=NULL are excluded by this filter (SQL three-valued logic).\n- is_resolved: bool (optional) - Filter by resolution status (true=resolved, false=unresolved)\n\nReturns:\n- List[CritiqueIssueOut]: List of matching critique issues, ordered by book, chapter, verse, and severity",
+        "operationId": "get_critique_issues_latest_agent_critique_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": false,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "all_assessments",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "All Assessments",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_translation_id",
+            "required": false,
+            "schema": {
+              "title": "Agent Translation Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vref",
+            "required": false,
+            "schema": {
+              "title": "Vref",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "title": "Book",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dimension",
+            "required": false,
+            "schema": {
+              "title": "Dimension",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "subtype",
+            "required": false,
+            "schema": {
+              "title": "Subtype",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_severity",
+            "required": false,
+            "schema": {
+              "title": "Min Severity",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_resolved",
+            "required": false,
+            "schema": {
+              "title": "Is Resolved",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CritiqueIssueOut"
+                  },
+                  "title": "Response Get Critique Issues Latest Agent Critique Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Critique Issues",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Store MQM-aligned critique issues linked to a specific agent translation.\n\nInput:\n- agent_translation_id: int - The ID of the translation being critiqued\n- issues: list[IssueIn] - MQM-aligned issues (dimension, subtype, optional\n  source_text/draft_text/comments/severity/detector/evidence)\n\nReturns:\n- List[CritiqueIssueOut]: List of all created critique issue entries",
+        "operationId": "add_critique_issues_latest_agent_critique_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CritiqueStorageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CritiqueIssueOut"
+                  },
+                  "title": "Response Add Critique Issues Latest Agent Critique Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Critique Issues",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/critique/{issue_id}/resolve": {
+      "patch": {
+        "description": "Mark a critique issue as resolved.\n\nPath Parameters:\n- issue_id: int (required) - The ID of the critique issue to resolve\n\nInput:\n- resolution_notes: str (optional) - Notes about how the issue was resolved\n\nReturns:\n- CritiqueIssueOut: The updated critique issue with resolution information",
+        "operationId": "resolve_critique_issue_latest_agent_critique__issue_id__resolve_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issue_id",
+            "required": true,
+            "schema": {
+              "title": "Issue Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CritiqueIssueResolutionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CritiqueIssueOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Resolve Critique Issue",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/critique/{issue_id}/unresolve": {
+      "patch": {
+        "description": "Mark a resolved critique issue as unresolved.\n\nPath Parameters:\n- issue_id: int (required) - The ID of the critique issue to unresolve\n\nReturns:\n- CritiqueIssueOut: The updated critique issue with resolution information cleared",
+        "operationId": "unresolve_critique_issue_latest_agent_critique__issue_id__unresolve_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issue_id",
+            "required": true,
+            "schema": {
+              "title": "Issue Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CritiqueIssueOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Unresolve Critique Issue",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/lexeme-card": {
+      "delete": {
+        "description": "Wipe every lexeme card for a target_version_id, across all source pairs.\n\nCards for a given target_version_id can live at multiple source_version_ids\n(current pivot, pre-pivot reference version, function-word extraction era).\nThe per-card DELETE plus a GET keyed on (source, target) misses cards at\nother source pairs, leaving rebuilds dirty. This endpoint deletes by\ntarget_version_id alone, regardless of source_version_id.\n\nDeletes child rows explicitly in child-to-parent order so each row count\nis authoritative (no pre-delete SELECT COUNTs that could drift under\nconcurrent writes). ``card_translation_examples`` rows are wiped via the\n``card_translations`` cascade \u2014 they share a parent and never escape it.\n\nThis is the bulk counterpart to ``DELETE /v3/agent/lexeme-card/{card_id}``\nand the shape mirrors ``DELETE /v3/tokenizer/training-artifacts/{version_id}``\nso aqua-assessments' Phase 4 rebuild can call them together.\n\nStatus codes:\n- 200: returns row counts deleted (zeros if nothing existed \u2014 idempotent)\n- 403: caller not authorized for this version \u2014 also returned for\n  non-existent version_ids when the caller is a regular user (no\n  enumeration leak)\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "delete_lexeme_cards_for_target_version_latest_agent_lexeme_card_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkLexemeCardDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Lexeme Cards For Target Version",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "get": {
+        "description": "Get lexeme cards filtered by language pair and optionally by other fields.\nResults are ordered by confidence in descending order (highest first).\nExamples are automatically filtered to only include those from Bible revisions\nthe current user has access to.\n\nQuery Parameters:\n- target_version_id: int (required) - Bible version ID for target\n- source_version_id: int (optional) - Bible version ID for source. When\n  provided, the canonical source is resolved via pivot routing (the SQL\n  filter rewrites to the pivot bible_version registered for the target's\n  iso, falling back to the given value). Internal callers that target a\n  specific canonical pair (pivot picker, derive, consolidation) should\n  keep passing this. When omitted, cards are matched on target_version_id\n  alone, which is what a UI showing \"cards for this revision\" wants.\n- source_word: str (optional) - Filter by source_lemma or source_surface_forms\n  (case-insensitive exact match)\n- target_word: str (optional) - Filter by target_lemma or surface_forms\n  (case-insensitive exact match)\n- target_words: str (optional) - Comma-separated list of target words. Returns\n  cards where target_lemma or any surface_form matches any of the given words\n  (case-insensitive, NFC-normalized). Cannot be used with target_word.\n- pos: str (optional) - Filter by part of speech\n- model: str (optional) - Filter by the model id/name that built the card.\n  Lets harvesters fetch only cards built by a trusted model (e.g. Sonnet)\n  and exclude poisoned ones. Exact match; cards with NULL ``model`` are\n  excluded when this filter is set.\n- lang: str (optional) - ISO 639-3 code for the desired source-side language.\n  When omitted or equal to the cards' canonical source_language_iso, returns\n  cards in their canonical shape (back-compat). When it differs, source-side\n  fields (source_lemma, source_surface_forms, senses, examples[].source)\n  are replaced by the matching card_translations row. Cards without a\n  translation in the requested language are still returned, with the\n  source-side overlay fields set to null, examples[].source set to null,\n  and ``has_translation_overlay=False``, so the UI can render the target\n  side and indicate the overlay is missing. (Note: the single-card by-id\n  endpoint returns 404 in that same situation \u2014 it's the derivation\n  trigger. Callers iterating the bulk list should check\n  ``has_translation_overlay`` before clicking through to by-id.)\n\n  When ``lang`` is omitted but a ``source_version_id`` is also provided and\n  pivot routing rewrites the source, ``lang`` is auto-derived from the\n  caller's ``source_version_id`` ISO so the pivot stays invisible. In that\n  case the overlay logic above applies as if ``lang`` had been passed\n  explicitly; the structured log payload includes ``lang_auto_derived=True``\n  so dashboards can distinguish UI-driven misses from pivot-driven ones.\n\nReturns:\n- List[LexemeCardOut]: List of matching lexeme cards, ordered by confidence (descending).\n  Examples are filtered based on the user's access to Bible revisions.",
+        "operationId": "get_lexeme_cards_latest_agent_lexeme_card_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_word",
+            "required": false,
+            "schema": {
+              "title": "Source Word",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_word",
+            "required": false,
+            "schema": {
+              "title": "Target Word",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_words",
+            "required": false,
+            "schema": {
+              "title": "Target Words",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pos",
+            "required": false,
+            "schema": {
+              "title": "Pos",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Model"
+            }
+          },
+          {
+            "in": "query",
+            "name": "lang",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 3,
+                  "minLength": 3,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lang"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LexemeCardOut"
+                  },
+                  "title": "Response Get Lexeme Cards Latest Agent Lexeme Card Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Lexeme Cards",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "patch": {
+        "deprecated": true,
+        "description": "**DEPRECATED \u2014 internal callers only.** Use\n``PATCH /v3/agent/lexeme-card/translation`` instead.\n\nPartially update a lexeme card by lemma lookup, writing directly to the\ncanonical ``agent_lexeme_cards`` row. This endpoint is **unsafe for UI\ncallers**: when the canonical's source language is the pivot (e.g. swh)\nand the UI is viewing the card in another language (e.g. eng), a write\nto ``source_lemma`` here will silently overwrite the pivot canonical\nwith the UI's language text and corrupt every other consumer's view.\n\nThe new ``/agent/lexeme-card/translation`` endpoint solves that by\nrouting source-side writes to the per-language ``card_translations``\noverlay row. UI clients MUST migrate.\n\nThis endpoint is kept only because aqua-assessments' derivation pipeline\n(``word_memory_builder.update_lexeme_by_lemma_api``) uses it as a\nPOST\u2192409 fallback to patch ``surface_forms`` / ``source_surface_forms``\n/ ``alignment_scores`` on the canonical it just built. Those writes are\nsafe because the caller knows the canonical's source language matches\nwhat it's writing. Once that pipeline migrates to the by-id PATCH or to\nthe new translation endpoint, this route should be removed.\n\nQuery Parameters:\n- target_lemma: str (required) - The target language lemma\n- source_version_id: int (required) - Bible version ID for source\n- target_version_id: int (required) - Bible version ID for target\n- source_lemma: str (optional) - Disambiguates when multiple cards\n  share the same (target_lemma, source_version_id, target_version_id).\n- list_mode: str (optional, default=\"append\") - append / replace / merge.\n- is_user_edit: bool (optional, default=False) - Sets last_user_edit.\n\nBody: LexemeCardPatch (all fields optional, only provided fields update).",
+        "operationId": "patch_lexeme_card_by_lemma_DEPRECATED_latest_agent_lexeme_card_patch",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_lemma",
+            "required": true,
+            "schema": {
+              "title": "Target Lemma",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_lemma",
+            "required": false,
+            "schema": {
+              "title": "Source Lemma",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "list_mode",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ListMode"
+                }
+              ],
+              "default": "append",
+              "title": "List Mode"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_user_edit",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Is User Edit",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LexemeCardPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Lexeme Card By Lemma Deprecated",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Add a new lexeme card entry or update an existing one.\n\nUniqueness is enforced at the DB level on (LOWER(target_lemma),\nsource_language_iso, target_version_id) \u2014 i.e. one canonical card per\n(lemma, source language, target version), regardless of which specific\nsource_version_id the card was written via. The Python pre-check below\nkeys on source_version_id so callers that re-POST the same exact pair\nupsert, but cross-source-version collisions inside the same source\nlanguage fall through to the IntegrityError handler and return 409\nwith the conflicting card's id so callers can PATCH by id.\n\nInput:\n- card: LexemeCardIn - The lexeme card data\n- revision_id: int (optional) - The Bible revision ID that the examples come\n  from. Required only when `card.examples` is non-empty (top-level examples\n  are stored in a revision-scoped table). May be omitted for example-less\n  writes; the card itself is keyed only by version pair.\n- replace_existing: bool (optional, default=False) - If True, replaces list fields\n  (surface_forms, senses) with new data and replaces examples for this revision_id.\n  If False, appends new data to existing lists.\n- is_user_edit: bool (optional, default=False) - If True, sets the last_user_edit\n  timestamp. Use for user-initiated writes to distinguish from automated updates.\n\nCard fields:\n- source_lemma: str (optional) - The source language lemma for cross-reference\n- target_lemma: str (required) - The target language lemma\n- source_version_id: int - Bible version ID for source\n- target_version_id: int - Bible version ID for target\n- pos: str (optional) - Part of speech\n- surface_forms: list (optional) - JSON array of target language surface forms\n- source_surface_forms: list (optional) - JSON array of source language surface forms\n- senses: list (optional) - JSON array of senses with definitions and examples\n- examples: list (optional) - JSON array of usage examples for the specified revision_id\n- confidence: float (optional) - Confidence score for the lexeme card\n- english_lemma: str (optional) - English lemma when source/target languages are not English\n- alignment_scores: dict (optional) - Dict with source words as keys and alignment scores as values\n\nReturns:\n- LexemeCardOut: The created or updated lexeme card entry (with examples for the specified revision_id)\n\nRaises:\n- 409 Conflict: If a card with same target_lemma and language pair exists but\n  has a different source_lemma. Response includes existing card ID for PATCH.",
+        "operationId": "add_lexeme_card_latest_agent_lexeme_card_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "replace_existing",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Replace Existing",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_user_edit",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Is User Edit",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LexemeCardIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Lexeme Card",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/lexeme-card/check-word": {
+      "get": {
+        "description": "Check if a word exists as a target lemma or in surface_forms of lexeme cards.\n\nQuery Parameters:\n- word: str (required) - The word to search for\n- source_version_id: int (required) - Bible version ID for source\n- target_version_id: int (required) - Bible version ID for target\n\nReturns:\n- count: int - Number of lexeme cards where the word matches (case-insensitive)",
+        "operationId": "check_word_in_lexeme_cards_latest_agent_lexeme_card_check_word_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "word",
+            "required": true,
+            "schema": {
+              "title": "Word",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Check Word In Lexeme Cards",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/lexeme-card/deduplicate": {
+      "post": {
+        "description": "Find and merge duplicate lexeme cards that differ only by case in target_lemma.\n\nQuery Parameters:\n- source_version_id: int (required) - Bible version ID for source\n- target_version_id: int (required) - Bible version ID for target\n- dry_run: bool (optional, default=True) - If True, only report duplicates without merging\n\nReturns:\n- Summary with dry_run status, counts, and group details",
+        "operationId": "deduplicate_lexeme_cards_latest_agent_lexeme_card_deduplicate_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dry_run",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Dry Run",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Deduplicate Lexeme Cards",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/lexeme-card/translation": {
+      "patch": {
+        "description": "Patch a lexeme card in the (target_version_id, language_iso) view.\n\nThis is the UI's PATCH primitive. The UI thinks in terms of \"I am editing\nthe card I'm looking at in language X\" \u2014 without any awareness of pivot\nrouting or canonical-vs-overlay storage. The endpoint splits the body\ninternally:\n\n- Source-side fields (source_lemma, source_surface_forms, senses) land in\n  the ``card_translations`` overlay row for ``(card_id, language_iso)``,\n  upserted on conflict. The canonical's source-side stays untouched, so\n  edits in (target, eng) view can't corrupt the (target, swh) pivot.\n- Target-side and shared fields (target_lemma, surface_forms, pos,\n  confidence, english_lemma, alignment_scores, build_version, model) land\n  in the canonical ``agent_lexeme_cards`` row. There is only one target\n  column physically, so all overlays project the same target text \u2014 fixing\n  a typo from any language view fixes it everywhere.\n- When ``language_iso`` equals the card's canonical ``source_language_iso``\n  (no pivot routing in play, or pivot resolves back to the requested\n  lang), everything goes to the canonical row \u2014 there is no overlay to\n  write to.\n\nLookup is pivot-routed via ``_effective_source_version_expr``: pass\n``source_version_id`` (typically the UI's reference version) only when\nmultiple canonicals share the same ``(target_lemma, target_version_id)``\nand disambiguation is required.\n\n``is_user_edit=true`` bumps ``last_user_edit`` on every row this patch\nactually writes to: the canonical row when target-side/shared fields\nare in the body, the overlay row when source-side fields are in the\nbody. A source-only edit does NOT bump the canonical's\n``last_user_edit`` \u2014 the user didn't approve the target state, they\njust changed the source view. The response's top-level\n``last_user_edit`` is the max of the two so the UI can render\n\"edited recently\" without having to inspect both timestamps.\n\n``examples`` are not yet supported in the overlay branch (when\n``language_iso != canonical iso``); pass the full overlay including\nexample translations via ``POST /v3/agent/lexeme-card/{card_id}/translation``\ninstead. They are supported in the canonical-match branch via the\nexisting canonical patch path.\n\nReturns the resulting card shaped as if ``GET /v3/agent/lexeme-card``\nhad just been called with the same ``language_iso``, so the UI can\nrebind its form state directly from the response.",
+        "operationId": "patch_lexeme_card_translation_latest_agent_lexeme_card_translation_patch",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_lemma",
+            "required": true,
+            "schema": {
+              "title": "Target Lemma",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "language_iso",
+            "required": true,
+            "schema": {
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Language Iso",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "list_mode",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ListMode"
+                }
+              ],
+              "default": "append",
+              "title": "List Mode"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_user_edit",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Is User Edit",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LexemeCardPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Lexeme Card Translation",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/lexeme-card/{card_id}": {
+      "delete": {
+        "description": "Delete a lexeme card by ID.\n\nAssociated examples are deleted automatically via cascade\n(both ORM-level cascade=\"all, delete-orphan\" and DB-level ondelete=\"CASCADE\").\n\nThis endpoint is used by aqua-assessments during card consolidation.\nAny authenticated user can delete any card (consistent with other card endpoints).\n\nReturns 204 No Content on success, 404 if card not found.",
+        "operationId": "delete_lexeme_card_latest_agent_lexeme_card__card_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_id",
+            "required": true,
+            "schema": {
+              "title": "Card Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Lexeme Card",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "get": {
+        "description": "Return a single lexeme card, optionally in a non-canonical language.\n\nWhen ``lang`` is omitted or equals the card's canonical\n``source_language_iso``, returns the canonical card. Otherwise looks up\nthe ``card_translations`` row for that language and returns a\n``LexemeCardOut`` with translation-language source-side fields and\nper-example translated source_text merged in. Returns 404 if the card\ndoes not exist, or if a non-canonical ``lang`` is requested and no\ntranslation row exists for it (the caller can then trigger derivation).",
+        "operationId": "get_lexeme_card_by_id_latest_agent_lexeme_card__card_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_id",
+            "required": true,
+            "schema": {
+              "title": "Card Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "lang",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 3,
+                  "minLength": 3,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lang"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Lexeme Card By Id",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "patch": {
+        "description": "Partially update a lexeme card by ID.\n\nPath Parameters:\n- card_id: int - The ID of the lexeme card to update\n\nQuery Parameters:\n- list_mode: str (optional, default=\"append\") - How to handle list fields:\n  - \"append\": Add new items to existing lists (no deduplication)\n  - \"replace\": Overwrite entire lists\n  - \"merge\": Append + deduplicate case-insensitively (for string lists like\n    surface_forms); preserves original casing of existing items\n- is_user_edit: bool (optional, default=False) - If True, sets the last_user_edit\n  timestamp. Use for user-initiated writes to distinguish from automated updates.\n\nNote: The POST endpoint's append behavior differs - it uses case-sensitive\ndeduplication via set(). Use list_mode=\"merge\" here for smart deduplication.\n\nBody:\n- LexemeCardPatch: Partial update data. Only provided fields are updated.\n  - source_lemma, target_lemma, pos, confidence, english_lemma: Scalar fields\n  - surface_forms, source_surface_forms: String list fields\n  - senses: List of sense dictionaries\n  - examples: List of example dicts, each must include revision_id\n  - alignment_scores: Dict - keys merge with existing; null value removes key\n\nReturns:\n- LexemeCardOut: The updated lexeme card",
+        "operationId": "patch_lexeme_card_by_id_latest_agent_lexeme_card__card_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_id",
+            "required": true,
+            "schema": {
+              "title": "Card Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "list_mode",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ListMode"
+                }
+              ],
+              "default": "append",
+              "title": "List Mode"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_user_edit",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Is User Edit",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LexemeCardPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Lexeme Card By Id",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/lexeme-card/{card_id}/translation": {
+      "post": {
+        "description": "Upsert a derived translation for a single lexeme card.\n\nStores the (card_id, language_iso) translation overlay and replaces\nits associated example translations wholesale. Used by the derivation\npipeline in aqua-assessments to persist MT output for cards built\nagainst a non-matching canonical pivot language.",
+        "operationId": "add_lexeme_card_translation_latest_agent_lexeme_card__card_id__translation_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_id",
+            "required": true,
+            "schema": {
+              "title": "Card Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CardTranslationIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CardTranslationOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Lexeme Card Translation",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/translation": {
+      "post": {
+        "description": "Store a single agent-generated translation for a verse.\n\nInput:\n- assessment_id: int - The assessment ID\n- vref: str - Verse reference (e.g., \"JHN 1:1\")\n- draft_text: str (optional) - The draft translation text\n- hyper_literal_translation: str (optional) - The hyper-literal back-translation\n- literal_translation: str (optional) - The literal back-translation\n\nThe version is auto-incremented for each new translation of the same assessment+vref.\n\nReturns:\n- AgentTranslationOut: The created translation entry with id, version, and created_at",
+        "operationId": "add_agent_translation_latest_agent_translation_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTranslationStorageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTranslationOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Agent Translation",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/translations": {
+      "get": {
+        "description": "Get agent-generated translations for an assessment or revision.\n\nQuery Parameters:\n- assessment_id: int (optional) - The assessment ID. If provided, returns\n  translations for this specific assessment (with authorization check).\n- revision_id: int (optional) - The revision ID. If provided without assessment_id,\n  returns the latest translation per vref (by created_at) across all assessments\n  for that revision (no authorization check).\n- reference_version_id: int (optional) - Reference Bible version ID. Required when using revision_id.\n- script: str (optional) - 4-letter ISO 15924 script code. If omitted, returns\n  translations across all scripts for the given reference version.\n- vref: str (optional) - Filter by specific verse reference (e.g., \"JHN 1:1\")\n- first_vref: str (optional) - Start of verse range (inclusive)\n- last_vref: str (optional) - End of verse range (inclusive)\n- version: int (optional) - Filter by specific version number\n- all_versions: bool (optional, default=False) - If True, return all versions;\n  if False, return only the latest version per vref\n\nNote: At least one of assessment_id or revision_id must be provided.\nIf both are provided, assessment_id takes precedence.\n\nReturns:\n- List[AgentTranslationOut]: List of matching translations, ordered by verse reference",
+        "operationId": "get_agent_translations_latest_agent_translations_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "script",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 4,
+                  "minLength": 4,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Script"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vref",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Vref"
+            }
+          },
+          {
+            "in": "query",
+            "name": "first_vref",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "First Vref"
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_vref",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last Vref"
+            }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Version"
+            }
+          },
+          {
+            "in": "query",
+            "name": "all_versions",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "All Versions",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentTranslationOut"
+                  },
+                  "title": "Response Get Agent Translations Latest Agent Translations Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Agent Translations",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Store multiple agent-generated translations in bulk.\n\nAll translations in a single request get the same version number, which is\nauto-incremented based on the max existing version for the revision+reference version+script.\n\nInput:\n- assessment_id: int - The assessment ID\n- translations: list - List of translations, each with:\n  - vref: str - Verse reference (e.g., \"JHN 1:1\")\n  - draft_text: str (optional) - The draft translation text\n  - hyper_literal_translation: str (optional) - The hyper-literal back-translation\n  - literal_translation: str (optional) - The literal back-translation\n\nReturns:\n- List[AgentTranslationOut]: List of created translation entries",
+        "operationId": "add_agent_translations_bulk_latest_agent_translations_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTranslationBulkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentTranslationOut"
+                  },
+                  "title": "Response Add Agent Translations Bulk Latest Agent Translations Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Agent Translations Bulk",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/translations-test": {
+      "post": {
+        "description": "Debug endpoint - just echo the body size",
+        "operationId": "test_bulk_latest_agent_translations_test_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Test Bulk",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/word-alignment": {
+      "get": {
+        "description": "Get word alignments filtered by language pair and optionally by source/target words.\n\nQuery Parameters:\n- source_version_id: int (required) - Bible version ID for source\n- target_version_id: int (required) - Bible version ID for target\n- source_words: str (optional) - Comma-separated list of words to match in source_word\n- target_words: str (optional) - Comma-separated list of words to match in target_word\n\nAt least one of source_words or target_words must be provided.\n\nReturns:\n- List[AgentWordAlignmentOut]: List of matching word alignment entries",
+        "operationId": "get_word_alignments_latest_agent_word_alignment_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_words",
+            "required": false,
+            "schema": {
+              "title": "Source Words",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_words",
+            "required": false,
+            "schema": {
+              "title": "Target Words",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentWordAlignmentOut"
+                  },
+                  "title": "Response Get Word Alignments Latest Agent Word Alignment Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Word Alignments",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Add a new word alignment entry to the agent_word_alignments table.\n\nInput:\n- source_word: str - The source language word\n- target_word: str - The target language word\n- source_version_id: int - Bible version ID for source\n- target_version_id: int - Bible version ID for target\n- score: float - NLLB alignment confidence score (default: 0.0)\n- is_human_verified: bool - Whether the alignment is human-verified (default: False)\n\nReturns:\n- AgentWordAlignmentOut: The created word alignment entry",
+        "operationId": "add_word_alignment_latest_agent_word_alignment_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWordAlignmentIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWordAlignmentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Word Alignment",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/word-alignment/all": {
+      "get": {
+        "description": "Get all word alignments for a language pair.\n\nInput:\n- source_version_id: int - Bible version ID for source (required)\n- target_version_id: int - Bible version ID for target (required)\n- page: int (optional) - Page number (1-indexed)\n- page_size: int (optional) - Number of results per page\n\nIf both page and page_size are provided, pagination is applied.\nOtherwise, all results are returned.\n\nResults are ordered by score descending.\n\nReturns:\n- List[AgentWordAlignmentOut]: List of word alignment entries",
+        "operationId": "get_all_word_alignments_latest_agent_word_alignment_all_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentWordAlignmentOut"
+                  },
+                  "title": "Response Get All Word Alignments Latest Agent Word Alignment All Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get All Word Alignments",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/agent/word-alignment/bulk": {
+      "post": {
+        "description": "Bulk upsert word alignments.\n\nFor each alignment in the request:\n- If an alignment with the same (source_word, target_word, source_version_id, target_version_id) exists,\n  update its score, is_human_verified, and last_updated fields.\n- Otherwise, insert a new alignment.\n\nInput:\n- source_version_id: int - Bible version ID for source\n- target_version_id: int - Bible version ID for target\n- alignments: list - List of alignment items, each with:\n  - source_word: str - The source language word\n  - target_word: str - The target language word\n  - score: float - NLLB alignment confidence score (default: 0.0)\n  - is_human_verified: bool - Whether human-verified (default: False)\n\nReturns:\n- List[AgentWordAlignmentOut]: List of created/updated word alignment entries",
+        "operationId": "add_word_alignments_bulk_latest_agent_word_alignment_bulk_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWordAlignmentBulkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentWordAlignmentOut"
+                  },
+                  "title": "Response Add Word Alignments Bulk Latest Agent Word Alignment Bulk Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Word Alignments Bulk",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/alignmentmatches": {
+      "get": {
+        "description": "Returns a list of all word alignments for a given word in a word alignment assessment.\n\nParameters\n----------\nrevision_id : int\n    The ID of the revision to get results for.\nreference_id : int\n    The ID of the reference to get results for.\nword : str\n    The word from the reference text to get alignments for.\nthreshold : float, optional\n    The minimum score for an alignment to be included in the results.\n    If not set, the value of the ALIGNMENT_THRESHOLD environment variable will be used, if set, or 0.2.",
+        "operationId": "get_word_alignments_latest_alignmentmatches_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": true,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "word",
+            "required": true,
+            "schema": {
+              "title": "Word",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "threshold",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Threshold"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner; ``true`` reads only eflomal, ``false`` only fastalign.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner; ``true`` reads only eflomal, ``false`` only fastalign.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/WordAlignment"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Word Alignments Latest Alignmentmatches Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Word Alignments",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/alignmentscores": {
+      "get": {
+        "description": "Returns a list of all alignment scores between words for a given word alignment assessment.\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\nscore_type : AlignmentScoreType, optional\n    Which alignment score table to read from. Defaults to ``top`` (top-source\n    scores). Pass ``threshold`` to read alignment threshold scores instead.\n\nReturns\n-------\nDict[str, Union[List[WordAlignment], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_alignment_scores_latest_alignmentscores_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "description": "Which alignment score table to read from: 'top' (top-source scores, default) or 'threshold' (threshold scores).",
+            "in": "query",
+            "name": "score_type",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AlignmentScoreType"
+                }
+              ],
+              "default": "top",
+              "description": "Which alignment score table to read from: 'top' (top-source scores, default) or 'threshold' (threshold scores).",
+              "title": "Score Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/WordAlignment"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Alignment Scores Latest Alignmentscores Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Alignment Scores",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment": {
+      "delete": {
+        "description": "Deletes an assessment if the user is authorized.\n\nInput:\n- assessment_id: int\nDescription: The unique identifier for the assessment.",
+        "operationId": "delete_assessment_latest_assessment_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Assessment",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "get": {
+        "description": "Returns a list of assessments the current user is authorized to access.\n\nOptional query parameters:\n- id: Filter by one or more assessment IDs (repeated param, e.g. ?id=1&id=2).\n  IDs that do not exist or are not accessible to the current user are silently\n  omitted; a partial result is not an error.\n- revision_id: Filter assessments by revision ID\n- reference_id: Filter assessments by reference ID\n- type: Filter assessments by assessment type\n\nCurrently supported assessment types are:\n\n- semantic-similarity (requires reference)\n- sentence-length\n- word-alignment (requires reference)\n- ngrams\n- tfidf\n- text-lengths (requires reference)\n- agent-critique (requires reference)\n\n\nReturns:\nFields(AssessmentOut):\n- id: int\nDescription: The unique identifier for the assessment.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- reference_id: Optional[int] = None\nDescription: The unique identifier for the reference revision.\n- type: AssessmentType\nDescription: The type of assessment to be run.\n- status: str\nDescription: The status of the assessment. (queued, failed, finished)\n- requested_time: datetime.datetime\nDescription: The time the assessment was requested.\n- start_time: datetime.datetime\nDescription: The time the assessment was started.\n- end_time: datetime.datetime\nDescription: The time the assessment was completed.\n- owner_id: int\nDescription: The unique identifier for the owner of the assessment.",
+        "operationId": "get_assessments_latest_assessment_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AssessmentOut"
+                  },
+                  "title": "Response Get Assessments Latest Assessment Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Assessments",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Requests an assessment to be run on a revision and (where required) a reference revision.\n\nCurrently supported assessment types are:\n- semantic-similarity (requires reference)\n- sentence-length\n- word-alignment (requires reference; runs eflomal-based alignment by default.\n  Pass `use_eflomal=false` to run fastalign instead. Source/target version IDs\n  are derived from reference_id and revision_id respectively.)\n- ngrams\n- tfidf\n- text-lengths\n- agent-critique (requires reference; pass `transcribed_audio=true` when the\n  draft is a transcription of recorded audio so the agent expects ASR\n  surface noise. Default off.)\n\nFor those assessments that require a reference, the reference_id should be the id of the revision with which the revision will be compared.\n\nOptional `extra_kwargs` query parameter accepts a JSON-encoded dict of extra keyword\narguments to pass through to the assessment function (e.g., `{\"top_k\": 5}`). Values\nmust be scalar types (str, int, float, bool, null). Max 20 keys.\n\nAdd an assessment entry. For regular users, an entry is added for each group they are part of.\nFor admin users, the entry is not linked to any specific group.",
+        "operationId": "add_assessment_latest_assessment_post",
+        "parameters": [
+          {
+            "description": "JSON-encoded dict of extra keyword arguments to pass to the assessment function",
+            "in": "query",
+            "name": "extra_kwargs",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "JSON-encoded dict of extra keyword arguments to pass to the assessment function",
+              "title": "Extra Kwargs"
+            }
+          },
+          {
+            "description": "Word-alignment runner selector. true runs eflomal, false runs fastalign. When omitted, eflomal runs by default unless use_eflomal was injected via extra_kwargs, in which case the injected value is honored \u2014 the typed query param always wins over an injected value. Source/target version IDs are derived from reference_id/revision_id.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Word-alignment runner selector. true runs eflomal, false runs fastalign. When omitted, eflomal runs by default unless use_eflomal was injected via extra_kwargs, in which case the injected value is honored \u2014 the typed query param always wins over an injected value. Source/target version IDs are derived from reference_id/revision_id.",
+              "title": "Use Eflomal"
+            }
+          },
+          {
+            "description": "agent-critique only. true tells the agent the draft is a transcription of recorded audio (ASR), so the back-translation/critique prompts expect surface transcription noise while still flagging genuine content differences. Default off (unset). The typed query param wins over a transcribed_audio value injected via extra_kwargs.",
+            "in": "query",
+            "name": "transcribed_audio",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "agent-critique only. true tells the agent the draft is a transcription of recorded audio (ASR), so the back-translation/critique prompts expect surface transcription noise while still flagging genuine content differences. Default off (unset). The typed query param wins over a transcribed_audio value injected via extra_kwargs.",
+              "title": "Transcribed Audio"
+            }
+          },
+          {
+            "description": "Force rerun even if a completed assessment already exists",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Force rerun even if a completed assessment already exists",
+              "title": "Force",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Modal environment to run the assessment in (e.g. 'main' or 'dev'). Defaults to server MODAL_ENV.",
+            "in": "query",
+            "name": "modal_env",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Modal environment to run the assessment in (e.g. 'main' or 'dev'). Defaults to server MODAL_ENV.",
+              "title": "Modal Env"
+            }
+          },
+          {
+            "in": "query",
+            "name": "return_all_results",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Return All Results",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AssessmentType"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Kwargs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AssessmentOut"
+                  },
+                  "title": "Response Add Assessment Latest Assessment Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Assessment",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/eflomal/results": {
+      "get": {
+        "description": "Pull eflomal training artifacts by assessment ID or version pair.\n\nProvide either assessment_id or both source_version_id and target_version_id.\nWhen querying by version pair, returns the most recent results.",
+        "operationId": "pull_eflomal_results_latest_assessment_eflomal_results_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target Version Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EflomalResultsPullResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Pull Eflomal Results",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Create the eflomal_assessment metadata row.\n\nCall this first, then push dictionary / target-word-counts / priors /\nBPE models via their own endpoints, then PATCH the assessment status\nto 'finished'.\n\nIdempotent: if results already exist for this assessment_id the existing\nrow is returned with 200 (safe to retry after a timeout).",
+        "operationId": "push_eflomal_metadata_latest_assessment_eflomal_results_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EflomalResultsPushRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EflomalAssessmentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Metadata",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/tfidf/artifacts": {
+      "get": {
+        "description": "Fetch TF-IDF encoder artifacts by assessment_id or latest by source version.\n\nExactly one of assessment_id or source_version_id must be provided.",
+        "operationId": "pull_tfidf_artifacts_latest_assessment_tfidf_artifacts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "description": "Wire format for the SVD components matrix. float32 (default) preserves stored precision; float16 halves the response, int8 quarters it (with an `int8_scale` for client-side rehydration). Stored DB row is unchanged regardless.",
+            "in": "query",
+            "name": "dtype",
+            "required": false,
+            "schema": {
+              "default": "float32",
+              "description": "Wire format for the SVD components matrix. float32 (default) preserves stored precision; float16 halves the response, int8 quarters it (with an `int8_scale` for client-side rehydration). Stored DB row is unchanged regardless.",
+              "enum": [
+                "float32",
+                "float16",
+                "int8"
+              ],
+              "title": "Dtype",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsPullResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Pull Tfidf Artifacts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/timeout-sweep": {
+      "post": {
+        "description": "Admin-only sweep that marks stuck non-terminal assessments as failed.\n\nAssessments accumulate in the database in non-terminal states (queued,\nrunning) when an upstream runner is lost or never reports a final status.\nCalling this endpoint transitions any such assessment older than `hours`\nto `failed` with a traceable status_detail.",
+        "operationId": "timeout_sweep_latest_assessment_timeout_sweep_post",
+        "parameters": [
+          {
+            "description": "Mark assessments as failed if they are still queued or running and their requested_time is older than this many hours.",
+            "in": "query",
+            "name": "hours",
+            "required": false,
+            "schema": {
+              "default": 24,
+              "description": "Mark assessments as failed if they are still queued or running and their requested_time is older than this many hours.",
+              "maximum": 87600,
+              "minimum": 2,
+              "title": "Hours",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeoutSweepResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Timeout Sweep",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/alignment-scores": {
+      "delete": {
+        "description": "Delete alignment top source scores by ID.",
+        "operationId": "delete_alignment_scores_latest_assessment__assessment_id__alignment_scores_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Alignment Scores",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert alignment top source scores.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.\n\n``hide`` is hardcoded to ``False`` and is not part of ``AlignmentScoreItem``\n\u2014 it is a UI-only flag managed by other endpoints, not by the assessment\nrunner that drives this insert. Without an explicit value the column landed\n``NULL``, which then 500'd ``GET /alignmentscores`` because the response\nmodel declares ``hide: bool`` (issue #596).",
+        "operationId": "push_alignment_scores_latest_assessment__assessment_id__alignment_scores_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/AlignmentScoreItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Alignment Scores",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/alignment-threshold-scores": {
+      "delete": {
+        "description": "Delete alignment threshold scores by ID.",
+        "operationId": "delete_alignment_threshold_scores_latest_assessment__assessment_id__alignment_threshold_scores_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Alignment Threshold Scores",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert alignment threshold scores.\n\nMirrors ``POST /assessment/{id}/alignment-scores`` but writes to\n``alignment_threshold_scores`` \u2014 the table that holds every link with\nscore >= threshold (possibly multiple targets per source word), not the\ndeduped per-(vref, source) top pick.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.\n\n``hide`` is explicitly set to ``False`` for parity with the top-source\nendpoint, so we don't depend on the column's ``server_default`` (added\nafter the fact by migration ``c9e7b1f2d3a4``) \u2014 that's the original\nissue #596 hazard, where omitting ``hide`` landed ``NULL`` on a schema\nthat lacked the default and 500'd ``GET /alignmentscores``.",
+        "operationId": "push_alignment_threshold_scores_latest_assessment__assessment_id__alignment_threshold_scores_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/AlignmentScoreItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Alignment Threshold Scores",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/eflomal-bpe-models": {
+      "post": {
+        "description": "Store the SentencePiece BPE models for an eflomal assessment.\n\nIdempotent on (assessment_id, direction): existing rows for this assessment\nare deleted and replaced with the new pair. The request body carries\nbase64-encoded serialized protobuf bytes for the source and target models.",
+        "operationId": "push_eflomal_bpe_models_latest_assessment__assessment_id__eflomal_bpe_models_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EflomalBpeModels"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Bpe Models",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/eflomal-dictionary": {
+      "post": {
+        "description": "Upsert dictionary entries for an eflomal assessment.\n\nMaximum of 5,000 items per request. Each row is keyed by\n(assessment_id, source_word, target_word); re-pushing a row updates\n`count` and `probability` in place. Disjoint chunks of a larger upload\ncoexist \u2014 the worker may safely chunk a >5,000-row dictionary across\nmultiple requests, and retries replay the full sequence safely.\n\nReturns the list of affected row IDs in the same order as the input.",
+        "operationId": "push_eflomal_dictionary_latest_assessment__assessment_id__eflomal_dictionary_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/EflomalDictionaryItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Dictionary",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/eflomal-priors": {
+      "post": {
+        "description": "Upsert LEX-format priors for an eflomal assessment.\n\nMaximum of 5,000 items per request. Each row is keyed by\n(assessment_id, source_bpe, target_bpe); re-pushing a row updates\n`alpha` in place. Disjoint chunks of a larger upload coexist \u2014 the\nworker may safely chunk a >5,000-row payload across multiple requests,\nand retries replay the full sequence safely.\n\nReturns the list of affected row IDs in the same order as the input.",
+        "operationId": "push_eflomal_priors_latest_assessment__assessment_id__eflomal_priors_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/EflomalPriorItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Priors",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/eflomal-target-word-counts": {
+      "post": {
+        "description": "Upsert target word count entries for an eflomal assessment.\n\nMaximum of 5,000 items per request. Each row is keyed by\n(assessment_id, word); re-pushing a row updates `count` in place.\nDisjoint chunks of a larger upload coexist \u2014 the worker may safely\nchunk a >5,000-row payload across multiple requests, and retries\nreplay the full sequence safely.\n\nReturns the list of affected row IDs in the same order as the input.",
+        "operationId": "push_eflomal_target_word_counts_latest_assessment__assessment_id__eflomal_target_word_counts_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/EflomalTargetWordCountItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Target Word Counts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/increment-attempts": {
+      "post": {
+        "description": "Atomically increment ``attempt_count`` for an assessment and return\nthe new value.\n\nCalled by the Modal runner's lifecycle helper at the start of each\nattempt (after the initial `running` PATCH, so terminal-409 retries\ndon't bump the counter for no-ops). The lifecycle uses the returned\ncount to decide whether to PATCH ``failed`` on exception (only once\n``attempt_count >= max_attempts``).\n\nThe UPDATE ... RETURNING runs as a single atomic statement so two\nconcurrent retries on the same row can't observe the same\npre-increment value \u2014 Postgres serializes the writes and each call\nsees its own post-increment count.\n\nAuth: admin, assessment owner, or any user with group access to the\nassessment's bible version. Mirrors ``update_assessment_status``.",
+        "operationId": "increment_assessment_attempts_latest_assessment__assessment_id__increment_attempts_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Increment Assessment Attempts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/ngrams": {
+      "delete": {
+        "description": "Delete ngrams and their associated vref rows by ngram ID.",
+        "operationId": "delete_ngrams_latest_assessment__assessment_id__ngrams_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Ngrams",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert ngram results with their verse references.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns the list of inserted ngram IDs in the same order as the input.",
+        "operationId": "push_ngrams_latest_assessment__assessment_id__ngrams_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/NgramItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Ngrams",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/results": {
+      "delete": {
+        "description": "Delete assessment results by ID.",
+        "operationId": "delete_results_latest_assessment__assessment_id__results_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Results",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert assessment results (assessment_result table).\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.",
+        "operationId": "push_results_latest_assessment__assessment_id__results_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/AssessmentResultItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Results",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/status": {
+      "patch": {
+        "description": "Runner callback to update assessment status.\n\nAuth: admin, assessment owner, or any user with group access to the\nassessment's bible version.  This mirrors the training PATCH pattern.",
+        "operationId": "update_assessment_status_latest_assessment__assessment_id__status_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssessmentStatusUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssessmentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Assessment Status",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/text-lengths": {
+      "delete": {
+        "description": "Delete text length rows by ID.",
+        "operationId": "delete_text_lengths_latest_assessment__assessment_id__text_lengths_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Text Lengths",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert text length statistics.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.",
+        "operationId": "push_text_lengths_latest_assessment__assessment_id__text_lengths_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/TextLengthsItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Text Lengths",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/tfidf-artifacts": {
+      "post": {
+        "description": "Store TF-IDF encoder artifacts (vectorizers + SVD) for an assessment.\n\nRe-posting replaces all artifacts for this assessment \u2014 safe to retry.",
+        "operationId": "push_tfidf_artifacts_latest_assessment__assessment_id__tfidf_artifacts_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsPushRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsPushResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Tfidf Artifacts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/tfidf-artifacts/abort": {
+      "post": {
+        "description": "Cancel an in-flight chunked upload and drop its staged chunks.\n\nAuthorization is at the assessment level \u2014 any caller authorized for the\nassessment can abort any in-flight upload for it (uploads have no\nper-initiator ownership by design).",
+        "operationId": "abort_tfidf_artifacts_upload_latest_assessment__assessment_id__tfidf_artifacts_abort_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsAbortRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsAbortResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Abort Tfidf Artifacts Upload",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/tfidf-artifacts/chunk": {
+      "post": {
+        "description": "Push one chunk of SVD components. Idempotent per (upload_id, chunk_index).",
+        "operationId": "upload_tfidf_artifact_chunk_latest_assessment__assessment_id__tfidf_artifacts_chunk_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsChunkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsChunkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Tfidf Artifact Chunk",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/tfidf-artifacts/commit": {
+      "post": {
+        "description": "Reassemble staged chunks and materialise final artifact rows.\n\nValidates all total_chunks chunks are present, vstacks them into a single\ncomponents_ matrix, and writes the TfidfArtifactRun + vectorizer + SVD rows\nin one transaction. Existing artifacts for the assessment are replaced.",
+        "operationId": "commit_tfidf_artifacts_upload_latest_assessment__assessment_id__tfidf_artifacts_commit_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsPushResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Commit Tfidf Artifacts Upload",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/tfidf-artifacts/init": {
+      "post": {
+        "description": "Start a chunked TF-IDF artifact upload.\n\nCreates a staging row with the vectorizer and SVD metadata. Returns an\nupload_id that the caller uses to POST chunks and finally commit.",
+        "operationId": "init_tfidf_artifacts_upload_latest_assessment__assessment_id__tfidf_artifacts_init_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsInitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsInitResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Init Tfidf Artifacts Upload",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/assessment/{assessment_id}/tfidf-vectors": {
+      "delete": {
+        "description": "Delete TF-IDF PCA vector rows by ID.",
+        "operationId": "delete_tfidf_vectors_latest_assessment__assessment_id__tfidf_vectors_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Tfidf Vectors",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert TF-IDF PCA vectors.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.",
+        "operationId": "push_tfidf_vectors_latest_assessment__assessment_id__tfidf_vectors_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/TfidfPcaVectorItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Tfidf Vectors",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/book": {
+      "get": {
+        "description": "Gets a list of verse texts for a revision for a given book.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible. e.g GEN, EXO, PSA.\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_book_latest_book_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": true,
+            "schema": {
+              "title": "Book",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Book Latest Book Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Book",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/change-password": {
+      "post": {
+        "operationId": "change_password_latest_change_password_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_change_password_latest_change_password_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Change Password",
+        "tags": [
+          "Latest"
+        ]
+      }
+    },
+    "/latest/chapter": {
+      "get": {
+        "description": "Gets a list of verse texts for a revision for a given chapter.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible. e.g GEN, EXO, PSA.\n- chapter: int\nDescription: The chapter of the book. e.g 1, 2, 3.\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_chapter_latest_chapter_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": true,
+            "schema": {
+              "title": "Book",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": true,
+            "schema": {
+              "title": "Chapter",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Chapter Latest Chapter Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Chapter",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/chapters": {
+      "get": {
+        "description": "Gets all available book/chapter combinations for a revision.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n\nReturns:\n- chapters: Dict[str, List[int]]\nDescription: A dictionary mapping book abbreviations (e.g., \"GEN\", \"EXO\")\nto lists of available chapter numbers. Books are ordered canonically\n(Genesis first) and chapters are sorted numerically within each book.",
+        "operationId": "get_available_chapters_latest_chapters_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionChapters"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Available Chapters",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/compare_text_lengths": {
+      "get": {
+        "description": "Returns the difference in text lengths between revision and reference assessments.\n\nThis endpoint finds the text-lengths assessments for both the revision and reference,\nand returns the difference (revision - reference) for each verse. Verses where either\nthe revision or reference has null or zero values are excluded from the results.\n\nParameters\n----------\nrevision_id : int, optional\n    The ID of the revision to compare. Must be provided with reference_id if using revision/reference mode.\nreference_id : int, optional\n    The ID of the reference to compare against. Must be provided with revision_id if using revision/reference mode.\nrevision_assessment_id : int, optional\n    The ID of the revision assessment to compare. Must be provided with reference_assessment_id if using assessment mode.\nreference_assessment_id : int, optional\n    The ID of the reference assessment to compare against. Must be provided with revision_assessment_id if using assessment mode.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\naggregate : str, optional\n    If set to \"chapter\", results will be aggregated by chapter.\n    If set to \"book\", results will be aggregated by book.\n    If set to \"text\", a single result will be returned for the whole text.\n    Otherwise results will be returned at the verse level.\n\nReturns\n-------\nDict[str, Union[List[TextLengthsResult], int]]\n    A dictionary containing the list of results (with differences) and the total count.",
+        "operationId": "compare_text_lengths_latest_compare_text_lengths_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/aggType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Aggregate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TextLengthsResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Compare Text Lengths Latest Compare Text Lengths Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Compare Text Lengths",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/compareresults": {
+      "get": {
+        "description": "Returns word alignment assessment results for a given revision and reference, but also\nreturns the average score and standard deviation of the average score for the baseline\nassessments when run against the same reference. Finally, a z-score is calculated for each\nresult, which is a measure of how many standard deviations the result is from the mean of the\nbaseline assessments.\n\nParameters\n----------\nrevision_id : int\n    The ID of the revision to get results for.\nreference_id : int\n    The ID of the reference to get results for.\nbaseline_ids : List[int], optional\n    A list of revision IDs to compare against. If not set, this route will essentially return\n    the same results as the /result route.\naggregate : str, optional\n    If set to \"chapter\", results will be aggregated by chapter.\n    If set to \"book\", results will be aggregated by book.\n    If set to \"text\", a single result will be returned, for the whole text.\n    Otherwise results will be returned at the verse level.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\n\nReturns\n-------\nDict[str, Union[List[MultipleResult], int, dict]]\n    A dictionary containing the list of results, the total count of results, and a dictionary\n    containing the score, average score and standard deviation for the baseline\n    assessments, and z-score of the score with respect to this baseline average and standard deviation.",
+        "operationId": "get_compare_results_latest_compareresults_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": true,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "baseline_ids",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "title": "Baseline Ids",
+              "type": "array"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/aggType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Aggregate"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner \u2014 the main revision and each baseline are chosen independently and may be different runners. ``true`` reads only eflomal, ``false`` only fastalign; an explicit runner applies to both the main revision and the baselines so their scores are never mixed.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner \u2014 the main revision and each baseline are chosen independently and may be different runners. ``true`` reads only eflomal, ``false`` only fastalign; an explicit runner applies to both the main revision and the baselines so their scores are never mixed.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/MultipleResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Compare Results Latest Compareresults Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Compare Results",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/groups": {
+      "delete": {
+        "operationId": "delete_group_latest_groups_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "groupname",
+            "required": true,
+            "schema": {
+              "title": "Groupname",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Group",
+        "tags": [
+          "Latest"
+        ]
+      },
+      "get": {
+        "operationId": "get_groups_latest_groups_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Group"
+                  },
+                  "title": "Response Get Groups Latest Groups Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Groups",
+        "tags": [
+          "Latest"
+        ]
+      },
+      "post": {
+        "operationId": "create_group_latest_groups_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "description",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Description"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Group"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Group",
+        "tags": [
+          "Latest"
+        ]
+      }
+    },
+    "/latest/groups/me": {
+      "get": {
+        "operationId": "get_groups_latest_groups_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Group"
+                  },
+                  "title": "Response Get Groups Latest Groups Me Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Groups",
+        "tags": [
+          "Latest"
+        ]
+      }
+    },
+    "/latest/language": {
+      "get": {
+        "description": "Get a list of ISO 639-2 language codes and their English names.\n\nReturns:\nFields(Language):\n- iso639: str\nDescription: The ISO 639-2 language code. e.g 'eng' for English. 'swa' for Swahili.\n- name: str\nDescription: The name of the language.",
+        "operationId": "list_languages_latest_language_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Language"
+                  },
+                  "title": "Response List Languages Latest Language Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Languages",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/language-pivot": {
+      "get": {
+        "description": "Resolve a target_iso to its pivot, or list all mappings.\n\nWith ``target_iso``: returns the resolved mapping on hit (200) or a\nstructured candidate list on miss (404 body). Without ``target_iso``:\nlists all mappings.",
+        "operationId": "get_language_pivot_latest_language_pivot_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_iso",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 3,
+                  "minLength": 3,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target Iso"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/LanguagePivotOut"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LanguagePivotListOut"
+                    }
+                  ],
+                  "title": "Response Get Language Pivot Latest Language Pivot Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguagePivotMissOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Language Pivot",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Upsert a target -> pivot mapping. Admin-only.\n\nRe-POST replaces the pivot for that target. Adding or changing a pivot\nis a curated decision tied to licensing/quality, so it should not be done\nautonomously by the agent. Fields omitted from the payload (e.g. ``notes``)\npreserve their existing value on update.",
+        "operationId": "upsert_language_pivot_latest_language_pivot_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LanguagePivotIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguagePivotOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upsert Language Pivot",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/language-pivot/{target_iso}": {
+      "delete": {
+        "operationId": "delete_language_pivot_latest_language_pivot__target_iso__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "target_iso",
+            "required": true,
+            "schema": {
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Target Iso",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "No mapping exists for this target_iso"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Language Pivot",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/link-user-group": {
+      "post": {
+        "operationId": "link_user_to_group_latest_link_user_group_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "username",
+            "required": false,
+            "schema": {
+              "title": "Username"
+            }
+          },
+          {
+            "in": "query",
+            "name": "groupname",
+            "required": false,
+            "schema": {
+              "title": "Groupname"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Link User To Group",
+        "tags": [
+          "Latest"
+        ]
+      }
+    },
+    "/latest/missingwords": {
+      "get": {
+        "description": "Returns a list of all missing words for a given missing words assessment.\n\nParameters\n----------\nrevision_id : int\n    The ID of the revision to get results for.\nreference_id : int\n    The ID of the reference to get results for.\nbaseline_ids : list, optional\n    A list of baseline revision ids to compare against.\nthreshold : float, optional\n    The threshold score for the a word to be considered missing. Default is None, which will default to environmental variable, if set, or 0.15.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\n\nReturns\n-------\nDict[str, Union[List[Result], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_missing_words_latest_missingwords_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": true,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "baseline_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Baseline Ids"
+            }
+          },
+          {
+            "in": "query",
+            "name": "threshold",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Threshold"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner \u2014 the main revision and each baseline are chosen independently and may be different runners. ``true`` reads only eflomal, ``false`` only fastalign; an explicit runner applies to both the main revision and the baselines so their scores are never mixed.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner \u2014 the main revision and each baseline are chosen independently and may be different runners. ``true`` reads only eflomal, ``false`` only fastalign; an explicit runner applies to both the main revision and the baselines so their scores are never mixed.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/Result_v2"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Missing Words Latest Missingwords Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Missing Words",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/ngrams_result": {
+      "get": {
+        "description": "Returns a list of n-gram results for a given assessment.\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\ndb : Session\n    The database session object to execute queries against.\n\nReturns\n-------\nDict[str, Union[List[NgramResult], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_ngrams_result_latest_ngrams_result_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 10000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/NgramResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Ngrams Result Latest Ngrams Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Ngrams Result",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/pivot-candidate": {
+      "get": {
+        "operationId": "list_pivot_candidates_latest_pivot_candidate_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PivotCandidateListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Pivot Candidates",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Create or update a pivot candidate. Admin-only.\n\nAdding a pivot is a curated decision tied to licensing/quality, so it\nshould not be done autonomously by the agent. Fields omitted from the\npayload (e.g. ``notes``) preserve their existing value on update.",
+        "operationId": "upsert_pivot_candidate_latest_pivot_candidate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PivotCandidateIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PivotCandidateOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upsert Pivot Candidate",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/predict": {
+      "post": {
+        "description": "Fan a PredictInput out to every configured assessment app in parallel.\n\nPer-app failures are isolated \u2014 a slow or failing app never blocks the others.",
+        "operationId": "predict_latest_predict_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictFanoutResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Predict",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/predict/jobs/{job_id}": {
+      "get": {
+        "description": "Poll a slow translation/critique job spawned by POST /predict.\n\nPairs are returned in the same order they were submitted to /predict,\neach with the original `vref` / `source_text` / `target_text` echoed\nback so callers that submit without a vref can still match results\nby index.",
+        "operationId": "get_predict_job_latest_predict_jobs__job_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictJobStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Predict Job",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/predict/semantic-similarity": {
+      "post": {
+        "operationId": "semantic_similarity_inference_latest_predict_semantic_similarity_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SemanticSimilarityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SemanticSimilarityResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Semantic Similarity Inference",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/predict/text-lengths": {
+      "get": {
+        "operationId": "text_lengths_inference_latest_predict_text_lengths_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "text1",
+            "required": true,
+            "schema": {
+              "maxLength": 10000,
+              "title": "Text1",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "text2",
+            "required": true,
+            "schema": {
+              "maxLength": 10000,
+              "title": "Text2",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextLengthsInferenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Text Lengths Inference",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/result": {
+      "get": {
+        "description": "Returns a list of all results for a given assessment. These results are generally one for each verse in the assessed text(s).\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\naggregate : str, optional\n    If set to \"chapter\", results will be aggregated by chapter. Otherwise results will be returned at the verse level.\n\nNotes\n-----\nSource and target are only returned for missing-words assessments. Source is single words from the source text. Target is\na json array of words that match this source in the \"baseline reference\" texts. These may be used to show how the source\nword has been translated in a few other major languages.\n\nFlag is a boolean value that is currently only implemented in missing-words assessments. It is used to indicate that the\nmissing word appears in the baseline reference texts, and so there is a higher likelihood that it is a word that should\nbe included in the text being assessed.",
+        "operationId": "get_result_latest_result_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/aggType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Aggregate"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reverse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "title": "Reverse"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/Result_v2"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Result Latest Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Result",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/revision": {
+      "delete": {
+        "description": "Deletes a revision.\n\nInput:\n- id: int\nDescription: The id of the revision to delete.",
+        "operationId": "delete_revision_latest_revision_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Revision",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "get": {
+        "description": "Returns a list of revisions.\n\nIf version_id is provided, returns a list of revisions for that version, otherwise returns a list of all revisions.\n\nInput:\n- version_id: Optional[int] = None\nDescription: The id of the version to which the revision belongs. If not provided, returns all revisions.\n\nReturns:\nFields(Revision):\n- version_id: int\nDescription: The id of the version to which the revision belongs.\n- name: str\nDescription: The name of the revision.\n- published: bool\nDescription: Whether the revision is published.\n- backTranslation: Optional[int] = None\nDescription: The id of the back translation revision.\n- machineTranslation: Optional[int] = None\nDescription: The id of the machine translation revision.\n- file: UploadFile\nDescription: The file containing the revision text.",
+        "operationId": "list_revisions_latest_revision_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Version Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RevisionOut_v3"
+                  },
+                  "title": "Response List Revisions Latest Revision Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Revisions",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Uploads a new revision.\n\nInput:\nFields(Revision):\n- version_id: int\nDescription: The id of the version to which the revision belongs.\n- name: str\nDescription: The name of the revision.\n- published: bool\nDescription: Whether the revision is published.\n- backTranslation: Optional[int] = None\nDescription: The id of the back translation revision.\n- machineTranslation: Optional[int] = None\nDescription: The id of the machine translation revision.\n- file: UploadFile\nDescription: The file containing the revision text.",
+        "operationId": "upload_revision_latest_revision_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "published",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "title": "Published"
+            }
+          },
+          {
+            "in": "query",
+            "name": "backTranslation",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Backtranslation"
+            }
+          },
+          {
+            "in": "query",
+            "name": "machineTranslation",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "title": "Machinetranslation"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_revision_latest_revision_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionOut_v3"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Revision",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "put": {
+        "description": "Rename a revision.\n\nInput:\n- id: int\nDescription: The id of the revision to rename.\n- new_name: str\nDescription: The new name for the revision.",
+        "operationId": "rename_revision_latest_revision_put",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "new_name",
+            "required": true,
+            "schema": {
+              "title": "New Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Rename Revision",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/script": {
+      "get": {
+        "description": "Get a list of ISO 15924 script codes and their English names.\n\nReturns:\nFields(Script):\n- iso15924: str\nDescription: The ISO 15924 script code. e.g 'Latn' for Latin. 'Cyrl' for Cyrillic.\n- name: str\nDescription: The name of the script.",
+        "operationId": "list_scripts_latest_script_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Script"
+                  },
+                  "title": "Response List Scripts Latest Script Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Scripts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/text": {
+      "get": {
+        "description": "Gets a list of verse texts for a whole revision.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- include_verses: IncludeVerses (all|union|intersection, default \"union\")\nDescription: Which verses to include. 'all' returns all 41,899 canonical\nverses with empty text for missing ones. 'union' and 'intersection' are\ntreated identically for a single revision (both return only verses that have text).\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_text_latest_text_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Which verses to include in the response. 'all': all 41,899 canonical verses, with empty text for missing verses. 'union': only verses that have text (default). 'intersection': treated identically to 'union' for a single revision.",
+            "in": "query",
+            "name": "include_verses",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/IncludeVerses"
+                }
+              ],
+              "default": "union",
+              "description": "Which verses to include in the response. 'all': all 41,899 canonical verses, with empty text for missing verses. 'union': only verses that have text (default). 'intersection': treated identically to 'union' for a single revision.",
+              "title": "Include Verses"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Text Latest Text Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Text",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/text_lengths_result": {
+      "get": {
+        "description": "Returns text lengths (word and character lengths and z-scores) for a given assessment.\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\naggregate : str, optional\n    If set to \"chapter\", results will be aggregated by chapter.\n    If set to \"book\", results will be aggregated by book.\n    If set to \"text\", a single result will be returned for the whole text.\n    Otherwise results will be returned at the verse level.\n\nReturns\n-------\nDict[str, Union[List[TextLengthsResult], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_text_lengths_latest_text_lengths_result_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/aggType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Aggregate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TextLengthsResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Text Lengths Latest Text Lengths Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Text Lengths",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/textalignmentmatches": {
+      "get": {
+        "description": "Returns aggregated alignment statistics across the entire text for a word alignment assessment.\n\nThis endpoint provides a summary of the top alignment matches for each source word,\nranked by probability and including various strength metrics.\n\nParameters\n----------\nrevision_id : int\n    The ID of the revision to get results for.\nreference_id : int\n    The ID of the reference to get results for.\ntop_k : int, optional\n    The maximum number of top target words to return per source word (default: 3).\nmin_support : float, optional\n    Minimum support mass threshold to include a source word (default: 20.0).\nmin_probability : float, optional\n    Minimum probability threshold to include an alignment (default: 0.4).\n\nReturns\n-------\nDict[str, Union[List[AlignmentMatch], int]]\n    A dictionary containing the list of alignment matches and the total count.\n\nNotes\n-----\nThe results include several strength metrics:\n- strength_mass: Expected alignment mass (probability * support_mass)\n- strength_margin_mass: Margin over next best match, weighted by support\n- strength_confidence: Confidence based on entropy and support",
+        "operationId": "get_text_alignment_matches_latest_textalignmentmatches_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": true,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top_k",
+            "required": false,
+            "schema": {
+              "default": 3,
+              "title": "Top K",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_support",
+            "required": false,
+            "schema": {
+              "default": 20.0,
+              "title": "Min Support",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_probability",
+            "required": false,
+            "schema": {
+              "default": 0.4,
+              "title": "Min Probability",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner; ``true`` reads only eflomal, ``false`` only fastalign.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner; ``true`` reads only eflomal, ``false`` only fastalign.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/AlignmentMatch"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Text Alignment Matches Latest Textalignmentmatches Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Text Alignment Matches",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/texts": {
+      "get": {
+        "description": "Gets verse texts for multiple revisions with range merging.\n\nWhen any revision has a \"<range>\" marker for a verse, that verse is merged\nwith preceding verses for ALL revisions to keep them consistently aligned.\n\nInput:\n- revision_ids: List[int]\nDescription: List of revision IDs to fetch (minimum 2).\n- include_verses: IncludeVerses (all|union|intersection, default \"union\")\nDescription: Which verses to include in the response.\n- limit: Optional[int]\nDescription: Maximum number of verses per revision_id. Sampling happens\nafter include_verses filtering and <range> merging.\n- random: bool (default false)\nDescription: If true, sample uniformly at random; otherwise return the\nfirst `limit` verses in canonical order.\n- seed: Optional[int]\nDescription: RNG seed. Combined with random=true, two calls with the\nsame seed return the same sample. Ignored if random=false.\n\nReturns:\nDict[str, List[VerseText]]: Dictionary keyed by revision_id (as string),\neach containing a list of VerseText objects. Merged verses will have\nverse_reference formatted as a range (e.g., \"GEN 1:1-3\").\n\nNotes:\n- The returned dictionary will include an entry for every requested\n  revision_id.\n- With include_verses='all', every revision gets all 41,899 canonical\n  verses (empty text for missing ones). With 'union' or 'intersection',\n  a revision with no matching verses will have an empty list.\n- If a verse exists in one revision but not another, the missing revision\n  will have an empty string for that verse's text.",
+        "operationId": "get_texts_latest_texts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_ids",
+            "required": true,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "min_items": 2,
+              "title": "Revision Ids",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Which verses to include in the response. 'all': all 41,899 canonical verses, with empty text for missing verses. 'union': verses where at least one revision has text (default). 'intersection': only verses where every revision has text.",
+            "in": "query",
+            "name": "include_verses",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/IncludeVerses"
+                }
+              ],
+              "default": "union",
+              "description": "Which verses to include in the response. 'all': all 41,899 canonical verses, with empty text for missing verses. 'union': verses where at least one revision has text (default). 'intersection': only verses where every revision has text.",
+              "title": "Include Verses"
+            }
+          },
+          {
+            "description": "Maximum number of verses to return per revision_id. With include_verses='all', limit applies to the 41,899 canonical verse slots (so some returned rows may have empty text).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of verses to return per revision_id. With include_verses='all', limit applies to the 41,899 canonical verse slots (so some returned rows may have empty text).",
+              "title": "Limit"
+            }
+          },
+          {
+            "description": "If true, sample uniformly at random (after include_verses filtering) instead of returning the first `limit` verses in canonical order. Response is still ordered canonically.",
+            "in": "query",
+            "name": "random",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "If true, sample uniformly at random (after include_verses filtering) instead of returning the first `limit` verses in canonical order. Response is still ordered canonically.",
+              "title": "Random",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "RNG seed for deterministic sampling. Only meaningful when random=true; ignored otherwise. If omitted with random=true, sampling is non-deterministic.",
+            "in": "query",
+            "name": "seed",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "RNG seed for deterministic sampling. Only meaningful when random=true; ignored otherwise. If omitted with random=true, sampling is non-deterministic.",
+              "title": "Seed"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/VerseText"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Get Texts Latest Texts Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Texts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/textsearch": {
+      "get": {
+        "description": "Search for verses containing a specific term in a revision text.\nReturns verses that contain the search term (case-insensitive).\n\nBy default matches whole words only. ``*`` acts as a wildcard for any\nrun of word characters, and may appear at the start, end, and/or\ninside the term:\n\n- ``foo``      \u2014 whole-word match (default)\n- ``foo*``     \u2014 words starting with ``foo``\n- ``*foo``     \u2014 words ending with ``foo``\n- ``*foo*``    \u2014 ``foo`` anywhere inside a word\n- ``fo*ar``    \u2014 word starting with ``fo`` and ending with ``ar``\n- ``*fo*ar*``  \u2014 ``fo`` followed (somewhere later) by ``ar`` in the\n  same word\n\nEvery ``*`` matches within a single word \u2014 internal wildcards will\nnot cross a word boundary. The term must contain at least one visible\n(non-whitespace, non-format) character.\n\nProvide exactly one of ``revision_id`` or ``version_id``.  When\n``version_id`` is given, results reflect the version's current text:\nfor each verse, the most recent non-empty revision is chosen first,\nand the search term is then matched against that latest text. A verse\nwhose latest revision no longer contains the term will not surface,\neven if an older revision did \u2014 searches return the version \"as it\nstands today,\" not its full revision history.\n\nOptionally provide at most one of ``comparison_revision_id`` or\n``comparison_version_id`` for parallel text. For ``comparison_version_id``\nthe same per-vref pick applies (latest non-empty wins; the search term\nis only required on the main side, not on the comparison).\n\nPass ``include_alignments=true`` to annotate each result with per-verse\nword alignments from the latest finished eflomal word-alignment\nassessment matching ``(revision_id, comparison_revision_id)``. Each\nresult gains an ``alignments`` array of ``{source, target, score}``\nobjects, where ``source`` is from the comparison side and ``target``\nis from the main side. Links below ``min_alignment_score`` are filtered\nserver-side. ``alignment_assessment_id`` overrides the auto-pick. When\nno matching assessment exists or the user lacks access to it, results\nare returned without the ``alignments`` field (no error).",
+        "operationId": "search_revision_text_latest_textsearch_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "maxLength": 200,
+              "minLength": 1,
+              "title": "Term",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "description": "Bible version id; per (book, chapter, verse) the most recent non-empty revision is chosen first, and the search term is then matched against that latest text. Older revisions only fill in for verses where the latest revision is empty or missing the row, not for term mismatches \u2014 results reflect the version's current text.",
+            "in": "query",
+            "name": "version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Bible version id; per (book, chapter, verse) the most recent non-empty revision is chosen first, and the search term is then matched against that latest text. Older revisions only fill in for verses where the latest revision is empty or missing the row, not for term mismatches \u2014 results reflect the version's current text.",
+              "title": "Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "comparison_revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Comparison Revision Id"
+            }
+          },
+          {
+            "description": "Bible version id for comparison text; per (book, chapter, verse) returns the latest non-empty revision (no search-term filter on the comparison side).",
+            "in": "query",
+            "name": "comparison_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Bible version id for comparison text; per (book, chapter, verse) returns the latest non-empty revision (no search-term filter on the comparison side).",
+              "title": "Comparison Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "random",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Random",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "If true, annotate each result with per-verse word alignments from the most recent finished word-alignment assessment for the (revision_id, comparison_revision_id) pair (runner selected by ``use_eflomal``). Each result gains an ``alignments`` array of ``{source, target, score}`` objects. If no matching assessment exists for the pair, results are returned without the ``alignments`` field (no error).",
+            "in": "query",
+            "name": "include_alignments",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "If true, annotate each result with per-verse word alignments from the most recent finished word-alignment assessment for the (revision_id, comparison_revision_id) pair (runner selected by ``use_eflomal``). Each result gains an ``alignments`` array of ``{source, target, score}`` objects. If no matching assessment exists for the pair, results are returned without the ``alignments`` field (no error).",
+              "title": "Include Alignments",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Filter alignment links below this score server-side. Only applies when ``include_alignments`` is true.",
+            "in": "query",
+            "name": "min_alignment_score",
+            "required": false,
+            "schema": {
+              "default": 0.3,
+              "description": "Filter alignment links below this score server-side. Only applies when ``include_alignments`` is true.",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "Min Alignment Score",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Optional explicit word-alignment assessment id to source alignments from. When omitted, the latest finished word-alignment assessment for the (revision_id, comparison_revision_id) pair is used.",
+            "in": "query",
+            "name": "alignment_assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional explicit word-alignment assessment id to source alignments from. When omitted, the latest finished word-alignment assessment for the (revision_id, comparison_revision_id) pair is used.",
+              "title": "Alignment Assessment Id"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to source alignments from when ``include_alignments`` is true. Omitted sources from the most recent finished assessment regardless of runner; ``true`` uses eflomal, ``false`` uses fastalign. Applies to both the explicit ``alignment_assessment_id`` and the auto-pick path.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to source alignments from when ``include_alignments`` is true. Omitted sources from the most recent finished assessment regardless of runner; ``true`` uses eflomal, ``false`` uses fastalign. Applies to both the explicit ``alignment_assessment_id`` and the auto-pick path.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Search Revision Text",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tfidf_result": {
+      "get": {
+        "description": "Returns the most similar verses to the given vref based on TF-IDF PCA vector similarity.\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\nvref : str\n    The verse reference to compare against.\nlimit : int, optional\n    The number of similar verses to return (default is 10).\nreference_id : Optional[int]\n    Not used in the assessment, but optionally to also return the reference text\n    for the given vrefs.\n\nReturns\n-------\nDict[str, Union[List[TfidfResult], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_tfidf_result_latest_tfidf_result_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vref",
+            "required": true,
+            "schema": {
+              "title": "Vref",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TfidfResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Tfidf Result Latest Tfidf Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tfidf_result/by_text": {
+      "post": {
+        "description": "Nearest-neighbour corpus verses to an arbitrary piece of text.\n\nEncodes `text` into the assessment's 300-dim TF-IDF/SVD space server-side\n(the step callers previously did out-of-band), then ranks it against the\ncorpus exactly like /tfidf_result/by_vector. `exclude_vref`/`exclude_book`\ndrop the query verse (or its whole book) from the neighbours.",
+        "operationId": "get_tfidf_result_by_text_latest_tfidf_result_by_text_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfByTextRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TfidfResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Tfidf Result By Text Latest Tfidf Result By Text Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result By Text",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tfidf_result/by_texts": {
+      "post": {
+        "description": "Batch companion to /tfidf_result/by_text \u2014 one neighbour set per text.\n\n`exclude_vrefs[i]` (if provided) applies to `texts[i]`; `exclude_book`\napplies to all of them.",
+        "operationId": "get_tfidf_result_by_texts_latest_tfidf_result_by_texts_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfByTextsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfByVectorsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result By Texts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tfidf_result/by_vector": {
+      "post": {
+        "description": "Nearest-neighbour corpus verses to an arbitrary query vector.\n\nCompanion to GET /tfidf_result \u2014 the vref-keyed endpoint requires the\nquery verse to already be in the corpus; this one accepts any vector\n(e.g. the output of a fresh predict() encoding).",
+        "operationId": "get_tfidf_result_by_vector_latest_tfidf_result_by_vector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfByVectorRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TfidfResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Tfidf Result By Vector Latest Tfidf Result By Vector Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result By Vector",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tfidf_result/by_vectors": {
+      "post": {
+        "description": "Batch companion to /tfidf_result/by_vector \u2014 one neighbour set per vector.\n\nSaves N HTTP round-trips for callers that encode a batch of texts (e.g. the\ntfidf predict() path from the fan-out predict endpoint).",
+        "operationId": "get_tfidf_result_by_vectors_latest_tfidf_result_by_vectors_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfByVectorsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfByVectorsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result By Vectors",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/token": {
+      "post": {
+        "operationId": "login_for_access_token_latest_token_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_login_for_access_token_latest_token_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Token"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Login For Access Token",
+        "tags": [
+          "Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/cooccurrences": {
+      "get": {
+        "operationId": "get_cooccurrences_latest_tokenizer_cooccurrences_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Iso",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "morpheme",
+            "required": true,
+            "schema": {
+              "title": "Morpheme",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "position_filter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(prefix|suffix|infix)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Position Filter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CooccurrenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Cooccurrences",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/index": {
+      "post": {
+        "operationId": "index_morphemes_latest_tokenizer_index_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Index Morphemes",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/morphemes-by-version/{version_id}": {
+      "get": {
+        "description": "Version-keyed read for language morphemes.\n\nReturns the soft union of rows version-stamped for this version\n*and* legacy rows with `target_version_id IS NULL` that share the\nversion's ISO. NULL-stamped rows are treated as \"shared across\nversions of the ISO\" until Phase 5 splits them into per-version\nrows. (Phase 2 of issue #687.)\n\nStatus codes:\n- 200: returns the soft union (may be empty)\n- 403: caller is not authorized for this version \u2014 also returned\n  for non-existent version_ids when the caller is a regular user,\n  so unauthorized callers can't enumerate valid versions\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "get_morphemes_by_version_latest_tokenizer_morphemes_by_version__version_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter to LEXICAL|GRAMMATICAL|BOUND_ROOT|UNKNOWN",
+            "in": "query",
+            "name": "class",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to LEXICAL|GRAMMATICAL|BOUND_ROOT|UNKNOWN",
+              "title": "Class"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MorphemeListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Morphemes By Version",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/morphemes/{iso}": {
+      "get": {
+        "operationId": "get_morphemes_latest_tokenizer_morphemes__iso__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "title": "Iso",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter to LEXICAL|GRAMMATICAL|BOUND_ROOT|UNKNOWN",
+            "in": "query",
+            "name": "class",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to LEXICAL|GRAMMATICAL|BOUND_ROOT|UNKNOWN",
+              "title": "Class"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MorphemeListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Morphemes",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/profile/{iso}": {
+      "get": {
+        "operationId": "get_language_profile_latest_tokenizer_profile__iso__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "title": "Iso",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageProfileOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Language Profile",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "put": {
+        "description": "Create or update a language profile.\n\nOn update, only fields present in the request body are modified; omitted\nfields retain their current values.  To clear a field, send it explicitly\nas ``null``.",
+        "operationId": "upsert_language_profile_latest_tokenizer_profile__iso__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "title": "Iso",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LanguageProfileIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageProfileOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upsert Language Profile",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/runs": {
+      "get": {
+        "operationId": "list_tokenizer_runs_latest_tokenizer_runs_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "iso",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Iso"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "description": "Filter by run status. Omit to list all runs regardless of status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by run status. Omit to list all runs regardless of status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenizerRunListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Tokenizer Runs",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Commit a tokenizer pipeline run.\n\nConcurrency note: this endpoint assumes a single pipeline writer per\n(iso, revision). Under concurrent writers, the SELECT-then-INSERT\ncheck-before-write pattern for morphemes races: two callers can both\nobserve a morpheme as missing, both try to insert, one wins via\nON CONFLICT DO NOTHING, and the loser's class-conflict counter\nundercounts. The stored class is still correct (first writer wins),\nbut the returned stats can be off by a few rows.",
+        "operationId": "commit_tokenizer_run_latest_tokenizer_runs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenizerRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenizerRunCommitResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Commit Tokenizer Run",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/search": {
+      "get": {
+        "operationId": "search_morpheme_latest_tokenizer_search_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "title": "Iso",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "morpheme",
+            "required": true,
+            "schema": {
+              "title": "Morpheme",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Revision to search in",
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "description": "Revision to search in",
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "comparison_revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Comparison Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MorphemeSearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Search Morpheme",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/training-artifacts/{version_id}": {
+      "delete": {
+        "description": "Clear agent-discovered tokenizer artifacts for a single bible_version.\n\nDeletes (atomically, in one transaction):\n- the `training_artifacts` row for this version (per-version\n  grammar_sketch / source_model)\n- `language_affixes` rows where `target_version_id == version_id`\n- `language_morphemes` rows where `target_version_id == version_id`\n\nLegacy `target_version_id IS NULL` rows and rows stamped to other\nversions of the same ISO are left intact, so other versions'\nsoft-union reads stay consistent. Lexeme cards are also untouched\n\u2014 they have their own DELETE endpoint.\n\nThis is the primitive that backs aqua-assessments' `build_mode=\n\"rebuild\"`: clear the version-scoped artifacts, then re-run `auto`\nagainst a fresh slate. (Phase 4 of issue #687.)\n\nStatus codes:\n- 200: returns row counts deleted (zeros if nothing existed \u2014\n  idempotent)\n- 403: caller is not authorized for this version \u2014 also returned\n  for non-existent version_ids when the caller is a regular user\n  (consistent with the GET endpoints; prevents enumeration)\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "delete_training_artifacts_latest_tokenizer_training_artifacts__version_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingArtifactsDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Training Artifacts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "get": {
+        "description": "Version-keyed read for tokenizer training artifacts.\n\nPrefers the per-version `training_artifacts` row; falls back to the\niso-keyed `language_profiles.grammar_sketch` when either no\nversion-keyed row exists OR the version-keyed row exists but its\n`grammar_sketch` is NULL (in which case the version-keyed\n`source_model` is still surfaced for provenance). Phase 2 of issue\n#687. Callers should treat the returned `source` field as advisory:\nit indicates which store satisfied the grammar_sketch read so we\ncan monitor cutover progress.\n\nStatus codes:\n- 200: artifact found (either version- or iso-keyed)\n- 403: caller is not authorized for this version \u2014 also returned\n  for non-existent version_ids when the caller is a regular user,\n  so unauthorized callers can't enumerate valid versions\n- 404: admin caller requesting a version_id that doesn't exist\n  (admins bypass the auth helper, so they reach the lookup)",
+        "operationId": "get_training_artifacts_latest_tokenizer_training_artifacts__version_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingArtifactOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Artifacts",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/tokenizer/word-index": {
+      "post": {
+        "operationId": "build_word_index_latest_tokenizer_word_index_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WordIndexRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WordIndexResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Build Word Index",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/train": {
+      "get": {
+        "description": "List training jobs accessible to the current user. The ?status filter\nmatches the linked Assessment.status.",
+        "operationId": "list_training_jobs_latest_train_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target Version Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TrainingJobOut"
+                  },
+                  "title": "Response List Training Jobs Latest Train Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Training Jobs",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Create and dispatch training jobs for all types in parallel.\n\nThe pair is identified by version_id (latest non-deleted revision is\nresolved) or by revision_id when a specific revision is required.",
+        "operationId": "create_training_job_latest_train_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrainingJobIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Training Job",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/train/status": {
+      "get": {
+        "description": "Get the status of a training session by session_id.",
+        "operationId": "get_training_status_latest_train_status_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Status",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/train/status/{session_id}/results": {
+      "get": {
+        "description": "Single read endpoint that returns training-job status + interleaved\nper-vref results for every completed job in the session.\n\nPer vref: semantic_similarity score (one row), word_alignment per-word\nrows plus a verse-level word_alignment_score, tfidf\n`{target_neighbours, source_neighbours}` nearest-neighbour blocks\n(one block per side, each neighbour hydrated with both revisions'\ntext), and ngrams `{target_corpus, source_corpus}` blocks listing\ntrained ngrams that fire on this verse with their full\ncross-corpus vrefs lists. The per-vref tfidf and ngrams shapes\nmirror the per-pair shape of `/v3/predict` so callers can share a\nparser between the two endpoints; predict's cross-axis ngrams\n(target ngrams in source text and vice versa) are not returned \u2014\ntrain-status reads stored corpus hits only.\n\nSource-side ngrams/tfidf are looked up as the latest finished\nassessment of the same type whose revision_id equals this session's\nsource_revision_id (typically created by a separate training\nsession that swapped source/target). When no source-side training\nis available, `source_corpus` is `None` for ngrams and\n`source_neighbours` is `[]` for tfidf.\n\nAgent_critique adds `lexeme_cards` per vref: when the session\nincludes an agent-critique training type, each vref carries the\nlexeme cards (filtered to those whose lemma/surface forms intersect\nthe verse text on either side) that were produced for the (source,\ntarget) version pair. Sessions without agent-critique return an\nempty list there.",
+        "operationId": "get_training_session_results_latest_train_status__session_id__results_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 1000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tfidf_top_k",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "maximum": 50,
+              "minimum": 1,
+              "title": "Tfidf Top K",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingSessionResultsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Session Results",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/train/{job_id}": {
+      "delete": {
+        "description": "Soft delete a training job (terminal jobs only).",
+        "operationId": "delete_training_job_latest_train__job_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Training Job",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "get": {
+        "description": "Get a single training job by ID.",
+        "operationId": "get_training_job_latest_train__job_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingJobOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Job",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/train/{job_id}/data": {
+      "get": {
+        "description": "Return parallel verse text for the training runner.",
+        "operationId": "get_training_data_latest_train__job_id__data_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "range_handling",
+            "required": false,
+            "schema": {
+              "default": "filter",
+              "pattern": "^(filter|merge|empty)$",
+              "title": "Range Handling",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Data",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/unlink-user-group": {
+      "post": {
+        "operationId": "unlink_user_from_group_latest_unlink_user_group_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "username",
+            "required": false,
+            "schema": {
+              "title": "Username"
+            }
+          },
+          {
+            "in": "query",
+            "name": "groupname",
+            "required": false,
+            "schema": {
+              "title": "Groupname"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Unlink User From Group",
+        "tags": [
+          "Latest"
+        ]
+      }
+    },
+    "/latest/users": {
+      "delete": {
+        "operationId": "delete_user_latest_users_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "username",
+            "required": true,
+            "schema": {
+              "title": "Username",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete User",
+        "tags": [
+          "Latest"
+        ]
+      },
+      "post": {
+        "operationId": "create_user_latest_users_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "username",
+            "required": true,
+            "schema": {
+              "title": "Username",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "email",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "format": "email",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Email"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_admin",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "title": "Is Admin"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_create_user_latest_users_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create User",
+        "tags": [
+          "Latest"
+        ]
+      }
+    },
+    "/latest/users/me": {
+      "get": {
+        "operationId": "read_users_me_latest_users_me_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Read Users Me",
+        "tags": [
+          "Latest"
+        ]
+      }
+    },
+    "/latest/verse": {
+      "get": {
+        "description": "Gets a single verse text for a revision for a given book, chapter, and verse.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible. e.g GEN, EXO, PSA.\n- chapter: int\nDescription: The chapter of the book. e.g 1, 2, 3.\n- verse: int\nDescription: The verse number. e.g 1, 2, 3.\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_verse_latest_verse_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": true,
+            "schema": {
+              "title": "Book",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": true,
+            "schema": {
+              "title": "Chapter",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": true,
+            "schema": {
+              "title": "Verse",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Verse Latest Verse Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Verse",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/version": {
+      "delete": {
+        "description": "Delete a version and all associated revisions, text, and assessments.\n\nInput:\n- id: int\nDescription: The unique identifier for the version.",
+        "operationId": "delete_version_latest_version_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Version",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "get": {
+        "description": "Get a list of all versions that the current user is authorized to access.\n\nAdmins may pass ``include_deleted=true`` to also return soft-deleted\nversions, so downstream mirrors can satisfy FK constraints against\nrevisions whose parent version has been soft-deleted. Non-admin callers\nnever receive soft-deleted versions regardless of this flag.",
+        "operationId": "list_version_latest_version_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include_deleted",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Deleted",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VersionOut_v3"
+                  },
+                  "title": "Response List Version Latest Version Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Version",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "post": {
+        "description": "Create a new version.\nOptionally only add the version to specific groups, specified by their IDs.\n\n\nInput:\nFields(Version):\n- name: str\nDescription: The name of the version.\n- iso_language: str\nDescription: The ISO 639-2 language code. e.g 'eng' for English. 'swa' for Swahili.\n- iso_script: str\nDescription: The ISO 15924 script code. e.g 'Latn' for Latin. 'Cyrl' for Cyrillic.\n- abbreviation: str\nDescription: The abbreviation of the version.\n- rights: str\nDescription: The rights of the version.\n- forwardTranslation: Optional[int]\nDescription: The ID of the forward translation version.\n- backTranslation: Optional[int]\nDescription: The ID of the back translation version.\n- machineTranslation: bool\nDescription: Whether the version is machine translated.\n- is_reference: bool\nDescription: Whether the version is a reference version.\n- transcribed_audio: bool\nDescription: Whether the version's revisions are transcriptions of recorded\naudio (ASR). Auto-applied to agent-critique assessments. Defaults to false.\n- add_to_groups: List[int] (required)\nDescription: The IDs of the groups to add the version to.\nAt least one group must be specified.\n\nReturns:\nFields(VersionOut):\nBesides the data provided for the input of the version:\n\n- id: int\nDescription: The unique identifier for the version.\n- owner_id : Union[int, None] = None\nDescription: The unique identifier for the owner of the version.\n- group_ids : List[int] = []\nDescription: The IDs of the groups that have access to the version.",
+        "operationId": "add_version_latest_version_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VersionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionOut_v3"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Version",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      },
+      "put": {
+        "description": "Update any parameter in a version.\n\nInput:\nFields(Version):\n- name: str\nDescription: The name of the version.\n- iso_language: str\nDescription: The ISO 639-2 language code. e.g 'eng' for English. 'swa' for Swahili.\n- iso_script: str\nDescription: The ISO 15924 script code. e.g 'Latn' for Latin. 'Cyrl' for Cyrillic.\n- abbreviation: str\nDescription: The abbreviation of the version.\n- rights: str\nDescription: The rights of the version.\n- forwardTranslation: Optional[int]\nDescription: The ID of the forward translation version.\n- backTranslation: Optional[int]\nDescription: The ID of the back translation version.\n- machineTranslation: bool\nDescription: Whether the version is machine translated.\n- is_reference: bool\nDescription: Whether the version is a reference version.\n- transcribed_audio: bool\nDescription: Whether the version's revisions are transcriptions of recorded\naudio (ASR). Auto-applied to agent-critique assessments. Defaults to false.\n- add_to_groups: Optional[List[int]]\nDescription: The IDs of the groups to add the version to,\nthe version will only be added to this groups, not to all tha groups of the user as usual.\n\nAdd groups functionality:\nIn case you want to add aversion to groups after it has been created, you can\nspecify in add_to_groups the IDs of the groups you want to add the version to.\n\nRemove groups functionality:\nIn case you want to remove a version from a group, you can specify in\nremove_from_groups, the IDs of the groups you want to remove the version from.",
+        "operationId": "modify_version_latest_version_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VersionUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Modify Version",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/vref-text": {
+      "get": {
+        "description": "Exports a revision's verse text in vref format.\n\nReturns a plain text file with 41,899 lines, one per canonical verse\nreference (matching fixtures/vref.txt). Lines with verse text get the\ntext; lines without get left blank.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n\nReturns:\n- Plain text with 41,899 lines.",
+        "operationId": "get_vref_text_latest_vref_text_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Vref Text",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/vrefs": {
+      "get": {
+        "description": "Gets a list of verse texts for a revision for a given list of verse references.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- vrefs: List[str]\nDescription: A list of full verse references, including book, chapter and text. Must be in the format \"GEN 1:1\".\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_vrefs_latest_vrefs_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vrefs",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "title": "Vrefs",
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Vrefs Latest Vrefs Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Vrefs",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/latest/words": {
+      "get": {
+        "description": "Gets unique words from a revision, optionally restricted to a verse range\nand/or capped to the most frequent N.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- first_verse, last_verse: Optional[str]\nDescription: Verse range bounds (e.g. \"GEN 1:1\"). Either both or neither\nmust be supplied. When omitted, all verses in the revision are scanned.\n- top_n: Optional[int]\nDescription: If set, return only the N most frequent words.\n- include_counts: bool (default false)\nDescription: When true, return List[{word, count}] sorted by count desc\n(ties broken alphabetically). When false (default), return List[str]\nsorted alphabetically.\n\nReturns:\n- List[str] or List[WordCount]\nDescription: Words extracted with sophisticated Unicode-aware splitting.",
+        "operationId": "get_words_latest_words_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "first_verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "First Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top_n",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Top N"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_counts",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Counts",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "$ref": "#/components/schemas/WordCount"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "title": "Response Get Words Latest Words Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Words",
+        "tags": [
+          "Version 3 / Latest"
+        ]
+      }
+    },
+    "/ready": {
+      "get": {
+        "description": "Readiness probe \u2014 verifies the database is reachable.\n\nUses the engine directly (not an ORM session) so the probe is a\nsingle round-trip with no implicit transaction overhead.",
+        "operationId": "ready_ready_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Ready",
+        "tags": [
+          "Health"
+        ]
+      }
+    },
+    "/v3/affixes": {
+      "get": {
+        "operationId": "get_affixes_v3_affixes_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Iso",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "position",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(prefix|suffix|infix)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Position"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Affixes",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Bulk upsert of language affixes, scoped to the payload's revision.\n\nWith ``revision_id`` set (the canonical agent path), conflicts are\ndetected against rows stamped to the same ``target_version_id``;\nrows owned by other versions of the same ISO are untouched (#798).\nWithout a ``revision_id``, conflicts are detected against the legacy\n``target_version_id IS NULL`` bucket only.\n\nSame gloss \u2192 idempotent upsert of examples/n_runs/source_model.\nDifferent gloss for an existing (form, position) within the scope \u2192\n**409** with body:\n\n    {\"detail\": {\"message\": ..., \"conflicts\": [\n        {\"form\", \"position\", \"submitted_gloss\",\n         \"existing_id\", \"existing_gloss\"}, ...\n    ]}}\n\nA single conflict aborts the whole batch \u2014 there are no partial inserts.\nCallers should PATCH /v3/affixes/{existing_id} to update the stored row.\n\nThe SELECT-then-INSERT pattern has a small race window: a concurrent\nwriter can land between the conflict check and the upsert. The\non_conflict_do_update clause omits `gloss` from set_, so a racing\nsame-key insert with a different gloss is silently dropped rather than\noverwriting the stored gloss.",
+        "operationId": "commit_affixes_v3_affixes_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AffixCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixCommitResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Commit Affixes",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "put": {
+        "operationId": "replace_affixes_v3_affixes_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AffixCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixReplaceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Replace Affixes",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/affixes-by-version/{version_id}": {
+      "delete": {
+        "description": "Wipe every affix the GET soft-union would return for ``version_id``.\n\nDeletes (atomically, in one transaction):\n- rows version-stamped to ``version_id`` (``target_version_id == version_id``)\n- legacy iso-keyed rows (``target_version_id IS NULL``) that share the\n  version's ISO \u2014 the same rows ``GET /affixes-by-version/{version_id}``\n  surfaces via its soft union.\n\nRows stamped to other versions of the same ISO are left intact, so other\nversions' soft-union reads stay consistent.\n\nThis is the affix analog of ``DELETE /v3/agent/lexeme-card`` (#703) and\nlets ``build_mode=\"rebuild\"`` clear affixes the same way it clears cards.\nThe existing ``DELETE /v3/tokenizer/training-artifacts/{version_id}``\nalready removes version-stamped affixes as a side effect, but it leaves\niso-keyed legacy rows behind and is awkward as the primary surface for\naffix-only cleanups.\n\nStatus codes:\n- 200: returns row counts deleted (zeros if nothing existed \u2014 idempotent)\n- 403: caller is not authorized for this version \u2014 also returned for\n  non-existent version_ids when the caller is a regular user, so\n  unauthorized callers can't enumerate valid versions (matches the GET)\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "delete_affixes_by_version_v3_affixes_by_version__version_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkAffixDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Affixes By Version",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "get": {
+        "description": "Version-keyed read for language affixes.\n\nReturns the soft union of rows version-stamped for this version\n*and* legacy rows with `target_version_id IS NULL` that share the\nversion's ISO. NULL-stamped rows are treated as \"shared across\nversions of the ISO\" until Phase 5 splits them into per-version\nrows. (Phase 2 of issue #687.)\n\nStatus codes:\n- 200: returns the soft union (may be empty)\n- 403: caller is not authorized for this version \u2014 also returned\n  for non-existent version_ids when the caller is a regular user,\n  so unauthorized callers can't enumerate valid versions\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "get_affixes_by_version_v3_affixes_by_version__version_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "position",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(prefix|suffix|infix)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Position"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Affixes By Version",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/affixes/{affix_id}": {
+      "patch": {
+        "description": "Partial update of a single affix by id.\n\nOnly provided fields are updated; an empty body is a no-op that returns\nthe unchanged row. NFC normalization is applied to `form` and `gloss` by\nPydantic validators; both must be non-empty after strip.\n\nReturns **409** with `{\"detail\": {\"message\", \"existing_id\"}}` if changing\n`form` and/or `position` would collide with another row in the same\nlanguage.",
+        "operationId": "patch_affix_v3_affixes__affix_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "affix_id",
+            "required": true,
+            "schema": {
+              "title": "Affix Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AffixPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AffixOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Affix",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/critique": {
+      "get": {
+        "description": "Get critique issues filtered by assessment and optionally by other criteria.\n\nQuery Parameters:\n- assessment_id: int (optional) - The assessment ID. Must provide either assessment_id OR (revision_id and reference_id).\n- revision_id: int (optional) - The revision ID. Must be provided with reference_id if not using assessment_id.\n- reference_id: int (optional) - The reference ID. Must be provided with revision_id if not using assessment_id.\n- all_assessments: bool (optional, default=True) - When using revision_id and reference_id, if True returns issues from all assessments between the revision and reference. If False, returns only issues from the latest assessment.\n- agent_translation_id: int (optional) - Filter by specific agent translation ID\n- vref: str (optional) - Filter by specific verse reference (e.g., \"JHN 1:1\")\n- book: str (optional) - Filter by book code (e.g., \"JHN\")\n- dimension: str (optional) - Filter by MQM dimension (e.g., \"accuracy\")\n- subtype: str (optional) - Filter by MQM subtype (e.g., \"wrong-key-term\")\n- min_severity: int (optional) - Minimum severity level (1-5). Issues with\n  severity=NULL are excluded by this filter (SQL three-valued logic).\n- is_resolved: bool (optional) - Filter by resolution status (true=resolved, false=unresolved)\n\nReturns:\n- List[CritiqueIssueOut]: List of matching critique issues, ordered by book, chapter, verse, and severity",
+        "operationId": "get_critique_issues_v3_agent_critique_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": false,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "all_assessments",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "All Assessments",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "agent_translation_id",
+            "required": false,
+            "schema": {
+              "title": "Agent Translation Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vref",
+            "required": false,
+            "schema": {
+              "title": "Vref",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "title": "Book",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dimension",
+            "required": false,
+            "schema": {
+              "title": "Dimension",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "subtype",
+            "required": false,
+            "schema": {
+              "title": "Subtype",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_severity",
+            "required": false,
+            "schema": {
+              "title": "Min Severity",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_resolved",
+            "required": false,
+            "schema": {
+              "title": "Is Resolved",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CritiqueIssueOut"
+                  },
+                  "title": "Response Get Critique Issues V3 Agent Critique Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Critique Issues",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Store MQM-aligned critique issues linked to a specific agent translation.\n\nInput:\n- agent_translation_id: int - The ID of the translation being critiqued\n- issues: list[IssueIn] - MQM-aligned issues (dimension, subtype, optional\n  source_text/draft_text/comments/severity/detector/evidence)\n\nReturns:\n- List[CritiqueIssueOut]: List of all created critique issue entries",
+        "operationId": "add_critique_issues_v3_agent_critique_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CritiqueStorageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CritiqueIssueOut"
+                  },
+                  "title": "Response Add Critique Issues V3 Agent Critique Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Critique Issues",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/critique/{issue_id}/resolve": {
+      "patch": {
+        "description": "Mark a critique issue as resolved.\n\nPath Parameters:\n- issue_id: int (required) - The ID of the critique issue to resolve\n\nInput:\n- resolution_notes: str (optional) - Notes about how the issue was resolved\n\nReturns:\n- CritiqueIssueOut: The updated critique issue with resolution information",
+        "operationId": "resolve_critique_issue_v3_agent_critique__issue_id__resolve_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issue_id",
+            "required": true,
+            "schema": {
+              "title": "Issue Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CritiqueIssueResolutionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CritiqueIssueOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Resolve Critique Issue",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/critique/{issue_id}/unresolve": {
+      "patch": {
+        "description": "Mark a resolved critique issue as unresolved.\n\nPath Parameters:\n- issue_id: int (required) - The ID of the critique issue to unresolve\n\nReturns:\n- CritiqueIssueOut: The updated critique issue with resolution information cleared",
+        "operationId": "unresolve_critique_issue_v3_agent_critique__issue_id__unresolve_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "issue_id",
+            "required": true,
+            "schema": {
+              "title": "Issue Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CritiqueIssueOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Unresolve Critique Issue",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/lexeme-card": {
+      "delete": {
+        "description": "Wipe every lexeme card for a target_version_id, across all source pairs.\n\nCards for a given target_version_id can live at multiple source_version_ids\n(current pivot, pre-pivot reference version, function-word extraction era).\nThe per-card DELETE plus a GET keyed on (source, target) misses cards at\nother source pairs, leaving rebuilds dirty. This endpoint deletes by\ntarget_version_id alone, regardless of source_version_id.\n\nDeletes child rows explicitly in child-to-parent order so each row count\nis authoritative (no pre-delete SELECT COUNTs that could drift under\nconcurrent writes). ``card_translation_examples`` rows are wiped via the\n``card_translations`` cascade \u2014 they share a parent and never escape it.\n\nThis is the bulk counterpart to ``DELETE /v3/agent/lexeme-card/{card_id}``\nand the shape mirrors ``DELETE /v3/tokenizer/training-artifacts/{version_id}``\nso aqua-assessments' Phase 4 rebuild can call them together.\n\nStatus codes:\n- 200: returns row counts deleted (zeros if nothing existed \u2014 idempotent)\n- 403: caller not authorized for this version \u2014 also returned for\n  non-existent version_ids when the caller is a regular user (no\n  enumeration leak)\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "delete_lexeme_cards_for_target_version_v3_agent_lexeme_card_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkLexemeCardDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Lexeme Cards For Target Version",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "get": {
+        "description": "Get lexeme cards filtered by language pair and optionally by other fields.\nResults are ordered by confidence in descending order (highest first).\nExamples are automatically filtered to only include those from Bible revisions\nthe current user has access to.\n\nQuery Parameters:\n- target_version_id: int (required) - Bible version ID for target\n- source_version_id: int (optional) - Bible version ID for source. When\n  provided, the canonical source is resolved via pivot routing (the SQL\n  filter rewrites to the pivot bible_version registered for the target's\n  iso, falling back to the given value). Internal callers that target a\n  specific canonical pair (pivot picker, derive, consolidation) should\n  keep passing this. When omitted, cards are matched on target_version_id\n  alone, which is what a UI showing \"cards for this revision\" wants.\n- source_word: str (optional) - Filter by source_lemma or source_surface_forms\n  (case-insensitive exact match)\n- target_word: str (optional) - Filter by target_lemma or surface_forms\n  (case-insensitive exact match)\n- target_words: str (optional) - Comma-separated list of target words. Returns\n  cards where target_lemma or any surface_form matches any of the given words\n  (case-insensitive, NFC-normalized). Cannot be used with target_word.\n- pos: str (optional) - Filter by part of speech\n- model: str (optional) - Filter by the model id/name that built the card.\n  Lets harvesters fetch only cards built by a trusted model (e.g. Sonnet)\n  and exclude poisoned ones. Exact match; cards with NULL ``model`` are\n  excluded when this filter is set.\n- lang: str (optional) - ISO 639-3 code for the desired source-side language.\n  When omitted or equal to the cards' canonical source_language_iso, returns\n  cards in their canonical shape (back-compat). When it differs, source-side\n  fields (source_lemma, source_surface_forms, senses, examples[].source)\n  are replaced by the matching card_translations row. Cards without a\n  translation in the requested language are still returned, with the\n  source-side overlay fields set to null, examples[].source set to null,\n  and ``has_translation_overlay=False``, so the UI can render the target\n  side and indicate the overlay is missing. (Note: the single-card by-id\n  endpoint returns 404 in that same situation \u2014 it's the derivation\n  trigger. Callers iterating the bulk list should check\n  ``has_translation_overlay`` before clicking through to by-id.)\n\n  When ``lang`` is omitted but a ``source_version_id`` is also provided and\n  pivot routing rewrites the source, ``lang`` is auto-derived from the\n  caller's ``source_version_id`` ISO so the pivot stays invisible. In that\n  case the overlay logic above applies as if ``lang`` had been passed\n  explicitly; the structured log payload includes ``lang_auto_derived=True``\n  so dashboards can distinguish UI-driven misses from pivot-driven ones.\n\nReturns:\n- List[LexemeCardOut]: List of matching lexeme cards, ordered by confidence (descending).\n  Examples are filtered based on the user's access to Bible revisions.",
+        "operationId": "get_lexeme_cards_v3_agent_lexeme_card_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_word",
+            "required": false,
+            "schema": {
+              "title": "Source Word",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_word",
+            "required": false,
+            "schema": {
+              "title": "Target Word",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_words",
+            "required": false,
+            "schema": {
+              "title": "Target Words",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "pos",
+            "required": false,
+            "schema": {
+              "title": "Pos",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "model",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Model"
+            }
+          },
+          {
+            "in": "query",
+            "name": "lang",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 3,
+                  "minLength": 3,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lang"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/LexemeCardOut"
+                  },
+                  "title": "Response Get Lexeme Cards V3 Agent Lexeme Card Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Lexeme Cards",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "patch": {
+        "deprecated": true,
+        "description": "**DEPRECATED \u2014 internal callers only.** Use\n``PATCH /v3/agent/lexeme-card/translation`` instead.\n\nPartially update a lexeme card by lemma lookup, writing directly to the\ncanonical ``agent_lexeme_cards`` row. This endpoint is **unsafe for UI\ncallers**: when the canonical's source language is the pivot (e.g. swh)\nand the UI is viewing the card in another language (e.g. eng), a write\nto ``source_lemma`` here will silently overwrite the pivot canonical\nwith the UI's language text and corrupt every other consumer's view.\n\nThe new ``/agent/lexeme-card/translation`` endpoint solves that by\nrouting source-side writes to the per-language ``card_translations``\noverlay row. UI clients MUST migrate.\n\nThis endpoint is kept only because aqua-assessments' derivation pipeline\n(``word_memory_builder.update_lexeme_by_lemma_api``) uses it as a\nPOST\u2192409 fallback to patch ``surface_forms`` / ``source_surface_forms``\n/ ``alignment_scores`` on the canonical it just built. Those writes are\nsafe because the caller knows the canonical's source language matches\nwhat it's writing. Once that pipeline migrates to the by-id PATCH or to\nthe new translation endpoint, this route should be removed.\n\nQuery Parameters:\n- target_lemma: str (required) - The target language lemma\n- source_version_id: int (required) - Bible version ID for source\n- target_version_id: int (required) - Bible version ID for target\n- source_lemma: str (optional) - Disambiguates when multiple cards\n  share the same (target_lemma, source_version_id, target_version_id).\n- list_mode: str (optional, default=\"append\") - append / replace / merge.\n- is_user_edit: bool (optional, default=False) - Sets last_user_edit.\n\nBody: LexemeCardPatch (all fields optional, only provided fields update).",
+        "operationId": "patch_lexeme_card_by_lemma_DEPRECATED_v3_agent_lexeme_card_patch",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_lemma",
+            "required": true,
+            "schema": {
+              "title": "Target Lemma",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_lemma",
+            "required": false,
+            "schema": {
+              "title": "Source Lemma",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "list_mode",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ListMode"
+                }
+              ],
+              "default": "append",
+              "title": "List Mode"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_user_edit",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Is User Edit",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LexemeCardPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Lexeme Card By Lemma Deprecated",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Add a new lexeme card entry or update an existing one.\n\nUniqueness is enforced at the DB level on (LOWER(target_lemma),\nsource_language_iso, target_version_id) \u2014 i.e. one canonical card per\n(lemma, source language, target version), regardless of which specific\nsource_version_id the card was written via. The Python pre-check below\nkeys on source_version_id so callers that re-POST the same exact pair\nupsert, but cross-source-version collisions inside the same source\nlanguage fall through to the IntegrityError handler and return 409\nwith the conflicting card's id so callers can PATCH by id.\n\nInput:\n- card: LexemeCardIn - The lexeme card data\n- revision_id: int (optional) - The Bible revision ID that the examples come\n  from. Required only when `card.examples` is non-empty (top-level examples\n  are stored in a revision-scoped table). May be omitted for example-less\n  writes; the card itself is keyed only by version pair.\n- replace_existing: bool (optional, default=False) - If True, replaces list fields\n  (surface_forms, senses) with new data and replaces examples for this revision_id.\n  If False, appends new data to existing lists.\n- is_user_edit: bool (optional, default=False) - If True, sets the last_user_edit\n  timestamp. Use for user-initiated writes to distinguish from automated updates.\n\nCard fields:\n- source_lemma: str (optional) - The source language lemma for cross-reference\n- target_lemma: str (required) - The target language lemma\n- source_version_id: int - Bible version ID for source\n- target_version_id: int - Bible version ID for target\n- pos: str (optional) - Part of speech\n- surface_forms: list (optional) - JSON array of target language surface forms\n- source_surface_forms: list (optional) - JSON array of source language surface forms\n- senses: list (optional) - JSON array of senses with definitions and examples\n- examples: list (optional) - JSON array of usage examples for the specified revision_id\n- confidence: float (optional) - Confidence score for the lexeme card\n- english_lemma: str (optional) - English lemma when source/target languages are not English\n- alignment_scores: dict (optional) - Dict with source words as keys and alignment scores as values\n\nReturns:\n- LexemeCardOut: The created or updated lexeme card entry (with examples for the specified revision_id)\n\nRaises:\n- 409 Conflict: If a card with same target_lemma and language pair exists but\n  has a different source_lemma. Response includes existing card ID for PATCH.",
+        "operationId": "add_lexeme_card_v3_agent_lexeme_card_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "replace_existing",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Replace Existing",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_user_edit",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Is User Edit",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LexemeCardIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Lexeme Card",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/lexeme-card/check-word": {
+      "get": {
+        "description": "Check if a word exists as a target lemma or in surface_forms of lexeme cards.\n\nQuery Parameters:\n- word: str (required) - The word to search for\n- source_version_id: int (required) - Bible version ID for source\n- target_version_id: int (required) - Bible version ID for target\n\nReturns:\n- count: int - Number of lexeme cards where the word matches (case-insensitive)",
+        "operationId": "check_word_in_lexeme_cards_v3_agent_lexeme_card_check_word_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "word",
+            "required": true,
+            "schema": {
+              "title": "Word",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Check Word In Lexeme Cards",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/lexeme-card/deduplicate": {
+      "post": {
+        "description": "Find and merge duplicate lexeme cards that differ only by case in target_lemma.\n\nQuery Parameters:\n- source_version_id: int (required) - Bible version ID for source\n- target_version_id: int (required) - Bible version ID for target\n- dry_run: bool (optional, default=True) - If True, only report duplicates without merging\n\nReturns:\n- Summary with dry_run status, counts, and group details",
+        "operationId": "deduplicate_lexeme_cards_v3_agent_lexeme_card_deduplicate_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "dry_run",
+            "required": false,
+            "schema": {
+              "default": true,
+              "title": "Dry Run",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Deduplicate Lexeme Cards",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/lexeme-card/translation": {
+      "patch": {
+        "description": "Patch a lexeme card in the (target_version_id, language_iso) view.\n\nThis is the UI's PATCH primitive. The UI thinks in terms of \"I am editing\nthe card I'm looking at in language X\" \u2014 without any awareness of pivot\nrouting or canonical-vs-overlay storage. The endpoint splits the body\ninternally:\n\n- Source-side fields (source_lemma, source_surface_forms, senses) land in\n  the ``card_translations`` overlay row for ``(card_id, language_iso)``,\n  upserted on conflict. The canonical's source-side stays untouched, so\n  edits in (target, eng) view can't corrupt the (target, swh) pivot.\n- Target-side and shared fields (target_lemma, surface_forms, pos,\n  confidence, english_lemma, alignment_scores, build_version, model) land\n  in the canonical ``agent_lexeme_cards`` row. There is only one target\n  column physically, so all overlays project the same target text \u2014 fixing\n  a typo from any language view fixes it everywhere.\n- When ``language_iso`` equals the card's canonical ``source_language_iso``\n  (no pivot routing in play, or pivot resolves back to the requested\n  lang), everything goes to the canonical row \u2014 there is no overlay to\n  write to.\n\nLookup is pivot-routed via ``_effective_source_version_expr``: pass\n``source_version_id`` (typically the UI's reference version) only when\nmultiple canonicals share the same ``(target_lemma, target_version_id)``\nand disambiguation is required.\n\n``is_user_edit=true`` bumps ``last_user_edit`` on every row this patch\nactually writes to: the canonical row when target-side/shared fields\nare in the body, the overlay row when source-side fields are in the\nbody. A source-only edit does NOT bump the canonical's\n``last_user_edit`` \u2014 the user didn't approve the target state, they\njust changed the source view. The response's top-level\n``last_user_edit`` is the max of the two so the UI can render\n\"edited recently\" without having to inspect both timestamps.\n\n``examples`` are not yet supported in the overlay branch (when\n``language_iso != canonical iso``); pass the full overlay including\nexample translations via ``POST /v3/agent/lexeme-card/{card_id}/translation``\ninstead. They are supported in the canonical-match branch via the\nexisting canonical patch path.\n\nReturns the resulting card shaped as if ``GET /v3/agent/lexeme-card``\nhad just been called with the same ``language_iso``, so the UI can\nrebind its form state directly from the response.",
+        "operationId": "patch_lexeme_card_translation_v3_agent_lexeme_card_translation_patch",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_lemma",
+            "required": true,
+            "schema": {
+              "title": "Target Lemma",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "language_iso",
+            "required": true,
+            "schema": {
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Language Iso",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "list_mode",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ListMode"
+                }
+              ],
+              "default": "append",
+              "title": "List Mode"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_user_edit",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Is User Edit",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LexemeCardPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Lexeme Card Translation",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/lexeme-card/{card_id}": {
+      "delete": {
+        "description": "Delete a lexeme card by ID.\n\nAssociated examples are deleted automatically via cascade\n(both ORM-level cascade=\"all, delete-orphan\" and DB-level ondelete=\"CASCADE\").\n\nThis endpoint is used by aqua-assessments during card consolidation.\nAny authenticated user can delete any card (consistent with other card endpoints).\n\nReturns 204 No Content on success, 404 if card not found.",
+        "operationId": "delete_lexeme_card_v3_agent_lexeme_card__card_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_id",
+            "required": true,
+            "schema": {
+              "title": "Card Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Lexeme Card",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "get": {
+        "description": "Return a single lexeme card, optionally in a non-canonical language.\n\nWhen ``lang`` is omitted or equals the card's canonical\n``source_language_iso``, returns the canonical card. Otherwise looks up\nthe ``card_translations`` row for that language and returns a\n``LexemeCardOut`` with translation-language source-side fields and\nper-example translated source_text merged in. Returns 404 if the card\ndoes not exist, or if a non-canonical ``lang`` is requested and no\ntranslation row exists for it (the caller can then trigger derivation).",
+        "operationId": "get_lexeme_card_by_id_v3_agent_lexeme_card__card_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_id",
+            "required": true,
+            "schema": {
+              "title": "Card Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "lang",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 3,
+                  "minLength": 3,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Lang"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Lexeme Card By Id",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "patch": {
+        "description": "Partially update a lexeme card by ID.\n\nPath Parameters:\n- card_id: int - The ID of the lexeme card to update\n\nQuery Parameters:\n- list_mode: str (optional, default=\"append\") - How to handle list fields:\n  - \"append\": Add new items to existing lists (no deduplication)\n  - \"replace\": Overwrite entire lists\n  - \"merge\": Append + deduplicate case-insensitively (for string lists like\n    surface_forms); preserves original casing of existing items\n- is_user_edit: bool (optional, default=False) - If True, sets the last_user_edit\n  timestamp. Use for user-initiated writes to distinguish from automated updates.\n\nNote: The POST endpoint's append behavior differs - it uses case-sensitive\ndeduplication via set(). Use list_mode=\"merge\" here for smart deduplication.\n\nBody:\n- LexemeCardPatch: Partial update data. Only provided fields are updated.\n  - source_lemma, target_lemma, pos, confidence, english_lemma: Scalar fields\n  - surface_forms, source_surface_forms: String list fields\n  - senses: List of sense dictionaries\n  - examples: List of example dicts, each must include revision_id\n  - alignment_scores: Dict - keys merge with existing; null value removes key\n\nReturns:\n- LexemeCardOut: The updated lexeme card",
+        "operationId": "patch_lexeme_card_by_id_v3_agent_lexeme_card__card_id__patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_id",
+            "required": true,
+            "schema": {
+              "title": "Card Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "list_mode",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/ListMode"
+                }
+              ],
+              "default": "append",
+              "title": "List Mode"
+            }
+          },
+          {
+            "in": "query",
+            "name": "is_user_edit",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Is User Edit",
+              "type": "boolean"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LexemeCardPatch"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LexemeCardOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Patch Lexeme Card By Id",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/lexeme-card/{card_id}/translation": {
+      "post": {
+        "description": "Upsert a derived translation for a single lexeme card.\n\nStores the (card_id, language_iso) translation overlay and replaces\nits associated example translations wholesale. Used by the derivation\npipeline in aqua-assessments to persist MT output for cards built\nagainst a non-matching canonical pivot language.",
+        "operationId": "add_lexeme_card_translation_v3_agent_lexeme_card__card_id__translation_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "card_id",
+            "required": true,
+            "schema": {
+              "title": "Card Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CardTranslationIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CardTranslationOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Lexeme Card Translation",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/translation": {
+      "post": {
+        "description": "Store a single agent-generated translation for a verse.\n\nInput:\n- assessment_id: int - The assessment ID\n- vref: str - Verse reference (e.g., \"JHN 1:1\")\n- draft_text: str (optional) - The draft translation text\n- hyper_literal_translation: str (optional) - The hyper-literal back-translation\n- literal_translation: str (optional) - The literal back-translation\n\nThe version is auto-incremented for each new translation of the same assessment+vref.\n\nReturns:\n- AgentTranslationOut: The created translation entry with id, version, and created_at",
+        "operationId": "add_agent_translation_v3_agent_translation_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTranslationStorageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTranslationOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Agent Translation",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/translations": {
+      "get": {
+        "description": "Get agent-generated translations for an assessment or revision.\n\nQuery Parameters:\n- assessment_id: int (optional) - The assessment ID. If provided, returns\n  translations for this specific assessment (with authorization check).\n- revision_id: int (optional) - The revision ID. If provided without assessment_id,\n  returns the latest translation per vref (by created_at) across all assessments\n  for that revision (no authorization check).\n- reference_version_id: int (optional) - Reference Bible version ID. Required when using revision_id.\n- script: str (optional) - 4-letter ISO 15924 script code. If omitted, returns\n  translations across all scripts for the given reference version.\n- vref: str (optional) - Filter by specific verse reference (e.g., \"JHN 1:1\")\n- first_vref: str (optional) - Start of verse range (inclusive)\n- last_vref: str (optional) - End of verse range (inclusive)\n- version: int (optional) - Filter by specific version number\n- all_versions: bool (optional, default=False) - If True, return all versions;\n  if False, return only the latest version per vref\n\nNote: At least one of assessment_id or revision_id must be provided.\nIf both are provided, assessment_id takes precedence.\n\nReturns:\n- List[AgentTranslationOut]: List of matching translations, ordered by verse reference",
+        "operationId": "get_agent_translations_v3_agent_translations_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "script",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 4,
+                  "minLength": 4,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Script"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vref",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Vref"
+            }
+          },
+          {
+            "in": "query",
+            "name": "first_vref",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "First Vref"
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_vref",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last Vref"
+            }
+          },
+          {
+            "in": "query",
+            "name": "version",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Version"
+            }
+          },
+          {
+            "in": "query",
+            "name": "all_versions",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "All Versions",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentTranslationOut"
+                  },
+                  "title": "Response Get Agent Translations V3 Agent Translations Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Agent Translations",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Store multiple agent-generated translations in bulk.\n\nAll translations in a single request get the same version number, which is\nauto-incremented based on the max existing version for the revision+reference version+script.\n\nInput:\n- assessment_id: int - The assessment ID\n- translations: list - List of translations, each with:\n  - vref: str - Verse reference (e.g., \"JHN 1:1\")\n  - draft_text: str (optional) - The draft translation text\n  - hyper_literal_translation: str (optional) - The hyper-literal back-translation\n  - literal_translation: str (optional) - The literal back-translation\n\nReturns:\n- List[AgentTranslationOut]: List of created translation entries",
+        "operationId": "add_agent_translations_bulk_v3_agent_translations_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTranslationBulkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentTranslationOut"
+                  },
+                  "title": "Response Add Agent Translations Bulk V3 Agent Translations Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Agent Translations Bulk",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/translations-test": {
+      "post": {
+        "description": "Debug endpoint - just echo the body size",
+        "operationId": "test_bulk_v3_agent_translations_test_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Test Bulk",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/word-alignment": {
+      "get": {
+        "description": "Get word alignments filtered by language pair and optionally by source/target words.\n\nQuery Parameters:\n- source_version_id: int (required) - Bible version ID for source\n- target_version_id: int (required) - Bible version ID for target\n- source_words: str (optional) - Comma-separated list of words to match in source_word\n- target_words: str (optional) - Comma-separated list of words to match in target_word\n\nAt least one of source_words or target_words must be provided.\n\nReturns:\n- List[AgentWordAlignmentOut]: List of matching word alignment entries",
+        "operationId": "get_word_alignments_v3_agent_word_alignment_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_words",
+            "required": false,
+            "schema": {
+              "title": "Source Words",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_words",
+            "required": false,
+            "schema": {
+              "title": "Target Words",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentWordAlignmentOut"
+                  },
+                  "title": "Response Get Word Alignments V3 Agent Word Alignment Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Word Alignments",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Add a new word alignment entry to the agent_word_alignments table.\n\nInput:\n- source_word: str - The source language word\n- target_word: str - The target language word\n- source_version_id: int - Bible version ID for source\n- target_version_id: int - Bible version ID for target\n- score: float - NLLB alignment confidence score (default: 0.0)\n- is_human_verified: bool - Whether the alignment is human-verified (default: False)\n\nReturns:\n- AgentWordAlignmentOut: The created word alignment entry",
+        "operationId": "add_word_alignment_v3_agent_word_alignment_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWordAlignmentIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWordAlignmentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Word Alignment",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/word-alignment/all": {
+      "get": {
+        "description": "Get all word alignments for a language pair.\n\nInput:\n- source_version_id: int - Bible version ID for source (required)\n- target_version_id: int - Bible version ID for target (required)\n- page: int (optional) - Page number (1-indexed)\n- page_size: int (optional) - Number of results per page\n\nIf both page and page_size are provided, pagination is applied.\nOtherwise, all results are returned.\n\nResults are ordered by score descending.\n\nReturns:\n- List[AgentWordAlignmentOut]: List of word alignment entries",
+        "operationId": "get_all_word_alignments_v3_agent_word_alignment_all_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": true,
+            "schema": {
+              "title": "Source Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": true,
+            "schema": {
+              "title": "Target Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentWordAlignmentOut"
+                  },
+                  "title": "Response Get All Word Alignments V3 Agent Word Alignment All Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get All Word Alignments",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/agent/word-alignment/bulk": {
+      "post": {
+        "description": "Bulk upsert word alignments.\n\nFor each alignment in the request:\n- If an alignment with the same (source_word, target_word, source_version_id, target_version_id) exists,\n  update its score, is_human_verified, and last_updated fields.\n- Otherwise, insert a new alignment.\n\nInput:\n- source_version_id: int - Bible version ID for source\n- target_version_id: int - Bible version ID for target\n- alignments: list - List of alignment items, each with:\n  - source_word: str - The source language word\n  - target_word: str - The target language word\n  - score: float - NLLB alignment confidence score (default: 0.0)\n  - is_human_verified: bool - Whether human-verified (default: False)\n\nReturns:\n- List[AgentWordAlignmentOut]: List of created/updated word alignment entries",
+        "operationId": "add_word_alignments_bulk_v3_agent_word_alignment_bulk_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWordAlignmentBulkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentWordAlignmentOut"
+                  },
+                  "title": "Response Add Word Alignments Bulk V3 Agent Word Alignment Bulk Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Word Alignments Bulk",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/alignmentmatches": {
+      "get": {
+        "description": "Returns a list of all word alignments for a given word in a word alignment assessment.\n\nParameters\n----------\nrevision_id : int\n    The ID of the revision to get results for.\nreference_id : int\n    The ID of the reference to get results for.\nword : str\n    The word from the reference text to get alignments for.\nthreshold : float, optional\n    The minimum score for an alignment to be included in the results.\n    If not set, the value of the ALIGNMENT_THRESHOLD environment variable will be used, if set, or 0.2.",
+        "operationId": "get_word_alignments_v3_alignmentmatches_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": true,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "word",
+            "required": true,
+            "schema": {
+              "title": "Word",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "threshold",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Threshold"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner; ``true`` reads only eflomal, ``false`` only fastalign.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner; ``true`` reads only eflomal, ``false`` only fastalign.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/WordAlignment"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Word Alignments V3 Alignmentmatches Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Word Alignments",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/alignmentscores": {
+      "get": {
+        "description": "Returns a list of all alignment scores between words for a given word alignment assessment.\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\nscore_type : AlignmentScoreType, optional\n    Which alignment score table to read from. Defaults to ``top`` (top-source\n    scores). Pass ``threshold`` to read alignment threshold scores instead.\n\nReturns\n-------\nDict[str, Union[List[WordAlignment], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_alignment_scores_v3_alignmentscores_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "description": "Which alignment score table to read from: 'top' (top-source scores, default) or 'threshold' (threshold scores).",
+            "in": "query",
+            "name": "score_type",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/AlignmentScoreType"
+                }
+              ],
+              "default": "top",
+              "description": "Which alignment score table to read from: 'top' (top-source scores, default) or 'threshold' (threshold scores).",
+              "title": "Score Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/WordAlignment"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Alignment Scores V3 Alignmentscores Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Alignment Scores",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment": {
+      "delete": {
+        "description": "Deletes an assessment if the user is authorized.\n\nInput:\n- assessment_id: int\nDescription: The unique identifier for the assessment.",
+        "operationId": "delete_assessment_v3_assessment_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Assessment",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "get": {
+        "description": "Returns a list of assessments the current user is authorized to access.\n\nOptional query parameters:\n- id: Filter by one or more assessment IDs (repeated param, e.g. ?id=1&id=2).\n  IDs that do not exist or are not accessible to the current user are silently\n  omitted; a partial result is not an error.\n- revision_id: Filter assessments by revision ID\n- reference_id: Filter assessments by reference ID\n- type: Filter assessments by assessment type\n\nCurrently supported assessment types are:\n\n- semantic-similarity (requires reference)\n- sentence-length\n- word-alignment (requires reference)\n- ngrams\n- tfidf\n- text-lengths (requires reference)\n- agent-critique (requires reference)\n\n\nReturns:\nFields(AssessmentOut):\n- id: int\nDescription: The unique identifier for the assessment.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- reference_id: Optional[int] = None\nDescription: The unique identifier for the reference revision.\n- type: AssessmentType\nDescription: The type of assessment to be run.\n- status: str\nDescription: The status of the assessment. (queued, failed, finished)\n- requested_time: datetime.datetime\nDescription: The time the assessment was requested.\n- start_time: datetime.datetime\nDescription: The time the assessment was started.\n- end_time: datetime.datetime\nDescription: The time the assessment was completed.\n- owner_id: int\nDescription: The unique identifier for the owner of the assessment.",
+        "operationId": "get_assessments_v3_assessment_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AssessmentOut"
+                  },
+                  "title": "Response Get Assessments V3 Assessment Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Assessments",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Requests an assessment to be run on a revision and (where required) a reference revision.\n\nCurrently supported assessment types are:\n- semantic-similarity (requires reference)\n- sentence-length\n- word-alignment (requires reference; runs eflomal-based alignment by default.\n  Pass `use_eflomal=false` to run fastalign instead. Source/target version IDs\n  are derived from reference_id and revision_id respectively.)\n- ngrams\n- tfidf\n- text-lengths\n- agent-critique (requires reference; pass `transcribed_audio=true` when the\n  draft is a transcription of recorded audio so the agent expects ASR\n  surface noise. Default off.)\n\nFor those assessments that require a reference, the reference_id should be the id of the revision with which the revision will be compared.\n\nOptional `extra_kwargs` query parameter accepts a JSON-encoded dict of extra keyword\narguments to pass through to the assessment function (e.g., `{\"top_k\": 5}`). Values\nmust be scalar types (str, int, float, bool, null). Max 20 keys.\n\nAdd an assessment entry. For regular users, an entry is added for each group they are part of.\nFor admin users, the entry is not linked to any specific group.",
+        "operationId": "add_assessment_v3_assessment_post",
+        "parameters": [
+          {
+            "description": "JSON-encoded dict of extra keyword arguments to pass to the assessment function",
+            "in": "query",
+            "name": "extra_kwargs",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "JSON-encoded dict of extra keyword arguments to pass to the assessment function",
+              "title": "Extra Kwargs"
+            }
+          },
+          {
+            "description": "Word-alignment runner selector. true runs eflomal, false runs fastalign. When omitted, eflomal runs by default unless use_eflomal was injected via extra_kwargs, in which case the injected value is honored \u2014 the typed query param always wins over an injected value. Source/target version IDs are derived from reference_id/revision_id.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Word-alignment runner selector. true runs eflomal, false runs fastalign. When omitted, eflomal runs by default unless use_eflomal was injected via extra_kwargs, in which case the injected value is honored \u2014 the typed query param always wins over an injected value. Source/target version IDs are derived from reference_id/revision_id.",
+              "title": "Use Eflomal"
+            }
+          },
+          {
+            "description": "agent-critique only. true tells the agent the draft is a transcription of recorded audio (ASR), so the back-translation/critique prompts expect surface transcription noise while still flagging genuine content differences. Default off (unset). The typed query param wins over a transcribed_audio value injected via extra_kwargs.",
+            "in": "query",
+            "name": "transcribed_audio",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "agent-critique only. true tells the agent the draft is a transcription of recorded audio (ASR), so the back-translation/critique prompts expect surface transcription noise while still flagging genuine content differences. Default off (unset). The typed query param wins over a transcribed_audio value injected via extra_kwargs.",
+              "title": "Transcribed Audio"
+            }
+          },
+          {
+            "description": "Force rerun even if a completed assessment already exists",
+            "in": "query",
+            "name": "force",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "Force rerun even if a completed assessment already exists",
+              "title": "Force",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Modal environment to run the assessment in (e.g. 'main' or 'dev'). Defaults to server MODAL_ENV.",
+            "in": "query",
+            "name": "modal_env",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Modal environment to run the assessment in (e.g. 'main' or 'dev'). Defaults to server MODAL_ENV.",
+              "title": "Modal Env"
+            }
+          },
+          {
+            "in": "query",
+            "name": "return_all_results",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Return All Results",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/AssessmentType"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "anyOf": [
+                  {
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ],
+                "title": "Kwargs"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AssessmentOut"
+                  },
+                  "title": "Response Add Assessment V3 Assessment Post",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Assessment",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/eflomal/results": {
+      "get": {
+        "description": "Pull eflomal training artifacts by assessment ID or version pair.\n\nProvide either assessment_id or both source_version_id and target_version_id.\nWhen querying by version pair, returns the most recent results.",
+        "operationId": "pull_eflomal_results_v3_assessment_eflomal_results_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target Version Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EflomalResultsPullResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Pull Eflomal Results",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Create the eflomal_assessment metadata row.\n\nCall this first, then push dictionary / target-word-counts / priors /\nBPE models via their own endpoints, then PATCH the assessment status\nto 'finished'.\n\nIdempotent: if results already exist for this assessment_id the existing\nrow is returned with 200 (safe to retry after a timeout).",
+        "operationId": "push_eflomal_metadata_v3_assessment_eflomal_results_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EflomalResultsPushRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EflomalAssessmentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Metadata",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/tfidf/artifacts": {
+      "get": {
+        "description": "Fetch TF-IDF encoder artifacts by assessment_id or latest by source version.\n\nExactly one of assessment_id or source_version_id must be provided.",
+        "operationId": "pull_tfidf_artifacts_v3_assessment_tfidf_artifacts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "description": "Wire format for the SVD components matrix. float32 (default) preserves stored precision; float16 halves the response, int8 quarters it (with an `int8_scale` for client-side rehydration). Stored DB row is unchanged regardless.",
+            "in": "query",
+            "name": "dtype",
+            "required": false,
+            "schema": {
+              "default": "float32",
+              "description": "Wire format for the SVD components matrix. float32 (default) preserves stored precision; float16 halves the response, int8 quarters it (with an `int8_scale` for client-side rehydration). Stored DB row is unchanged regardless.",
+              "enum": [
+                "float32",
+                "float16",
+                "int8"
+              ],
+              "title": "Dtype",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsPullResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Pull Tfidf Artifacts",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/timeout-sweep": {
+      "post": {
+        "description": "Admin-only sweep that marks stuck non-terminal assessments as failed.\n\nAssessments accumulate in the database in non-terminal states (queued,\nrunning) when an upstream runner is lost or never reports a final status.\nCalling this endpoint transitions any such assessment older than `hours`\nto `failed` with a traceable status_detail.",
+        "operationId": "timeout_sweep_v3_assessment_timeout_sweep_post",
+        "parameters": [
+          {
+            "description": "Mark assessments as failed if they are still queued or running and their requested_time is older than this many hours.",
+            "in": "query",
+            "name": "hours",
+            "required": false,
+            "schema": {
+              "default": 24,
+              "description": "Mark assessments as failed if they are still queued or running and their requested_time is older than this many hours.",
+              "maximum": 87600,
+              "minimum": 2,
+              "title": "Hours",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimeoutSweepResult"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Timeout Sweep",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/alignment-scores": {
+      "delete": {
+        "description": "Delete alignment top source scores by ID.",
+        "operationId": "delete_alignment_scores_v3_assessment__assessment_id__alignment_scores_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Alignment Scores",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert alignment top source scores.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.\n\n``hide`` is hardcoded to ``False`` and is not part of ``AlignmentScoreItem``\n\u2014 it is a UI-only flag managed by other endpoints, not by the assessment\nrunner that drives this insert. Without an explicit value the column landed\n``NULL``, which then 500'd ``GET /alignmentscores`` because the response\nmodel declares ``hide: bool`` (issue #596).",
+        "operationId": "push_alignment_scores_v3_assessment__assessment_id__alignment_scores_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/AlignmentScoreItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Alignment Scores",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/alignment-threshold-scores": {
+      "delete": {
+        "description": "Delete alignment threshold scores by ID.",
+        "operationId": "delete_alignment_threshold_scores_v3_assessment__assessment_id__alignment_threshold_scores_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Alignment Threshold Scores",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert alignment threshold scores.\n\nMirrors ``POST /assessment/{id}/alignment-scores`` but writes to\n``alignment_threshold_scores`` \u2014 the table that holds every link with\nscore >= threshold (possibly multiple targets per source word), not the\ndeduped per-(vref, source) top pick.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.\n\n``hide`` is explicitly set to ``False`` for parity with the top-source\nendpoint, so we don't depend on the column's ``server_default`` (added\nafter the fact by migration ``c9e7b1f2d3a4``) \u2014 that's the original\nissue #596 hazard, where omitting ``hide`` landed ``NULL`` on a schema\nthat lacked the default and 500'd ``GET /alignmentscores``.",
+        "operationId": "push_alignment_threshold_scores_v3_assessment__assessment_id__alignment_threshold_scores_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/AlignmentScoreItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Alignment Threshold Scores",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/eflomal-bpe-models": {
+      "post": {
+        "description": "Store the SentencePiece BPE models for an eflomal assessment.\n\nIdempotent on (assessment_id, direction): existing rows for this assessment\nare deleted and replaced with the new pair. The request body carries\nbase64-encoded serialized protobuf bytes for the source and target models.",
+        "operationId": "push_eflomal_bpe_models_v3_assessment__assessment_id__eflomal_bpe_models_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EflomalBpeModels"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Bpe Models",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/eflomal-dictionary": {
+      "post": {
+        "description": "Upsert dictionary entries for an eflomal assessment.\n\nMaximum of 5,000 items per request. Each row is keyed by\n(assessment_id, source_word, target_word); re-pushing a row updates\n`count` and `probability` in place. Disjoint chunks of a larger upload\ncoexist \u2014 the worker may safely chunk a >5,000-row dictionary across\nmultiple requests, and retries replay the full sequence safely.\n\nReturns the list of affected row IDs in the same order as the input.",
+        "operationId": "push_eflomal_dictionary_v3_assessment__assessment_id__eflomal_dictionary_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/EflomalDictionaryItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Dictionary",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/eflomal-priors": {
+      "post": {
+        "description": "Upsert LEX-format priors for an eflomal assessment.\n\nMaximum of 5,000 items per request. Each row is keyed by\n(assessment_id, source_bpe, target_bpe); re-pushing a row updates\n`alpha` in place. Disjoint chunks of a larger upload coexist \u2014 the\nworker may safely chunk a >5,000-row payload across multiple requests,\nand retries replay the full sequence safely.\n\nReturns the list of affected row IDs in the same order as the input.",
+        "operationId": "push_eflomal_priors_v3_assessment__assessment_id__eflomal_priors_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/EflomalPriorItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Priors",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/eflomal-target-word-counts": {
+      "post": {
+        "description": "Upsert target word count entries for an eflomal assessment.\n\nMaximum of 5,000 items per request. Each row is keyed by\n(assessment_id, word); re-pushing a row updates `count` in place.\nDisjoint chunks of a larger upload coexist \u2014 the worker may safely\nchunk a >5,000-row payload across multiple requests, and retries\nreplay the full sequence safely.\n\nReturns the list of affected row IDs in the same order as the input.",
+        "operationId": "push_eflomal_target_word_counts_v3_assessment__assessment_id__eflomal_target_word_counts_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/EflomalTargetWordCountItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Eflomal Target Word Counts",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/increment-attempts": {
+      "post": {
+        "description": "Atomically increment ``attempt_count`` for an assessment and return\nthe new value.\n\nCalled by the Modal runner's lifecycle helper at the start of each\nattempt (after the initial `running` PATCH, so terminal-409 retries\ndon't bump the counter for no-ops). The lifecycle uses the returned\ncount to decide whether to PATCH ``failed`` on exception (only once\n``attempt_count >= max_attempts``).\n\nThe UPDATE ... RETURNING runs as a single atomic statement so two\nconcurrent retries on the same row can't observe the same\npre-increment value \u2014 Postgres serializes the writes and each call\nsees its own post-increment count.\n\nAuth: admin, assessment owner, or any user with group access to the\nassessment's bible version. Mirrors ``update_assessment_status``.",
+        "operationId": "increment_assessment_attempts_v3_assessment__assessment_id__increment_attempts_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Increment Assessment Attempts",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/ngrams": {
+      "delete": {
+        "description": "Delete ngrams and their associated vref rows by ngram ID.",
+        "operationId": "delete_ngrams_v3_assessment__assessment_id__ngrams_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Ngrams",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert ngram results with their verse references.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns the list of inserted ngram IDs in the same order as the input.",
+        "operationId": "push_ngrams_v3_assessment__assessment_id__ngrams_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/NgramItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Ngrams",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/results": {
+      "delete": {
+        "description": "Delete assessment results by ID.",
+        "operationId": "delete_results_v3_assessment__assessment_id__results_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Results",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert assessment results (assessment_result table).\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.",
+        "operationId": "push_results_v3_assessment__assessment_id__results_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/AssessmentResultItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Results",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/status": {
+      "patch": {
+        "description": "Runner callback to update assessment status.\n\nAuth: admin, assessment owner, or any user with group access to the\nassessment's bible version.  This mirrors the training PATCH pattern.",
+        "operationId": "update_assessment_status_v3_assessment__assessment_id__status_patch",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssessmentStatusUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssessmentOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Update Assessment Status",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/text-lengths": {
+      "delete": {
+        "description": "Delete text length rows by ID.",
+        "operationId": "delete_text_lengths_v3_assessment__assessment_id__text_lengths_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Text Lengths",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert text length statistics.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.",
+        "operationId": "push_text_lengths_v3_assessment__assessment_id__text_lengths_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/TextLengthsItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Text Lengths",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/tfidf-artifacts": {
+      "post": {
+        "description": "Store TF-IDF encoder artifacts (vectorizers + SVD) for an assessment.\n\nRe-posting replaces all artifacts for this assessment \u2014 safe to retry.",
+        "operationId": "push_tfidf_artifacts_v3_assessment__assessment_id__tfidf_artifacts_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsPushRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsPushResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Tfidf Artifacts",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/tfidf-artifacts/abort": {
+      "post": {
+        "description": "Cancel an in-flight chunked upload and drop its staged chunks.\n\nAuthorization is at the assessment level \u2014 any caller authorized for the\nassessment can abort any in-flight upload for it (uploads have no\nper-initiator ownership by design).",
+        "operationId": "abort_tfidf_artifacts_upload_v3_assessment__assessment_id__tfidf_artifacts_abort_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsAbortRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsAbortResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Abort Tfidf Artifacts Upload",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/tfidf-artifacts/chunk": {
+      "post": {
+        "description": "Push one chunk of SVD components. Idempotent per (upload_id, chunk_index).",
+        "operationId": "upload_tfidf_artifact_chunk_v3_assessment__assessment_id__tfidf_artifacts_chunk_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsChunkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsChunkResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Tfidf Artifact Chunk",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/tfidf-artifacts/commit": {
+      "post": {
+        "description": "Reassemble staged chunks and materialise final artifact rows.\n\nValidates all total_chunks chunks are present, vstacks them into a single\ncomponents_ matrix, and writes the TfidfArtifactRun + vectorizer + SVD rows\nin one transaction. Existing artifacts for the assessment are replaced.",
+        "operationId": "commit_tfidf_artifacts_upload_v3_assessment__assessment_id__tfidf_artifacts_commit_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsCommitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsPushResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Commit Tfidf Artifacts Upload",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/tfidf-artifacts/init": {
+      "post": {
+        "description": "Start a chunked TF-IDF artifact upload.\n\nCreates a staging row with the vectorizer and SVD metadata. Returns an\nupload_id that the caller uses to POST chunks and finally commit.",
+        "operationId": "init_tfidf_artifacts_upload_v3_assessment__assessment_id__tfidf_artifacts_init_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfArtifactsInitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfArtifactsInitResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Init Tfidf Artifacts Upload",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/assessment/{assessment_id}/tfidf-vectors": {
+      "delete": {
+        "description": "Delete TF-IDF PCA vector rows by ID.",
+        "operationId": "delete_tfidf_vectors_v3_assessment__assessment_id__tfidf_vectors_delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Tfidf Vectors",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Bulk insert TF-IDF PCA vectors.\n\nMaximum of 5,000 items per request. For larger datasets, split into\nmultiple requests of 5,000 items or fewer.\n\nReturns an empty ``ids`` list; generated IDs are intentionally not fetched\nduring bulk inserts.",
+        "operationId": "push_tfidf_vectors_v3_assessment__assessment_id__tfidf_vectors_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "items": {
+                  "$ref": "#/components/schemas/TfidfPcaVectorItem"
+                },
+                "title": "Body",
+                "type": "array"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InsertResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Push Tfidf Vectors",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/book": {
+      "get": {
+        "description": "Gets a list of verse texts for a revision for a given book.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible. e.g GEN, EXO, PSA.\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_book_v3_book_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": true,
+            "schema": {
+              "title": "Book",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Book V3 Book Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Book",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/chapter": {
+      "get": {
+        "description": "Gets a list of verse texts for a revision for a given chapter.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible. e.g GEN, EXO, PSA.\n- chapter: int\nDescription: The chapter of the book. e.g 1, 2, 3.\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_chapter_v3_chapter_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": true,
+            "schema": {
+              "title": "Book",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": true,
+            "schema": {
+              "title": "Chapter",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Chapter V3 Chapter Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Chapter",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/chapters": {
+      "get": {
+        "description": "Gets all available book/chapter combinations for a revision.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n\nReturns:\n- chapters: Dict[str, List[int]]\nDescription: A dictionary mapping book abbreviations (e.g., \"GEN\", \"EXO\")\nto lists of available chapter numbers. Books are ordered canonically\n(Genesis first) and chapters are sorted numerically within each book.",
+        "operationId": "get_available_chapters_v3_chapters_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionChapters"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Available Chapters",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/compare_text_lengths": {
+      "get": {
+        "description": "Returns the difference in text lengths between revision and reference assessments.\n\nThis endpoint finds the text-lengths assessments for both the revision and reference,\nand returns the difference (revision - reference) for each verse. Verses where either\nthe revision or reference has null or zero values are excluded from the results.\n\nParameters\n----------\nrevision_id : int, optional\n    The ID of the revision to compare. Must be provided with reference_id if using revision/reference mode.\nreference_id : int, optional\n    The ID of the reference to compare against. Must be provided with revision_id if using revision/reference mode.\nrevision_assessment_id : int, optional\n    The ID of the revision assessment to compare. Must be provided with reference_assessment_id if using assessment mode.\nreference_assessment_id : int, optional\n    The ID of the reference assessment to compare against. Must be provided with revision_assessment_id if using assessment mode.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\naggregate : str, optional\n    If set to \"chapter\", results will be aggregated by chapter.\n    If set to \"book\", results will be aggregated by book.\n    If set to \"text\", a single result will be returned for the whole text.\n    Otherwise results will be returned at the verse level.\n\nReturns\n-------\nDict[str, Union[List[TextLengthsResult], int]]\n    A dictionary containing the list of results (with differences) and the total count.",
+        "operationId": "compare_text_lengths_v3_compare_text_lengths_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Assessment Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/aggType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Aggregate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TextLengthsResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Compare Text Lengths V3 Compare Text Lengths Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Compare Text Lengths",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/compareresults": {
+      "get": {
+        "description": "Returns word alignment assessment results for a given revision and reference, but also\nreturns the average score and standard deviation of the average score for the baseline\nassessments when run against the same reference. Finally, a z-score is calculated for each\nresult, which is a measure of how many standard deviations the result is from the mean of the\nbaseline assessments.\n\nParameters\n----------\nrevision_id : int\n    The ID of the revision to get results for.\nreference_id : int\n    The ID of the reference to get results for.\nbaseline_ids : List[int], optional\n    A list of revision IDs to compare against. If not set, this route will essentially return\n    the same results as the /result route.\naggregate : str, optional\n    If set to \"chapter\", results will be aggregated by chapter.\n    If set to \"book\", results will be aggregated by book.\n    If set to \"text\", a single result will be returned, for the whole text.\n    Otherwise results will be returned at the verse level.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\n\nReturns\n-------\nDict[str, Union[List[MultipleResult], int, dict]]\n    A dictionary containing the list of results, the total count of results, and a dictionary\n    containing the score, average score and standard deviation for the baseline\n    assessments, and z-score of the score with respect to this baseline average and standard deviation.",
+        "operationId": "get_compare_results_v3_compareresults_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": true,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "baseline_ids",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "title": "Baseline Ids",
+              "type": "array"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/aggType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Aggregate"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner \u2014 the main revision and each baseline are chosen independently and may be different runners. ``true`` reads only eflomal, ``false`` only fastalign; an explicit runner applies to both the main revision and the baselines so their scores are never mixed.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner \u2014 the main revision and each baseline are chosen independently and may be different runners. ``true`` reads only eflomal, ``false`` only fastalign; an explicit runner applies to both the main revision and the baselines so their scores are never mixed.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/MultipleResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "object"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Compare Results V3 Compareresults Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Compare Results",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/language": {
+      "get": {
+        "description": "Get a list of ISO 639-2 language codes and their English names.\n\nReturns:\nFields(Language):\n- iso639: str\nDescription: The ISO 639-2 language code. e.g 'eng' for English. 'swa' for Swahili.\n- name: str\nDescription: The name of the language.",
+        "operationId": "list_languages_v3_language_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Language"
+                  },
+                  "title": "Response List Languages V3 Language Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Languages",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/language-pivot": {
+      "get": {
+        "description": "Resolve a target_iso to its pivot, or list all mappings.\n\nWith ``target_iso``: returns the resolved mapping on hit (200) or a\nstructured candidate list on miss (404 body). Without ``target_iso``:\nlists all mappings.",
+        "operationId": "get_language_pivot_v3_language_pivot_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "target_iso",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 3,
+                  "minLength": 3,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target Iso"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/LanguagePivotOut"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LanguagePivotListOut"
+                    }
+                  ],
+                  "title": "Response Get Language Pivot V3 Language Pivot Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguagePivotMissOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Language Pivot",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Upsert a target -> pivot mapping. Admin-only.\n\nRe-POST replaces the pivot for that target. Adding or changing a pivot\nis a curated decision tied to licensing/quality, so it should not be done\nautonomously by the agent. Fields omitted from the payload (e.g. ``notes``)\npreserve their existing value on update.",
+        "operationId": "upsert_language_pivot_v3_language_pivot_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LanguagePivotIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguagePivotOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upsert Language Pivot",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/language-pivot/{target_iso}": {
+      "delete": {
+        "operationId": "delete_language_pivot_v3_language_pivot__target_iso__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "target_iso",
+            "required": true,
+            "schema": {
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Target Iso",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "No mapping exists for this target_iso"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Language Pivot",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/missingwords": {
+      "get": {
+        "description": "Returns a list of all missing words for a given missing words assessment.\n\nParameters\n----------\nrevision_id : int\n    The ID of the revision to get results for.\nreference_id : int\n    The ID of the reference to get results for.\nbaseline_ids : list, optional\n    A list of baseline revision ids to compare against.\nthreshold : float, optional\n    The threshold score for the a word to be considered missing. Default is None, which will default to environmental variable, if set, or 0.15.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\n\nReturns\n-------\nDict[str, Union[List[Result], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_missing_words_v3_missingwords_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": true,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "baseline_ids",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "items": {
+                    "type": "integer"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Baseline Ids"
+            }
+          },
+          {
+            "in": "query",
+            "name": "threshold",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Threshold"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner \u2014 the main revision and each baseline are chosen independently and may be different runners. ``true`` reads only eflomal, ``false`` only fastalign; an explicit runner applies to both the main revision and the baselines so their scores are never mixed.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner \u2014 the main revision and each baseline are chosen independently and may be different runners. ``true`` reads only eflomal, ``false`` only fastalign; an explicit runner applies to both the main revision and the baselines so their scores are never mixed.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/Result_v2"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Missing Words V3 Missingwords Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Missing Words",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/ngrams_result": {
+      "get": {
+        "description": "Returns a list of n-gram results for a given assessment.\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\ndb : Session\n    The database session object to execute queries against.\n\nReturns\n-------\nDict[str, Union[List[NgramResult], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_ngrams_result_v3_ngrams_result_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 10000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/NgramResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Ngrams Result V3 Ngrams Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Ngrams Result",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/pivot-candidate": {
+      "get": {
+        "operationId": "list_pivot_candidates_v3_pivot_candidate_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PivotCandidateListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Pivot Candidates",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Create or update a pivot candidate. Admin-only.\n\nAdding a pivot is a curated decision tied to licensing/quality, so it\nshould not be done autonomously by the agent. Fields omitted from the\npayload (e.g. ``notes``) preserve their existing value on update.",
+        "operationId": "upsert_pivot_candidate_v3_pivot_candidate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PivotCandidateIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PivotCandidateOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upsert Pivot Candidate",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/predict": {
+      "post": {
+        "description": "Fan a PredictInput out to every configured assessment app in parallel.\n\nPer-app failures are isolated \u2014 a slow or failing app never blocks the others.",
+        "operationId": "predict_v3_predict_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictInput"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictFanoutResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Predict",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/predict/jobs/{job_id}": {
+      "get": {
+        "description": "Poll a slow translation/critique job spawned by POST /predict.\n\nPairs are returned in the same order they were submitted to /predict,\neach with the original `vref` / `source_text` / `target_text` echoed\nback so callers that submit without a vref can still match results\nby index.",
+        "operationId": "get_predict_job_v3_predict_jobs__job_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictJobStatusResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Predict Job",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/predict/semantic-similarity": {
+      "post": {
+        "operationId": "semantic_similarity_inference_v3_predict_semantic_similarity_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SemanticSimilarityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SemanticSimilarityResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Semantic Similarity Inference",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/predict/text-lengths": {
+      "get": {
+        "operationId": "text_lengths_inference_v3_predict_text_lengths_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "text1",
+            "required": true,
+            "schema": {
+              "maxLength": 10000,
+              "title": "Text1",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "text2",
+            "required": true,
+            "schema": {
+              "maxLength": 10000,
+              "title": "Text2",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextLengthsInferenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Text Lengths Inference",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/result": {
+      "get": {
+        "description": "Returns a list of all results for a given assessment. These results are generally one for each verse in the assessed text(s).\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\naggregate : str, optional\n    If set to \"chapter\", results will be aggregated by chapter. Otherwise results will be returned at the verse level.\n\nNotes\n-----\nSource and target are only returned for missing-words assessments. Source is single words from the source text. Target is\na json array of words that match this source in the \"baseline reference\" texts. These may be used to show how the source\nword has been translated in a few other major languages.\n\nFlag is a boolean value that is currently only implemented in missing-words assessments. It is used to indicate that the\nmissing word appears in the baseline reference texts, and so there is a higher likelihood that it is a word that should\nbe included in the text being assessed.",
+        "operationId": "get_result_v3_result_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/aggType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Aggregate"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reverse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "title": "Reverse"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/Result_v2"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Result V3 Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Result",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/revision": {
+      "delete": {
+        "description": "Deletes a revision.\n\nInput:\n- id: int\nDescription: The id of the revision to delete.",
+        "operationId": "delete_revision_v3_revision_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Revision",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "get": {
+        "description": "Returns a list of revisions.\n\nIf version_id is provided, returns a list of revisions for that version, otherwise returns a list of all revisions.\n\nInput:\n- version_id: Optional[int] = None\nDescription: The id of the version to which the revision belongs. If not provided, returns all revisions.\n\nReturns:\nFields(Revision):\n- version_id: int\nDescription: The id of the version to which the revision belongs.\n- name: str\nDescription: The name of the revision.\n- published: bool\nDescription: Whether the revision is published.\n- backTranslation: Optional[int] = None\nDescription: The id of the back translation revision.\n- machineTranslation: Optional[int] = None\nDescription: The id of the machine translation revision.\n- file: UploadFile\nDescription: The file containing the revision text.",
+        "operationId": "list_revisions_v3_revision_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Version Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/RevisionOut_v3"
+                  },
+                  "title": "Response List Revisions V3 Revision Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Revisions",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Uploads a new revision.\n\nInput:\nFields(Revision):\n- version_id: int\nDescription: The id of the version to which the revision belongs.\n- name: str\nDescription: The name of the revision.\n- published: bool\nDescription: Whether the revision is published.\n- backTranslation: Optional[int] = None\nDescription: The id of the back translation revision.\n- machineTranslation: Optional[int] = None\nDescription: The id of the machine translation revision.\n- file: UploadFile\nDescription: The file containing the revision text.",
+        "operationId": "upload_revision_v3_revision_post",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Name"
+            }
+          },
+          {
+            "in": "query",
+            "name": "published",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "title": "Published"
+            }
+          },
+          {
+            "in": "query",
+            "name": "backTranslation",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Backtranslation"
+            }
+          },
+          {
+            "in": "query",
+            "name": "machineTranslation",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": false,
+              "title": "Machinetranslation"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_revision_v3_revision_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RevisionOut_v3"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upload Revision",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "put": {
+        "description": "Rename a revision.\n\nInput:\n- id: int\nDescription: The id of the revision to rename.\n- new_name: str\nDescription: The new name for the revision.",
+        "operationId": "rename_revision_v3_revision_put",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "new_name",
+            "required": true,
+            "schema": {
+              "title": "New Name",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Rename Revision",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/script": {
+      "get": {
+        "description": "Get a list of ISO 15924 script codes and their English names.\n\nReturns:\nFields(Script):\n- iso15924: str\nDescription: The ISO 15924 script code. e.g 'Latn' for Latin. 'Cyrl' for Cyrillic.\n- name: str\nDescription: The name of the script.",
+        "operationId": "list_scripts_v3_script_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Script"
+                  },
+                  "title": "Response List Scripts V3 Script Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Scripts",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/text": {
+      "get": {
+        "description": "Gets a list of verse texts for a whole revision.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- include_verses: IncludeVerses (all|union|intersection, default \"union\")\nDescription: Which verses to include. 'all' returns all 41,899 canonical\nverses with empty text for missing ones. 'union' and 'intersection' are\ntreated identically for a single revision (both return only verses that have text).\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_text_v3_text_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Which verses to include in the response. 'all': all 41,899 canonical verses, with empty text for missing verses. 'union': only verses that have text (default). 'intersection': treated identically to 'union' for a single revision.",
+            "in": "query",
+            "name": "include_verses",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/IncludeVerses"
+                }
+              ],
+              "default": "union",
+              "description": "Which verses to include in the response. 'all': all 41,899 canonical verses, with empty text for missing verses. 'union': only verses that have text (default). 'intersection': treated identically to 'union' for a single revision.",
+              "title": "Include Verses"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Text V3 Text Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Text",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/text_lengths_result": {
+      "get": {
+        "description": "Returns text lengths (word and character lengths and z-scores) for a given assessment.\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\nbook : str, optional\n    Restrict results to one book.\nchapter : int, optional\n    Restrict results to one chapter. If set, book must also be set.\nverse : int, optional\n    Restrict results to one verse. If set, book and chapter must also be set.\npage : int, optional\n    The page of results to return. If set, page_size must also be set.\npage_size : int, optional\n    The number of results to return per page. If set, page must also be set.\naggregate : str, optional\n    If set to \"chapter\", results will be aggregated by chapter.\n    If set to \"book\", results will be aggregated by book.\n    If set to \"text\", a single result will be returned for the whole text.\n    Otherwise results will be returned at the verse level.\n\nReturns\n-------\nDict[str, Union[List[TextLengthsResult], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_text_lengths_v3_text_lengths_result_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "aggregate",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/aggType"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Aggregate"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TextLengthsResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Text Lengths V3 Text Lengths Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Text Lengths",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/textalignmentmatches": {
+      "get": {
+        "description": "Returns aggregated alignment statistics across the entire text for a word alignment assessment.\n\nThis endpoint provides a summary of the top alignment matches for each source word,\nranked by probability and including various strength metrics.\n\nParameters\n----------\nrevision_id : int\n    The ID of the revision to get results for.\nreference_id : int\n    The ID of the reference to get results for.\ntop_k : int, optional\n    The maximum number of top target words to return per source word (default: 3).\nmin_support : float, optional\n    Minimum support mass threshold to include a source word (default: 20.0).\nmin_probability : float, optional\n    Minimum probability threshold to include an alignment (default: 0.4).\n\nReturns\n-------\nDict[str, Union[List[AlignmentMatch], int]]\n    A dictionary containing the list of alignment matches and the total count.\n\nNotes\n-----\nThe results include several strength metrics:\n- strength_mass: Expected alignment mass (probability * support_mass)\n- strength_margin_mass: Margin over next best match, weighted by support\n- strength_confidence: Confidence based on entropy and support",
+        "operationId": "get_text_alignment_matches_v3_textalignmentmatches_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": true,
+            "schema": {
+              "title": "Reference Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top_k",
+            "required": false,
+            "schema": {
+              "default": 3,
+              "title": "Top K",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_support",
+            "required": false,
+            "schema": {
+              "default": 20.0,
+              "title": "Min Support",
+              "type": "number"
+            }
+          },
+          {
+            "in": "query",
+            "name": "min_probability",
+            "required": false,
+            "schema": {
+              "default": 0.4,
+              "title": "Min Probability",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner; ``true`` reads only eflomal, ``false`` only fastalign.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to read. Omitted returns the most recent word-alignment assessment regardless of runner; ``true`` reads only eflomal, ``false`` only fastalign.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/AlignmentMatch"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Text Alignment Matches V3 Textalignmentmatches Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Text Alignment Matches",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/texts": {
+      "get": {
+        "description": "Gets verse texts for multiple revisions with range merging.\n\nWhen any revision has a \"<range>\" marker for a verse, that verse is merged\nwith preceding verses for ALL revisions to keep them consistently aligned.\n\nInput:\n- revision_ids: List[int]\nDescription: List of revision IDs to fetch (minimum 2).\n- include_verses: IncludeVerses (all|union|intersection, default \"union\")\nDescription: Which verses to include in the response.\n- limit: Optional[int]\nDescription: Maximum number of verses per revision_id. Sampling happens\nafter include_verses filtering and <range> merging.\n- random: bool (default false)\nDescription: If true, sample uniformly at random; otherwise return the\nfirst `limit` verses in canonical order.\n- seed: Optional[int]\nDescription: RNG seed. Combined with random=true, two calls with the\nsame seed return the same sample. Ignored if random=false.\n\nReturns:\nDict[str, List[VerseText]]: Dictionary keyed by revision_id (as string),\neach containing a list of VerseText objects. Merged verses will have\nverse_reference formatted as a range (e.g., \"GEN 1:1-3\").\n\nNotes:\n- The returned dictionary will include an entry for every requested\n  revision_id.\n- With include_verses='all', every revision gets all 41,899 canonical\n  verses (empty text for missing ones). With 'union' or 'intersection',\n  a revision with no matching verses will have an empty list.\n- If a verse exists in one revision but not another, the missing revision\n  will have an empty string for that verse's text.",
+        "operationId": "get_texts_v3_texts_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_ids",
+            "required": true,
+            "schema": {
+              "items": {
+                "type": "integer"
+              },
+              "min_items": 2,
+              "title": "Revision Ids",
+              "type": "array"
+            }
+          },
+          {
+            "description": "Which verses to include in the response. 'all': all 41,899 canonical verses, with empty text for missing verses. 'union': verses where at least one revision has text (default). 'intersection': only verses where every revision has text.",
+            "in": "query",
+            "name": "include_verses",
+            "required": false,
+            "schema": {
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/IncludeVerses"
+                }
+              ],
+              "default": "union",
+              "description": "Which verses to include in the response. 'all': all 41,899 canonical verses, with empty text for missing verses. 'union': verses where at least one revision has text (default). 'intersection': only verses where every revision has text.",
+              "title": "Include Verses"
+            }
+          },
+          {
+            "description": "Maximum number of verses to return per revision_id. With include_verses='all', limit applies to the 41,899 canonical verse slots (so some returned rows may have empty text).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of verses to return per revision_id. With include_verses='all', limit applies to the 41,899 canonical verse slots (so some returned rows may have empty text).",
+              "title": "Limit"
+            }
+          },
+          {
+            "description": "If true, sample uniformly at random (after include_verses filtering) instead of returning the first `limit` verses in canonical order. Response is still ordered canonically.",
+            "in": "query",
+            "name": "random",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "If true, sample uniformly at random (after include_verses filtering) instead of returning the first `limit` verses in canonical order. Response is still ordered canonically.",
+              "title": "Random",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "RNG seed for deterministic sampling. Only meaningful when random=true; ignored otherwise. If omitted with random=true, sampling is non-deterministic.",
+            "in": "query",
+            "name": "seed",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "RNG seed for deterministic sampling. Only meaningful when random=true; ignored otherwise. If omitted with random=true, sampling is non-deterministic.",
+              "title": "Seed"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "items": {
+                      "$ref": "#/components/schemas/VerseText"
+                    },
+                    "type": "array"
+                  },
+                  "title": "Response Get Texts V3 Texts Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Texts",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/textsearch": {
+      "get": {
+        "description": "Search for verses containing a specific term in a revision text.\nReturns verses that contain the search term (case-insensitive).\n\nBy default matches whole words only. ``*`` acts as a wildcard for any\nrun of word characters, and may appear at the start, end, and/or\ninside the term:\n\n- ``foo``      \u2014 whole-word match (default)\n- ``foo*``     \u2014 words starting with ``foo``\n- ``*foo``     \u2014 words ending with ``foo``\n- ``*foo*``    \u2014 ``foo`` anywhere inside a word\n- ``fo*ar``    \u2014 word starting with ``fo`` and ending with ``ar``\n- ``*fo*ar*``  \u2014 ``fo`` followed (somewhere later) by ``ar`` in the\n  same word\n\nEvery ``*`` matches within a single word \u2014 internal wildcards will\nnot cross a word boundary. The term must contain at least one visible\n(non-whitespace, non-format) character.\n\nProvide exactly one of ``revision_id`` or ``version_id``.  When\n``version_id`` is given, results reflect the version's current text:\nfor each verse, the most recent non-empty revision is chosen first,\nand the search term is then matched against that latest text. A verse\nwhose latest revision no longer contains the term will not surface,\neven if an older revision did \u2014 searches return the version \"as it\nstands today,\" not its full revision history.\n\nOptionally provide at most one of ``comparison_revision_id`` or\n``comparison_version_id`` for parallel text. For ``comparison_version_id``\nthe same per-vref pick applies (latest non-empty wins; the search term\nis only required on the main side, not on the comparison).\n\nPass ``include_alignments=true`` to annotate each result with per-verse\nword alignments from the latest finished eflomal word-alignment\nassessment matching ``(revision_id, comparison_revision_id)``. Each\nresult gains an ``alignments`` array of ``{source, target, score}``\nobjects, where ``source`` is from the comparison side and ``target``\nis from the main side. Links below ``min_alignment_score`` are filtered\nserver-side. ``alignment_assessment_id`` overrides the auto-pick. When\nno matching assessment exists or the user lacks access to it, results\nare returned without the ``alignments`` field (no error).",
+        "operationId": "search_revision_text_v3_textsearch_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "term",
+            "required": true,
+            "schema": {
+              "maxLength": 200,
+              "minLength": 1,
+              "title": "Term",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "description": "Bible version id; per (book, chapter, verse) the most recent non-empty revision is chosen first, and the search term is then matched against that latest text. Older revisions only fill in for verses where the latest revision is empty or missing the row, not for term mismatches \u2014 results reflect the version's current text.",
+            "in": "query",
+            "name": "version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Bible version id; per (book, chapter, verse) the most recent non-empty revision is chosen first, and the search term is then matched against that latest text. Older revisions only fill in for verses where the latest revision is empty or missing the row, not for term mismatches \u2014 results reflect the version's current text.",
+              "title": "Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "comparison_revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Comparison Revision Id"
+            }
+          },
+          {
+            "description": "Bible version id for comparison text; per (book, chapter, verse) returns the latest non-empty revision (no search-term filter on the comparison side).",
+            "in": "query",
+            "name": "comparison_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Bible version id for comparison text; per (book, chapter, verse) returns the latest non-empty revision (no search-term filter on the comparison side).",
+              "title": "Comparison Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "random",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Random",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "If true, annotate each result with per-verse word alignments from the most recent finished word-alignment assessment for the (revision_id, comparison_revision_id) pair (runner selected by ``use_eflomal``). Each result gains an ``alignments`` array of ``{source, target, score}`` objects. If no matching assessment exists for the pair, results are returned without the ``alignments`` field (no error).",
+            "in": "query",
+            "name": "include_alignments",
+            "required": false,
+            "schema": {
+              "default": false,
+              "description": "If true, annotate each result with per-verse word alignments from the most recent finished word-alignment assessment for the (revision_id, comparison_revision_id) pair (runner selected by ``use_eflomal``). Each result gains an ``alignments`` array of ``{source, target, score}`` objects. If no matching assessment exists for the pair, results are returned without the ``alignments`` field (no error).",
+              "title": "Include Alignments",
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Filter alignment links below this score server-side. Only applies when ``include_alignments`` is true.",
+            "in": "query",
+            "name": "min_alignment_score",
+            "required": false,
+            "schema": {
+              "default": 0.3,
+              "description": "Filter alignment links below this score server-side. Only applies when ``include_alignments`` is true.",
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "title": "Min Alignment Score",
+              "type": "number"
+            }
+          },
+          {
+            "description": "Optional explicit word-alignment assessment id to source alignments from. When omitted, the latest finished word-alignment assessment for the (revision_id, comparison_revision_id) pair is used.",
+            "in": "query",
+            "name": "alignment_assessment_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Optional explicit word-alignment assessment id to source alignments from. When omitted, the latest finished word-alignment assessment for the (revision_id, comparison_revision_id) pair is used.",
+              "title": "Alignment Assessment Id"
+            }
+          },
+          {
+            "description": "Select which word-alignment runner to source alignments from when ``include_alignments`` is true. Omitted sources from the most recent finished assessment regardless of runner; ``true`` uses eflomal, ``false`` uses fastalign. Applies to both the explicit ``alignment_assessment_id`` and the auto-pick path.",
+            "in": "query",
+            "name": "use_eflomal",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Select which word-alignment runner to source alignments from when ``include_alignments`` is true. Omitted sources from the most recent finished assessment regardless of runner; ``true`` uses eflomal, ``false`` uses fastalign. Applies to both the explicit ``alignment_assessment_id`` and the auto-pick path.",
+              "title": "Use Eflomal"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Search Revision Text",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tfidf_result": {
+      "get": {
+        "description": "Returns the most similar verses to the given vref based on TF-IDF PCA vector similarity.\n\nParameters\n----------\nassessment_id : int\n    The ID of the assessment to get results for.\nvref : str\n    The verse reference to compare against.\nlimit : int, optional\n    The number of similar verses to return (default is 10).\nreference_id : Optional[int]\n    Not used in the assessment, but optionally to also return the reference text\n    for the given vrefs.\n\nReturns\n-------\nDict[str, Union[List[TfidfResult], int]]\n    A dictionary containing the list of results and the total count of results.",
+        "operationId": "get_tfidf_result_v3_tfidf_result_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "assessment_id",
+            "required": true,
+            "schema": {
+              "title": "Assessment Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vref",
+            "required": true,
+            "schema": {
+              "title": "Vref",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 10,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reference_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Reference Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TfidfResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Tfidf Result V3 Tfidf Result Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tfidf_result/by_text": {
+      "post": {
+        "description": "Nearest-neighbour corpus verses to an arbitrary piece of text.\n\nEncodes `text` into the assessment's 300-dim TF-IDF/SVD space server-side\n(the step callers previously did out-of-band), then ranks it against the\ncorpus exactly like /tfidf_result/by_vector. `exclude_vref`/`exclude_book`\ndrop the query verse (or its whole book) from the neighbours.",
+        "operationId": "get_tfidf_result_by_text_v3_tfidf_result_by_text_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfByTextRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TfidfResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Tfidf Result By Text V3 Tfidf Result By Text Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result By Text",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tfidf_result/by_texts": {
+      "post": {
+        "description": "Batch companion to /tfidf_result/by_text \u2014 one neighbour set per text.\n\n`exclude_vrefs[i]` (if provided) applies to `texts[i]`; `exclude_book`\napplies to all of them.",
+        "operationId": "get_tfidf_result_by_texts_v3_tfidf_result_by_texts_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfByTextsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfByVectorsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result By Texts",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tfidf_result/by_vector": {
+      "post": {
+        "description": "Nearest-neighbour corpus verses to an arbitrary query vector.\n\nCompanion to GET /tfidf_result \u2014 the vref-keyed endpoint requires the\nquery verse to already be in the corpus; this one accepts any vector\n(e.g. the output of a fresh predict() encoding).",
+        "operationId": "get_tfidf_result_by_vector_v3_tfidf_result_by_vector_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfByVectorRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "items": {
+                          "$ref": "#/components/schemas/TfidfResult"
+                        },
+                        "type": "array"
+                      },
+                      {
+                        "type": "integer"
+                      }
+                    ]
+                  },
+                  "title": "Response Get Tfidf Result By Vector V3 Tfidf Result By Vector Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result By Vector",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tfidf_result/by_vectors": {
+      "post": {
+        "description": "Batch companion to /tfidf_result/by_vector \u2014 one neighbour set per vector.\n\nSaves N HTTP round-trips for callers that encode a batch of texts (e.g. the\ntfidf predict() path from the fan-out predict endpoint).",
+        "operationId": "get_tfidf_result_by_vectors_v3_tfidf_result_by_vectors_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TfidfByVectorsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TfidfByVectorsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Tfidf Result By Vectors",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/cooccurrences": {
+      "get": {
+        "operationId": "get_cooccurrences_v3_tokenizer_cooccurrences_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "maxLength": 3,
+              "minLength": 3,
+              "title": "Iso",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "morpheme",
+            "required": true,
+            "schema": {
+              "title": "Morpheme",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "position_filter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "pattern": "^(prefix|suffix|infix)$",
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Position Filter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 100,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CooccurrenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Cooccurrences",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/index": {
+      "post": {
+        "operationId": "index_morphemes_v3_tokenizer_index_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Index Morphemes",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/morphemes-by-version/{version_id}": {
+      "get": {
+        "description": "Version-keyed read for language morphemes.\n\nReturns the soft union of rows version-stamped for this version\n*and* legacy rows with `target_version_id IS NULL` that share the\nversion's ISO. NULL-stamped rows are treated as \"shared across\nversions of the ISO\" until Phase 5 splits them into per-version\nrows. (Phase 2 of issue #687.)\n\nStatus codes:\n- 200: returns the soft union (may be empty)\n- 403: caller is not authorized for this version \u2014 also returned\n  for non-existent version_ids when the caller is a regular user,\n  so unauthorized callers can't enumerate valid versions\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "get_morphemes_by_version_v3_tokenizer_morphemes_by_version__version_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Filter to LEXICAL|GRAMMATICAL|BOUND_ROOT|UNKNOWN",
+            "in": "query",
+            "name": "class",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to LEXICAL|GRAMMATICAL|BOUND_ROOT|UNKNOWN",
+              "title": "Class"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MorphemeListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Morphemes By Version",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/morphemes/{iso}": {
+      "get": {
+        "operationId": "get_morphemes_v3_tokenizer_morphemes__iso__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "title": "Iso",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter to LEXICAL|GRAMMATICAL|BOUND_ROOT|UNKNOWN",
+            "in": "query",
+            "name": "class",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter to LEXICAL|GRAMMATICAL|BOUND_ROOT|UNKNOWN",
+              "title": "Class"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Limit"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MorphemeListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Morphemes",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/profile/{iso}": {
+      "get": {
+        "operationId": "get_language_profile_v3_tokenizer_profile__iso__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "title": "Iso",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageProfileOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Language Profile",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "put": {
+        "description": "Create or update a language profile.\n\nOn update, only fields present in the request body are modified; omitted\nfields retain their current values.  To clear a field, send it explicitly\nas ``null``.",
+        "operationId": "upsert_language_profile_v3_tokenizer_profile__iso__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "title": "Iso",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LanguageProfileIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageProfileOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Upsert Language Profile",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/runs": {
+      "get": {
+        "operationId": "list_tokenizer_runs_v3_tokenizer_runs_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "iso",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Iso"
+            }
+          },
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Revision Id"
+            }
+          },
+          {
+            "description": "Filter by run status. Omit to list all runs regardless of status.",
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by run status. Omit to list all runs regardless of status.",
+              "title": "Status"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenizerRunListOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Tokenizer Runs",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Commit a tokenizer pipeline run.\n\nConcurrency note: this endpoint assumes a single pipeline writer per\n(iso, revision). Under concurrent writers, the SELECT-then-INSERT\ncheck-before-write pattern for morphemes races: two callers can both\nobserve a morpheme as missing, both try to insert, one wins via\nON CONFLICT DO NOTHING, and the loser's class-conflict counter\nundercounts. The stored class is still correct (first writer wins),\nbut the returned stats can be off by a few rows.",
+        "operationId": "commit_tokenizer_run_v3_tokenizer_runs_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TokenizerRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenizerRunCommitResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Commit Tokenizer Run",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/search": {
+      "get": {
+        "operationId": "search_morpheme_v3_tokenizer_search_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "iso",
+            "required": true,
+            "schema": {
+              "title": "Iso",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "morpheme",
+            "required": true,
+            "schema": {
+              "title": "Morpheme",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Revision to search in",
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "description": "Revision to search in",
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "comparison_revision_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Comparison Revision Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 20,
+              "maximum": 1000,
+              "minimum": 1,
+              "title": "Limit",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MorphemeSearchResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Search Morpheme",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/training-artifacts/{version_id}": {
+      "delete": {
+        "description": "Clear agent-discovered tokenizer artifacts for a single bible_version.\n\nDeletes (atomically, in one transaction):\n- the `training_artifacts` row for this version (per-version\n  grammar_sketch / source_model)\n- `language_affixes` rows where `target_version_id == version_id`\n- `language_morphemes` rows where `target_version_id == version_id`\n\nLegacy `target_version_id IS NULL` rows and rows stamped to other\nversions of the same ISO are left intact, so other versions'\nsoft-union reads stay consistent. Lexeme cards are also untouched\n\u2014 they have their own DELETE endpoint.\n\nThis is the primitive that backs aqua-assessments' `build_mode=\n\"rebuild\"`: clear the version-scoped artifacts, then re-run `auto`\nagainst a fresh slate. (Phase 4 of issue #687.)\n\nStatus codes:\n- 200: returns row counts deleted (zeros if nothing existed \u2014\n  idempotent)\n- 403: caller is not authorized for this version \u2014 also returned\n  for non-existent version_ids when the caller is a regular user\n  (consistent with the GET endpoints; prevents enumeration)\n- 404: admin caller requesting a version_id that doesn't exist",
+        "operationId": "delete_training_artifacts_v3_tokenizer_training_artifacts__version_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingArtifactsDeleteResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Training Artifacts",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "get": {
+        "description": "Version-keyed read for tokenizer training artifacts.\n\nPrefers the per-version `training_artifacts` row; falls back to the\niso-keyed `language_profiles.grammar_sketch` when either no\nversion-keyed row exists OR the version-keyed row exists but its\n`grammar_sketch` is NULL (in which case the version-keyed\n`source_model` is still surfaced for provenance). Phase 2 of issue\n#687. Callers should treat the returned `source` field as advisory:\nit indicates which store satisfied the grammar_sketch read so we\ncan monitor cutover progress.\n\nStatus codes:\n- 200: artifact found (either version- or iso-keyed)\n- 403: caller is not authorized for this version \u2014 also returned\n  for non-existent version_ids when the caller is a regular user,\n  so unauthorized callers can't enumerate valid versions\n- 404: admin caller requesting a version_id that doesn't exist\n  (admins bypass the auth helper, so they reach the lookup)",
+        "operationId": "get_training_artifacts_v3_tokenizer_training_artifacts__version_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "version_id",
+            "required": true,
+            "schema": {
+              "title": "Version Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingArtifactOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Artifacts",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/tokenizer/word-index": {
+      "post": {
+        "operationId": "build_word_index_v3_tokenizer_word_index_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WordIndexRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WordIndexResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Build Word Index",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/train": {
+      "get": {
+        "description": "List training jobs accessible to the current user. The ?status filter\nmatches the linked Assessment.status.",
+        "operationId": "list_training_jobs_v3_train_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "source_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Source Version Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "target_version_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Target Version Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/TrainingJobOut"
+                  },
+                  "title": "Response List Training Jobs V3 Train Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Training Jobs",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Create and dispatch training jobs for all types in parallel.\n\nThe pair is identified by version_id (latest non-deleted revision is\nresolved) or by revision_id when a specific revision is required.",
+        "operationId": "create_training_job_v3_train_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrainingJobIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Create Training Job",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/train/status": {
+      "get": {
+        "description": "Get the status of a training session by session_id.",
+        "operationId": "get_training_status_v3_train_status_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Status",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/train/status/{session_id}/results": {
+      "get": {
+        "description": "Single read endpoint that returns training-job status + interleaved\nper-vref results for every completed job in the session.\n\nPer vref: semantic_similarity score (one row), word_alignment per-word\nrows plus a verse-level word_alignment_score, tfidf\n`{target_neighbours, source_neighbours}` nearest-neighbour blocks\n(one block per side, each neighbour hydrated with both revisions'\ntext), and ngrams `{target_corpus, source_corpus}` blocks listing\ntrained ngrams that fire on this verse with their full\ncross-corpus vrefs lists. The per-vref tfidf and ngrams shapes\nmirror the per-pair shape of `/v3/predict` so callers can share a\nparser between the two endpoints; predict's cross-axis ngrams\n(target ngrams in source text and vice versa) are not returned \u2014\ntrain-status reads stored corpus hits only.\n\nSource-side ngrams/tfidf are looked up as the latest finished\nassessment of the same type whose revision_id equals this session's\nsource_revision_id (typically created by a separate training\nsession that swapped source/target). When no source-side training\nis available, `source_corpus` is `None` for ngrams and\n`source_neighbours` is `[]` for tfidf.\n\nAgent_critique adds `lexeme_cards` per vref: when the session\nincludes an agent-critique training type, each vref carries the\nlexeme cards (filtered to those whose lemma/surface forms intersect\nthe verse text on either side) that were produced for the (source,\ntarget) version pair. Sessions without agent-critique return an\nempty list there.",
+        "operationId": "get_training_session_results_v3_train_status__session_id__results_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "title": "Session Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Book"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Chapter"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page"
+            }
+          },
+          {
+            "in": "query",
+            "name": "page_size",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maximum": 1000,
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Page Size"
+            }
+          },
+          {
+            "in": "query",
+            "name": "tfidf_top_k",
+            "required": false,
+            "schema": {
+              "default": 5,
+              "maximum": 50,
+              "minimum": 1,
+              "title": "Tfidf Top K",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingSessionResultsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Session Results",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/train/{job_id}": {
+      "delete": {
+        "description": "Soft delete a training job (terminal jobs only).",
+        "operationId": "delete_training_job_v3_train__job_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Training Job",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "get": {
+        "description": "Get a single training job by ID.",
+        "operationId": "get_training_job_v3_train__job_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrainingJobOut"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Job",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/train/{job_id}/data": {
+      "get": {
+        "description": "Return parallel verse text for the training runner.",
+        "operationId": "get_training_data_v3_train__job_id__data_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "job_id",
+            "required": true,
+            "schema": {
+              "title": "Job Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "range_handling",
+            "required": false,
+            "schema": {
+              "default": "filter",
+              "pattern": "^(filter|merge|empty)$",
+              "title": "Range Handling",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Training Data",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/verse": {
+      "get": {
+        "description": "Gets a single verse text for a revision for a given book, chapter, and verse.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible. e.g GEN, EXO, PSA.\n- chapter: int\nDescription: The chapter of the book. e.g 1, 2, 3.\n- verse: int\nDescription: The verse number. e.g 1, 2, 3.\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_verse_v3_verse_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "book",
+            "required": true,
+            "schema": {
+              "title": "Book",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "chapter",
+            "required": true,
+            "schema": {
+              "title": "Chapter",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "verse",
+            "required": true,
+            "schema": {
+              "title": "Verse",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Verse V3 Verse Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Verse",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/version": {
+      "delete": {
+        "description": "Delete a version and all associated revisions, text, and assessments.\n\nInput:\n- id: int\nDescription: The unique identifier for the version.",
+        "operationId": "delete_version_v3_version_delete",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "title": "Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Delete Version",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "get": {
+        "description": "Get a list of all versions that the current user is authorized to access.\n\nAdmins may pass ``include_deleted=true`` to also return soft-deleted\nversions, so downstream mirrors can satisfy FK constraints against\nrevisions whose parent version has been soft-deleted. Non-admin callers\nnever receive soft-deleted versions regardless of this flag.",
+        "operationId": "list_version_v3_version_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include_deleted",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Deleted",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VersionOut_v3"
+                  },
+                  "title": "Response List Version V3 Version Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "List Version",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "post": {
+        "description": "Create a new version.\nOptionally only add the version to specific groups, specified by their IDs.\n\n\nInput:\nFields(Version):\n- name: str\nDescription: The name of the version.\n- iso_language: str\nDescription: The ISO 639-2 language code. e.g 'eng' for English. 'swa' for Swahili.\n- iso_script: str\nDescription: The ISO 15924 script code. e.g 'Latn' for Latin. 'Cyrl' for Cyrillic.\n- abbreviation: str\nDescription: The abbreviation of the version.\n- rights: str\nDescription: The rights of the version.\n- forwardTranslation: Optional[int]\nDescription: The ID of the forward translation version.\n- backTranslation: Optional[int]\nDescription: The ID of the back translation version.\n- machineTranslation: bool\nDescription: Whether the version is machine translated.\n- is_reference: bool\nDescription: Whether the version is a reference version.\n- transcribed_audio: bool\nDescription: Whether the version's revisions are transcriptions of recorded\naudio (ASR). Auto-applied to agent-critique assessments. Defaults to false.\n- add_to_groups: List[int] (required)\nDescription: The IDs of the groups to add the version to.\nAt least one group must be specified.\n\nReturns:\nFields(VersionOut):\nBesides the data provided for the input of the version:\n\n- id: int\nDescription: The unique identifier for the version.\n- owner_id : Union[int, None] = None\nDescription: The unique identifier for the owner of the version.\n- group_ids : List[int] = []\nDescription: The IDs of the groups that have access to the version.",
+        "operationId": "add_version_v3_version_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VersionIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VersionOut_v3"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Add Version",
+        "tags": [
+          "Version 3"
+        ]
+      },
+      "put": {
+        "description": "Update any parameter in a version.\n\nInput:\nFields(Version):\n- name: str\nDescription: The name of the version.\n- iso_language: str\nDescription: The ISO 639-2 language code. e.g 'eng' for English. 'swa' for Swahili.\n- iso_script: str\nDescription: The ISO 15924 script code. e.g 'Latn' for Latin. 'Cyrl' for Cyrillic.\n- abbreviation: str\nDescription: The abbreviation of the version.\n- rights: str\nDescription: The rights of the version.\n- forwardTranslation: Optional[int]\nDescription: The ID of the forward translation version.\n- backTranslation: Optional[int]\nDescription: The ID of the back translation version.\n- machineTranslation: bool\nDescription: Whether the version is machine translated.\n- is_reference: bool\nDescription: Whether the version is a reference version.\n- transcribed_audio: bool\nDescription: Whether the version's revisions are transcriptions of recorded\naudio (ASR). Auto-applied to agent-critique assessments. Defaults to false.\n- add_to_groups: Optional[List[int]]\nDescription: The IDs of the groups to add the version to,\nthe version will only be added to this groups, not to all tha groups of the user as usual.\n\nAdd groups functionality:\nIn case you want to add aversion to groups after it has been created, you can\nspecify in add_to_groups the IDs of the groups you want to add the version to.\n\nRemove groups functionality:\nIn case you want to remove a version from a group, you can specify in\nremove_from_groups, the IDs of the groups you want to remove the version from.",
+        "operationId": "modify_version_v3_version_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VersionUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Modify Version",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/vref-text": {
+      "get": {
+        "description": "Exports a revision's verse text in vref format.\n\nReturns a plain text file with 41,899 lines, one per canonical verse\nreference (matching fixtures/vref.txt). Lines with verse text get the\ntext; lines without get left blank.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n\nReturns:\n- Plain text with 41,899 lines.",
+        "operationId": "get_vref_text_v3_vref_text_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Vref Text",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/vrefs": {
+      "get": {
+        "description": "Gets a list of verse texts for a revision for a given list of verse references.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- vrefs: List[str]\nDescription: A list of full verse references, including book, chapter and text. Must be in the format \"GEN 1:1\".\n\nReturns:\nFields(VerseText):\n- id: int\nDescription: The unique identifier for the verse.\n- text: str\nDescription: The text of the verse.\n- verse_reference: str\nDescription: The full verse reference, including book, chapter and text.\n- revision_id: int\nDescription: The unique identifier for the revision.\n- book: str\nDescription: The book of the Bible.\n- chapter: int\nDescription: The chapter of the book.\n- verse: int\nDescription: The verse number.",
+        "operationId": "get_vrefs_v3_vrefs_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "vrefs",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "title": "Vrefs",
+              "type": "array"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/VerseText"
+                  },
+                  "title": "Response Get Vrefs V3 Vrefs Get",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Vrefs",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    },
+    "/v3/words": {
+      "get": {
+        "description": "Gets unique words from a revision, optionally restricted to a verse range\nand/or capped to the most frequent N.\n\nInput:\n- revision_id: int\nDescription: The unique identifier for the revision.\n- first_verse, last_verse: Optional[str]\nDescription: Verse range bounds (e.g. \"GEN 1:1\"). Either both or neither\nmust be supplied. When omitted, all verses in the revision are scanned.\n- top_n: Optional[int]\nDescription: If set, return only the N most frequent words.\n- include_counts: bool (default false)\nDescription: When true, return List[{word, count}] sorted by count desc\n(ties broken alphabetically). When false (default), return List[str]\nsorted alphabetically.\n\nReturns:\n- List[str] or List[WordCount]\nDescription: Words extracted with sophisticated Unicode-aware splitting.",
+        "operationId": "get_words_v3_words_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "revision_id",
+            "required": true,
+            "schema": {
+              "title": "Revision Id",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "first_verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "First Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "last_verse",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Last Verse"
+            }
+          },
+          {
+            "in": "query",
+            "name": "top_n",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Top N"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_counts",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Counts",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "$ref": "#/components/schemas/WordCount"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "title": "Response Get Words V3 Words Get"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "security": [
+          {
+            "OAuth2PasswordBearer": []
+          }
+        ],
+        "summary": "Get Words",
+        "tags": [
+          "Version 3"
+        ]
+      }
+    }
+  }
+}

--- a/test/test_openapi_contract.py
+++ b/test/test_openapi_contract.py
@@ -1,0 +1,70 @@
+"""v3 OpenAPI contract snapshot test — the v3 freeze guard (issue #756).
+
+Once v3 is frozen beside v4 (epic #842), the top risk is that an edit to
+*shared* code — especially the Pydantic schemas in ``models.py`` — silently
+changes frozen v3's wire contract. No other unit test catches "a required
+field was added / renamed / retyped." This test does: it compares the live
+``GET /openapi.json`` output against the committed baseline
+``test/snapshots/openapi_v3.json`` and fails on any difference.
+
+The test is **read-only** — it never writes the baseline. When v3 changes on
+purpose (or a FastAPI/Pydantic upgrade legitimately churns the generated
+schema), regenerate the baseline with::
+
+    python scripts/regen_openapi_snapshot.py   # or: make regen-openapi-snapshot
+
+and commit the diff. Strictness is the point: every change to the frozen v3
+surface gets a human decision in review.
+"""
+
+import difflib
+import json
+
+import pytest
+
+from scripts.regen_openapi_snapshot import (
+    OPENAPI_PATH,
+    SNAPSHOT_PATH,
+    dump_schema,
+    get_openapi_response,
+)
+
+_REGEN_HINT = (
+    "v3 OpenAPI contract changed. If this is an INTENTIONAL v3 change, "
+    "regenerate the baseline: python scripts/regen_openapi_snapshot.py "
+    "(or: make regen-openapi-snapshot). Otherwise you have broken the frozen "
+    "v3 contract (see epic #842)."
+)
+
+
+def test_openapi_contract_matches_baseline(client):
+    # Fetch through the same helper the regen script uses, so the test and the
+    # committed baseline are produced by identical code and cannot drift.
+    resp = get_openapi_response(client)
+    assert (
+        resp.status_code == 200
+    ), f"GET {OPENAPI_PATH} returned {resp.status_code}, expected 200"
+    actual = resp.json()
+
+    assert SNAPSHOT_PATH.exists(), (
+        f"Baseline snapshot missing at {SNAPSHOT_PATH}. Generate it with "
+        "python scripts/regen_openapi_snapshot.py (or: make "
+        "regen-openapi-snapshot)."
+    )
+    baseline = json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+    # Compare parsed objects (dict equality), so key ordering / whitespace in
+    # the baseline file can never cause a false failure.
+    if actual != baseline:
+        # Render the diff over both sides serialized identically to how the
+        # baseline is stored on disk, so the diff lines up with the committed
+        # file and is reviewable.
+        diff = "".join(
+            difflib.unified_diff(
+                dump_schema(baseline).splitlines(keepends=True),
+                dump_schema(actual).splitlines(keepends=True),
+                fromfile="baseline: test/snapshots/openapi_v3.json",
+                tofile="current:  GET /openapi.json",
+            )
+        )
+        pytest.fail(f"{_REGEN_HINT}\n\n{diff}")


### PR DESCRIPTION
## Summary

Implements #756 — the **v3 freeze guard** for the v3→v4 migration (epic #842).

Once v3 is frozen beside v4, the top risk is that an edit to *shared* code — especially the schemas in `models.py`, which #729 is about to split — silently changes frozen v3's wire contract. No existing unit test catches "a required field got added / renamed / retyped." This test is the CI mechanism that catches exactly that. It should land **before/alongside** the #729 `models.py` split so the split is proven to be a no-op on the v3 contract.

## What's in this PR (4 paths)

- **`test/snapshots/openapi_v3.json`** — committed baseline: the live `GET /openapi.json` output, pretty-printed (`indent=2, sort_keys=True`, trailing newline) so diffs are reviewable line-by-line in PRs.
- **`test/test_openapi_contract.py`** — read-only test. Fetches `/openapi.json` via the existing `client` fixture, asserts 200, compares the **parsed dict** against the baseline (dict equality, so key ordering / whitespace never causes a false failure). On mismatch it fails with an actionable regen message plus a `difflib.unified_diff`.
- **`scripts/regen_openapi_snapshot.py`** — no-args regeneration script. The test and script **share one fetch path** (`get_openapi_response`) and **one serializer** (`dump_schema`) so they can never drift.
- **`Makefile`** — `regen-openapi-snapshot` target for discoverability (no DB required).

## How to regenerate (intentional v3 changes only)

```
python scripts/regen_openapi_snapshot.py   # or: make regen-openapi-snapshot
```

The test **never** writes the baseline — regenerating is a deliberate, reviewable act.

## Verification

- ✅ `pytest test/test_openapi_contract.py` passes on this branch.
- ✅ Introducing a spurious required field in a `models.py` schema that v3 serializes (`VersionOut_v3`) makes the test **FAIL** with the exact message and a diff pinpointing the field. Reverted — not part of this PR.
- ✅ `python scripts/regen_openapi_snapshot.py` round-trips byte-identically; the test then passes with no manual editing.
- ✅ Collects cleanly alongside all 1175 tests; black / isort / flake8 (project ignore set) clean.

## Design note

`app.openapi` is **not** overridden — `my_schema()` populates `app.openapi_schema` at import, so the default handler serves the custom schema. The test/script deliberately snapshot the live endpoint (not `my_schema()` directly), so the baseline is exactly the wire contract clients receive.

## Known tradeoff

A FastAPI/Pydantic upgrade (#734) can legitimately churn the generated schema (e.g. the OpenAPI version string). That's acceptable: the reviewer regenerates the baseline via `scripts/regen_openapi_snapshot.py` and the diff documents the change. Strictness is the point — every diff to the frozen v3 surface gets a human decision.

## Scope

MVP is the full `/openapi.json` snapshot only. Per-endpoint response-body snapshots ("ideally key response shapes" in the issue) are left as a follow-up.

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)