### PR TITLE
ci: smoke-test the built image before pushing (#876)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,12 @@ jobs:
         REGISTRY: ${{ env.AWS_REGISTRY }}
         IMAGENAME: ${{ env.IMAGE_NAME }}
 
+    - name: Smoke-test built image
+      run: make smoke-test
+      env:
+        REGISTRY: ${{ env.AWS_REGISTRY }}
+        IMAGENAME: ${{ env.IMAGE_NAME }}
+
     - name: Test API
       env:
         MODAL_WEBHOOK_TOKEN: ${{ secrets.MODAL_WEBHOOK_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,11 @@ jobs:
       env:
         REGISTRY: ${{ secrets.AWS_REGISTRY }}
 
+    - name: Smoke-test built image
+      run: make smoke-test
+      env:
+        REGISTRY: ${{ secrets.AWS_REGISTRY }}
+
     - name: Test API
       env:
         MODAL_WEBHOOK_TOKEN: ${{ secrets.MODAL_WEBHOOK_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
         REGISTRY: ${{ env.AWS_REGISTRY }}
         IMAGENAME: ${{ env.IMAGE_NAME }}
 
+    - name: Smoke-test built image
+      run: make smoke-test
+      env:
+        REGISTRY: ${{ env.AWS_REGISTRY }}
+        IMAGENAME: ${{ env.IMAGE_NAME }}
+
     - name: Test API
       env:
         MODAL_WEBHOOK_TOKEN: ${{ secrets.MODAL_WEBHOOK_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,27 @@ build-local:
 build-actions:
 	docker build --force-rm=true -t ${REGISTRY}/${IMAGENAME}:latest .
 
+# Boot the freshly built :latest image and verify it serves /health before we
+# push it (issue #876). Catches image-only breakage — a missing COPY/ADD, a bad
+# ENV PATH, an import error in the shipped layout — that the source-tree `make
+# test` can't see because it runs against the host checkout, not the container.
+# /health is a dependency-free liveness probe, so dummy AQUA_DB/SECRET_KEY (both
+# required at import) are enough to prove the app actually booted.
+smoke-test:
+	docker rm -f aqua-smoke >/dev/null 2>&1 || true
+	docker run -d --name aqua-smoke \
+		-e AQUA_DB="postgresql+asyncpg://smoke:smoke@localhost:5432/smoke" \
+		-e SECRET_KEY="smoke-test-key" \
+		${REGISTRY}/${IMAGENAME}:latest
+	@ok=0; \
+	for i in $$(seq 1 30); do \
+		if docker exec aqua-smoke curl -fsS http://localhost:8000/health; then echo " /health OK"; ok=1; break; fi; \
+		sleep 2; \
+	done; \
+	docker logs aqua-smoke; \
+	docker rm -f aqua-smoke >/dev/null 2>&1 || true; \
+	if [ "$$ok" != "1" ]; then echo "Smoke test FAILED: /health did not return 200"; exit 1; fi
+
 setup-pgvector:
 	@echo "Setting up pgvector extension..."
 	@docker exec -i $$(docker compose ps -q db) psql -U dbuser -d dbname -c "CREATE EXTENSION IF NOT EXISTS vector;" || echo "pgvector extension setup completed"

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,11 @@ smoke-test:
 	docker run -d --name aqua-smoke \
 		-e AQUA_DB="postgresql+asyncpg://smoke:smoke@localhost:5432/smoke" \
 		-e SECRET_KEY="smoke-test-key" \
-		${REGISTRY}/${IMAGENAME}:latest
+		${REGISTRY}/${IMAGENAME}:latest \
+		|| { echo "Smoke test FAILED: container did not start"; docker rm -f aqua-smoke >/dev/null 2>&1 || true; exit 1; }
 	@ok=0; \
 	for i in $$(seq 1 30); do \
-		if docker exec aqua-smoke curl -fsS http://localhost:8000/health; then echo " /health OK"; ok=1; break; fi; \
+		if docker exec aqua-smoke curl -fsS --connect-timeout 2 --max-time 5 http://localhost:8000/health; then echo " /health OK"; ok=1; break; fi; \
 		sleep 2; \
 	done; \
 	docker logs aqua-smoke; \

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ smoke-test:
 		if docker exec aqua-smoke curl -fsS --connect-timeout 2 --max-time 5 http://localhost:8000/health; then echo " /health OK"; ok=1; break; fi; \
 		sleep 2; \
 	done; \
-	docker logs aqua-smoke; \
+	if [ "$$ok" != "1" ]; then echo "Smoke test FAILED: /health did not return 200 within timeout; container logs follow:"; docker logs aqua-smoke; fi; \
 	docker rm -f aqua-smoke >/dev/null 2>&1 || true; \
-	if [ "$$ok" != "1" ]; then echo "Smoke test FAILED: /health did not return 200"; exit 1; fi
+	if [ "$$ok" != "1" ]; then exit 1; fi
 
 setup-pgvector:
 	@echo "Setting up pgvector extension..."


### PR DESCRIPTION
## What this does

CI builds the Docker image but **never runs it** — the `Test API` step runs `pytest` against the host checkout, not the container. Image-only breakage (a missing `COPY`/`ADD`, a bad `ENV PATH`, an import error in the shipped layout) builds clean, passes every test, pushes to ECR, and only fails at container boot in prod.

This is not hypothetical: it forced fixup commit `3a659467` ("copy schemas/ and api_v4/ into the image") on the uv-build promotion (#875), where host `make test` stayed green while the built image would have failed to import every v3 route at boot.

## Change

- New `make smoke-test` target: boots the freshly built `:latest` image and verifies it serves `/health` (a dependency-free liveness probe, so dummy `AQUA_DB`/`SECRET_KEY` are enough to prove the app actually booted). Curl runs **inside** the container, so there's no host-port conflict.
- Wired into all three workflows (`pr.yml`, `main.yml`, `release.yml`) between **Build API** and **Test API**, so image-layout breakage fails CI before the ECR push — on PRs as well as on main/release.

## Test plan

- [x] Built the image locally (`make build-local`) and ran `make smoke-test` — container booted all 8 workers, `/health` returned `{"status":"ok"}` 200, `make` exited 0. The retry loop correctly rode out the ~2s startup before the first successful probe.
- [x] YAML validated for all three workflows.
- [ ] Observe the smoke-test step run green in this PR's own CI.

Fixes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)