### PR TITLE
ci(docker): boot the built image and probe it before deploy (#876)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,12 @@ jobs:
         REGISTRY: ${{ env.AWS_REGISTRY }}
         IMAGENAME: ${{ env.IMAGE_NAME }}
 
+    - name: Smoke-test image (boot container, probe /health + /v4)
+      run: make smoke-test
+      env:
+        REGISTRY: ${{ env.AWS_REGISTRY }}
+        IMAGENAME: ${{ env.IMAGE_NAME }}
+
     - name: Test API
       env:
         MODAL_WEBHOOK_TOKEN: ${{ secrets.MODAL_WEBHOOK_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,6 +41,11 @@ jobs:
       env:
         REGISTRY: ${{ secrets.AWS_REGISTRY }}
 
+    - name: Smoke-test image (boot container, probe /health + /v4)
+      run: make smoke-test
+      env:
+        REGISTRY: ${{ secrets.AWS_REGISTRY }}
+
     - name: Test API
       env:
         MODAL_WEBHOOK_TOKEN: ${{ secrets.MODAL_WEBHOOK_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
         REGISTRY: ${{ env.AWS_REGISTRY }}
         IMAGENAME: ${{ env.IMAGE_NAME }}
 
+    - name: Smoke-test image (boot container, probe /health + /v4)
+      run: make smoke-test
+      env:
+        REGISTRY: ${{ env.AWS_REGISTRY }}
+        IMAGENAME: ${{ env.IMAGE_NAME }}
+
     - name: Test API
       env:
         MODAL_WEBHOOK_TOKEN: ${{ secrets.MODAL_WEBHOOK_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,14 @@ build-local:
 build-actions:
 	docker build --force-rm=true -t ${REGISTRY}/${IMAGENAME}:latest .
 
+# Boot the freshly built image and probe it, so an image-only failure (a missing
+# COPY, an unimportable module, a broken CMD) fails the build instead of shipping
+# silently. CI otherwise only builds the image and tests the source TREE, never
+# the container itself. Requires the same REGISTRY/IMAGENAME used for the build.
+# See scripts/smoke_test.sh and issue #876.
+smoke-test:
+	@REGISTRY="${REGISTRY}" IMAGENAME="${IMAGENAME}" bash ./scripts/smoke_test.sh
+
 setup-pgvector:
 	@echo "Setting up pgvector extension..."
 	@docker exec -i $$(docker compose ps -q db) psql -U dbuser -d dbname -c "CREATE EXTENSION IF NOT EXISTS vector;" || echo "pgvector extension setup completed"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -41,12 +41,28 @@ dump_logs_and_fail() {
 # Clear any leftover container from a previous local run (CI runners are fresh).
 cleanup
 
+# Fail fast if the locally built image is missing, and never fall back to a
+# remote pull. The whole point is to test the image we JUST built; a stale
+# same-tag image in ECR (from a prior deploy) could otherwise be pulled and
+# smoke-tested instead, giving a false green. The pre-flight inspect gives a
+# clear, actionable message; --pull=never enforces the no-pull guarantee on
+# `docker run` even if the tag drifts past the check.
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "ERROR: image '$IMAGE' not found locally -- build it first (make build-actions)." >&2
+  echo "       REGISTRY/IMAGENAME must match the build step." >&2
+  exit 1
+fi
+
 echo "Booting $IMAGE ..."
-docker run -d --name "$CONTAINER" \
+if ! docker run -d --name "$CONTAINER" --pull=never \
   -e AQUA_DB="postgresql+asyncpg://smoke:smoke@127.0.0.1:5432/smoke" \
   -e SECRET_KEY="smoke-test-secret" \
   -p "${PORT}:8000" \
-  "$IMAGE" >/dev/null
+  "$IMAGE" >/dev/null; then
+  echo "ERROR: 'docker run' failed to start the container (see docker output above)." >&2
+  echo "       Common causes: host port ${PORT} already in use, or a daemon error." >&2
+  exit 1
+fi
 
 # Poll liveness until the app is serving (the 8 uvicorn workers need a moment
 # to import the app and bind). 30 x 2s = 60s ceiling.

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Boot the built Docker image the way the container starts in production and
+# probe it, so an image-only failure (a missing COPY, an unimportable module, a
+# broken CMD) fails the build instead of shipping silently.
+#
+# WHY THIS EXISTS (issue #876): CI builds the image (`make build-actions`) and
+# runs the test suite against the source TREE (`make test` -> pytest with
+# PYTHONPATH=$PWD), but never boots the image itself -- so the container
+# filesystem is never exercised by CI. The regression that motivated this:
+# schemas/ and api_v4/ were absent from the Dockerfile COPY set, so
+# `uvicorn app:app` died at container start with ModuleNotFoundError while every
+# CI check stayed green (fixed in 3a65946). Each v4 contract issue (#825-#831)
+# adds new top-level modules imported at ASGI load, so this is a recurring class
+# of bug, not a one-off.
+#
+# Dummy AQUA_DB/SECRET_KEY satisfy the fail-fast boot validation (config.py and
+# security_routes.utilities reject a missing/empty value) WITHOUT a live
+# database: SQLAlchemy engine creation is lazy, so /health (which touches
+# nothing external) serves regardless. We probe /health (liveness) and /v4
+# (proves the mounted sub-app and the new top-level packages import at ASGI
+# load -- the exact regression class above). We deliberately do NOT probe /ready
+# (it opens a real DB connection) since this test runs without a database.
+set -euo pipefail
+
+IMAGE="${REGISTRY:-docker-local}/${IMAGENAME:-aqua-api-dev}:latest"
+CONTAINER="aqua-smoke"
+PORT="${SMOKE_PORT:-8000}"
+
+cleanup() {
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+dump_logs_and_fail() {
+  echo "ERROR: $1" >&2
+  echo "----- docker logs $CONTAINER -----" >&2
+  docker logs "$CONTAINER" >&2 || true
+  exit 1
+}
+
+# Clear any leftover container from a previous local run (CI runners are fresh).
+cleanup
+
+echo "Booting $IMAGE ..."
+docker run -d --name "$CONTAINER" \
+  -e AQUA_DB="postgresql+asyncpg://smoke:smoke@127.0.0.1:5432/smoke" \
+  -e SECRET_KEY="smoke-test-secret" \
+  -p "${PORT}:8000" \
+  "$IMAGE" >/dev/null
+
+# Poll liveness until the app is serving (the 8 uvicorn workers need a moment
+# to import the app and bind). 30 x 2s = 60s ceiling.
+echo "Waiting for /health ..."
+for i in $(seq 1 30); do
+  if curl -fsS "http://localhost:${PORT}/health" >/dev/null 2>&1; then
+    echo "Container is live."
+    break
+  fi
+  if ! docker ps -q --filter "name=^${CONTAINER}$" | grep -q .; then
+    dump_logs_and_fail "container exited before serving /health"
+  fi
+  if [ "$i" -eq 30 ]; then
+    dump_logs_and_fail "container did not serve /health within 60s"
+  fi
+  sleep 2
+done
+
+echo "GET /health"
+curl -fsS "http://localhost:${PORT}/health" || dump_logs_and_fail "/health did not return success"
+echo
+
+echo "GET /v4"
+curl -fsS "http://localhost:${PORT}/v4" || dump_logs_and_fail "/v4 did not return success (v4 sub-app failed to mount?)"
+echo
+
+echo "Smoke test passed."


### PR DESCRIPTION
## Summary

Closes #876.

CI builds the Docker image (`make build-actions`) and runs the test suite against the source **tree** (`make test` → `pytest` with `PYTHONPATH=$PWD`), but never boots the image itself — so the container filesystem is never exercised by CI, and an **image-only failure ships green**.

This is not hypothetical: commit `3a65946` on `main` fixed a Dockerfile that omitted `schemas/` and `api_v4/` from its COPY set. That crashed `uvicorn app:app` at container start with `ModuleNotFoundError` while every CI check passed; it was caught only by manual verification. Each v4 contract issue (#825–#831) adds new top-level modules imported at ASGI load, so this is a **recurring class of bug** — worth closing now, as the last piece of v4 groundwork, before v4 code starts landing.

## What this does

- Adds a `smoke-test` make target backed by `scripts/smoke_test.sh` that:
  - boots the freshly built image with **dummy** `AQUA_DB`/`SECRET_KEY` — enough to satisfy the fail-fast boot validation (`config.py`, `security_routes.utilities`); SQLAlchemy engine creation is lazy, so **no live DB is required**;
  - probes **`/health`** (liveness, no external deps) and **`/v4`** (proves the mounted sub-app and the split-out `schemas/` + `api_v4/` packages import at ASGI load — the exact regression class above);
  - on failure, dumps `docker logs` and exits non-zero. It deliberately does **not** probe `/ready` (that opens a real DB connection).
- Wires `make smoke-test` into all three workflows, immediately after the build:
  - **`pr.yml`** — the pre-merge gate (this is what would have caught `3a65946` before merge);
  - **`main.yml`** — staging deploy;
  - **`release.yml`** — prod deploy.

## Scope

CI/build safety net only. No application code changes; the v3 wire surface is untouched (and still guarded by the OpenAPI contract snapshot from #756). Migrations-in-deploy (#719) is a separate concern and out of scope.

## Verification

Ran end-to-end locally against a real build:

- **Good image** → exit 0; `/health` → `{"status":"ok"}`, `/v4` → `{"version":"v4","status":"preview"}`.
- **Broken image** (rebuilt without the `schemas/` COPY, reproducing the pre-`3a65946` bug) → exit 1, with the exact container traceback surfaced:
  ```
  File "/app/models.py", line 15, in <module>
      from schemas import *  # noqa: F401,F403
  ModuleNotFoundError: No module named 'schemas'
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)