### PR TITLE
feat(v4): structured error contract + global exception handlers (#828)

### DIFF
--- a/api_v4/app.py
+++ b/api_v4/app.py
@@ -36,11 +36,17 @@ Consequently:
   divergent v4 CORS would require removing the parent CORS layer from the mount
   path, not just changing this call.
 
-Unhandled-exception contract (see :func:`create_v4_app`): a mounted sub-app has
-its *own* Starlette ``ServerErrorMiddleware``, which by default sends a plaintext
-``Internal Server Error`` 500 — diverging from the JSON ``{"detail": ...}`` body
-``LoggingMiddleware`` produces for every other route. We register a handler on
-the sub-app to restore the shared JSON contract.
+Error contract (see :func:`create_v4_app` and :mod:`api_v4.errors`): the v4
+sub-app registers its own structured-error handlers via
+:func:`api_v4.errors.register_exception_handlers`, emitting the
+``{"error": {"code", "message", "details"}}`` envelope (issue #828) for domain
+errors, ``HTTPException``, validation errors, and uncaught exceptions. This
+deliberately diverges from the frozen-v3 ``{"detail": ...}`` body — v4 clients
+branch on the stable ``code``. The catch-all 500 handler returns only a generic
+body; the sub-app's own ``ServerErrorMiddleware`` re-raises the exception after
+sending it, so the traceback still reaches the parent ``LoggingMiddleware`` for
+logging (never the client). Without any handler the mount's ``ServerErrorMiddleware``
+would send a plaintext ``Internal Server Error`` 500 instead.
 
 Lifespan caveat: Starlette ``Mount`` only dispatches ``http``/``websocket``
 scopes, never ``lifespan`` — so a ``lifespan=`` passed to this sub-app would
@@ -50,21 +56,9 @@ have the parent lifespan explicitly enter this sub-app's lifespan context.
 """
 
 import fastapi
-from fastapi.responses import JSONResponse
 
+from api_v4.errors import register_exception_handlers
 from api_v4.meta_routes import router as meta_router
-
-
-async def _v4_internal_error_handler(request, exc):
-    """Return the API-wide JSON 500 body for unhandled errors on ``/v4``.
-
-    Without this, the sub-app's default ``ServerErrorMiddleware`` sends a
-    plaintext ``Internal Server Error``, breaking the ``{"detail": ...}`` JSON
-    contract every other route honors (see module docstring). Registered for the
-    base ``Exception`` so it matches the parent ``LoggingMiddleware`` shape; the
-    exception still propagates up to ``LoggingMiddleware`` for logging.
-    """
-    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
 
 
 def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
@@ -84,10 +78,11 @@ def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
         ),
     )
 
-    # Preserve the JSON 500 contract on the isolated sub-app (see module
-    # docstring): the mount's own ServerErrorMiddleware would otherwise return a
-    # plaintext body for unhandled exceptions.
-    v4_app.add_exception_handler(Exception, _v4_internal_error_handler)
+    # Register the v4 structured-error contract (issue #828): shapes domain
+    # errors, HTTPException, validation errors, and uncaught exceptions into the
+    # {"error": {...}} envelope on this isolated sub-app. See api_v4/errors.py for
+    # the envelope and the re-raise-for-logging behavior of the 500 handler.
+    register_exception_handlers(v4_app)
 
     # Reuse the main app's CORS configuration verbatim (see module docstring).
     configure_cors(v4_app)

--- a/api_v4/errors.py
+++ b/api_v4/errors.py
@@ -1,0 +1,233 @@
+"""Structured error contract and global exception handlers for /v4 (issue #828,
+epic #842).
+
+Every error leaving the ``/v4`` sub-app is shaped into one envelope so clients
+branch on a stable machine ``code`` instead of parsing free-text messages, and so
+server internals (tracebacks, exception args) never reach the wire::
+
+    {
+      "error": {
+        "code": "REVISION_NOT_FOUND",
+        "message": "Revision 42 does not exist.",
+        "details": { "revision_id": 42 }
+      }
+    }
+
+``details`` is optional and omitted when absent (see ``exclude_none`` below), so a
+plain error is just ``{"error": {"code": ..., "message": ...}}``.
+
+:func:`register_exception_handlers` wires four handlers onto the sub-app:
+
+* :class:`V4APIError` — the exception v4 endpoints raise for domain errors. Its
+  own ``status_code`` / ``code`` / ``message`` / ``details`` pass straight
+  through. This is the *only* sanctioned way for a v4 endpoint to signal a 4xx.
+* ``starlette.exceptions.HTTPException`` — also catches ``fastapi.HTTPException``
+  (a subclass). Preserves ``exc.status_code``, derives ``code`` from the status
+  name (404 -> ``NOT_FOUND``, 401 -> ``UNAUTHORIZED``), uses ``exc.detail`` as the
+  message, and re-emits ``exc.headers`` (e.g. ``WWW-Authenticate`` on a 401).
+* ``fastapi.exceptions.RequestValidationError`` — HTTP 422,
+  ``code="VALIDATION_ERROR"``, with the validation errors under
+  ``details.errors`` (run through ``jsonable_encoder`` first — ``exc.errors()``
+  can contain non-JSON-serializable objects such as ``ValueError`` instances).
+* ``Exception`` — the catch-all. HTTP 500, ``code="INTERNAL_ERROR"`` and a fixed,
+  generic message; the exception's own text, args, and traceback are never put in
+  the body.
+
+Re-raise-for-logging (do not "fix" this): the ``Exception`` handler only
+*returns* the clean 500 body. The sub-app's own ``ServerErrorMiddleware`` is what
+calls this handler, sends its response, and *then re-raises the exception* — which
+propagates up through the mount to the parent app's ``LoggingMiddleware``
+(``middleware.py``), which logs the traceback. So the client gets clean JSON and
+the traceback still lands in the logs. The handler must therefore neither suppress
+the exception (impossible from here anyway — the re-raise is in the middleware)
+nor try to log it itself (that would double-log). Registering the catch-all on the
+base ``Exception`` is what routes it to ``ServerErrorMiddleware`` in the first
+place; moving it to a status-code handler would break the re-raise.
+"""
+
+from __future__ import annotations
+
+import http
+
+import fastapi
+from fastapi import status
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from api_v4.schemas.base import V4BaseModel
+
+
+class V4APIError(Exception):
+    """Domain error raised by v4 endpoints, carrying the full error envelope.
+
+    Raising this is how a v4 endpoint reports an expected 4xx (a missing
+    resource, a conflict, invalid input the framework can't catch). The registered
+    handler turns it into the structured body verbatim, so endpoints never build
+    error responses by hand.
+
+    ``details`` is an optional, JSON-serializable dict of machine-readable context
+    (e.g. ``{"revision_id": 42}``) — never free-form prose, which belongs in
+    ``message``.
+    """
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        code: str,
+        message: str,
+        details: dict | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.details = details
+        super().__init__(message)
+
+
+class V4ErrorDetail(V4BaseModel):
+    """The inner object of the v4 error envelope (the value of ``error``)."""
+
+    code: str
+    message: str
+    details: dict | None = None
+
+
+class V4ErrorResponse(V4BaseModel):
+    """The v4 error envelope — the response body for every v4 error."""
+
+    error: V4ErrorDetail
+
+
+def _error_response(
+    *,
+    status_code: int,
+    code: str,
+    message: str,
+    details: dict | None = None,
+    headers: dict | None = None,
+) -> JSONResponse:
+    """Build the JSON error envelope response.
+
+    The body is dumped from :class:`V4ErrorResponse` (not a hand-built dict) so the
+    wire shape can never drift from the declared schema. ``exclude_none`` drops
+    ``details`` when it is absent, keeping plain errors compact; it only affects
+    model fields, so ``None`` values *inside* a supplied ``details`` dict are kept.
+
+    ``details`` is run through ``jsonable_encoder`` first: a domain
+    :class:`V4APIError` may put arbitrary objects (sets, dates, even exception
+    instances) in it, and ``model_dump(mode="json")`` *raises* on a truly unknown
+    type. That exception would escape this handler and get reshaped by the
+    catch-all into a generic 500 — silently downgrading the intended 4xx and
+    burying its ``code``/``message`` (the reshaped 500 does not chain the original
+    error, so logs show only the serialization failure). Coercing up front turns
+    that landmine into a normal serialization. ``jsonable_encoder(None)`` is
+    ``None``, so absent details still drop out via ``exclude_none``.
+    """
+    payload = V4ErrorResponse(
+        error=V4ErrorDetail(
+            code=code, message=message, details=jsonable_encoder(details)
+        )
+    )
+    return JSONResponse(
+        status_code=status_code,
+        content=payload.model_dump(mode="json", exclude_none=True),
+        headers=headers,
+    )
+
+
+def _code_from_status(status_code: int) -> str:
+    """Derive a stable ``code`` from an HTTP status (404 -> ``NOT_FOUND``).
+
+    Falls back to ``HTTP_<n>`` for any non-standard status so the handler never
+    itself raises on an unusual ``exc.status_code``.
+    """
+    try:
+        return http.HTTPStatus(status_code).name
+    except ValueError:
+        return f"HTTP_{status_code}"
+
+
+def _phrase_from_status(status_code: int) -> str:
+    """Human-readable status phrase (404 -> ``Not Found``), for use as a fallback
+    ``message`` when an ``HTTPException`` carries a non-string ``detail``.
+
+    Falls back to ``HTTP <n>`` for any non-standard status.
+    """
+    try:
+        return http.HTTPStatus(status_code).phrase
+    except ValueError:
+        return f"HTTP {status_code}"
+
+
+async def _handle_v4_api_error(request: fastapi.Request, exc: V4APIError):
+    return _error_response(
+        status_code=exc.status_code,
+        code=exc.code,
+        message=exc.message,
+        details=exc.details,
+    )
+
+
+async def _handle_http_exception(request: fastapi.Request, exc: StarletteHTTPException):
+    # exc.detail is normally a plain string. HTTPException also permits a
+    # structured detail (a dict/list — a common FastAPI idiom); stringifying that
+    # into a Python repr would be lossy and ugly, so keep a clean status-derived
+    # message and preserve the original structure under details instead. (details
+    # is jsonable-encoded in _error_response.)
+    detail = exc.detail
+    if isinstance(detail, str):
+        message, details = detail, None
+    else:
+        message = _phrase_from_status(exc.status_code)
+        details = {"detail": detail} if detail is not None else None
+    return _error_response(
+        status_code=exc.status_code,
+        code=_code_from_status(exc.status_code),
+        message=message,
+        details=details,
+        # Preserve response headers the exception carries — most importantly
+        # WWW-Authenticate on a 401, which clients rely on.
+        headers=getattr(exc, "headers", None),
+    )
+
+
+async def _handle_validation_error(
+    request: fastapi.Request, exc: RequestValidationError
+):
+    return _error_response(
+        status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+        code="VALIDATION_ERROR",
+        message="Request validation failed.",
+        # exc.errors() can hold non-serializable objects (e.g. the original
+        # ValueError under `ctx`); _error_response jsonable-encodes details, so
+        # they are made JSON-safe there.
+        details={"errors": exc.errors()},
+    )
+
+
+async def _handle_unexpected_exception(request: fastapi.Request, exc: Exception):
+    # Return ONLY — never re-raise or log here. See the module docstring: the
+    # sub-app's ServerErrorMiddleware re-raises after sending this body, so the
+    # parent LoggingMiddleware logs the traceback. The body stays generic so no
+    # exception text, args, or traceback leak to the client.
+    return _error_response(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        code="INTERNAL_ERROR",
+        message="An internal error occurred.",
+    )
+
+
+def register_exception_handlers(app: fastapi.FastAPI) -> None:
+    """Register the four v4 error handlers on ``app`` (the ``/v4`` sub-app).
+
+    Call this instead of registering ad-hoc handlers so every v4 error is shaped
+    by one place. See the module docstring for the envelope and the
+    re-raise-for-logging contract of the catch-all handler.
+    """
+    app.add_exception_handler(V4APIError, _handle_v4_api_error)
+    app.add_exception_handler(StarletteHTTPException, _handle_http_exception)
+    app.add_exception_handler(RequestValidationError, _handle_validation_error)
+    app.add_exception_handler(Exception, _handle_unexpected_exception)

--- a/test/test_v4_errors.py
+++ b/test/test_v4_errors.py
@@ -1,0 +1,215 @@
+"""Tests for the v4 structured error contract (issue #828, epic #842).
+
+Every error leaving /v4 must be the ``{"error": {"code", "message", "details"}}``
+envelope with a stable machine ``code`` and no server internals. These tests
+attach throwaway probe routes to a freshly built sub-app and assert, for each of
+the four registered handlers, the HTTP status, the envelope shape, the stable
+``code``, and (for the catch-all) that no exception text or traceback leaks.
+
+The sub-app is exercised in isolation via ``create_v4_app`` (no DB, no parent
+app). ``TestClient(app, raise_server_exceptions=False)`` is required so the 500
+handler's re-raise (ServerErrorMiddleware always re-raises after sending) does not
+abort the test — see api_v4/errors.py. test_v4_subapp.py covers the same 500 path
+end to end through the parent mount.
+"""
+
+import fastapi
+import pytest
+from fastapi.testclient import TestClient
+
+import app as app_module
+from api_v4.app import create_v4_app
+from api_v4.errors import V4APIError
+from api_v4.schemas.base import V4BaseModel
+
+ENVELOPE_KEYS = {"code", "message", "details"}
+
+
+class _ProbeBody(V4BaseModel):
+    value: int
+
+
+@pytest.fixture
+def error_app():
+    """A /v4 sub-app with probe routes that each trigger one handler.
+
+    CORS is a no-op here so the assertions isolate error shaping from the CORS
+    layer (its own concern, covered in test_v4_subapp.py).
+    """
+    v4_app = create_v4_app(configure_cors=lambda _app: None)
+
+    @v4_app.get("/_raise_v4_api_error")
+    async def _raise_v4_api_error():
+        raise V4APIError(
+            status_code=404,
+            code="REVISION_NOT_FOUND",
+            message="Revision 42 does not exist.",
+            details={"revision_id": 42},
+        )
+
+    @v4_app.get("/_raise_http_404")
+    async def _raise_http_404():
+        raise fastapi.HTTPException(status_code=404, detail="No such thing.")
+
+    @v4_app.get("/_raise_http_401")
+    async def _raise_http_401():
+        raise fastapi.HTTPException(
+            status_code=401,
+            detail="Not authenticated.",
+            headers={"WWW-Authenticate": "Bearer"},
+        )
+
+    @v4_app.get("/_raise_http_structured_detail")
+    async def _raise_http_structured_detail():
+        # HTTPException permits a structured (dict) detail; the handler must
+        # preserve it rather than stringify it into a Python repr.
+        raise fastapi.HTTPException(
+            status_code=400,
+            detail={"field": "name", "problem": "required"},
+        )
+
+    @v4_app.get("/_raise_v4_api_error_unserializable")
+    async def _raise_v4_api_error_unserializable():
+        # details holds a set — not JSON-native. Building the envelope must not
+        # crash and downgrade this 409 into a generic 500.
+        raise V4APIError(
+            status_code=409,
+            code="CONFLICT_STATE",
+            message="Conflicting ids.",
+            details={"ids": {3, 1, 2}},
+        )
+
+    @v4_app.post("/_validate")
+    async def _validate(body: _ProbeBody):
+        return {"ok": True}
+
+    @v4_app.get("/_raise_bare_exception")
+    async def _raise_bare_exception():
+        raise RuntimeError("secret internal detail: password=hunter2")
+
+    return v4_app
+
+
+@pytest.fixture
+def client(error_app):
+    with TestClient(error_app, raise_server_exceptions=False) as c:
+        yield c
+
+
+def _assert_envelope(body):
+    """The body is exactly ``{"error": {...}}`` and the inner object has no keys
+    beyond the contract's code/message/details."""
+    assert set(body) == {"error"}, f"top-level must be just 'error', got {set(body)}"
+    error = body["error"]
+    assert "code" in error and "message" in error
+    assert set(error) <= ENVELOPE_KEYS, f"unexpected keys in error: {set(error)}"
+    assert isinstance(error["code"], str) and error["code"]
+    assert isinstance(error["message"], str) and error["message"]
+
+
+def test_v4_api_error_passes_through(client):
+    response = client.get("/_raise_v4_api_error")
+    assert response.status_code == 404
+    assert response.headers["content-type"].startswith("application/json")
+    assert response.json() == {
+        "error": {
+            "code": "REVISION_NOT_FOUND",
+            "message": "Revision 42 does not exist.",
+            "details": {"revision_id": 42},
+        }
+    }
+
+
+def test_http_exception_maps_status_to_code(client):
+    response = client.get("/_raise_http_404")
+    assert response.status_code == 404
+    body = response.json()
+    _assert_envelope(body)
+    assert body["error"]["code"] == "NOT_FOUND"
+    assert body["error"]["message"] == "No such thing."
+    # details omitted when absent (exclude_none), not present-as-null.
+    assert "details" not in body["error"]
+
+
+def test_http_exception_preserves_headers(client):
+    response = client.get("/_raise_http_401")
+    assert response.status_code == 401
+    body = response.json()
+    _assert_envelope(body)
+    assert body["error"]["code"] == "UNAUTHORIZED"
+    assert body["error"]["message"] == "Not authenticated."
+    # The WWW-Authenticate header the exception carried must survive re-emission.
+    assert response.headers.get("www-authenticate") == "Bearer"
+
+
+def test_http_exception_structured_detail_preserved(client):
+    response = client.get("/_raise_http_structured_detail")
+    assert response.status_code == 400
+    body = response.json()
+    _assert_envelope(body)
+    assert body["error"]["code"] == "BAD_REQUEST"
+    # Clean status-derived message; the structured detail is preserved, not
+    # flattened into a repr string.
+    assert body["error"]["message"] == "Bad Request"
+    assert body["error"]["details"]["detail"] == {
+        "field": "name",
+        "problem": "required",
+    }
+
+
+def test_v4_api_error_with_unserializable_details_does_not_downgrade(client):
+    # A domain error whose details carry a non-JSON-native value (a set) must
+    # still return its intended 4xx envelope, not crash into a generic 500.
+    response = client.get("/_raise_v4_api_error_unserializable")
+    assert response.status_code == 409
+    body = response.json()
+    _assert_envelope(body)
+    assert body["error"]["code"] == "CONFLICT_STATE"
+    assert sorted(body["error"]["details"]["ids"]) == [1, 2, 3]
+
+
+def test_validation_error_returns_422_envelope(client):
+    response = client.post("/_validate", json={"value": "not-an-int"})
+    assert response.status_code == 422
+    body = response.json()
+    _assert_envelope(body)
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    errors = body["error"]["details"]["errors"]
+    assert isinstance(errors, list) and errors, "expected a non-empty errors list"
+    # Fully JSON round-trippable (jsonable_encoder ran on exc.errors()).
+    assert response.json() == body
+
+
+def test_unhandled_exception_returns_generic_500(client):
+    response = client.get("/_raise_bare_exception")
+    assert response.status_code == 500
+    body = response.json()
+    _assert_envelope(body)
+    assert body == {
+        "error": {"code": "INTERNAL_ERROR", "message": "An internal error occurred."}
+    }
+    # No exception message, args, class name, or traceback may leak into the body.
+    leaked = (
+        "hunter2",
+        "secret internal detail",
+        "RuntimeError",
+        "Traceback",
+        "password",
+    )
+    assert not any(token in response.text for token in leaked), response.text
+
+
+def test_v3_error_shape_unchanged_freeze_regression():
+    """Registering v4 handlers on the isolated sub-app must NOT alter the main
+    app's (frozen v3) error shape. The main app keeps FastAPI's default
+    ``{"detail": ...}`` body — it must never emit the v4 ``{"error": {...}}``
+    envelope. A DB-free 404 on an unknown main-app path proves it.
+    """
+    mock_app = fastapi.FastAPI()
+    app_module.configure(mock_app)
+    with TestClient(mock_app) as c:
+        response = c.get("/definitely-not-a-real-path")
+    assert response.status_code == 404
+    body = response.json()
+    assert body == {"detail": "Not Found"}
+    assert "error" not in body, "main app must not adopt the v4 error envelope"

--- a/test/test_v4_subapp.py
+++ b/test/test_v4_subapp.py
@@ -142,14 +142,16 @@ def test_v4_root_rejects_wrong_method(client):
 
 def test_v4_unhandled_exception_returns_json_500():
     """A mounted sub-app has its own ServerErrorMiddleware that defaults to a
-    *plaintext* 500 body — diverging from the JSON ``{"detail": ...}`` contract
-    ``LoggingMiddleware`` produces for every other route. #830 registers a
-    handler on the sub-app to restore that contract; this guards it against a
-    regression (e.g. the handler being dropped).
+    *plaintext* 500 body. The v4 error contract (#828) registers handlers on the
+    sub-app that instead emit the structured ``{"error": {...}}`` envelope; this
+    guards, through the full parent app + mount, that an unhandled exception is
+    caught and reshaped rather than leaking a plaintext body or internals.
 
-    A throwing probe route is attached to the mounted sub-app directly, and a
-    client with ``raise_server_exceptions=False`` inspects the wire response the
-    client would actually receive.
+    This exercises the re-raise-for-logging path end to end: the sub-app's
+    ServerErrorMiddleware sends this JSON body and re-raises, and the exception
+    propagates up through the mount to the parent LoggingMiddleware. A client with
+    ``raise_server_exceptions=False`` inspects the wire response it would receive.
+    See test_v4_errors.py for the isolated per-handler assertions.
     """
     mock_app = fastapi.FastAPI()
     app_module.configure(mock_app)
@@ -173,4 +175,8 @@ def test_v4_unhandled_exception_returns_json_500():
 
     assert response.status_code == 500
     assert response.headers["content-type"].startswith("application/json")
-    assert response.json() == {"detail": "Internal server error"}
+    assert response.json() == {
+        "error": {"code": "INTERNAL_ERROR", "message": "An internal error occurred."}
+    }
+    # The raised exception's text must never reach the client.
+    assert "boom" not in response.text


### PR DESCRIPTION
Implements the v4 structured error contract and global exception handlers. Closes #828. Part of epic #842 (v4 migration). Design reference: migration guide §8 "Errors".

## What this does

Replaces the v4 sub-app's placeholder 500 handler (`{"detail": "Internal server error"}`) with the full structured contract. Every error leaving `/v4` is now one envelope, so clients branch on a stable machine `code` instead of parsing message text, and no server internals reach the wire:

```json
{ "error": { "code": "REVISION_NOT_FOUND", "message": "Revision 42 does not exist.", "details": { "revision_id": 42 } } }
```

`details` is optional and omitted when absent, so a plain error is just `{"error": {"code": ..., "message": ...}}`.

## New `api_v4/errors.py`

- **`V4APIError(Exception)`** — `__init__(*, status_code, code, message, details=None)`. The sanctioned way for a v4 endpoint to signal a domain 4xx.
- **Typed envelope models** `V4ErrorResponse` / `V4ErrorDetail` (subclass `V4BaseModel`). The response body is dumped from these models rather than a hand-built dict, so the wire shape can't drift from the schema; future domain routes attach them via `responses={...}` to document errors in OpenAPI.
- **`register_exception_handlers(app)`** registers four handlers, all emitting the envelope:

| Exception | Status | `code` | Notes |
|---|---|---|---|
| `V4APIError` | its own | its own | `status_code`/`code`/`message`/`details` pass through |
| `starlette.HTTPException` (catches `fastapi.HTTPException`) | preserved | derived from status name (404→`NOT_FOUND`, 401→`UNAUTHORIZED`) | **preserves `exc.headers`** (e.g. `WWW-Authenticate` on 401) |
| `RequestValidationError` | 422 | `VALIDATION_ERROR` | validation errors under `details.errors` |
| `Exception` (catch-all) | 500 | `INTERNAL_ERROR` | fixed generic message; **never** leaks exc text/args/traceback |

## Re-raise-for-logging (intentional)

The catch-all 500 handler **only returns** the clean body. The v4 sub-app's own `ServerErrorMiddleware` calls the handler, sends the response, and *then re-raises* the exception, which propagates up through the mount to the parent app's `LoggingMiddleware` (`middleware.py`) that logs the traceback. So the client gets clean JSON and the traceback still lands in the logs. `middleware.py` and everything in the main app / frozen v3 are untouched — the "no internals in bodies" requirement is met *within v4* by the generic 500 body plus v4 never hand-raising 500s.

This deliberately changes the v4 500 body from `{"detail": ...}` to `{"error": {...}}`; v3 keeps its `{"detail": ...}` shape.

## Robustness (from expert review)

- `details` is run through `jsonable_encoder` before serialization, so a domain error carrying arbitrary objects (sets, dates, ...) can't raise mid-handler and silently downgrade a 4xx into a generic 500 (which would also bury the original `code`/`message` in logs).
- A non-string `HTTPException.detail` (dict/list) is preserved under `details` with a clean status-phrase message, rather than flattened into a Python repr.

## Wiring

`create_v4_app()` drops `_v4_internal_error_handler` and calls `register_exception_handlers(v4_app)`.

## Tests

- **`test/test_v4_errors.py`** (new) — one probe route per handler on a `create_v4_app(...)` sub-app under `TestClient(raise_server_exceptions=False)`: correct status, envelope shape, stable `code`, header preservation, structured/unserializable `details`, and that no exception text/traceback leaks into the 500 body. Plus a **v3-freeze regression** guard asserting the main app still returns `{"detail": ...}`.
- **`test/test_v4_subapp.py`** — the existing unhandled-exception test updated to the new envelope, now also asserting no exception text leaks through the full parent + mount path (exercises re-raise-for-logging end to end).

All 20 v4 tests pass; the OpenAPI contract snapshot and app-level tests are unaffected. (`test_ready_endpoint` fails locally only because it needs a live DB — unrelated to this change.)

## Out of scope

Real v4 endpoints, auth/API-keys (#831), pagination (#829), job envelope (#827), v3 routes, `middleware.py`, and any DB migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)