### PR TITLE
feat(v4): limit/offset pagination + typed list envelope (#829)

### DIFF
--- a/api_v4/pagination.py
+++ b/api_v4/pagination.py
@@ -1,0 +1,156 @@
+"""Reusable pagination contract for every /v4 list endpoint (issue #829, epic #842).
+
+This module ships the two shared pieces that make every v4 list endpoint page the
+same way — bounded, predictable, and self-documenting in OpenAPI:
+
+* :class:`PaginationParams` — a FastAPI dependency-class declaring the ``limit``
+  and ``offset`` query parameters with their documented defaults and maximums. An
+  endpoint consumes it as ``page: PaginationParams = Depends()`` and hands
+  ``page.limit`` / ``page.offset`` to its (future) service/query layer.
+* :class:`V4Page` — the generic list envelope every v4 list endpoint returns::
+
+      {"items": [...], "total": 128, "limit": 20, "offset": 0}
+
+  A route declares ``response_model=V4Page[SomeModel]`` and builds the body with
+  :meth:`V4Page.create`, so no endpoint reassembles the envelope by hand.
+
+Scope: this PR defines the reusable *contract only* (shapes + validation). It does
+not wire pagination into any real resource endpoint or touch the query layer —
+that happens in the Versions/Revisions vertical slice.
+
+Deliberate contract decisions (issue #829, migration guide §9):
+
+**limit/offset, not page/page_size.** v4 standardizes on ``limit``/``offset``.
+The ``page``/``page_size`` validation referenced by #486 is a *v3* concern and is
+deliberately **not** implemented here — the two paging styles are never mixed on
+the v4 surface.
+
+**Out-of-range inputs reject with 422, they are never silently clamped.** The
+``Query`` bounds below (``ge`` / ``le``) make ``limit > MAX_LIMIT``, ``limit < 1``,
+or ``offset < 0`` raise :class:`fastapi.exceptions.RequestValidationError`. That
+flows through the existing #828 exception handler and surfaces as the
+``{"error": {"code": "VALIDATION_ERROR", "details": {"errors": [...]}}}`` envelope
+— this module introduces **no new error shape**, it only produces inputs the #828
+handler already knows how to shape. Rejecting rather than clamping is explicit and
+self-documenting in OpenAPI: a caller learns their request was malformed instead of
+silently receiving a different page than they asked for.
+
+**DEFAULT_LIMIT / MAX_LIMIT = 20 / 100.** These are the documented default page
+size and hard ceiling for the v4 *catalog* lists (versions, revisions,
+assessments). v3's ``le=1000`` / ``le=10_000`` caps live on the verse-level
+*result / search* endpoints — a different, far larger category — and even there v3
+had to add a separate absolute SQL cap because an unbounded ``limit=1000`` could
+pull tens of thousands of rows. 100 keeps a single v4 page's payload and DB scan
+bounded; a client that needs more walks pages via ``offset``. This is a policy
+decision, not a hard constraint: a future heavy list that genuinely needs a larger
+ceiling should define its own params dependency rather than raise this shared cap.
+"""
+
+from typing import Generic, TypeVar
+
+from fastapi import Query
+
+from api_v4.schemas.base import V4BaseModel
+
+#: Default page size when a caller supplies no ``limit``.
+DEFAULT_LIMIT = 20
+#: Hard maximum page size; ``limit`` above this is a 422, not a clamp. See the
+#: module docstring for why 100 (and not v3's result-endpoint ``le=1000``).
+MAX_LIMIT = 100
+
+
+class PaginationParams:
+    """FastAPI dependency declaring the ``limit`` / ``offset`` query parameters.
+
+    Consumed as ``page: PaginationParams = Depends()``; the endpoint then reads
+    ``page.limit`` / ``page.offset``. Using the dependency-class pattern (rather
+    than bare ``Query`` params on each route) keeps the validation declarative and
+    makes the parameters show up in OpenAPI on every list endpoint identically.
+
+    The ``Query`` bounds make an out-of-range value raise
+    ``RequestValidationError`` — surfaced as the #828 ``VALIDATION_ERROR`` envelope
+    — rather than clamp it. See the module docstring.
+    """
+
+    def __init__(
+        self,
+        limit: int = Query(
+            DEFAULT_LIMIT,
+            ge=1,
+            le=MAX_LIMIT,
+            description=(
+                f"Maximum number of items to return. Defaults to {DEFAULT_LIMIT}; "
+                f"must be between 1 and {MAX_LIMIT} (out-of-range values are "
+                f"rejected with 422, not clamped)."
+            ),
+        ),
+        offset: int = Query(
+            0,
+            ge=0,
+            description=(
+                "Number of items to skip before collecting the page. "
+                "Defaults to 0; must be >= 0."
+            ),
+        ),
+    ) -> None:
+        self.limit = limit
+        self.offset = offset
+
+
+DataT = TypeVar("DataT")
+
+
+class V4Page(V4BaseModel, Generic[DataT]):
+    """The list envelope returned by every v4 list endpoint.
+
+    Declare it as a route's ``response_model=V4Page[SomeModel]`` and build the body
+    with :meth:`create`. FastAPI/Pydantic render the parametrized model in OpenAPI
+    under a generated name like ``V4Page_VersionOut_`` — verbose, but valid and
+    unambiguous; clients read the ``$ref``, not the name.
+    """
+
+    #: The page of results (at most ``limit`` items).
+    items: list[DataT]
+    #: Total rows matching the query, ignoring ``limit`` / ``offset`` — this is the
+    #: full-result count a client needs to know how many pages exist, NOT
+    #: ``len(items)``.
+    total: int
+    #: The ``limit`` that produced this page (echoed back from the request).
+    limit: int
+    #: The ``offset`` that produced this page (echoed back from the request).
+    offset: int
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        items: list[DataT],
+        total: int,
+        pagination: PaginationParams,
+    ) -> "V4Page[DataT]":
+        """Assemble a page from a result slice, its total count, and the request's
+        :class:`PaginationParams`.
+
+        Endpoints call this instead of re-copying ``limit`` / ``offset`` out of the
+        dependency by hand, so the echoed-back values can never drift from what the
+        request actually used. ``total`` is the count of *all* matching rows
+        (ignoring ``limit`` / ``offset``), which the caller computes from its query
+        — not ``len(items)``.
+
+        Item validation note: only the *parametrized* form
+        ``V4Page[SomeModel].create(...)`` validates and filters ``items`` against
+        ``SomeModel`` here — on the bare ``V4Page.create(...)`` the ``DataT`` type
+        var resolves to ``Any``, so items pass through unshaped. In an HTTP handler
+        that is harmless because the contract requires a ``response_model``
+        (``response_model=V4Page[SomeModel]``, issue #829), and FastAPI re-validates
+        and filters the body against *that* on the way out regardless of how this
+        object was built. But if you ever consume the returned page directly (a
+        non-HTTP helper, or a unit test asserting on the object), use the
+        parametrized form so item shaping isn't silently skipped.
+        """
+        return cls(
+            items=items,
+            total=total,
+            limit=pagination.limit,
+            offset=pagination.offset,
+        )

--- a/api_v4/pagination.py
+++ b/api_v4/pagination.py
@@ -49,6 +49,7 @@ ceiling should define its own params dependency rather than raise this shared ca
 from typing import Generic, TypeVar
 
 from fastapi import Query
+from pydantic import Field
 
 from api_v4.schemas.base import V4BaseModel
 
@@ -93,8 +94,11 @@ class PaginationParams:
             ),
         ),
     ) -> None:
-        self.limit = limit
-        self.offset = offset
+        # Annotate the instance attributes explicitly so consumers
+        # (``page.limit`` / ``page.offset``) get static types and editor support;
+        # the values are already range-validated by the Query bounds above.
+        self.limit: int = limit
+        self.offset: int = offset
 
 
 DataT = TypeVar("DataT")
@@ -109,16 +113,29 @@ class V4Page(V4BaseModel, Generic[DataT]):
     unambiguous; clients read the ``$ref``, not the name.
     """
 
-    #: The page of results (at most ``limit`` items).
-    items: list[DataT]
-    #: Total rows matching the query, ignoring ``limit`` / ``offset`` — this is the
-    #: full-result count a client needs to know how many pages exist, NOT
-    #: ``len(items)``.
-    total: int
-    #: The ``limit`` that produced this page (echoed back from the request).
-    limit: int
-    #: The ``offset`` that produced this page (echoed back from the request).
-    offset: int
+    items: list[DataT] = Field(
+        description="The page of results (at most ``limit`` items)."
+    )
+    total: int = Field(
+        ge=0,
+        description=(
+            "Total rows matching the query, ignoring limit/offset — the "
+            "full-result count for computing how many pages exist, not len(items)."
+        ),
+    )
+    # ge=1 mirrors the PaginationParams floor and makes the response schema
+    # self-documenting/self-validating. Deliberately NO le=MAX_LIMIT here: the
+    # envelope is shared, and a future heavy list may define its own params
+    # dependency with a higher cap (see module docstring) whose echoed limit must
+    # still validate against this model.
+    limit: int = Field(
+        ge=1,
+        description="The limit that produced this page (echoed from the request).",
+    )
+    offset: int = Field(
+        ge=0,
+        description="The offset that produced this page (echoed from the request).",
+    )
 
     @classmethod
     def create(

--- a/test/test_v4_pagination.py
+++ b/test/test_v4_pagination.py
@@ -62,6 +62,13 @@ def client():
         yield c
 
 
+@pytest.fixture
+def openapi(client):
+    """The sub-app's generated OpenAPI document, built once for the OpenAPI tests
+    (generation walks every route/schema, so avoid regenerating per assertion)."""
+    return client.app.openapi()
+
+
 def _assert_validation_envelope(response):
     """The response is a 422 shaped by the #828 error contract:
     ``{"error": {"code": "VALIDATION_ERROR", ...}}``."""
@@ -131,28 +138,35 @@ def test_non_numeric_limit_rejected_with_422_envelope(client):
     _assert_validation_envelope(client.get("/_widgets", params={"limit": "abc"}))
 
 
-def test_openapi_contains_paginated_response_schema(client):
+def test_openapi_contains_paginated_response_schema(openapi):
     # The sub-app's own OpenAPI must contain the generic page schema and reference
     # it from the list route's 200 response.
-    openapi = client.app.openapi()
     page_schemas = [
         name for name in openapi["components"]["schemas"] if name.startswith("V4Page")
     ]
-    assert page_schemas == ["V4Page_WidgetOut_"], page_schemas
+    # Exactly one paginated schema, and it names its item type — asserted
+    # semantically rather than pinning the exact generated identifier, whose
+    # format can shift across FastAPI/Pydantic versions.
+    assert len(page_schemas) == 1, page_schemas
+    assert "WidgetOut" in page_schemas[0], page_schemas[0]
 
     ok_content = openapi["paths"]["/_widgets"]["get"]["responses"]["200"]["content"]
     ref = ok_content["application/json"]["schema"]["$ref"]
     assert ref == f"#/components/schemas/{page_schemas[0]}", ref
 
+    # The envelope's numeric fields carry their non-negativity constraints into
+    # the schema (self-documenting responses): total/offset >= 0, limit >= 1.
+    props = openapi["components"]["schemas"][page_schemas[0]]["properties"]
+    assert props["total"]["minimum"] == 0
+    assert props["offset"]["minimum"] == 0
+    assert props["limit"]["minimum"] == 1
 
-def test_openapi_declares_limit_offset_query_params(client):
+
+def test_openapi_declares_limit_offset_query_params(openapi):
     # The other half of the contract: limit/offset must render as documented query
     # params (bounds + defaults) on the list route, so every list endpoint that
     # depends on PaginationParams advertises pagination identically in OpenAPI.
-    params = {
-        p["name"]: p
-        for p in client.app.openapi()["paths"]["/_widgets"]["get"]["parameters"]
-    }
+    params = {p["name"]: p for p in openapi["paths"]["/_widgets"]["get"]["parameters"]}
     assert set(params) == {"limit", "offset"}
 
     limit = params["limit"]

--- a/test/test_v4_pagination.py
+++ b/test/test_v4_pagination.py
@@ -1,0 +1,168 @@
+"""Tests for the v4 pagination contract (issue #829, epic #842).
+
+Pins the reusable pieces from :mod:`api_v4.pagination`:
+
+* :class:`~api_v4.pagination.PaginationParams` applies the documented defaults
+  (``limit=20``, ``offset=0``) and echoes caller-supplied values;
+* :class:`~api_v4.pagination.V4Page` is exactly ``{items, total, limit, offset}``,
+  with ``total`` independent of ``len(items)``;
+* out-of-range inputs (``limit`` above ``MAX_LIMIT``, ``limit < 1``, ``offset < 0``)
+  return **422 in the #828 ``VALIDATION_ERROR`` envelope** — the key integration
+  point with the error contract; nothing new is invented here;
+* the generic response model renders in the sub-app's OpenAPI schema.
+
+A throwaway list route is attached to a freshly built /v4 sub-app (mirroring
+test_v4_errors.py / test_v4_subapp.py). No DB is needed.
+"""
+
+import pytest
+from fastapi import Depends
+from fastapi.testclient import TestClient
+
+from api_v4.app import create_v4_app
+from api_v4.pagination import DEFAULT_LIMIT, MAX_LIMIT, PaginationParams, V4Page
+from api_v4.schemas.base import V4BaseModel
+
+ENVELOPE_KEYS = {"items", "total", "limit", "offset"}
+
+# A distinctive total that can never equal len(items) below, so a test that the
+# envelope's `total` is the full-result count (not the page length) can't pass by
+# coincidence.
+TOTAL_ROWS = 128
+
+
+class WidgetOut(V4BaseModel):
+    """A minimal item model, only so the generic ``V4Page[WidgetOut]`` has a
+    concrete type argument to render in OpenAPI."""
+
+    id: int
+    name: str
+
+
+PAGE_ITEMS = [WidgetOut(id=1, name="alpha"), WidgetOut(id=2, name="beta")]
+
+
+@pytest.fixture
+def client():
+    """A /v4 sub-app with a throwaway list route using the pagination contract.
+
+    CORS is a no-op so assertions isolate pagination/validation from the CORS
+    layer (its own concern, covered in test_v4_subapp.py).
+    """
+    v4_app = create_v4_app(configure_cors=lambda _app: None)
+
+    @v4_app.get("/_widgets", response_model=V4Page[WidgetOut])
+    async def _list_widgets(page: PaginationParams = Depends()):
+        # A real endpoint would slice its query by page.limit/page.offset and count
+        # matching rows for `total`; here we return a fixed slice and a fixed total
+        # so the echoed limit/offset and the total/items round-trip are observable.
+        return V4Page.create(items=PAGE_ITEMS, total=TOTAL_ROWS, pagination=page)
+
+    with TestClient(v4_app) as c:
+        yield c
+
+
+def _assert_validation_envelope(response):
+    """The response is a 422 shaped by the #828 error contract:
+    ``{"error": {"code": "VALIDATION_ERROR", ...}}``."""
+    assert response.status_code == 422
+    body = response.json()
+    assert set(body) == {"error"}, f"expected the #828 envelope, got {set(body)}"
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+    # The offending query param is reported under details.errors (jsonable).
+    errors = body["error"]["details"]["errors"]
+    assert isinstance(errors, list) and errors
+
+
+def test_defaults_applied_when_no_query_params(client):
+    response = client.get("/_widgets")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["limit"] == DEFAULT_LIMIT == 20
+    assert body["offset"] == 0
+
+
+def test_envelope_has_exactly_the_contract_keys(client):
+    body = client.get("/_widgets").json()
+    assert set(body) == ENVELOPE_KEYS, f"unexpected envelope keys: {set(body)}"
+
+
+def test_total_and_items_echo_correctly(client):
+    body = client.get("/_widgets").json()
+    # `total` is the full-result count, deliberately != the number of items on the
+    # page — the envelope must report both independently.
+    assert body["total"] == TOTAL_ROWS
+    assert len(body["items"]) == len(PAGE_ITEMS) < body["total"]
+    assert body["items"] == [{"id": 1, "name": "alpha"}, {"id": 2, "name": "beta"}]
+
+
+def test_supplied_limit_and_offset_are_echoed(client):
+    body = client.get("/_widgets", params={"limit": 50, "offset": 10}).json()
+    assert body["limit"] == 50
+    assert body["offset"] == 10
+
+
+def test_boundary_values_are_accepted(client):
+    # The inclusive bounds themselves are valid: limit=1, limit=MAX_LIMIT, offset=0.
+    assert client.get("/_widgets", params={"limit": 1}).status_code == 200
+    at_max = client.get("/_widgets", params={"limit": MAX_LIMIT})
+    assert at_max.status_code == 200
+    assert at_max.json()["limit"] == MAX_LIMIT == 100
+    assert client.get("/_widgets", params={"offset": 0}).status_code == 200
+
+
+def test_limit_above_max_rejected_with_422_envelope(client):
+    _assert_validation_envelope(
+        client.get("/_widgets", params={"limit": MAX_LIMIT + 1})
+    )
+
+
+def test_limit_below_one_rejected_with_422_envelope(client):
+    _assert_validation_envelope(client.get("/_widgets", params={"limit": 0}))
+
+
+def test_negative_offset_rejected_with_422_envelope(client):
+    _assert_validation_envelope(client.get("/_widgets", params={"offset": -1}))
+
+
+def test_non_numeric_limit_rejected_with_422_envelope(client):
+    # A non-integer value hits Pydantic type coercion (int_parsing) rather than a
+    # range check, but must still surface as the same #828 VALIDATION_ERROR envelope.
+    _assert_validation_envelope(client.get("/_widgets", params={"limit": "abc"}))
+
+
+def test_openapi_contains_paginated_response_schema(client):
+    # The sub-app's own OpenAPI must contain the generic page schema and reference
+    # it from the list route's 200 response.
+    openapi = client.app.openapi()
+    page_schemas = [
+        name for name in openapi["components"]["schemas"] if name.startswith("V4Page")
+    ]
+    assert page_schemas == ["V4Page_WidgetOut_"], page_schemas
+
+    ok_content = openapi["paths"]["/_widgets"]["get"]["responses"]["200"]["content"]
+    ref = ok_content["application/json"]["schema"]["$ref"]
+    assert ref == f"#/components/schemas/{page_schemas[0]}", ref
+
+
+def test_openapi_declares_limit_offset_query_params(client):
+    # The other half of the contract: limit/offset must render as documented query
+    # params (bounds + defaults) on the list route, so every list endpoint that
+    # depends on PaginationParams advertises pagination identically in OpenAPI.
+    params = {
+        p["name"]: p
+        for p in client.app.openapi()["paths"]["/_widgets"]["get"]["parameters"]
+    }
+    assert set(params) == {"limit", "offset"}
+
+    limit = params["limit"]
+    assert limit["in"] == "query" and limit["required"] is False
+    assert limit["schema"]["default"] == DEFAULT_LIMIT == 20
+    assert limit["schema"]["minimum"] == 1
+    assert limit["schema"]["maximum"] == MAX_LIMIT == 100
+
+    offset = params["offset"]
+    assert offset["in"] == "query" and offset["required"] is False
+    assert offset["schema"]["default"] == 0
+    assert offset["schema"]["minimum"] == 0
+    assert "maximum" not in offset["schema"]


### PR DESCRIPTION
Closes #829. Part of the v4 migration epic #842. Design reference: migration guide §9 "Responses & pagination".

## What this adds

A single reusable module, `api_v4/pagination.py`, defining the pagination **contract** every v4 list endpoint will share. Two pieces:

**1. `V4Page[DataT]` — the generic list envelope**
```json
{ "items": [ {} ], "total": 128, "limit": 20, "offset": 0 }
```
- Subclasses `V4BaseModel` (snake_case canonical), so serialization is `items`/`total`/`limit`/`offset` — exactly those four keys.
- `total` is the count of **all** matching rows, ignoring `limit`/`offset` (not `len(items)`).
- Ergonomic constructor `V4Page.create(*, items, total, pagination)` pulls `limit`/`offset` straight off the request's `PaginationParams`, so the echoed values can't drift from what the request used.
- Endpoints declare `response_model=V4Page[SomeModel]`.

**2. `PaginationParams` — the params dependency**
- FastAPI dependency-class (`page: PaginationParams = Depends()`) declaring `limit` (default 20, `ge=1`, `le=100`) and `offset` (default 0, `ge=0`) as **OpenAPI-visible query params** with descriptions.
- Module constants `DEFAULT_LIMIT = 20` / `MAX_LIMIT = 100` — the documented defaults + maximums the issue asks for.

## Deliberate decisions (please sanity-check)

- **`limit`/`offset`, not `page`/`page_size`.** v4 standardizes on limit/offset (guide §9). The `page`/`page_size` validation referenced by #486 is a **v3** concern and is intentionally *not* implemented here — the two paging styles are never mixed on the v4 surface.
- **Out-of-range inputs reject with 422, never silently clamp.** The `Query(ge=…, le=…)` bounds make `limit>MAX_LIMIT`, `limit<1`, and `offset<0` raise `RequestValidationError`, which the **existing #828 handler** turns into the `{"error": {"code": "VALIDATION_ERROR", "details": {"errors": […]}}}` envelope. **No new error shape is introduced** — this PR just produces inputs the #828 contract already shapes. Rejecting (vs. clamping) is explicit and self-documenting in OpenAPI. Happy to switch to clamping if reviewers prefer friendlier semantics, but flagging it as a conscious choice rather than a default.
- **`DEFAULT_LIMIT`/`MAX_LIMIT` = 20/100.** v3's `le=1000` / `le=10_000` caps live only on the verse-level **result/search** endpoints (`assessment_routes/v3/results_query_routes.py:760`, `train_routes/v3/train_routes.py`) — a different, far-larger category — and even there v3 added a *separate absolute SQL cap* because an unbounded `limit=1000` could pull tens of thousands of rows. 100 is the right ceiling for the v4 **catalog** lists (versions/revisions/assessments). A future heavy list that genuinely needs more should define its own params dependency rather than raise this shared cap. This is a policy call — easy to adjust.
- **Generic response model renders cleanly.** `V4Page[VersionOut]` produces OpenAPI component `V4Page_VersionOut_` with a readable `title: "V4Page[VersionOut]"`; `limit`/`offset` render as query params with correct `minimum`/`maximum`/`default`. Verbose name, but valid and unambiguous (clients read the `$ref`, not the name). Nothing ugly to report.

## Scope

- **In scope:** the envelope model, the params dependency, constants, tests. Pure request/response shaping.
- **Out of scope (untouched):** real v4 resource endpoints, the service/repository/query layer, DB queries, v3, `middleware.py`, auth (#831), the job envelope (#827), filtering (#433), page/page_size (#486), and any migrations. The envelope gets *wired into* real endpoints later, in the Versions/Revisions vertical slice.

## Tests

`test/test_v4_pagination.py` (11 tests, no DB) builds a `/v4` sub-app via `create_v4_app(...)` with a throwaway list route, and asserts:
- defaults applied when no query params (`limit==20`, `offset==0`);
- `total`/`items` echo correctly with `total` independent of page length; envelope has exactly `items/total/limit/offset`;
- `limit>MAX_LIMIT`, `limit<1`, `offset<0`, **and** a non-numeric `limit` each return **422 in the #828 `VALIDATION_ERROR` envelope** (the key integration point with #828);
- boundary values (`limit=1`, `limit=100`, `offset=0`) accepted;
- generated OpenAPI contains the `V4Page_*` response schema **and** declares `limit`/`offset` as query params with the documented bounds/defaults.

Full `test/` suite collects cleanly (1216 tests); the four v4 suites (pagination/errors/subapp/base) pass. black + isort clean.

## Reviewed

A FastAPI/Pydantic-v2 expert pass verified (with live repros on this exact stack — FastAPI 0.115.6 / Pydantic 2.4.2) the generic-model construction, dependency-class rendering, and the 422→#828 flow. Its one substantive note — that bare `V4Page.create(...)` skips item validation while `V4Page[X].create(...)` doesn't (moot on the wire because the mandatory `response_model` re-validates) — is now documented on `create()` to steer real endpoints correctly, and the request-side OpenAPI shape is now pinned by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)