### PR TITLE
feat(v4): scaffold /v4 opt-in surface beside frozen v3 (#824)

### DIFF
--- a/api_v4/meta_routes.py
+++ b/api_v4/meta_routes.py
@@ -5,6 +5,12 @@ import fastapi
 router = fastapi.APIRouter()
 
 
+# Register the bare (``/v4``) and trailing-slash (``/v4/``) forms on the same
+# handler so both return 200 directly. With only ``@router.get("/")`` the bare
+# form 307-redirects to ``/v4/``, which trips health-check probes and strict
+# clients that don't follow redirects. The bare form is hidden from the schema
+# so the OpenAPI surface still shows a single ``/v4/`` path.
+@router.get("", include_in_schema=False)
 @router.get("/")
 async def v4_root():
     """v4 API root — the stable signal that the ``/v4`` surface is mounted.

--- a/api_v4/meta_routes.py
+++ b/api_v4/meta_routes.py
@@ -1,0 +1,21 @@
+__version__ = "v4"
+
+import fastapi
+
+router = fastapi.APIRouter()
+
+
+@router.get("/")
+async def v4_root():
+    """v4 API root — the stable signal that the ``/v4`` surface is mounted.
+
+    v4 is released **beside** a frozen v3 as an opt-in surface (epic #842);
+    ``/latest`` deliberately stays pinned to v3. The individual v4 resources
+    are added under this prefix by the contract issues (#825-#831). Until then
+    this root is the only guaranteed ``/v4`` endpoint, so clients and health
+    checks have something to hit to confirm v4 is live.
+
+    ``status`` is ``"preview"`` while v4 is being built out; it becomes
+    ``"stable"`` when the contract is finalized.
+    """
+    return {"version": "v4", "status": "preview"}

--- a/app.py
+++ b/app.py
@@ -12,6 +12,7 @@ from agent_routes.v3.affix_routes import router as affix_router_v3
 from agent_routes.v3.agent_routes import router as agent_router_v3
 from agent_routes.v3.pivot_routes import router as pivot_router_v3
 from agent_routes.v3.tokenizer_routes import router as tokenizer_router_v3
+from api_v4.meta_routes import router as meta_router_v4
 from assessment_routes.v3.assessment_routes import router as assessment_router_v3
 from assessment_routes.v3.eflomal_routes import router as eflomal_router_v3
 from assessment_routes.v3.results_push_routes import router as results_write_router_v3
@@ -135,6 +136,16 @@ def configure_cors(app):
 
 
 def configure_routing(app):
+    # Versioning model (epic #842):
+    #   /v3     — frozen, fixes only. Guarded by the OpenAPI contract snapshot
+    #             test so any change to its wire surface needs a reviewed diff.
+    #   /latest — deliberately stays pinned to v3; it does NOT move to v4 when
+    #             v4 releases. The /latest -> /v4 flip is a separate, deferred
+    #             manual step with no committed date.
+    #   /v4     — new, opt-in surface released beside v3. Domain resources are
+    #             added under <domain>_routes/v4/ by the contract issues
+    #             (#825-#831); today it exposes only the /v4/ discovery root.
+    #   v1/v2   — removed as unused (#711).
     app.include_router(language_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(revision_router_v3, prefix="/v3", tags=["Version 3"])
     app.include_router(version_router_v3, prefix="/v3", tags=["Version 3"])
@@ -187,6 +198,10 @@ def configure_routing(app):
 
     app.include_router(security_router, prefix="/latest", tags=["Latest"])
     app.include_router(admin_router, prefix="/latest", tags=["Latest"])
+
+    # v4: opt-in surface beside frozen v3. Only the discovery root exists so
+    # far; contract issues (#825-#831) add domain routers under this prefix.
+    app.include_router(meta_router_v4, prefix="/v4", tags=["Version 4"])
 
     @app.get("/")
     async def read_root():

--- a/test/snapshots/openapi_v3.json
+++ b/test/snapshots/openapi_v3.json
@@ -26016,6 +26016,26 @@
           "Version 3"
         ]
       }
+    },
+    "/v4/": {
+      "get": {
+        "description": "v4 API root \u2014 the stable signal that the ``/v4`` surface is mounted.\n\nv4 is released **beside** a frozen v3 as an opt-in surface (epic #842);\n``/latest`` deliberately stays pinned to v3. The individual v4 resources\nare added under this prefix by the contract issues (#825-#831). Until then\nthis root is the only guaranteed ``/v4`` endpoint, so clients and health\nchecks have something to hit to confirm v4 is live.\n\n``status`` is ``\"preview\"`` while v4 is being built out; it becomes\n``\"stable\"`` when the contract is finalized.",
+        "operationId": "v4_root_v4__get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "V4 Root",
+        "tags": [
+          "Version 4"
+        ]
+      }
     }
   }
 }

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -43,6 +43,17 @@ def test_ready_endpoint(client):
     assert response.json() == {"status": "ready"}
 
 
+def test_v4_root_endpoint(client):
+    # The /v4 discovery root reports the preview status of the opt-in v4
+    # surface (epic #842, #824). Both the trailing-slash and bare forms are
+    # served directly with no 307 redirect (follow_redirects=False) so health
+    # checks and strict clients can hit either.
+    for path in ("/v4/", "/v4"):
+        response = client.get(path, follow_redirects=False)
+        assert response.status_code == 200, path
+        assert response.json() == {"version": "v4", "status": "preview"}
+
+
 def test_ready_endpoint_returns_503_when_db_unreachable(client, monkeypatch):
     # Force the engine.connect() call inside /ready to raise so we exercise
     # the failure path and confirm the 503 contract.

--- a/test/test_app_versioning.py
+++ b/test/test_app_versioning.py
@@ -47,3 +47,29 @@ def test_every_v3_route_is_also_exposed_under_latest():
         "every /v3 route must also be exposed under /latest; "
         f"missing from /latest: {sorted(missing)}"
     )
+
+
+def test_v4_surface_is_mounted():
+    """v4 is released beside v3 (epic #842, #824). Guard that the /v4 surface
+    exists so a lost include_router is caught, without pinning the exact set of
+    v4 routes (those grow as the contract issues land)."""
+    configured_app = fastapi.FastAPI()
+    app.configure(configured_app)
+
+    v4_routes = _routes_under(configured_app, "/v4")
+    assert ("GET", "/") in v4_routes, "expected the /v4/ discovery root to be mounted"
+
+
+def test_latest_is_pinned_to_v3_not_v4():
+    """The /latest -> /v4 flip is a deferred manual step (#824); until then
+    /latest must mirror v3 and must NOT pick up v4-only routes. This fails if
+    someone repoints /latest at v4 prematurely."""
+    configured_app = fastapi.FastAPI()
+    app.configure(configured_app)
+
+    v3_routes = _routes_under(configured_app, "/v3")
+    latest_routes = _routes_under(configured_app, "/latest")
+
+    # /latest is a superset of v3 (security/admin live only under /latest), but
+    # every v3 route must still be present -> /latest is anchored to v3.
+    assert v3_routes <= latest_routes

--- a/test/test_app_versioning.py
+++ b/test/test_app_versioning.py
@@ -68,8 +68,19 @@ def test_latest_is_pinned_to_v3_not_v4():
     app.configure(configured_app)
 
     v3_routes = _routes_under(configured_app, "/v3")
+    v4_routes = _routes_under(configured_app, "/v4")
     latest_routes = _routes_under(configured_app, "/latest")
 
-    # /latest is a superset of v3 (security/admin live only under /latest), but
+    # /latest is a superset of v3 (security/admin live only under /latest), so
     # every v3 route must still be present -> /latest is anchored to v3.
-    assert v3_routes <= latest_routes
+    missing = v3_routes - latest_routes
+    assert not missing, f"/latest dropped v3 routes: {sorted(missing)}"
+
+    # ...and no v4-only route may leak into /latest. A subset check alone only
+    # detects v3 routes disappearing; it is blind to v4 routes being *added*
+    # under /latest (the realistic partial/premature flip), so assert that too.
+    leaked = v4_routes & latest_routes
+    assert not leaked, (
+        "/latest picked up v4-only routes (premature /latest -> /v4 flip): "
+        f"{sorted(leaked)}"
+    )


### PR DESCRIPTION
Closes #824. Part of the AQuA API v4 migration (epic #842) — Phase 1 (non-breaking foundation).

## What

Stands up the `/v4` router tree as an **additive, opt-in** surface beside a frozen v3. This is the mechanical prerequisite that gives all subsequent v4 endpoint work (#825–#831) somewhere to live. No behavior changes for any existing client.

- **`api_v4/` package** with a single `GET /v4/` discovery root returning `{"version": "v4", "status": "preview"}` — makes the surface live, self-documenting, and testable before the contract issues add domain routers under `<domain>_routes/v4/`.
- **`app.py`** — mounts the v4 router at `/v4` (tag `Version 4`) and documents the versioning model in `configure_routing`: `/v3` frozen, `/latest` stays pinned to v3, v1/v2 removed (#711).
- **`test/test_app_versioning.py`** — two guards: `/v4` is mounted, and `/latest` stays anchored to v3 (catches a premature `/latest`→`/v4` flip).
- **`test/snapshots/openapi_v3.json`** — regenerated via `scripts/regen_openapi_snapshot.py`; only diff is the added `/v4/` path.

## Rollout invariants preserved

| Surface | State |
|---|---|
| `/v3` | frozen, unchanged |
| `/latest` | still pinned to v3 (the `/latest`→`/v4` flip is a deferred, separate step) |
| `/v4` | new, opt-in; discovery root only for now |
| `/v1`, `/v2` | removed (#711) |

## Not in scope

Actual v4 resources/contract (#825–#831) and the deferred `/latest`→`/v4` flip + v3 deprecation headers (#751).

## Note

The freeze-guard snapshot captures the whole schema, so v4 additions will churn it going forward — caveat + fix options filed on #756 (cross-ref #837).

## Test plan

- [x] `pytest test/test_app_versioning.py test/test_openapi_contract.py test/test_app.py test/test_layout.py` — 9 passed
- [x] `import app` clean; black/isort clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)