### PR TITLE
fix(db): restore pool sizing + statement_timeout dropped by #836

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,14 @@ AQUA_DB=postgresql+asyncpg://dbuser:dbpassword@localhost:5432/dbname
 # Set AQUA_DB_POOLCLASS=null to force SQLAlchemy's NullPool (the test suite
 # does this). Leave unset in production to use the pooled engine below.
 # AQUA_DB_POOLCLASS=null
-AQUA_DB_POOL_SIZE=2
-AQUA_DB_MAX_OVERFLOW=3
-AQUA_DB_POOL_TIMEOUT=10
+AQUA_DB_POOL_SIZE=5
+AQUA_DB_MAX_OVERFLOW=10
+AQUA_DB_POOL_TIMEOUT=30
 AQUA_DB_POOL_RECYCLE=1800
+# Server-side statement_timeout in ms (caps how long one query can pin a
+# pooled connection). 0 disables. This is the safety net against a single
+# runaway query starving the pool and cascading into QueuePool 500s.
+AQUA_DB_STATEMENT_TIMEOUT_MS=60000
 
 # --- Auth (required) ------------------------------------------------------
 # Secret used to sign JWTs. Must be non-empty (whitespace-only counts as

--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ wiring in ``app.configure_cors`` rely on.
 from typing import Optional
 
 from dotenv import load_dotenv
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Load .env into os.environ before Settings reads it. Existing environment
@@ -64,16 +64,22 @@ class Settings(BaseSettings):
     # TestClient spawns a fresh event loop per request). Anything else uses the
     # pooled engine configured below.
     aqua_db_poolclass: Optional[str] = None
-    aqua_db_pool_size: int = 5
-    aqua_db_max_overflow: int = 10
-    aqua_db_pool_timeout: int = 30
-    aqua_db_pool_recycle: int = 1800
+    # Lower bounds keep the module's fail-loud-at-boot contract: a negative
+    # (typo'd) value would otherwise pass Settings() and only surface as an
+    # opaque error when the engine/asyncpg first uses it. pool_recycle allows
+    # SQLAlchemy's -1 sentinel ("disable recycling"); statement_timeout allows
+    # 0 (Postgres' "no limit"). pool_size/pool_timeout must be strictly
+    # positive — a 0-size pool or 0s checkout timeout is nonsensical here.
+    aqua_db_pool_size: int = Field(default=5, gt=0)
+    aqua_db_max_overflow: int = Field(default=10, ge=0)
+    aqua_db_pool_timeout: int = Field(default=30, gt=0)
+    aqua_db_pool_recycle: int = Field(default=1800, ge=-1)
     # Server-side statement_timeout (ms) passed to asyncpg. The real safety
     # net against pool exhaustion: caps how long any single query can pin a
     # pooled connection, so one runaway query fails its own request instead
     # of starving every other caller on the worker. 0 disables (Postgres
     # default — no limit). See PR #656 / issue behind the QueuePool 500s.
-    aqua_db_statement_timeout_ms: int = 60_000
+    aqua_db_statement_timeout_ms: int = Field(default=60_000, ge=0)
 
     @field_validator(
         "aqua_db_pool_size",

--- a/config.py
+++ b/config.py
@@ -64,16 +64,23 @@ class Settings(BaseSettings):
     # TestClient spawns a fresh event loop per request). Anything else uses the
     # pooled engine configured below.
     aqua_db_poolclass: Optional[str] = None
-    aqua_db_pool_size: int = 2
-    aqua_db_max_overflow: int = 3
-    aqua_db_pool_timeout: int = 10
+    aqua_db_pool_size: int = 5
+    aqua_db_max_overflow: int = 10
+    aqua_db_pool_timeout: int = 30
     aqua_db_pool_recycle: int = 1800
+    # Server-side statement_timeout (ms) passed to asyncpg. The real safety
+    # net against pool exhaustion: caps how long any single query can pin a
+    # pooled connection, so one runaway query fails its own request instead
+    # of starving every other caller on the worker. 0 disables (Postgres
+    # default — no limit). See PR #656 / issue behind the QueuePool 500s.
+    aqua_db_statement_timeout_ms: int = 60_000
 
     @field_validator(
         "aqua_db_pool_size",
         "aqua_db_max_overflow",
         "aqua_db_pool_timeout",
         "aqua_db_pool_recycle",
+        "aqua_db_statement_timeout_ms",
         mode="before",
     )
     @classmethod

--- a/database/dependencies.py
+++ b/database/dependencies.py
@@ -18,8 +18,11 @@ DATABASE_URL = settings.aqua_db
 # RDS default max_connections is LEAST({DBInstanceClassMemory/9531392},
 # 5000) — roughly 170 on db.t3.small, 340 on db.t3.medium, 675 on
 # db.m5.large — so 120/container leaves comfortable headroom even on
-# small instance classes. Tune the env vars if running many containers
-# or if other consumers (alembic, batch jobs, replicas) eat the budget.
+# small instance classes. NOTE: this budget is per-container — N concurrent
+# App Runner instances multiply it (2 × 120 already exceeds t3.small's ~170),
+# and there is no fleet-wide saturation alert yet. See #747. Tune the env
+# vars if running many containers or if other consumers (alembic, batch
+# jobs, replicas) eat the budget.
 #
 # An earlier 2+3 default starved /v3/textsearch (with comparison) under
 # moderate concurrency: a handful of slow searches consumed a worker's

--- a/database/dependencies.py
+++ b/database/dependencies.py
@@ -13,13 +13,19 @@ DATABASE_URL = settings.aqua_db
 # Production runs a single persistent loop per worker and benefits from
 # pooling — avoids the asyncpg+TLS handshake on every request.
 #
-# Default sizing: with 8 uvicorn workers, steady-state is ~16 conns per
-# container (8 × pool_size 2) and the burst ceiling is 40 (8 × (2 + 3)).
+# Default sizing: with 8 uvicorn workers, steady-state is ~40 conns per
+# container (8 × pool_size 5) and the burst ceiling is 120 (8 × (5 + 10)).
 # RDS default max_connections is LEAST({DBInstanceClassMemory/9531392},
 # 5000) — roughly 170 on db.t3.small, 340 on db.t3.medium, 675 on
-# db.m5.large — so 40/container leaves comfortable headroom even on
+# db.m5.large — so 120/container leaves comfortable headroom even on
 # small instance classes. Tune the env vars if running many containers
 # or if other consumers (alembic, batch jobs, replicas) eat the budget.
+#
+# An earlier 2+3 default starved /v3/textsearch (with comparison) under
+# moderate concurrency: a handful of slow searches consumed a worker's
+# whole pool, and the next request — even just the auth lookup — timed
+# out in get_db. Pair the bigger pool with a server-side statement_timeout
+# so a single slow query can't pin a connection indefinitely.
 if settings.aqua_db_poolclass and settings.aqua_db_poolclass.lower() == "null":
     from sqlalchemy.pool import NullPool
 
@@ -32,6 +38,11 @@ else:
         pool_timeout=settings.aqua_db_pool_timeout,
         pool_recycle=settings.aqua_db_pool_recycle,
         pool_pre_ping=True,
+        connect_args={
+            "server_settings": {
+                "statement_timeout": str(settings.aqua_db_statement_timeout_ms),
+            },
+        },
     )
 AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,16 @@ services:
       - GRAPHQL_URL=${GRAPHQL_URL}
       - GRAPHQL_SECRET=${GRAPHQL_SECRET}
       - AQUA_DB=postgresql+asyncpg://dbuser:dbpassword@db:5432/dbname
-      # DB connection pool tuning (defaults: pool_size=2, max_overflow=3,
-      # timeout=10, recycle=1800). Set AQUA_DB_POOLCLASS=null to disable
-      # pooling entirely (one connection per request).
+      # DB connection pool tuning (defaults: pool_size=5, max_overflow=10,
+      # timeout=30, recycle=1800, statement_timeout=60000ms). Set
+      # AQUA_DB_POOLCLASS=null to disable pooling entirely (one connection
+      # per request).
       - AQUA_DB_POOLCLASS=${AQUA_DB_POOLCLASS:-}
       - AQUA_DB_POOL_SIZE=${AQUA_DB_POOL_SIZE:-}
       - AQUA_DB_MAX_OVERFLOW=${AQUA_DB_MAX_OVERFLOW:-}
       - AQUA_DB_POOL_TIMEOUT=${AQUA_DB_POOL_TIMEOUT:-}
       - AQUA_DB_POOL_RECYCLE=${AQUA_DB_POOL_RECYCLE:-}
+      - AQUA_DB_STATEMENT_TIMEOUT_MS=${AQUA_DB_STATEMENT_TIMEOUT_MS:-}
       - TEST_KEY=${TEST_KEY}
       - FAIL_KEY=${FAIL_KEY}
       - KEY_VAULT=${KEY_VAULT}

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -113,6 +113,35 @@ def test_valid_pool_config_coerced_to_int(
     assert getattr(settings_cls(), field_name) == 7
 
 
+# (env var, an out-of-range value that must fail the field's lower bound).
+# pool_recycle permits -1 (SQLAlchemy "disable") and statement_timeout permits
+# 0 (Postgres "no limit"), so their rejection cases sit below those sentinels.
+_OUT_OF_RANGE = [
+    ("AQUA_DB_POOL_SIZE", "0"),
+    ("AQUA_DB_POOL_SIZE", "-1"),
+    ("AQUA_DB_MAX_OVERFLOW", "-1"),
+    ("AQUA_DB_POOL_TIMEOUT", "0"),
+    ("AQUA_DB_POOL_RECYCLE", "-2"),
+    ("AQUA_DB_STATEMENT_TIMEOUT_MS", "-1"),
+]
+
+
+@pytest.mark.parametrize("env_name,value", _OUT_OF_RANGE)
+def test_out_of_range_pool_config_rejected_at_boot(
+    settings_cls, monkeypatch, env_name, value
+):
+    """A negative/zero pool value fails fast at boot, not later in the engine.
+
+    Preserves this module's fail-loud contract: a typo'd value must raise at
+    Settings() construction rather than surfacing as an opaque SQLAlchemy or
+    asyncpg error when the connection pool is first used.
+    """
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv(env_name, value)
+    with pytest.raises(ValidationError):
+        settings_cls()
+
+
 @pytest.mark.parametrize(
     "raw,expected",
     [

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -58,6 +58,7 @@ _VALID_DB = "postgresql+asyncpg://u:p@localhost:5432/db"
         "AQUA_DB_MAX_OVERFLOW",
         "AQUA_DB_POOL_TIMEOUT",
         "AQUA_DB_POOL_RECYCLE",
+        "AQUA_DB_STATEMENT_TIMEOUT_MS",
     ],
 )
 def test_non_numeric_pool_config_rejected_at_boot(settings_cls, monkeypatch, env_name):
@@ -74,12 +75,13 @@ def test_non_numeric_pool_config_rejected_at_boot(settings_cls, monkeypatch, env
         settings_cls()
 
 
-# (env var, field name, declared default) for the four pooled int settings.
+# (env var, field name, declared default) for the pooled int settings.
 _POOL_FIELDS = [
-    ("AQUA_DB_POOL_SIZE", "aqua_db_pool_size", 2),
-    ("AQUA_DB_MAX_OVERFLOW", "aqua_db_max_overflow", 3),
-    ("AQUA_DB_POOL_TIMEOUT", "aqua_db_pool_timeout", 10),
+    ("AQUA_DB_POOL_SIZE", "aqua_db_pool_size", 5),
+    ("AQUA_DB_MAX_OVERFLOW", "aqua_db_max_overflow", 10),
+    ("AQUA_DB_POOL_TIMEOUT", "aqua_db_pool_timeout", 30),
     ("AQUA_DB_POOL_RECYCLE", "aqua_db_pool_recycle", 1800),
+    ("AQUA_DB_STATEMENT_TIMEOUT_MS", "aqua_db_statement_timeout_ms", 60_000),
 ]
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -142,6 +142,26 @@ def test_out_of_range_pool_config_rejected_at_boot(
         settings_cls()
 
 
+# (env var, field name, sentinel value) that must be ACCEPTED despite looking
+# out-of-range: pool_recycle=-1 disables recycling (SQLAlchemy), and
+# statement_timeout=0 means "no limit" (Postgres). Locks these in so a future
+# tightening of the bound (ge=-1 -> ge=0, or ge=0 -> gt=0) fails loudly here.
+_SENTINELS = [
+    ("AQUA_DB_POOL_RECYCLE", "aqua_db_pool_recycle", -1),
+    ("AQUA_DB_STATEMENT_TIMEOUT_MS", "aqua_db_statement_timeout_ms", 0),
+]
+
+
+@pytest.mark.parametrize("env_name,field_name,value", _SENTINELS)
+def test_sentinel_pool_config_accepted_at_boot(
+    settings_cls, monkeypatch, env_name, field_name, value
+):
+    """The disable/no-limit sentinels construct cleanly and round-trip."""
+    monkeypatch.setenv("AQUA_DB", _VALID_DB)
+    monkeypatch.setenv(env_name, str(value))
+    assert getattr(settings_cls(), field_name) == value
+
+
 @pytest.mark.parametrize(
     "raw,expected",
     [

--- a/test/test_db_engine.py
+++ b/test/test_db_engine.py
@@ -1,0 +1,54 @@
+import importlib
+import os
+
+import sqlalchemy.ext.asyncio as sa_async
+
+import config
+import database.dependencies as deps
+
+
+def test_pooled_engine_wires_statement_timeout(monkeypatch):
+    """Regression guard for the #836 revert.
+
+    PR #656 fixed QueuePool exhaustion by (a) raising the pool defaults and
+    (b) passing a server-side ``statement_timeout`` through asyncpg
+    ``connect_args`` — the real safety net that stops one runaway query from
+    pinning a pooled connection and cascading into 500s. The typed-config
+    refactor (#836) branched from a stale base and silently dropped both.
+
+    ``test_config.py`` now covers the defaults; this asserts the *engine
+    construction path itself* still wires ``connect_args`` on the pooled
+    branch. conftest forces ``AQUA_DB_POOLCLASS=null`` for the whole suite, so
+    we flip to the pooled branch, spy on ``create_async_engine``, reload the
+    module, then restore the real NullPool engine so later test modules (which
+    drive the app over TestClient's per-request event loops) are unaffected.
+    """
+    real_cae = sa_async.create_async_engine
+    real_settings = config.settings
+
+    captured = {}
+
+    def spy(url, **kwargs):
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return object()
+
+    monkeypatch.delenv("AQUA_DB_POOLCLASS", raising=False)
+    monkeypatch.setattr(sa_async, "create_async_engine", spy)
+    monkeypatch.setattr(config, "settings", config.Settings())
+
+    try:
+        importlib.reload(deps)
+
+        kwargs = captured["kwargs"]
+        assert kwargs["pool_size"] == config.settings.aqua_db_pool_size
+        assert kwargs["max_overflow"] == config.settings.aqua_db_max_overflow
+        server_settings = kwargs["connect_args"]["server_settings"]
+        assert server_settings["statement_timeout"] == str(
+            config.settings.aqua_db_statement_timeout_ms
+        )
+    finally:
+        sa_async.create_async_engine = real_cae
+        config.settings = real_settings
+        os.environ["AQUA_DB_POOLCLASS"] = "null"
+        importlib.reload(deps)

--- a/test/test_db_engine.py
+++ b/test/test_db_engine.py
@@ -43,6 +43,8 @@ def test_pooled_engine_wires_statement_timeout(monkeypatch):
         kwargs = captured["kwargs"]
         assert kwargs["pool_size"] == config.settings.aqua_db_pool_size
         assert kwargs["max_overflow"] == config.settings.aqua_db_max_overflow
+        assert kwargs["pool_timeout"] == config.settings.aqua_db_pool_timeout
+        assert kwargs["pool_recycle"] == config.settings.aqua_db_pool_recycle
         server_settings = kwargs["connect_args"]["server_settings"]
         assert server_settings["statement_timeout"] == str(
             config.settings.aqua_db_statement_timeout_ms


### PR DESCRIPTION
## Summary

Restores the QueuePool-exhaustion fix that PR #656 (`faeafab2`) landed and the #836 typed-config refactor (`fb5d7739`) **silently reverted** by branching from a stale base.

**Incident:** QueuePool exhaustion resurged in prod — `TimeoutError "QueuePool limit of size 2 overflow 3 reached"` across `/textsearch`, `/chapter`, `/assessment`, `/alignmentscores`. A single slow query pins a worker's whole 5-connection pool; every other request on that worker (including the auth lookup at the top of each endpoint) then times out in `get_db` and 500s.

**Root cause:** #836 moved pool config into `config.py` from a base predating #656, dropping both halves of the fix:
- pool defaults fell back from `5/10/30` → `2/3/10`
- the asyncpg server-side `statement_timeout` (the real safety net) was removed entirely

## Changes
- `config.py`: defaults back to `pool_size=5 / max_overflow=10 / pool_timeout=30`; new `aqua_db_statement_timeout_ms` (default 60000), covered by the blank→default validator
- `database/dependencies.py`: re-add `connect_args` server-side `statement_timeout`; fix stale 40→120 conns/container comment
- `docker-compose.yml` / `.env.example`: re-expose + document `AQUA_DB_STATEMENT_TIMEOUT_MS`
- `test/test_db_engine.py`: **new guard test** asserting the pooled engine actually wires `connect_args` `statement_timeout`, so a future refactor can't silently drop it again
- `test/test_config.py`: update expected defaults, cover the new setting

Sizing: 8 workers × (5+10) = **120 conns/container**, well under RDS limits (~170 on db.t3.small). Tests unaffected — conftest forces `NullPool`, bypassing `connect_args`.

Related: #747 (pool-budget docs + saturation alerting — not closed by this PR).

## Test plan
- [x] `pytest test/test_config.py` — 41 passed
- [x] `pytest test/test_db_engine.py` — new guard passes
- [x] Pollution check: `test_db_engine.py` + `test_app.py` in one process — 47 passed (app over TestClient still works after the reload/restore)
- [x] black / isort / flake8 clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)