### PR TITLE
feat(v4): Versions vertical slice — list/get/create/delete (#825/#826/#831/#833)

### DIFF
--- a/api_v4/app.py
+++ b/api_v4/app.py
@@ -59,6 +59,8 @@ import fastapi
 
 from api_v4.errors import register_exception_handlers
 from api_v4.meta_routes import router as meta_router
+from bible_routes.v4.version_routes import router as version_router
+from security_routes.auth_routes import get_current_user
 
 
 def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
@@ -88,7 +90,19 @@ def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
     configure_cors(v4_app)
 
     # The meta/discovery router; its ``/`` becomes ``/v4/`` once mounted.
-    # Future v4 domain routers (<domain>_routes/v4/*) are included here too.
+    # Left PUBLIC on purpose: the ``/v4/`` discovery root (and the parent app's
+    # bare ``/v4`` health shim that reuses its payload) must answer without a
+    # token, so do NOT attach auth here.
     v4_app.include_router(meta_router)
+
+    # Domain routers are auth-protected at the router level (#831): a
+    # ``dependencies=[Depends(get_current_user)]`` here makes "protected by
+    # default" the failure mode, so a handler that forgets its own auth
+    # dependency still cannot ship unauthenticated. Handlers that need the user
+    # re-declare ``current_user: UserModel = Depends(get_current_user)`` — FastAPI
+    # dedupes the dependency, so it runs once per request.
+    v4_app.include_router(
+        version_router, dependencies=[fastapi.Depends(get_current_user)]
+    )
 
     return v4_app

--- a/api_v4/schemas/bible.py
+++ b/api_v4/schemas/bible.py
@@ -99,5 +99,5 @@ class VersionOut(V4BaseModel):
     is_reference: bool = False
     transcribed_audio: bool = False
     owner_id: int | None = None
-    group_ids: list[int] = []
+    group_ids: list[int] = Field(default_factory=list)
     deleted: bool = False

--- a/api_v4/schemas/bible.py
+++ b/api_v4/schemas/bible.py
@@ -1,0 +1,103 @@
+"""v4 Bible-domain request/response schemas (issues #825/#826/#830, epic #842).
+
+The first vertical slice on the v4 surface is Versions. These schemas subclass
+:class:`api_v4.schemas.base.V4BaseModel`, so the wire contract is **snake_case**
+(issue #830): every field's canonical name is its snake_case Python attribute,
+and that is what v4 emits.
+
+Legacy v3 spellings that were camelCase (``forwardTranslation``,
+``backTranslation``, ``machineTranslation``) are accepted on *input* via a
+``validation_alias`` of ``AliasChoices(<snake_case>, <legacy camelCase>)`` so
+existing callers can migrate without a flag day. Two properties matter, and both
+are load-bearing for the #830 goal:
+
+* ``validation_alias`` (not a plain ``alias``) is input-only, so responses keep
+  emitting snake_case — see the :class:`V4BaseModel` docstring for why a plain
+  ``alias`` would leak the legacy name back onto the wire.
+* Listing the **snake_case name first** in ``AliasChoices`` makes it the property
+  name in the generated OpenAPI request schema (FastAPI serializes schemas with
+  ``by_alias=True``, and Pydantic uses the first choice), so ``/v4/openapi.json``
+  documents the canonical snake_case field while still accepting the legacy name.
+  A bare ``validation_alias="machineTranslation"`` would validate fine but
+  document only the *deprecated* spelling — the opposite of #830.
+"""
+
+from pydantic import AliasChoices, Field
+
+from api_v4.schemas.base import V4BaseModel
+
+
+class VersionCreate(V4BaseModel):
+    """Request body for ``POST /v4/versions`` (issue #826: JSON-only bodies).
+
+    Snake_case is canonical; the three formerly-camelCase fields also accept
+    their legacy v3 spelling on input via ``validation_alias``.
+    """
+
+    name: str
+    iso_language: str
+    iso_script: str
+    abbreviation: str
+    rights: str | None = None
+    # Legacy v3 camelCase names accepted on input; canonical (and emitted) name
+    # stays snake_case. snake_case is listed first in AliasChoices so it is the
+    # name documented in the OpenAPI schema (see the module docstring).
+    forward_translation: int | None = Field(
+        default=None,
+        validation_alias=AliasChoices("forward_translation", "forwardTranslation"),
+    )
+    back_translation: int | None = Field(
+        default=None,
+        validation_alias=AliasChoices("back_translation", "backTranslation"),
+    )
+    machine_translation: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("machine_translation", "machineTranslation"),
+    )
+    is_reference: bool = False
+    transcribed_audio: bool = False
+    # Required, mirroring v3: a version must be created into at least one group
+    # the caller belongs to. An empty list is a domain error (400), a missing
+    # field is a framework validation error (422) — see version_service /
+    # version_routes.
+    add_to_groups: list[int]
+
+    model_config = {
+        **V4BaseModel.model_config,
+        "json_schema_extra": {
+            "example": {
+                "name": "English King James Version",
+                "iso_language": "eng",
+                "iso_script": "Latn",
+                "abbreviation": "english_-_king_james_version",
+                "machine_translation": False,
+                "add_to_groups": [1],
+            }
+        },
+    }
+
+
+class VersionOut(V4BaseModel):
+    """Response body for the ``/v4/versions`` endpoints.
+
+    Plain snake_case fields — no aliases. The router builds this from the ORM
+    row explicitly (see ``version_routes._to_out``) rather than validating the
+    ORM object, so the ORM-attribute-name differences (``forward_translation_id``
+    -> ``forward_translation``) are handled in one obvious place and this stays a
+    pure output contract.
+    """
+
+    id: int
+    name: str
+    iso_language: str
+    iso_script: str
+    abbreviation: str
+    rights: str | None = None
+    forward_translation: int | None = None
+    back_translation: int | None = None
+    machine_translation: bool = False
+    is_reference: bool = False
+    transcribed_audio: bool = False
+    owner_id: int | None = None
+    group_ids: list[int] = []
+    deleted: bool = False

--- a/bible_routes/v4/version_routes.py
+++ b/bible_routes/v4/version_routes.py
@@ -130,6 +130,16 @@ async def create_version(
             message=str(exc),
             details={"group_id": exc.group_id},
         ) from exc
+    except version_service.InvalidReference as exc:
+        raise V4APIError(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="INVALID_REFERENCE",
+            message=(
+                "A referenced value does not exist. Check the FK-backed fields: "
+                "iso_language, iso_script, back_translation."
+            ),
+            details={"fields": list(version_service.InvalidReference.FIELDS)},
+        ) from exc
     group_map = await version_service.group_ids_for_versions(db, [version.id])
     return _to_out(version, group_map.get(version.id, []))
 

--- a/bible_routes/v4/version_routes.py
+++ b/bible_routes/v4/version_routes.py
@@ -20,6 +20,8 @@ domain signals onto the #828 :class:`~api_v4.errors.V4APIError` envelope. The
 error ``code`` values are the stable contract clients branch on.
 """
 
+__version__ = "v4"
+
 import fastapi
 from fastapi import Depends, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/bible_routes/v4/version_routes.py
+++ b/bible_routes/v4/version_routes.py
@@ -1,0 +1,160 @@
+"""v4 Versions router (issues #825/#826/#828/#829/#831/#833, epic #842).
+
+The first real resource on the v4 surface — the walking skeleton where the v4
+primitives (structured errors #828, pagination #829, snake_case canon #830) meet
+a DB-backed endpoint. Four endpoints:
+
+* ``GET  /v4/versions``        — paginated, group-scoped list (``V4Page[VersionOut]``).
+* ``GET  /v4/versions/{id}``   — single version; 404 ``VERSION_NOT_FOUND``.
+* ``POST /v4/versions``        — create (201); JSON body; group-membership checked.
+* ``DELETE /v4/versions/{id}`` — soft-delete (204); 404 / 403 as appropriate.
+
+Resource-style plural kebab-case URL (#825) and a single JSON body (#826). Auth
+is applied at the router level in :func:`api_v4.app.create_v4_app` (#831,
+protected-by-default), so these handlers only re-declare ``current_user`` when
+they need it (FastAPI dedupes the dependency).
+
+This module owns the HTTP concerns only: it calls
+:mod:`bible_routes.v4.version_service` for all data access and maps the service's
+domain signals onto the #828 :class:`~api_v4.errors.V4APIError` envelope. The
+error ``code`` values are the stable contract clients branch on.
+"""
+
+import fastapi
+from fastapi import Depends, Response, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_v4.errors import V4APIError
+from api_v4.pagination import PaginationParams, V4Page
+from api_v4.schemas.bible import VersionCreate, VersionOut
+from bible_routes.v4 import version_service
+from database.dependencies import get_db
+from database.models import BibleVersion
+from database.models import UserDB as UserModel
+from security_routes.auth_routes import get_current_user
+
+router = fastapi.APIRouter(prefix="/versions", tags=["Versions"])
+
+
+def _to_out(version: BibleVersion, group_ids: list[int]) -> VersionOut:
+    """Build the snake_case ``VersionOut`` from an ORM row + its group ids.
+
+    The one place ORM-attribute-name differences are bridged
+    (``forward_translation_id`` -> ``forward_translation``). Booleans are coerced
+    with ``bool(...)`` because their columns are nullable and legacy rows may hold
+    NULL (mirrors v3's null-to-false coercion for ``deleted``).
+    """
+    return VersionOut(
+        id=version.id,
+        name=version.name,
+        iso_language=version.iso_language,
+        iso_script=version.iso_script,
+        abbreviation=version.abbreviation,
+        rights=version.rights,
+        forward_translation=version.forward_translation_id,
+        back_translation=version.back_translation_id,
+        machine_translation=bool(version.machine_translation),
+        is_reference=bool(version.is_reference),
+        transcribed_audio=bool(version.transcribed_audio),
+        owner_id=version.owner_id,
+        group_ids=group_ids,
+        deleted=bool(version.deleted),
+    )
+
+
+@router.get("", response_model=V4Page[VersionOut])
+async def list_versions(
+    page: PaginationParams = Depends(),
+    include_deleted: bool = False,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+) -> V4Page[VersionOut]:
+    """List versions the caller may access, newest-id last, paginated.
+
+    Admins may pass ``include_deleted=true`` to also receive soft-deleted rows;
+    the flag is ignored for non-admins (see the service).
+    """
+    versions, total = await version_service.list_versions(
+        db,
+        current_user,
+        limit=page.limit,
+        offset=page.offset,
+        include_deleted=include_deleted,
+    )
+    group_map = await version_service.group_ids_for_versions(
+        db, [v.id for v in versions]
+    )
+    items = [_to_out(v, group_map.get(v.id, [])) for v in versions]
+    return V4Page[VersionOut].create(items=items, total=total, pagination=page)
+
+
+@router.get("/{version_id}", response_model=VersionOut)
+async def get_version(
+    version_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+) -> VersionOut:
+    """Fetch a single version by id, scoped to what the caller may see."""
+    try:
+        version = await version_service.get_version(db, current_user, version_id)
+    except version_service.VersionNotFound as exc:
+        raise V4APIError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="VERSION_NOT_FOUND",
+            message=str(exc),
+            details={"version_id": version_id},
+        ) from exc
+    group_map = await version_service.group_ids_for_versions(db, [version.id])
+    return _to_out(version, group_map.get(version.id, []))
+
+
+@router.post("", response_model=VersionOut, status_code=status.HTTP_201_CREATED)
+async def create_version(
+    data: VersionCreate,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+) -> VersionOut:
+    """Create a version owned by the caller and grant its groups access."""
+    try:
+        version = await version_service.create_version(db, current_user, data)
+    except version_service.VersionGroupRequired as exc:
+        raise V4APIError(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            code="VERSION_GROUP_REQUIRED",
+            message="A version must be added to at least one group.",
+        ) from exc
+    except version_service.GroupMembershipRequired as exc:
+        raise V4APIError(
+            status_code=status.HTTP_403_FORBIDDEN,
+            code="GROUP_MEMBERSHIP_REQUIRED",
+            message=str(exc),
+            details={"group_id": exc.group_id},
+        ) from exc
+    group_map = await version_service.group_ids_for_versions(db, [version.id])
+    return _to_out(version, group_map.get(version.id, []))
+
+
+@router.delete("/{version_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_version(
+    version_id: int,
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+) -> Response:
+    """Soft-delete a version (owner or admin only)."""
+    try:
+        await version_service.soft_delete_version(db, current_user, version_id)
+    except version_service.VersionNotFound as exc:
+        raise V4APIError(
+            status_code=status.HTTP_404_NOT_FOUND,
+            code="VERSION_NOT_FOUND",
+            message=str(exc),
+            details={"version_id": version_id},
+        ) from exc
+    except version_service.VersionAccessForbidden as exc:
+        raise V4APIError(
+            status_code=status.HTTP_403_FORBIDDEN,
+            code="VERSION_ACCESS_FORBIDDEN",
+            message=str(exc),
+            details={"version_id": version_id},
+        ) from exc
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/bible_routes/v4/version_service.py
+++ b/bible_routes/v4/version_service.py
@@ -18,7 +18,12 @@ Authorization semantics preserved from v3:
 
 * **Visibility** (list / get): an admin sees every version; a non-admin sees a
   version only if it is non-deleted and one of the caller's groups has access
-  to it via ``bible_version_access``.
+  to it via ``bible_version_access``. "Non-deleted" is ``deleted IS NOT TRUE``
+  (v4 refinement over v3's ``deleted IS FALSE``): ``BibleVersion.deleted`` is a
+  nullable column and legacy rows may hold NULL, which the response layer already
+  coerces to ``False`` — so a NULL row must stay *visible*, not silently vanish
+  from listings. Authorization is unchanged; only the NULL sentinel is treated
+  consistently.
 * **``include_deleted``** (list): honored only for admins; a non-admin never
   receives soft-deleted rows regardless of the flag.
 * **Create**: the version is owned by the caller and added only to groups the
@@ -83,11 +88,12 @@ def _visible_versions_query(user: UserDB, *, include_deleted: bool):
     if user.is_admin:
         stmt = select(BibleVersion)
         if not include_deleted:
-            stmt = stmt.where(BibleVersion.deleted.is_(False))
+            # IS NOT TRUE keeps NULL-deleted (legacy) rows visible; see docstring.
+            stmt = stmt.where(BibleVersion.deleted.is_not(True))
         return stmt
 
     # Non-admin: only versions accessible through a group the user belongs to,
-    # and never soft-deleted ones.
+    # and never soft-deleted ones (NULL counts as not-deleted — see docstring).
     return (
         select(BibleVersion)
         .distinct()
@@ -96,7 +102,7 @@ def _visible_versions_query(user: UserDB, *, include_deleted: bool):
             BibleVersion.id == BibleVersionAccess.bible_version_id,
         )
         .where(
-            BibleVersion.deleted.is_(False),
+            BibleVersion.deleted.is_not(True),
             BibleVersionAccess.group_id.in_(
                 select(UserGroup.group_id).where(UserGroup.user_id == user.id)
             ),
@@ -231,9 +237,15 @@ async def soft_delete_version(
     if not user.is_admin and version.owner_id != user.id:
         raise VersionAccessForbidden(version_id)
 
-    version.deleted = True
-    version.deletedAt = date.today()
-    await db.commit()
+    # Roll back on a failed commit so the shared session is never left in an
+    # aborted-transaction state (same guard as create_version).
+    try:
+        version.deleted = True
+        version.deletedAt = date.today()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
     return version
 
 

--- a/bible_routes/v4/version_service.py
+++ b/bible_routes/v4/version_service.py
@@ -1,0 +1,262 @@
+"""Version data-access service for the v4 surface (issue #833, epic #842).
+
+This is the first extraction of query/authorization logic out of a route and
+into a reusable, HTTP-agnostic service — the pattern the rest of the v4 slices
+follow. It replicates the behavior of the frozen v3 ``/version`` routes
+(``bible_routes/v3/version_routes.py``) so v4 preserves v3's authorization
+semantics exactly, while owning its own (paginated) query surface.
+
+Boundary: functions here take an :class:`~sqlalchemy.ext.asyncio.AsyncSession`,
+the current :class:`~database.models.UserDB`, and plain data; they return ORM
+rows / plain values and raise the small :class:`VersionServiceError` signals
+below. They know nothing about HTTP status codes or the v4 error envelope —
+the router (``version_routes.py``) maps each signal to a
+:class:`api_v4.errors.V4APIError`. v3 is untouched; consolidating v3 onto this
+service is deliberately a later pass (rest of #833).
+
+Authorization semantics preserved from v3:
+
+* **Visibility** (list / get): an admin sees every version; a non-admin sees a
+  version only if it is non-deleted and one of the caller's groups has access
+  to it via ``bible_version_access``.
+* **``include_deleted``** (list): honored only for admins; a non-admin never
+  receives soft-deleted rows regardless of the flag.
+* **Create**: the version is owned by the caller and added only to groups the
+  caller belongs to — with no admin bypass, exactly as v3. Group membership is
+  validated *before* the row is inserted (v4 refinement: v3 inserted first and
+  could leave an orphan version if a later group check failed; the who-can-do-
+  what semantics are unchanged).
+* **Delete**: soft-delete (``deleted=True`` + ``deletedAt``); allowed for the
+  owner or an admin. The lookup is global by id (not visibility-scoped), so a
+  non-owner who can see the row still gets 403 — mirroring v3.
+"""
+
+from collections import defaultdict
+from datetime import date
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.models import BibleVersion, BibleVersionAccess, UserDB, UserGroup
+
+
+class VersionServiceError(Exception):
+    """Base for version-service domain signals the router maps to V4APIError."""
+
+
+class VersionNotFound(VersionServiceError):
+    """No version with this id is visible to (list/get) or reachable by the caller."""
+
+    def __init__(self, version_id: int) -> None:
+        self.version_id = version_id
+        super().__init__(f"Version {version_id} does not exist.")
+
+
+class VersionAccessForbidden(VersionServiceError):
+    """Caller may see the version but is neither its owner nor an admin (delete)."""
+
+    def __init__(self, version_id: int) -> None:
+        self.version_id = version_id
+        super().__init__(f"Not authorized to modify version {version_id}.")
+
+
+class VersionGroupRequired(VersionServiceError):
+    """``add_to_groups`` was empty — a version must join at least one group."""
+
+
+class GroupMembershipRequired(VersionServiceError):
+    """Caller tried to add a version to a group they do not belong to."""
+
+    def __init__(self, group_id: int) -> None:
+        self.group_id = group_id
+        super().__init__(f"Not authorized to add a version to group {group_id}.")
+
+
+def _visible_versions_query(user: UserDB, *, include_deleted: bool):
+    """Base ``SELECT BibleVersion`` scoped to what ``user`` may see.
+
+    No ``limit``/``offset``/``order_by`` — callers add those (and the count query
+    wraps this as a subquery), so the filter/authorization logic lives in exactly
+    one place. ``include_deleted`` is honored only on the admin branch; the
+    non-admin branch always excludes soft-deleted rows.
+    """
+    if user.is_admin:
+        stmt = select(BibleVersion)
+        if not include_deleted:
+            stmt = stmt.where(BibleVersion.deleted.is_(False))
+        return stmt
+
+    # Non-admin: only versions accessible through a group the user belongs to,
+    # and never soft-deleted ones.
+    return (
+        select(BibleVersion)
+        .distinct()
+        .join(
+            BibleVersionAccess,
+            BibleVersion.id == BibleVersionAccess.bible_version_id,
+        )
+        .where(
+            BibleVersion.deleted.is_(False),
+            BibleVersionAccess.group_id.in_(
+                select(UserGroup.group_id).where(UserGroup.user_id == user.id)
+            ),
+        )
+    )
+
+
+async def list_versions(
+    db: AsyncSession,
+    user: UserDB,
+    *,
+    limit: int,
+    offset: int,
+    include_deleted: bool,
+) -> tuple[list[BibleVersion], int]:
+    """Return one page of versions the user may see, plus the total match count.
+
+    ``total`` is the count of *all* matching rows ignoring ``limit``/``offset``
+    (for the pagination envelope), computed from the *same* scoped query as the
+    page so the two share one filter/authorization definition. They are still two
+    statements, so a concurrent insert/delete between them can cause the usual
+    (rare) offset-pagination drift between ``total`` and ``len(items)``.
+    """
+    effective_include_deleted = include_deleted and user.is_admin
+    stmt = _visible_versions_query(user, include_deleted=effective_include_deleted)
+
+    total = (
+        await db.execute(select(func.count()).select_from(stmt.subquery()))
+    ).scalar_one()
+    result = await db.execute(
+        stmt.order_by(BibleVersion.id).limit(limit).offset(offset)
+    )
+    return list(result.scalars().all()), total
+
+
+async def get_version(db: AsyncSession, user: UserDB, version_id: int) -> BibleVersion:
+    """Return a single version the user may see, or raise :class:`VersionNotFound`.
+
+    Visibility-scoped: a non-admin asking for a version they cannot see gets the
+    same ``VersionNotFound`` as a truly missing id, so existence is not leaked.
+    (There is no v3 GET-one endpoint to mirror; this is the secure default.)
+    """
+    stmt = _visible_versions_query(user, include_deleted=False).where(
+        BibleVersion.id == version_id
+    )
+    version = (await db.execute(stmt)).scalars().first()
+    if version is None:
+        raise VersionNotFound(version_id)
+    return version
+
+
+async def create_version(db: AsyncSession, user: UserDB, data) -> BibleVersion:
+    """Create a version owned by ``user`` and grant its ``add_to_groups`` access.
+
+    ``data`` is a ``VersionCreate``. Raises :class:`VersionGroupRequired` if no
+    group was given and :class:`GroupMembershipRequired` for any group the caller
+    does not belong to — both validated before any row is written. Duplicate group
+    ids in ``add_to_groups`` are collapsed (order-preserving) so a caller cannot
+    create duplicate access rows.
+    """
+    if not data.add_to_groups:
+        raise VersionGroupRequired()
+
+    # De-duplicate while preserving order: [1, 1, 2] -> [1, 2]. bible_version_access
+    # has no unique constraint, so without this a repeated id would write duplicate
+    # rows (and surface as duplicate group_ids in the response).
+    group_ids = list(dict.fromkeys(data.add_to_groups))
+
+    user_group_ids = set(
+        (
+            await db.execute(
+                select(UserGroup.group_id).where(UserGroup.user_id == user.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for group_id in group_ids:
+        if group_id not in user_group_ids:
+            raise GroupMembershipRequired(group_id)
+
+    new_version = BibleVersion(
+        name=data.name,
+        iso_language=data.iso_language,
+        iso_script=data.iso_script,
+        abbreviation=data.abbreviation,
+        rights=data.rights,
+        forward_translation_id=data.forward_translation,
+        back_translation_id=data.back_translation,
+        machine_translation=data.machine_translation,
+        owner_id=user.id,
+        is_reference=data.is_reference,
+        transcribed_audio=data.transcribed_audio,
+    )
+    # The version row and its access rows must commit all-or-nothing: flush to
+    # assign new_version.id without ending the transaction, add the access rows,
+    # then one commit. Roll back on any DB error so a failed write never leaves
+    # the shared session in a poisoned (aborted-transaction) state — the
+    # convention this service is the template for (cf. v3 revision_routes).
+    try:
+        db.add(new_version)
+        await db.flush()
+        for group_id in group_ids:
+            db.add(
+                BibleVersionAccess(bible_version_id=new_version.id, group_id=group_id)
+            )
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    await db.refresh(new_version)
+    return new_version
+
+
+async def soft_delete_version(
+    db: AsyncSession, user: UserDB, version_id: int
+) -> BibleVersion:
+    """Soft-delete a version (owner or admin only). Mirrors v3 ``DELETE /version``.
+
+    Looks the row up globally by id (not visibility-scoped), raising
+    :class:`VersionNotFound` if truly absent and :class:`VersionAccessForbidden`
+    if the caller is neither the owner nor an admin. Idempotent: re-deleting an
+    already-soft-deleted row is allowed.
+    """
+    version = (
+        (await db.execute(select(BibleVersion).where(BibleVersion.id == version_id)))
+        .scalars()
+        .first()
+    )
+    if version is None:
+        raise VersionNotFound(version_id)
+    if not user.is_admin and version.owner_id != user.id:
+        raise VersionAccessForbidden(version_id)
+
+    version.deleted = True
+    version.deletedAt = date.today()
+    await db.commit()
+    return version
+
+
+async def group_ids_for_versions(
+    db: AsyncSession, version_ids: list[int]
+) -> dict[int, list[int]]:
+    """Map each version id to the sorted list of group ids that can access it.
+
+    Batch-loaded in one query (avoids N+1) and shared by list/get/create so the
+    ``group_ids`` on every ``VersionOut`` is produced the same way.
+    """
+    group_map: dict[int, list[int]] = defaultdict(list)
+    if not version_ids:
+        return group_map
+
+    result = await db.execute(
+        select(BibleVersionAccess.bible_version_id, BibleVersionAccess.group_id)
+        .where(BibleVersionAccess.bible_version_id.in_(version_ids))
+        # distinct(): defensive against duplicate access rows (no unique
+        # constraint on bible_version_access) so group_ids never repeats a group.
+        .distinct()
+        .order_by(BibleVersionAccess.bible_version_id, BibleVersionAccess.group_id)
+    )
+    for version_id, group_id in result.all():
+        group_map[version_id].append(group_id)
+    return group_map

--- a/bible_routes/v4/version_service.py
+++ b/bible_routes/v4/version_service.py
@@ -40,6 +40,7 @@ from collections import defaultdict
 from datetime import date
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from database.models import BibleVersion, BibleVersionAccess, UserDB, UserGroup
@@ -75,6 +76,21 @@ class GroupMembershipRequired(VersionServiceError):
     def __init__(self, group_id: int) -> None:
         self.group_id = group_id
         super().__init__(f"Not authorized to add a version to group {group_id}.")
+
+
+class InvalidReference(VersionServiceError):
+    """A create referenced a value that fails a FK constraint on insert.
+
+    ``BibleVersion.iso_language`` / ``iso_script`` are FK-backed reference codes
+    and ``back_translation_id`` is a FK to ``bible_version.id``; a bad code or a
+    non-existent version id raises an ``IntegrityError`` on flush. The router maps
+    this to a stable 4xx (``INVALID_REFERENCE``) instead of letting it fall
+    through to the catch-all 500 — that is the whole point of the #828 contract.
+    """
+
+    #: FK-backed request fields, surfaced in the error details as a hint to the
+    #: client about which inputs can trigger this.
+    FIELDS = ("iso_language", "iso_script", "back_translation")
 
 
 def _visible_versions_query(user: UserDB, *, include_deleted: bool):
@@ -159,7 +175,10 @@ async def create_version(db: AsyncSession, user: UserDB, data) -> BibleVersion:
 
     ``data`` is a ``VersionCreate``. Raises :class:`VersionGroupRequired` if no
     group was given and :class:`GroupMembershipRequired` for any group the caller
-    does not belong to — both validated before any row is written. Duplicate group
+    does not belong to — both validated before any row is written. A FK violation
+    on insert (unknown ``iso_language`` / ``iso_script`` code, or a non-existent
+    ``back_translation`` id) becomes :class:`InvalidReference` rather than a raw
+    ``IntegrityError`` (which the catch-all would turn into a 500). Duplicate group
     ids in ``add_to_groups`` are collapsed (order-preserving) so a caller cannot
     create duplicate access rows.
     """
@@ -210,6 +229,11 @@ async def create_version(db: AsyncSession, user: UserDB, data) -> BibleVersion:
                 BibleVersionAccess(bible_version_id=new_version.id, group_id=group_id)
             )
         await db.commit()
+    except IntegrityError as exc:
+        # Client input referenced a non-existent FK target (iso code / version).
+        # Translate to a domain signal → stable 4xx, never a catch-all 500.
+        await db.rollback()
+        raise InvalidReference() from exc
     except Exception:
         await db.rollback()
         raise

--- a/test/test_bible_routes/test_version_routes_v4.py
+++ b/test/test_bible_routes/test_version_routes_v4.py
@@ -358,6 +358,28 @@ class TestGroupDedup:
         assert page["total"] == len(set(ids))
 
 
+class TestNullDeletedVisibility:
+    def test_null_deleted_row_stays_visible(self, client, regular_token1, db_session):
+        """A legacy row with ``deleted IS NULL`` must still appear in the default
+        list — v4 filters on ``deleted IS NOT TRUE``, not ``IS FALSE``, so NULL
+        counts as not-deleted (and is coerced to False in the response)."""
+        created = _create(client, regular_token1, db_session, abbreviation="V4NULLDEL")
+        version_id = created.json()["id"]
+
+        # BibleVersion.deleted is nullable; force NULL as legacy rows can have.
+        db_session.expire_all()
+        row = db_session.query(BibleVersionModel).filter_by(id=version_id).first()
+        row.deleted = None
+        db_session.commit()
+
+        page = client.get(
+            f"{PREFIX}/versions", params={"limit": 100}, headers=_auth(regular_token1)
+        ).json()
+        by_id = {i["id"]: i for i in page["items"]}
+        assert version_id in by_id, "NULL-deleted row must stay visible"
+        assert by_id[version_id]["deleted"] is False
+
+
 class TestAdminIncludeDeleted:
     def test_include_deleted_flag_is_admin_only(
         self, client, regular_token1, admin_token, db_session

--- a/test/test_bible_routes/test_version_routes_v4.py
+++ b/test/test_bible_routes/test_version_routes_v4.py
@@ -166,6 +166,38 @@ class TestCreate:
         assert resp.json()["error"]["code"] == "VALIDATION_ERROR"
         assert "add_to_groups" in resp.text
 
+    def test_create_unknown_iso_language_is_400_invalid_reference(
+        self, client, regular_token1, db_session
+    ):
+        """An unknown FK-backed iso code becomes a stable 400, not a catch-all 500."""
+        body = {
+            **BASE_VERSION,
+            "abbreviation": "V4BADISO",
+            "iso_language": "zzz",  # not in iso_language reference table
+            "add_to_groups": [_group_id(db_session, "Group1")],
+        }
+        resp = client.post(
+            f"{PREFIX}/versions", json=body, headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["error"]["code"] == "INVALID_REFERENCE"
+
+    def test_create_nonexistent_back_translation_is_400_invalid_reference(
+        self, client, regular_token1, db_session
+    ):
+        """A non-existent back_translation FK id becomes a stable 400, not a 500."""
+        body = {
+            **BASE_VERSION,
+            "abbreviation": "V4BADBT",
+            "back_translation": 9999999,  # no such bible_version.id
+            "add_to_groups": [_group_id(db_session, "Group1")],
+        }
+        resp = client.post(
+            f"{PREFIX}/versions", json=body, headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["error"]["code"] == "INVALID_REFERENCE"
+
 
 class TestListAndGet:
     def test_list_returns_envelope_and_is_group_scoped(

--- a/test/test_bible_routes/test_version_routes_v4.py
+++ b/test/test_bible_routes/test_version_routes_v4.py
@@ -1,0 +1,397 @@
+"""Tests for the v4 Versions slice (issues #825/#826/#828/#829/#831/#833).
+
+Mounted at ``/v4`` on the same app as v3, so these reuse the shared test
+fixtures (``client``, ``regular_token1/2``, ``admin_token``, ``db_session``).
+Language codes are restricted to ``eng``/``swh`` per the test fixtures.
+
+What each assertion is pinning down:
+
+* the list endpoint returns the #829 ``V4Page`` envelope and is group-scoped;
+* create accepts BOTH the canonical snake_case body and the legacy camelCase
+  names, and always responds in snake_case (#830);
+* adding to a group the caller does not belong to is rejected with the mapped
+  #828 error code, and no orphan version is left behind;
+* unknown-id GET is a 404 ``VERSION_NOT_FOUND``;
+* an unauthenticated request is a 401 (proving router-level auth, #831);
+* delete soft-deletes and returns 204.
+"""
+
+from database.models import BibleVersion as BibleVersionModel
+from database.models import Group
+from database.models import UserDB as UserModel
+from database.models import UserGroup
+
+PREFIX = "/v4"
+
+BASE_VERSION = {
+    "name": "V4 Version",
+    "iso_language": "eng",
+    "iso_script": "Latn",
+    "abbreviation": "V4V",
+    "rights": "Some Rights",
+}
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _group_id(db_session, name):
+    group = db_session.query(Group).filter_by(name=name).first()
+    assert group is not None, f"expected group {name} in fixtures"
+    return group.id
+
+
+def _user_id(db_session, username):
+    user = db_session.query(UserModel).filter_by(username=username).first()
+    assert user is not None
+    return user.id
+
+
+def _create(client, token, db_session, *, group_name="Group1", **overrides):
+    """POST a version into ``group_name`` and return the response."""
+    body = {
+        **BASE_VERSION,
+        **overrides,
+        "add_to_groups": [_group_id(db_session, group_name)],
+    }
+    return client.post(f"{PREFIX}/versions", json=body, headers=_auth(token))
+
+
+class TestAuth:
+    def test_no_token_is_401(self, client):
+        """Router-level auth (#831): the collection is protected by default."""
+        resp = client.get(f"{PREFIX}/versions")
+        assert resp.status_code == 401, resp.text
+        assert resp.json()["error"]["code"] == "UNAUTHORIZED"
+        assert resp.headers.get("www-authenticate") == "Bearer"
+
+    def test_meta_root_stays_public(self, client):
+        """The /v4 discovery root must remain unauthenticated."""
+        resp = client.get(f"{PREFIX}/")
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["version"] == "v4"
+
+
+class TestCreate:
+    def test_create_snake_case_body_returns_snake_case(
+        self, client, regular_token1, db_session
+    ):
+        resp = _create(
+            client,
+            regular_token1,
+            db_session,
+            abbreviation="V4SNAKE",
+            machine_translation=True,
+            forward_translation=None,
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        # snake_case on the wire, never the legacy camelCase spellings (#830)
+        assert body["machine_translation"] is True
+        assert "machineTranslation" not in body
+        assert "forwardTranslation" not in body
+        assert body["owner_id"] == _user_id(db_session, "testuser1")
+        assert body["group_ids"] == [_group_id(db_session, "Group1")]
+
+    def test_create_accepts_legacy_camelcase_input(
+        self, client, regular_token1, db_session
+    ):
+        """Legacy v3 camelCase names still accepted on input; response snake_case."""
+        body = {
+            **BASE_VERSION,
+            "abbreviation": "V4CAMEL",
+            "machineTranslation": True,
+            "forwardTranslation": None,
+            "backTranslation": None,
+            "add_to_groups": [_group_id(db_session, "Group1")],
+        }
+        resp = client.post(
+            f"{PREFIX}/versions", json=body, headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 201, resp.text
+        out = resp.json()
+        assert out["machine_translation"] is True
+        assert "machineTranslation" not in out
+
+    def test_create_into_non_member_group_forbidden_no_orphan(
+        self, client, regular_token1, db_session
+    ):
+        """Adding to a group the caller does not belong to -> 403, and (v4 fix)
+        the version row is NOT created."""
+        user1_id = _user_id(db_session, "testuser1")
+        group2_id = _group_id(db_session, "Group2")  # testuser1 is NOT a member
+
+        before = (
+            db_session.query(BibleVersionModel)
+            .filter_by(owner_id=user1_id, abbreviation="V4ORPHAN")
+            .count()
+        )
+
+        body = {
+            **BASE_VERSION,
+            "abbreviation": "V4ORPHAN",
+            "add_to_groups": [group2_id],
+        }
+        resp = client.post(
+            f"{PREFIX}/versions", json=body, headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 403, resp.text
+        err = resp.json()["error"]
+        assert err["code"] == "GROUP_MEMBERSHIP_REQUIRED"
+        assert err["details"]["group_id"] == group2_id
+
+        db_session.expire_all()
+        after = (
+            db_session.query(BibleVersionModel)
+            .filter_by(owner_id=user1_id, abbreviation="V4ORPHAN")
+            .count()
+        )
+        assert after == before, "failed group check must not leave an orphan version"
+
+    def test_create_empty_groups_is_400(self, client, regular_token1):
+        body = {**BASE_VERSION, "abbreviation": "V4EMPTY", "add_to_groups": []}
+        resp = client.post(
+            f"{PREFIX}/versions", json=body, headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 400, resp.text
+        assert resp.json()["error"]["code"] == "VERSION_GROUP_REQUIRED"
+
+    def test_create_missing_groups_is_422(self, client, regular_token1):
+        body = {**BASE_VERSION, "abbreviation": "V4MISSING"}  # no add_to_groups
+        resp = client.post(
+            f"{PREFIX}/versions", json=body, headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["error"]["code"] == "VALIDATION_ERROR"
+        assert "add_to_groups" in resp.text
+
+
+class TestListAndGet:
+    def test_list_returns_envelope_and_is_group_scoped(
+        self, client, regular_token1, regular_token2, db_session
+    ):
+        created = _create(client, regular_token1, db_session, abbreviation="V4LIST")
+        assert created.status_code == 201, created.text
+        version_id = created.json()["id"]
+
+        # Owner sees it, and the response is the #829 envelope.
+        resp = client.get(f"{PREFIX}/versions", headers=_auth(regular_token1))
+        assert resp.status_code == 200, resp.text
+        page = resp.json()
+        assert set(page) == {"items", "total", "limit", "offset"}
+        assert page["limit"] == 20 and page["offset"] == 0
+        ids = {item["id"] for item in page["items"]}
+        assert version_id in ids
+        # snake_case items
+        sample = next(i for i in page["items"] if i["id"] == version_id)
+        assert "machine_translation" in sample and "machineTranslation" not in sample
+
+        # A user in a different group must NOT see it.
+        resp2 = client.get(f"{PREFIX}/versions", headers=_auth(regular_token2))
+        assert resp2.status_code == 200, resp2.text
+        assert version_id not in {item["id"] for item in resp2.json()["items"]}
+
+    def test_get_single_ok_and_visibility_scoped_404(
+        self, client, regular_token1, regular_token2, db_session
+    ):
+        created = _create(client, regular_token1, db_session, abbreviation="V4GETONE")
+        version_id = created.json()["id"]
+
+        ok = client.get(
+            f"{PREFIX}/versions/{version_id}", headers=_auth(regular_token1)
+        )
+        assert ok.status_code == 200, ok.text
+        assert ok.json()["id"] == version_id
+
+        # Non-member: existence is hidden as a 404, not a 403.
+        hidden = client.get(
+            f"{PREFIX}/versions/{version_id}", headers=_auth(regular_token2)
+        )
+        assert hidden.status_code == 404, hidden.text
+        assert hidden.json()["error"]["code"] == "VERSION_NOT_FOUND"
+
+    def test_get_unknown_id_is_404(self, client, regular_token1):
+        resp = client.get(f"{PREFIX}/versions/9999999", headers=_auth(regular_token1))
+        assert resp.status_code == 404, resp.text
+        err = resp.json()["error"]
+        assert err["code"] == "VERSION_NOT_FOUND"
+        assert err["details"]["version_id"] == 9999999
+
+    def test_pagination_limit_and_out_of_range(
+        self, client, regular_token1, db_session
+    ):
+        # Ensure at least two visible versions exist for testuser1.
+        _create(client, regular_token1, db_session, abbreviation="V4PAG1")
+        _create(client, regular_token1, db_session, abbreviation="V4PAG2")
+
+        full = client.get(
+            f"{PREFIX}/versions", params={"limit": 100}, headers=_auth(regular_token1)
+        )
+        total = full.json()["total"]
+        assert total >= 2
+
+        one = client.get(
+            f"{PREFIX}/versions", params={"limit": 1}, headers=_auth(regular_token1)
+        )
+        page = one.json()
+        assert len(page["items"]) == 1
+        assert page["limit"] == 1 and page["total"] == total
+
+        # Out-of-range limits reject with 422 (#829: reject, never clamp).
+        assert (
+            client.get(
+                f"{PREFIX}/versions",
+                params={"limit": 0},
+                headers=_auth(regular_token1),
+            ).status_code
+            == 422
+        )
+        assert (
+            client.get(
+                f"{PREFIX}/versions",
+                params={"limit": 101},
+                headers=_auth(regular_token1),
+            ).status_code
+            == 422
+        )
+
+
+class TestDelete:
+    def test_delete_soft_deletes_and_returns_204(
+        self, client, regular_token1, db_session
+    ):
+        created = _create(client, regular_token1, db_session, abbreviation="V4DEL")
+        version_id = created.json()["id"]
+
+        resp = client.delete(
+            f"{PREFIX}/versions/{version_id}", headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 204, resp.text
+        assert resp.content == b""
+
+        # Soft-deleted in the DB (row still present, deleted flag set).
+        db_session.expire_all()
+        row = db_session.query(BibleVersionModel).filter_by(id=version_id).first()
+        assert row is not None and row.deleted is True
+
+        # No longer visible via list or get.
+        listed = client.get(f"{PREFIX}/versions", headers=_auth(regular_token1))
+        assert version_id not in {i["id"] for i in listed.json()["items"]}
+        gone = client.get(
+            f"{PREFIX}/versions/{version_id}", headers=_auth(regular_token1)
+        )
+        assert gone.status_code == 404
+
+    def test_delete_not_owner_is_403(
+        self, client, regular_token1, regular_token2, db_session
+    ):
+        created = _create(client, regular_token1, db_session, abbreviation="V4DELOWN")
+        version_id = created.json()["id"]
+
+        resp = client.delete(
+            f"{PREFIX}/versions/{version_id}", headers=_auth(regular_token2)
+        )
+        assert resp.status_code == 403, resp.text
+        assert resp.json()["error"]["code"] == "VERSION_ACCESS_FORBIDDEN"
+
+    def test_delete_unknown_id_is_404(self, client, regular_token1):
+        resp = client.delete(
+            f"{PREFIX}/versions/9999999", headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 404, resp.text
+        assert resp.json()["error"]["code"] == "VERSION_NOT_FOUND"
+
+
+class TestGroupDedup:
+    def test_duplicate_add_to_groups_collapses(
+        self, client, regular_token1, db_session
+    ):
+        """Repeated group ids must not create duplicate access / group_ids."""
+        group1_id = _group_id(db_session, "Group1")
+        body = {
+            **BASE_VERSION,
+            "abbreviation": "V4DUP",
+            "add_to_groups": [group1_id, group1_id],
+        }
+        resp = client.post(
+            f"{PREFIX}/versions", json=body, headers=_auth(regular_token1)
+        )
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["group_ids"] == [group1_id]
+
+    def test_version_in_two_of_users_groups_is_not_double_counted(
+        self, client, regular_token1, db_session
+    ):
+        """A version reachable through two of the caller's groups must appear
+        exactly once in the list (guards the join + distinct + count logic)."""
+        user1_id = _user_id(db_session, "testuser1")
+        group1_id = _group_id(db_session, "Group1")
+
+        # Give testuser1 a second group and create a version in BOTH groups.
+        extra_group = Group(name="V4MultiGroup", description="v4 dedup test")
+        db_session.add(extra_group)
+        db_session.commit()
+        db_session.add(UserGroup(user_id=user1_id, group_id=extra_group.id))
+        db_session.commit()
+
+        created = client.post(
+            f"{PREFIX}/versions",
+            json={
+                **BASE_VERSION,
+                "abbreviation": "V4MULTI",
+                "add_to_groups": [group1_id, extra_group.id],
+            },
+            headers=_auth(regular_token1),
+        )
+        assert created.status_code == 201, created.text
+        version_id = created.json()["id"]
+        assert created.json()["group_ids"] == sorted([group1_id, extra_group.id])
+
+        page = client.get(
+            f"{PREFIX}/versions", params={"limit": 100}, headers=_auth(regular_token1)
+        ).json()
+        ids = [i["id"] for i in page["items"]]
+        # Appears exactly once despite two matching access rows (join dedup)...
+        assert ids.count(version_id) == 1
+        # ...and total is not inflated by the join.
+        assert page["total"] == len(set(ids))
+
+
+class TestAdminIncludeDeleted:
+    def test_include_deleted_flag_is_admin_only(
+        self, client, regular_token1, admin_token, db_session
+    ):
+        created = _create(client, regular_token1, db_session, abbreviation="V4INCDEL")
+        version_id = created.json()["id"]
+        assert (
+            client.delete(
+                f"{PREFIX}/versions/{version_id}", headers=_auth(regular_token1)
+            ).status_code
+            == 204
+        )
+
+        admin_incl = client.get(
+            f"{PREFIX}/versions",
+            params={"include_deleted": "true"},
+            headers=_auth(admin_token),
+        )
+        by_id = {i["id"]: i for i in admin_incl.json()["items"]}
+        assert version_id in by_id
+        assert by_id[version_id]["deleted"] is True
+
+        # Admin without the flag: hidden.
+        admin_excl = client.get(
+            f"{PREFIX}/versions",
+            params={"include_deleted": "false"},
+            headers=_auth(admin_token),
+        )
+        assert version_id not in {i["id"] for i in admin_excl.json()["items"]}
+
+        # Non-admin with the flag: still hidden.
+        user_incl = client.get(
+            f"{PREFIX}/versions",
+            params={"include_deleted": "true"},
+            headers=_auth(regular_token1),
+        )
+        assert version_id not in {i["id"] for i in user_incl.json()["items"]}

--- a/test/test_v4_pagination.py
+++ b/test/test_v4_pagination.py
@@ -140,23 +140,27 @@ def test_non_numeric_limit_rejected_with_422_envelope(client):
 
 def test_openapi_contains_paginated_response_schema(openapi):
     # The sub-app's own OpenAPI must contain the generic page schema and reference
-    # it from the list route's 200 response.
+    # it from the list route's 200 response. create_v4_app now also mounts real
+    # paginated resource endpoints (e.g. Versions -> V4Page_VersionOut_), so there
+    # can be several V4Page_* schemas; select the throwaway widget route's own by
+    # its item type rather than assuming it is the only one.
     page_schemas = [
         name for name in openapi["components"]["schemas"] if name.startswith("V4Page")
     ]
-    # Exactly one paginated schema, and it names its item type — asserted
+    widget_pages = [name for name in page_schemas if "WidgetOut" in name]
+    # Exactly one paginated schema for THIS route's item type — asserted
     # semantically rather than pinning the exact generated identifier, whose
     # format can shift across FastAPI/Pydantic versions.
-    assert len(page_schemas) == 1, page_schemas
-    assert "WidgetOut" in page_schemas[0], page_schemas[0]
+    assert len(widget_pages) == 1, page_schemas
+    widget_page = widget_pages[0]
 
     ok_content = openapi["paths"]["/_widgets"]["get"]["responses"]["200"]["content"]
     ref = ok_content["application/json"]["schema"]["$ref"]
-    assert ref == f"#/components/schemas/{page_schemas[0]}", ref
+    assert ref == f"#/components/schemas/{widget_page}", ref
 
     # The envelope's numeric fields carry their non-negativity constraints into
     # the schema (self-documenting responses): total/offset >= 0, limit >= 1.
-    props = openapi["components"]["schemas"][page_schemas[0]]["properties"]
+    props = openapi["components"]["schemas"][widget_page]["properties"]
     assert props["total"]["minimum"] == 0
     assert props["offset"]["minimum"] == 0
     assert props["limit"]["minimum"] == 1


### PR DESCRIPTION
## Summary

First real, DB-backed resource on the `/v4` surface — the **Versions** vertical slice (epic #842). This is the walking skeleton where the v4 primitives land on a real endpoint for the first time: structured errors (#828), the pagination envelope (#829), and the snake_case field canon (#830) all meet a live resource.

**Partially advances #825, #826, #831, #833 and epic #842 — closes none.** Those four issues are cross-cutting dimensions of every endpoint (URL shape, body shape, auth, service layer), so each slice PR advances all of them and they close only when the last resource lands.

### Endpoints (all under router-level auth)

| Method | Path | Notes |
|---|---|---|
| `GET` | `/v4/versions` | Paginated `V4Page[VersionOut]`, group-scoped exactly as v3; admin `include_deleted` retained |
| `GET` | `/v4/versions/{id}` | Single resource; not-found → `404 VERSION_NOT_FOUND` (visibility-scoped) |
| `POST` | `/v4/versions` | `201`; single JSON body; group-membership validated |
| `DELETE` | `/v4/versions/{id}` | `204`; **soft-delete** (mirrors v3); `404` / `403` mapped |

The deferred `PUT`→`PATCH` split and the `groups/{group_id}` access sub-resource are intentionally **not** in this slice (fiddliest part, not needed to establish the pattern).

## What's in it

- **`api_v4/schemas/bible.py`** — `VersionCreate` accepts **both** the legacy v3 camelCase names (`forwardTranslation`, `backTranslation`, `machineTranslation`) **and** their snake_case canon on input, via `validation_alias=AliasChoices("<snake>", "<camel>")`. Listing the snake_case name **first** matters: it becomes the property name in the generated OpenAPI request schema (FastAPI serializes with `by_alias=True`), so `/v4/openapi.json` documents the canonical snake_case field while still accepting the legacy spelling — the point of #830. A bare `validation_alias="machineTranslation"` would validate fine but document only the deprecated name. `VersionOut` emits **snake_case only** on the wire.
- **`bible_routes/v4/version_service.py`** — a thin, HTTP-agnostic data-access service (first #833 extraction). It replicates v3's authorization/visibility logic (`bible_routes/v3/version_routes.py`) and raises small domain signals; it knows nothing about HTTP status codes. **v3 is untouched** — consolidating v3 onto shared services is a deliberate later pass.
- **`bible_routes/v4/version_routes.py`** — the four endpoints; each maps the service's domain signals onto the #828 `V4APIError` envelope with stable codes (`VERSION_NOT_FOUND`, `VERSION_ACCESS_FORBIDDEN`, `GROUP_MEMBERSHIP_REQUIRED`, `VERSION_GROUP_REQUIRED`).
- **`api_v4/app.py`** — registers the router with `dependencies=[Depends(get_current_user)]` so v4 is **protected-by-default** (#831). `meta_router` is deliberately left public (the `/v4/` discovery root must answer without a token).

### Behavior-preserving service extraction (v3 semantics kept)

- Non-admins see/create versions only in groups they belong to; admins see all; `include_deleted` is honored for admins only.
- Create has **no admin bypass** on group membership (exactly v3).
- **Latent v3 bug fixed:** v3's `add_version` inserts the version row *before* checking group membership, so a failed check leaves a permanent orphan version. v4 validates all memberships first and writes nothing until they pass (regression-tested).
- Duplicate ids in `add_to_groups` are collapsed so a caller can't create duplicate access rows.

## v3 freeze snapshot: green, no regen

`/v4` is a mounted sub-app, so its routes live at `/v4/openapi.json` and never enter the main app's `/openapi.json`. `test/test_openapi_contract.py` passes unchanged with **no snapshot regeneration**.

## Design point for reviewers — DELETE existence disclosure (deliberate v3 parity)

`DELETE /v4/versions/{id}` looks the row up **globally** (not visibility-scoped), then owner-checks — so a non-owner who cannot otherwise see a version gets `403` rather than `404`, which discloses that the id exists. This exactly mirrors frozen v3's `DELETE /version` and matches this slice's stated "not-owner → 403" contract. `GET`/`list` remain visibility-scoped (uniform `404`). Flagging it because the service is the template future slices copy — if we'd rather v4 hide existence on delete too, that's a small change here, but it's a deviation from v3 parity so I left it as-specified.

## Tests

- **`test/test_bible_routes/test_version_routes_v4.py`** (new, 17 cases): the `V4Page` envelope + group-scoping; create accepts both snake_case and legacy camelCase and responds snake_case (`201`); non-member group → mapped `403 GROUP_MEMBERSHIP_REQUIRED` **with no orphan row**; empty groups → `400 VERSION_GROUP_REQUIRED`; missing groups → `422 VALIDATION_ERROR`; unknown id → `404 VERSION_NOT_FOUND`; no token → `401` (proves router-level auth); soft-delete → `204`; not-owner → `403`; admin `include_deleted` flag is admin-only; and a group-dedup / two-group visibility case guarding the `distinct()` count path.
- **`test/test_v4_pagination.py`** (updated): selects the throwaway widget page schema by its item type, since `create_v4_app` now also mounts a real `V4Page[VersionOut]` endpoint (there's legitimately more than one `V4Page_*` schema now). Intent preserved.
- v4 tests, the v3 OpenAPI freeze test, and pre-commit (black/isort) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
