### PR TITLE
feat(v4): mount /v4 as isolated sub-app + shared snake_case base model

### DIFF
--- a/agent_routes/v4/__init__.py
+++ b/agent_routes/v4/__init__.py
@@ -1,0 +1,6 @@
+"""v4 agent routers (epic #842).
+
+Mirrors ``agent_routes/v3/``. Route modules added here are registered on the v4
+sub-application in :func:`api_v4.app.create_v4_app`. Intentionally empty until
+the per-domain contract issues (#825-#831) land their v4 routes.
+"""

--- a/api_v4/__init__.py
+++ b/api_v4/__init__.py
@@ -1,0 +1,13 @@
+"""The v4 API surface (epic #842).
+
+``api_v4`` owns everything specific to the ``/v4`` sub-application:
+
+* :mod:`api_v4.app` — the ``create_v4_app`` factory; the main app mounts its
+  result at ``/v4``.
+* :mod:`api_v4.meta_routes` — the ``/v4/`` discovery root.
+* :mod:`api_v4.schemas` — v4 Pydantic schemas (shared ``V4BaseModel`` base).
+
+Domain routers live under the ``<domain>_routes/v4/`` convention (mirroring
+``<domain>_routes/v3/``) and are registered on the sub-app in
+:func:`api_v4.app.create_v4_app`.
+"""

--- a/api_v4/app.py
+++ b/api_v4/app.py
@@ -1,0 +1,59 @@
+"""The ``/v4`` sub-application (issue #830, epic #842).
+
+v4 is mounted on the main app as its own :class:`fastapi.FastAPI` instance
+(``app.mount("/v4", ...)``) rather than a router with a ``/v4`` prefix. The
+point is **isolation**: later PRs register v4-only exception handlers, response
+classes, and dependencies on this sub-app with zero risk of altering the frozen
+v3 surface. Mounting also moves the v4 OpenAPI schema to ``/v4/openapi.json``
+(docs at ``/v4/docs``), so v4 no longer appears in the main app's schema.
+
+Domain routers follow the ``<domain>_routes/v4/`` convention (mirroring the
+existing ``<domain>_routes/v3/`` layout) and get registered in
+:func:`create_v4_app` as the contract issues (#825-#831) land them. Today only
+the meta/discovery router is wired up.
+
+Middleware note (verified, not assumed): a mounted sub-app still runs *inside*
+the parent app's middleware stack, so every ``/v4`` request already passes
+through the main app's ``LoggingMiddleware`` (which logs the request — including
+exception tracebacks, which propagate up through the mount) and its CORS layer.
+Consequently:
+
+* We do **not** add a second ``LoggingMiddleware`` here — it would emit a
+  duplicate log line for every ``/v4`` request while adding nothing.
+* We **do** re-apply CORS via the shared :func:`app.configure_cors` (passed in
+  to avoid a circular import). Re-applying is idempotent for the response header
+  (it is *set*, not appended, so no duplicate ``Access-Control-Allow-Origin``),
+  and it keeps v4's CORS policy co-located and self-contained so a future PR can
+  evolve it independently of v3.
+"""
+
+import fastapi
+
+from api_v4.meta_routes import router as meta_router
+
+
+def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
+    """Build the ``/v4`` sub-application.
+
+    ``configure_cors`` is injected (rather than imported) so this module never
+    imports ``app`` — ``app`` imports *this* factory, and forking the CORS logic
+    is exactly what the shared helper exists to prevent. The main app hands in
+    its own ``app.configure_cors`` so ``/v4`` and v3 share one allowlist policy.
+    """
+    v4_app = fastapi.FastAPI(
+        title="AQuA API — v4 (preview)",
+        version="v4",
+        description=(
+            "Version 4 of the AQuA API — the opt-in, standardized contract "
+            "released beside the frozen v3 surface (epic #842)."
+        ),
+    )
+
+    # Reuse the main app's CORS configuration verbatim (see module docstring).
+    configure_cors(v4_app)
+
+    # The meta/discovery router; its ``/`` becomes ``/v4/`` once mounted.
+    # Future v4 domain routers (<domain>_routes/v4/*) are included here too.
+    v4_app.include_router(meta_router)
+
+    return v4_app

--- a/api_v4/app.py
+++ b/api_v4/app.py
@@ -21,15 +21,50 @@ Consequently:
 * We do **not** add a second ``LoggingMiddleware`` here — it would emit a
   duplicate log line for every ``/v4`` request while adding nothing.
 * We **do** re-apply CORS via the shared :func:`app.configure_cors` (passed in
-  to avoid a circular import). Re-applying is idempotent for the response header
-  (it is *set*, not appended, so no duplicate ``Access-Control-Allow-Origin``),
-  and it keeps v4's CORS policy co-located and self-contained so a future PR can
-  evolve it independently of v3.
+  to avoid a circular import). Re-applying is idempotent for the simple-response
+  header (it is *set*, not appended, so no duplicate
+  ``Access-Control-Allow-Origin``) and keeps v4's CORS policy co-located.
+
+  Scope caveat (verified): re-applying CORS here does **not** let v4 evolve its
+  CORS policy fully independently of v3 today. Starlette's ``CORSMiddleware``
+  answers every preflight (``OPTIONS``) request by short-circuiting *before* the
+  wrapped app is called, and the parent app's CORS layer wraps the whole mount —
+  so all ``/v4`` preflight traffic is handled by the parent (v3) policy and the
+  sub-app's own CORS layer never sees it. For simple responses both layers run,
+  but the parent's is outermost and wins on any disagreement. It works cleanly
+  now only because the parent hands in the identical ``configure_cors``. Truly
+  divergent v4 CORS would require removing the parent CORS layer from the mount
+  path, not just changing this call.
+
+Unhandled-exception contract (see :func:`create_v4_app`): a mounted sub-app has
+its *own* Starlette ``ServerErrorMiddleware``, which by default sends a plaintext
+``Internal Server Error`` 500 — diverging from the JSON ``{"detail": ...}`` body
+``LoggingMiddleware`` produces for every other route. We register a handler on
+the sub-app to restore the shared JSON contract.
+
+Lifespan caveat: Starlette ``Mount`` only dispatches ``http``/``websocket``
+scopes, never ``lifespan`` — so a ``lifespan=`` passed to this sub-app would
+*silently never run*. A later PR that needs v4-only startup/shutdown resources
+must build them in the *parent* app's lifespan (and inject via ``app.state``) or
+have the parent lifespan explicitly enter this sub-app's lifespan context.
 """
 
 import fastapi
+from fastapi.responses import JSONResponse
 
 from api_v4.meta_routes import router as meta_router
+
+
+async def _v4_internal_error_handler(request, exc):
+    """Return the API-wide JSON 500 body for unhandled errors on ``/v4``.
+
+    Without this, the sub-app's default ``ServerErrorMiddleware`` sends a
+    plaintext ``Internal Server Error``, breaking the ``{"detail": ...}`` JSON
+    contract every other route honors (see module docstring). Registered for the
+    base ``Exception`` so it matches the parent ``LoggingMiddleware`` shape; the
+    exception still propagates up to ``LoggingMiddleware`` for logging.
+    """
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
 
 
 def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
@@ -48,6 +83,11 @@ def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
             "released beside the frozen v3 surface (epic #842)."
         ),
     )
+
+    # Preserve the JSON 500 contract on the isolated sub-app (see module
+    # docstring): the mount's own ServerErrorMiddleware would otherwise return a
+    # plaintext body for unhandled exceptions.
+    v4_app.add_exception_handler(Exception, _v4_internal_error_handler)
 
     # Reuse the main app's CORS configuration verbatim (see module docstring).
     configure_cors(v4_app)

--- a/api_v4/meta_routes.py
+++ b/api_v4/meta_routes.py
@@ -5,12 +5,21 @@ import fastapi
 router = fastapi.APIRouter()
 
 
-# Register the bare (``/v4``) and trailing-slash (``/v4/``) forms on the same
-# handler so both return 200 directly. With only ``@router.get("/")`` the bare
-# form 307-redirects to ``/v4/``, which trips health-check probes and strict
-# clients that don't follow redirects. The bare form is hidden from the schema
-# so the OpenAPI surface still shows a single ``/v4/`` path.
-@router.get("", include_in_schema=False)
+def v4_status_payload() -> dict:
+    """The v4 discovery payload — the single source of truth for what ``/v4``
+    reports about itself.
+
+    Shared so the mounted sub-app's ``/v4/`` root and the parent-app bare
+    ``/v4`` health-check shim (``app.py``) can never drift apart. See
+    :func:`v4_root` for the meaning of each field.
+    """
+    return {"version": "v4", "status": "preview"}
+
+
+# Only the trailing-slash root lives on the sub-app. The bare ``/v4`` form is
+# handled by a hidden route on the *parent* app (``app.py``): once ``/v4`` is a
+# mount, Starlette 307-redirects a request for the bare mount path to ``/v4/``
+# before it can reach this router, so a bare handler here would be dead code.
 @router.get("/")
 async def v4_root():
     """v4 API root — the stable signal that the ``/v4`` surface is mounted.
@@ -24,4 +33,4 @@ async def v4_root():
     ``status`` is ``"preview"`` while v4 is being built out; it becomes
     ``"stable"`` when the contract is finalized.
     """
-    return {"version": "v4", "status": "preview"}
+    return v4_status_payload()

--- a/api_v4/schemas/__init__.py
+++ b/api_v4/schemas/__init__.py
@@ -1,0 +1,12 @@
+"""v4 Pydantic schemas (issue #830, epic #842).
+
+Home for the v4 request/response models. Kept under ``api_v4/`` — deliberately
+*outside* the top-level ``schemas/`` package — so v4 schemas never leak into the
+legacy ``models`` shim (``schemas/__init__.py`` re-exports every ``schemas/*``
+module for the frozen v3 ``from models import X`` surface; v4 must stay off that
+surface).
+
+New v4 schemas subclass :class:`api_v4.schemas.base.V4BaseModel`. Per-domain
+modules (``api_v4/schemas/bible.py`` etc.) are added by the contract issues
+(#825-#831); this PR ships only the shared base.
+"""

--- a/api_v4/schemas/base.py
+++ b/api_v4/schemas/base.py
@@ -1,0 +1,56 @@
+"""Shared base model for all v4 schemas (issue #830, epic #842).
+
+v4 standardizes the wire contract on **snake_case** field names — the canonical
+name of a field *is* its snake_case Python attribute, and that is what v4 emits.
+This is the deliberate break from v3, whose schemas mixed conventions
+(``machineTranslation``, ``forwardTranslation``, ...). v3 stays frozen; v4 fixes
+the contract going forward.
+
+:class:`V4BaseModel` supplies only the config every v4 schema needs:
+
+* ``populate_by_name=True`` — a model can always be constructed (and validated)
+  using its canonical snake_case field name, *regardless* of any alias a field
+  later carries. This is what makes the per-domain migration safe: a field can
+  gain an alias for its legacy v3 name without breaking internal callers that
+  build the model by field name.
+
+Scope of this PR is the base infrastructure only. It deliberately does **not**
+migrate any real field names or attach deprecation aliases — that is per-domain
+work in the contract issues (#825-#831).
+
+Guidance for those later PRs (so snake_case stays canonical *on the wire*):
+accept a legacy v3 name as an *input-only* ``validation_alias`` rather than a
+plain ``alias``. FastAPI serializes responses with ``by_alias=True`` by default,
+so a plain ``alias`` would push the legacy name back onto the wire — the exact
+thing v4 is standardizing away from. ``validation_alias`` accepts the old name
+on input while serialization keeps emitting the snake_case field name. Example::
+
+    from pydantic import Field
+    from api_v4.schemas.base import V4BaseModel
+
+    class RevisionOut(V4BaseModel):
+        machine_translation: bool = Field(
+            default=False,
+            validation_alias="machineTranslation",  # accept legacy v3 input
+        )
+    # -> emits {"machine_translation": ...}; accepts either name on input.
+"""
+
+from pydantic import BaseModel, ConfigDict
+
+
+class V4BaseModel(BaseModel):
+    """Base class for every v4 request/response schema.
+
+    See the module docstring for the contract rationale. Subclass this instead
+    of ``pydantic.BaseModel`` directly so the whole v4 surface shares one
+    canonical-name / alias policy.
+    """
+
+    model_config = ConfigDict(
+        # Build/validate by the canonical snake_case field name even when a
+        # field also defines an alias (e.g. a legacy-v3-name deprecation alias
+        # added by a later per-domain PR). Without this, once a field has an
+        # alias, constructing the model by its Python field name would raise.
+        populate_by_name=True,
+    )

--- a/app.py
+++ b/app.py
@@ -12,7 +12,8 @@ from agent_routes.v3.affix_routes import router as affix_router_v3
 from agent_routes.v3.agent_routes import router as agent_router_v3
 from agent_routes.v3.pivot_routes import router as pivot_router_v3
 from agent_routes.v3.tokenizer_routes import router as tokenizer_router_v3
-from api_v4.meta_routes import router as meta_router_v4
+from api_v4.app import create_v4_app
+from api_v4.meta_routes import v4_status_payload
 from assessment_routes.v3.assessment_routes import router as assessment_router_v3
 from assessment_routes.v3.eflomal_routes import router as eflomal_router_v3
 from assessment_routes.v3.results_push_routes import router as results_write_router_v3
@@ -199,9 +200,25 @@ def configure_routing(app):
     app.include_router(security_router, prefix="/latest", tags=["Latest"])
     app.include_router(admin_router, prefix="/latest", tags=["Latest"])
 
-    # v4: opt-in surface beside frozen v3. Only the discovery root exists so
-    # far; contract issues (#825-#831) add domain routers under this prefix.
-    app.include_router(meta_router_v4, prefix="/v4", tags=["Version 4"])
+    # v4: opt-in surface beside frozen v3, mounted as an isolated sub-app so
+    # later PRs can register v4-only exception handlers / response behavior
+    # without any risk of touching v3 (issue #830). Mounting also moves the v4
+    # OpenAPI schema to /v4/openapi.json (docs at /v4/docs), so v4 no longer
+    # appears in the main app schema. See api_v4/app.py for the middleware
+    # rationale (CORS re-applied; LoggingMiddleware NOT duplicated — the parent
+    # stack already wraps the mount).
+    #
+    # Bare-/v4 health-check shim: once /v4 is a mount, Starlette 307-redirects
+    # the bare mount path (/v4 -> /v4/). The #824 scaffold deliberately served
+    # a non-redirecting 200 at bare /v4 for health-check probes and clients that
+    # don't follow redirects, so we preserve that here with an explicit,
+    # schema-hidden parent route (an exact-path route wins over the mount's
+    # redirect). It reuses the sub-app's discovery payload so the two can't drift.
+    @app.get("/v4", include_in_schema=False)
+    async def v4_root_bare():
+        return v4_status_payload()
+
+    app.mount("/v4", create_v4_app(configure_cors=configure_cors))
 
     @app.get("/")
     async def read_root():

--- a/assessment_routes/v4/__init__.py
+++ b/assessment_routes/v4/__init__.py
@@ -1,0 +1,6 @@
+"""v4 assessment routers (epic #842).
+
+Mirrors ``assessment_routes/v3/``. Route modules added here are registered on
+the v4 sub-application in :func:`api_v4.app.create_v4_app`. Intentionally empty
+until the per-domain contract issues (#825-#831) land their v4 routes.
+"""

--- a/bible_routes/v4/__init__.py
+++ b/bible_routes/v4/__init__.py
@@ -1,0 +1,6 @@
+"""v4 bible routers (epic #842).
+
+Mirrors ``bible_routes/v3/``. Route modules added here are registered on the v4
+sub-application in :func:`api_v4.app.create_v4_app`. Intentionally empty until
+the per-domain contract issues (#825-#831) land their v4 routes.
+"""

--- a/predict_routes/v4/__init__.py
+++ b/predict_routes/v4/__init__.py
@@ -1,0 +1,6 @@
+"""v4 predict routers (epic #842).
+
+Mirrors ``predict_routes/v3/``. Route modules added here are registered on the
+v4 sub-application in :func:`api_v4.app.create_v4_app`. Intentionally empty
+until the per-domain contract issues (#825-#831) land their v4 routes.
+"""

--- a/test/snapshots/openapi_v3.json
+++ b/test/snapshots/openapi_v3.json
@@ -26016,26 +26016,6 @@
           "Version 3"
         ]
       }
-    },
-    "/v4/": {
-      "get": {
-        "description": "v4 API root \u2014 the stable signal that the ``/v4`` surface is mounted.\n\nv4 is released **beside** a frozen v3 as an opt-in surface (epic #842);\n``/latest`` deliberately stays pinned to v3. The individual v4 resources\nare added under this prefix by the contract issues (#825-#831). Until then\nthis root is the only guaranteed ``/v4`` endpoint, so clients and health\nchecks have something to hit to confirm v4 is live.\n\n``status`` is ``\"preview\"`` while v4 is being built out; it becomes\n``\"stable\"`` when the contract is finalized.",
-        "operationId": "v4_root_v4__get",
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {}
-              }
-            },
-            "description": "Successful Response"
-          }
-        },
-        "summary": "V4 Root",
-        "tags": [
-          "Version 4"
-        ]
-      }
     }
   }
 }

--- a/test/test_app_versioning.py
+++ b/test/test_app_versioning.py
@@ -13,6 +13,7 @@ variable prefixes, or reformatted include_router calls.
 """
 
 import fastapi
+from starlette.routing import Mount
 
 import app
 
@@ -50,14 +51,39 @@ def test_every_v3_route_is_also_exposed_under_latest():
 
 
 def test_v4_surface_is_mounted():
-    """v4 is released beside v3 (epic #842, #824). Guard that the /v4 surface
-    exists so a lost include_router is caught, without pinning the exact set of
-    v4 routes (those grow as the contract issues land)."""
+    """v4 is released beside v3 (epic #842, #824) as an isolated sub-app
+    mounted at /v4 (#830). Guard that the mount exists and still exposes the
+    discovery root, so a lost mount is caught, without pinning the exact set of
+    v4 routes (those grow as the contract issues land).
+
+    A mount's internal routes are not in the *parent* app's route table (they
+    live on the sub-app), so this checks the mount directly rather than via
+    ``_routes_under``, which only sees the parent table.
+    """
     configured_app = fastapi.FastAPI()
     app.configure(configured_app)
 
-    v4_routes = _routes_under(configured_app, "/v4")
-    assert ("GET", "/") in v4_routes, "expected the /v4/ discovery root to be mounted"
+    v4_mount = next(
+        (
+            route
+            for route in configured_app.routes
+            if isinstance(route, Mount) and route.path == "/v4"
+        ),
+        None,
+    )
+    assert v4_mount is not None, "expected a sub-application mounted at /v4"
+
+    # The discovery root must exist inside the mounted sub-app. Its path is "/"
+    # on the sub-app (it becomes /v4/ externally).
+    sub_routes = {
+        (method, getattr(route, "path", None))
+        for route in v4_mount.routes
+        for method in (getattr(route, "methods", None) or [])
+    }
+    assert (
+        "GET",
+        "/",
+    ) in sub_routes, "expected the /v4/ discovery root inside the mounted sub-app"
 
 
 def test_latest_is_pinned_to_v3_not_v4():

--- a/test/test_app_versioning.py
+++ b/test/test_app_versioning.py
@@ -110,3 +110,18 @@ def test_latest_is_pinned_to_v3_not_v4():
         "/latest picked up v4-only routes (premature /latest -> /v4 flip): "
         f"{sorted(leaked)}"
     )
+
+    # Since #830, v4 is a mounted sub-app — its routes live inside the mount and
+    # do NOT appear in the parent route table above, so the `leaked` check can no
+    # longer see them. The realistic premature flip is now mounting the v4
+    # sub-app at /latest. /latest must stay include_router-based (mirroring v3),
+    # never a mount, so guard that directly.
+    latest_mounts = [
+        route
+        for route in configured_app.routes
+        if isinstance(route, Mount) and route.path == "/latest"
+    ]
+    assert not latest_mounts, (
+        "/latest must not be a mounted sub-app (premature /latest -> /v4 flip); "
+        "/latest stays pinned to v3 via include_router"
+    )

--- a/test/test_v4_base_model.py
+++ b/test/test_v4_base_model.py
@@ -1,0 +1,91 @@
+"""Unit tests for the shared v4 Pydantic base model (issue #830, epic #842).
+
+These primitives have no route consumer yet, so they are tested directly. The
+contract V4BaseModel must guarantee:
+
+* snake_case is the canonical field name and what gets serialized;
+* a model can be populated by its field name even when the field has an alias
+  (``populate_by_name=True``);
+* a field's alias still works for input and is available for serialization when
+  explicitly requested.
+
+The sample models below define an alias purely as a test fixture — this PR does
+NOT migrate any real field names or attach deprecation aliases (that is
+per-domain work in #825-#831).
+"""
+
+from pydantic import ConfigDict, Field
+
+from api_v4.schemas.base import V4BaseModel
+
+
+class _Sample(V4BaseModel):
+    # `machineTranslation` stands in for a legacy v3 name kept as an alias; the
+    # canonical field name is snake_case.
+    machine_translation: bool = Field(default=False, alias="machineTranslation")
+    forward_translation: int = 0
+
+
+def test_base_model_config_is_populate_by_name():
+    # The base contract other v4 schemas inherit.
+    assert V4BaseModel.model_config.get("populate_by_name") is True
+
+
+def test_populate_by_name_roundtrip():
+    # Construct using the canonical snake_case field name even though the field
+    # defines an alias. Without populate_by_name=True this raises.
+    m = _Sample(machine_translation=True, forward_translation=3)
+    assert m.machine_translation is True
+    assert m.forward_translation == 3
+
+
+def test_populate_by_alias():
+    # The alias remains a valid input key.
+    m = _Sample(machineTranslation=True)
+    assert m.machine_translation is True
+
+
+def test_model_validate_accepts_both_names():
+    assert _Sample.model_validate({"machine_translation": True}).machine_translation
+    assert _Sample.model_validate({"machineTranslation": True}).machine_translation
+
+
+def test_serializes_snake_case_by_default():
+    # Canonical wire form is snake_case: default dump uses the field name, not
+    # the alias.
+    dumped = _Sample(machine_translation=True).model_dump()
+    assert "machine_translation" in dumped
+    assert "machineTranslation" not in dumped
+    assert dumped["machine_translation"] is True
+
+
+def test_alias_available_when_explicitly_requested():
+    # by_alias=True still exposes the alias, so per-domain schemas can opt into
+    # alias serialization where the contract calls for it.
+    dumped = _Sample(machine_translation=True).model_dump(by_alias=True)
+    assert dumped["machineTranslation"] is True
+    assert "machine_translation" not in dumped
+
+
+def test_json_roundtrip_is_snake_case():
+    m = _Sample(machine_translation=True, forward_translation=5)
+    restored = _Sample.model_validate_json(m.model_dump_json())
+    assert restored.machine_translation is True
+    assert restored.forward_translation == 5
+
+
+def test_subclass_inherits_config_without_redeclaring():
+    # _Sample declares no model_config of its own, yet populate-by-name works
+    # (proven above) — i.e. the config is inherited. Assert that directly.
+    assert _Sample.model_config.get("populate_by_name") is True
+
+
+def test_subclass_can_extend_config():
+    # A subclass may add its own config (e.g. from_attributes for ORM reads)
+    # while keeping the inherited populate_by_name semantics.
+    class _Child(V4BaseModel):
+        model_config = ConfigDict(populate_by_name=True, from_attributes=True)
+        value: int = Field(alias="theValue")
+
+    assert _Child(value=1).value == 1
+    assert _Child.model_validate({"theValue": 2}).value == 2

--- a/test/test_v4_subapp.py
+++ b/test/test_v4_subapp.py
@@ -155,10 +155,14 @@ def test_v4_unhandled_exception_returns_json_500():
     app_module.configure(mock_app)
 
     v4_mount = next(
-        route
-        for route in mock_app.routes
-        if isinstance(route, Mount) and route.path == "/v4"
+        (
+            route
+            for route in mock_app.routes
+            if isinstance(route, Mount) and route.path == "/v4"
+        ),
+        None,
     )
+    assert v4_mount is not None, "expected a sub-application mounted at /v4"
 
     @v4_mount.app.get("/_boom_probe")
     async def _boom_probe():

--- a/test/test_v4_subapp.py
+++ b/test/test_v4_subapp.py
@@ -10,7 +10,11 @@ pin the observable consequences of that switch:
   mount otherwise 307-redirects the bare mount path);
 * v4 no longer appears in the *main* app OpenAPI schema (it moved to
   /v4/openapi.json);
-* CORS is applied correctly for /v4/* with no duplicate header.
+* CORS is applied correctly for /v4/* with no duplicate header;
+* unhandled exceptions on /v4 keep the API-wide JSON 500 contract (the mount's
+  own ServerErrorMiddleware would otherwise return a plaintext body);
+* unknown /v4 paths 404 and wrong methods 405 (the mount boundary behaves);
+* the bare-/v4 parent shim shares the mounted root's CORS policy.
 
 A fresh app is built per the module (mirroring test_app.py / test_cors.py) so
 these do not depend on the shared module-level app or the database.
@@ -19,6 +23,7 @@ these do not depend on the shared module-level app or the database.
 import fastapi
 import pytest
 from fastapi.testclient import TestClient
+from starlette.routing import Mount
 
 import app as app_module
 from api_v4.meta_routes import v4_status_payload
@@ -102,3 +107,66 @@ def test_cors_preflight_allowed_for_v4(client):
     )
     assert response.status_code == 200
     assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+
+
+def test_bare_v4_shares_cors_policy_with_mounted_root(client):
+    # The bare /v4 form is a parent-app shim, not part of the mount, so it only
+    # ever gets the parent's CORS layer. Pin that it still agrees with the
+    # mounted root: allowed origin echoed, disallowed origin omitted. Catches a
+    # future divergence where v4's CORS is changed on the mount but not the shim.
+    allowed = client.get(
+        "/v4", headers={"Origin": ALLOWED_ORIGIN}, follow_redirects=False
+    )
+    assert allowed.status_code == 200
+    assert allowed.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+
+    disallowed = client.get(
+        "/v4", headers={"Origin": DISALLOWED_ORIGIN}, follow_redirects=False
+    )
+    assert disallowed.status_code == 200
+    assert "access-control-allow-origin" not in {k.lower() for k in disallowed.headers}
+
+
+def test_v4_unknown_path_returns_404(client):
+    # The mount must not swallow unknown paths (e.g. an errant catch-all route on
+    # the sub-app). Guards the 404 boundary before real domain routers land.
+    response = client.get("/v4/does-not-exist", follow_redirects=False)
+    assert response.status_code == 404
+
+
+def test_v4_root_rejects_wrong_method(client):
+    # The discovery root is GET-only; other methods must 405, not 200/500.
+    response = client.post("/v4/", follow_redirects=False)
+    assert response.status_code == 405
+
+
+def test_v4_unhandled_exception_returns_json_500():
+    """A mounted sub-app has its own ServerErrorMiddleware that defaults to a
+    *plaintext* 500 body — diverging from the JSON ``{"detail": ...}`` contract
+    ``LoggingMiddleware`` produces for every other route. #830 registers a
+    handler on the sub-app to restore that contract; this guards it against a
+    regression (e.g. the handler being dropped).
+
+    A throwing probe route is attached to the mounted sub-app directly, and a
+    client with ``raise_server_exceptions=False`` inspects the wire response the
+    client would actually receive.
+    """
+    mock_app = fastapi.FastAPI()
+    app_module.configure(mock_app)
+
+    v4_mount = next(
+        route
+        for route in mock_app.routes
+        if isinstance(route, Mount) and route.path == "/v4"
+    )
+
+    @v4_mount.app.get("/_boom_probe")
+    async def _boom_probe():
+        raise ValueError("boom")
+
+    with TestClient(mock_app, raise_server_exceptions=False) as probe_client:
+        response = probe_client.get("/v4/_boom_probe")
+
+    assert response.status_code == 500
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {"detail": "Internal server error"}

--- a/test/test_v4_subapp.py
+++ b/test/test_v4_subapp.py
@@ -1,0 +1,104 @@
+"""Behavior tests for the mounted /v4 sub-application (issue #830, epic #842).
+
+v4 is mounted as its own FastAPI app at /v4 so later PRs can add v4-only
+exception handlers / response behavior without touching frozen v3. These tests
+pin the observable consequences of that switch:
+
+* the discovery root still answers at /v4/;
+* the bare /v4 form still returns a non-redirecting 200 (the #824 health-check
+  property, deliberately preserved via a parent-app shim because a Starlette
+  mount otherwise 307-redirects the bare mount path);
+* v4 no longer appears in the *main* app OpenAPI schema (it moved to
+  /v4/openapi.json);
+* CORS is applied correctly for /v4/* with no duplicate header.
+
+A fresh app is built per the module (mirroring test_app.py / test_cors.py) so
+these do not depend on the shared module-level app or the database.
+"""
+
+import fastapi
+import pytest
+from fastapi.testclient import TestClient
+
+import app as app_module
+from api_v4.meta_routes import v4_status_payload
+
+ALLOWED_ORIGIN = app_module.DEFAULT_ALLOWED_ORIGINS[0]
+DISALLOWED_ORIGIN = "https://not-allowed.invalid"
+
+
+@pytest.fixture
+def client():
+    mock_app = fastapi.FastAPI()
+    app_module.configure(mock_app)
+    with TestClient(mock_app) as client:
+        yield client
+
+
+def test_v4_root_through_subapp(client):
+    response = client.get("/v4/", follow_redirects=False)
+    assert response.status_code == 200
+    assert response.json() == v4_status_payload()
+    assert response.json() == {"version": "v4", "status": "preview"}
+
+
+def test_bare_v4_returns_200_without_redirect(client):
+    # Decision (#830): preserve the #824 non-redirecting health-check behavior.
+    # A Starlette mount would 307 /v4 -> /v4/; the parent-app shim prevents that.
+    response = client.get("/v4", follow_redirects=False)
+    assert response.status_code == 200, "bare /v4 must not 307-redirect"
+    assert "location" not in {k.lower() for k in response.headers}
+    assert response.json() == v4_status_payload()
+
+
+def test_v4_absent_from_main_openapi_schema(client):
+    # Mounting removes v4 from the main app schema (it moves to /v4/openapi.json).
+    schema = client.get("/openapi.json").json()
+    v4_paths = [p for p in schema["paths"] if p.startswith("/v4")]
+    assert v4_paths == [], f"v4 must not appear in the main schema, found: {v4_paths}"
+
+
+def test_v3_still_present_in_main_openapi_schema(client):
+    # The v4 change must not disturb the frozen v3 surface in the main schema.
+    schema = client.get("/openapi.json").json()
+    v3_paths = [p for p in schema["paths"] if p.startswith("/v3/")]
+    assert v3_paths, "expected /v3 paths to remain in the main schema"
+
+
+def test_subapp_serves_its_own_openapi(client):
+    # The sub-app exposes its own schema/docs under the mount.
+    resp = client.get("/v4/openapi.json")
+    assert resp.status_code == 200
+    subschema = resp.json()
+    assert "/" in subschema["paths"], "sub-app schema should contain its root path"
+
+
+def test_cors_applied_to_v4_for_allowed_origin(client):
+    response = client.get("/v4/", headers={"Origin": ALLOWED_ORIGIN})
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN
+    # No duplicate ACAO header despite CORS on both the parent and the sub-app.
+    acao = [
+        kv
+        for kv in response.headers.multi_items()
+        if kv[0].lower() == "access-control-allow-origin"
+    ]
+    assert len(acao) == 1, f"expected exactly one ACAO header, got {acao}"
+
+
+def test_cors_not_applied_to_v4_for_disallowed_origin(client):
+    response = client.get("/v4/", headers={"Origin": DISALLOWED_ORIGIN})
+    assert response.status_code == 200
+    assert "access-control-allow-origin" not in {k.lower() for k in response.headers}
+
+
+def test_cors_preflight_allowed_for_v4(client):
+    response = client.options(
+        "/v4/",
+        headers={
+            "Origin": ALLOWED_ORIGIN,
+            "Access-Control-Request-Method": "GET",
+        },
+    )
+    assert response.status_code == 200
+    assert response.headers.get("access-control-allow-origin") == ALLOWED_ORIGIN

--- a/train_routes/v4/__init__.py
+++ b/train_routes/v4/__init__.py
@@ -1,0 +1,6 @@
+"""v4 train routers (epic #842).
+
+Mirrors ``train_routes/v3/``. Route modules added here are registered on the v4
+sub-application in :func:`api_v4.app.create_v4_app`. Intentionally empty until
+the per-domain contract issues (#825-#831) land their v4 routes.
+"""


### PR DESCRIPTION
## What & why

First structural PR of the **v4 API migration** (epic #842). It lays the foundation every later v4 PR depends on, **without changing v3 on the wire**:

1. **`/v4` is now an isolated mounted sub-application** (`app.mount("/v4", create_v4_app(...))`) instead of a router with a `/v4` prefix. This lets later PRs register v4-only exception handlers / response behavior on the sub-app with zero risk of touching frozen v3.
2. **The `<domain>_routes/v4/` package convention** is established (mirrors the existing `<domain>_routes/v3/` layout) for `agent`, `assessment`, `bible`, `predict`, and `train`. Empty for now — domain routers land in the contract issues (#825–#831). The meta/discovery router is wired through the sub-app in `api_v4/app.py::create_v4_app`.
3. **Shared v4 Pydantic base model** — `api_v4/schemas/base.py::V4BaseModel` (snake_case canonical field names, `populate_by_name=True`). Kept under `api_v4/` — deliberately *outside* the top-level `schemas/` package — so v4 schemas never leak into the legacy `models` shim.

Addresses the **base-model portion of #830** — does **not** close #830 (the per-domain field-name migration and deprecation aliases are still to come).

## What is explicitly NOT in this PR
- No v3 behavior changes. No edits to `schemas/*.py`, the `models` shim, or any `*_routes/v3/` code. The v3/`latest` `include_router` lines in `app.py` are byte-for-byte unchanged (registration-loop refactor deferred).
- No real field-name migration / deprecation aliases yet (per-domain, later).
- No job envelope or pagination (PR 3). This PR adds a *minimal* v4 exception handler to preserve the JSON 500 contract (see below); the full standardized v4 error envelope is still PR 2.

## 👀 Reviewers: two gotcha decisions to focus on

### 1. v4 no longer appears in the main OpenAPI schema (intentional)
Mounting a sub-app removes its paths from the **main** app's `/openapi.json`; v4's schema/docs move to `/v4/openapi.json` and `/v4/docs`. The #756 contract-snapshot guard snapshots the **whole** main-app schema, so `/v4/` was previously in it. I regenerated the baseline (`make regen-openapi-snapshot`). **The snapshot diff is exactly the removal of the `/v4/` path block (20 deletions) and nothing else** — the v3 portion is byte-identical, which is the proof that the frozen v3 wire contract is unchanged.

### 2. Bare `/v4` health-check behavior — preserved (needs a nod)
The #824 scaffold deliberately served a **non-redirecting 200** at bare `/v4` (no trailing slash) for health-check probes and clients that don't follow redirects. A Starlette **mount 307-redirects the bare mount path** (`/v4` → `/v4/`) *before* the request reaches the sub-app, so that property would have regressed silently. I preserved it with an explicit, **schema-hidden** parent-app route at `/v4` that returns the same discovery payload (an exact-path route wins over the mount's redirect; `include_in_schema=False` keeps it out of the main schema). Behavior is unchanged from #824; the implementation moved from a hidden router route to a parent shim. Pinned by `test_bare_v4_returns_200_without_redirect`.

### Middleware re-attachment — a finding worth a look
The task called for re-attaching Logging + CORS to the sub-app. I verified empirically that **a mounted sub-app still runs inside the parent app's middleware stack**, so every `/v4` request already passes through the main app's `LoggingMiddleware` and CORS. Given that:

- **CORS is re-applied** on the sub-app via the shared `configure_cors` (injected to avoid a circular import; not forked). Re-applying is idempotent for the response header — verified **single** `Access-Control-Allow-Origin` for `/v4/*`, correct allowlist behavior, preflight OK — and it keeps v4's CORS policy co-located.
  - **Scope caveat (documented in `api_v4/app.py`):** re-applying CORS does *not* yet let v4 evolve its policy fully independently of v3. Starlette's `CORSMiddleware` short-circuits every preflight (`OPTIONS`) *before* the wrapped app runs, and the parent CORS layer wraps the whole mount — so all `/v4` preflight is answered by the parent (v3) policy. It works cleanly now only because the parent hands in the identical `configure_cors`. Truly divergent v4 CORS would require removing the parent CORS layer from the mount path.
- **`LoggingMiddleware` is deliberately NOT duplicated** on the sub-app. The parent's instance already logs every `/v4` request (and exception tracebacks — they propagate up through the mount), so a second instance would emit a **duplicate log line per request** while adding nothing. Confirmed single log line per `/v4` request.

If reviewers would rather have full middleware symmetry (accepting duplicate `/v4` logs) or drop the sub-app CORS entirely (relying on the parent), both are one-line changes — flagging so it's a conscious call.

### v4 unhandled-error format — now matches v3 (fixed in this PR)
Because v4 is its own app with its own error-handling stack, an **unhandled** exception would render as the sub-app's Starlette `ServerErrorMiddleware` plaintext 500 (`text/plain` "Internal Server Error") — diverging from v3's `{"detail": "Internal server error"}` (`application/json`) body produced by `LoggingMiddleware`. Rather than defer this to PR 2 and let every future v4 domain PR inherit a subtly-broken error contract, this PR registers a minimal `Exception` handler on the sub-app (`api_v4/app.py::_v4_internal_error_handler`) that restores the shared JSON 500 shape. The exception still propagates up to `LoggingMiddleware` for logging. Pinned by `test_v4_unhandled_exception_returns_json_500`. The *full* standardized v4 error envelope (structured error codes etc.) remains PR 2 work; this only preserves the existing JSON contract. Sensitive-path log redaction is unaffected — the parent `LoggingMiddleware` still sees the full `/v4/...` path, so a future `/v4/token` is redacted like v3.

## Tests
New/updated (these primitives have no route consumer yet, so they're tested directly):
- `test/test_v4_base_model.py` — snake_case serialization, `populate_by_name` round-trip, alias input/output behavior, JSON round-trip.
- `test/test_v4_subapp.py` — `/v4/` discovery payload, bare-`/v4` non-redirect, v4 absent from main schema / v3 still present, sub-app serves its own OpenAPI, CORS on `/v4/*` (allowed/disallowed/preflight, single header), **JSON 500 contract, unknown-path 404, wrong-method 405, bare-`/v4` CORS parity**.
- `test/test_app_versioning.py::test_v4_surface_is_mounted` — updated to check the **mount** + the discovery root inside the sub-app (the sub-app's routes are no longer in the parent route table).
- `test/test_app_versioning.py::test_latest_is_pinned_to_v3_not_v4` — strengthened: since v4's routes now live inside the mount (invisible to parent route-table introspection), it additionally asserts `/latest` is never itself a mounted sub-app, which is the realistic shape of a premature `/latest`→v4 flip.
- `test/snapshots/openapi_v3.json` — regenerated (v4 removed; v3 identical).

Refs: epic #842, #830 (base-model portion; not closed), builds on #824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
