### PR TITLE
feat(v4): shared async job envelope contract — JobState / JobEnvelope / 202 submit (#827)

### DIFF
--- a/api_v4/jobs.py
+++ b/api_v4/jobs.py
@@ -1,0 +1,548 @@
+"""Reusable async-job contract for every /v4 long-running operation (issue #827,
+epic #842).
+
+Assessments, training runs, and predict's slow path are all "submit now, answer
+later" operations that v3 exposes three different ways. v4 gives them **one**
+envelope, **one** submit response, and **one** poll shape (migration guide §7,
+mirroring AERO's task pattern)::
+
+    POST /v4/assessments        -> 202 Accepted
+                                   Location: /v4/assessments/42
+                                   Retry-After: 30
+                                   {"job_id": "42"}
+
+    GET  /v4/assessments/42     -> 200 (or 202 while PENDING)
+                                   {"job_id": "42", "state": "SUCCEEDED",
+                                    "result": {...}, "error": null}
+
+This module ships four pieces:
+
+* :class:`JobState` — the closed, public state vocabulary (``PENDING`` /
+  ``RUNNING`` / ``SUCCEEDED`` / ``FAILED``) plus
+  :data:`ASSESSMENT_STATE_MAP` / :func:`state_for_assessment_status`, the
+  translation from the internal ``queued/running/finished/failed`` vocabulary.
+* :class:`JobEnvelope` — the ``{job_id, state, result, error}`` poll body.
+* :func:`job_accepted_response` — the 202 submit response (``Location`` +
+  ``Retry-After``, body ``{"job_id": ...}``).
+* :func:`poll_status_code` / :func:`set_poll_headers` — the poll-side half of the
+  same contract, so every slice answers a poll identically.
+
+Scope: this PR defines the reusable *contract only*. It deliberately wires
+nothing into assessments, training, or predict — those are separate vertical
+slices that will consume this module the way the Versions slice (#883) consumed
+:class:`~api_v4.pagination.V4Page` and :class:`~api_v4.errors.V4APIError`. It
+also ships **no idempotency-key handling** (see "Not in this module" below).
+
+
+Deliberate contract decisions
+-----------------------------
+
+**The state vocabulary is closed, uppercase, and public.** Four states, and a
+client may branch exhaustively on them. ``CANCELED`` / ``CANCELLING`` are
+deliberately **not** shipped: nothing in the system can cancel a Modal run today,
+so a fifth state would only make every client's exhaustive switch wrong for a
+capability that does not exist. Adding a state later is a breaking change for
+exhaustive clients, which is precisely why the set stays minimal until something
+can actually produce the new value. The internal vocabulary keeps its own
+lowercase spellings (``schemas.assessment.AssessmentStatus``,
+``predict_jobs.status``) — v4 does not rename database values, it translates them
+at the edge.
+
+**The adapter seam is a per-slice mapping function, not a protocol and not a
+``from_model`` constructor.** The three future consumers do not share a shape:
+
+===============  ====================================  ============================
+Model            Status source                         Vocabulary
+===============  ====================================  ============================
+``Assessment``   ``assessment.status`` (``Text``)       queued/running/finished/failed
+``TrainingJob``  ``training_job.assessment.status``     (borrowed — see below)
+``PredictJob``   ``predict_jobs.status`` (CHECK'd)      running/complete/failed
+===============  ====================================  ============================
+
+So each slice writes its own total function ``(row) -> JobState`` and builds the
+envelope itself; **this module imports nothing from** :mod:`database.models`, and
+the dependency direction is always slice -> infrastructure. Rejected
+alternatives, and why:
+
+* *A* ``Protocol`` *with a* ``status: str`` *attribute.* Structurally all three
+  would satisfy it and it would guarantee nothing — the whole difficulty is that
+  the three ``status`` values mean different things. Worse, ``TrainingJob`` has no
+  ``status`` column at all (it is metadata only; status/timing/progress live on
+  the linked ``Assessment`` row — see aqua-api#584/#593), so the one model that
+  most needs the seam would fail the protocol.
+* *A* ``JobEnvelope.from_model(row)`` *classmethod.* That is exactly the import
+  this module must not have: shared v4 infrastructure would then depend on three
+  ORM models and grow an ``isinstance`` ladder that every new job-bearing
+  resource has to edit.
+* *A registry slices register adapters into.* Runtime indirection with exactly
+  one implementation per slice, plus a half-populated-registry failure mode that
+  is invisible until a request arrives.
+
+**...but the assessment mapping ships here, and predict's does not.** That
+asymmetry is intentional, not an oversight. ``AssessmentStatus`` is the *shared*
+internal status vocabulary of **two** of the three consumers — the assessments
+slice reads it directly, and the training slice reads it through
+``TrainingJob.assessment`` — and the guide's §7 state table is written in it. A
+vocabulary two slices must agree on belongs in the shared module; predict's
+vocabulary is private to its own table (enforced by
+``ck_predict_jobs_status``) and belongs in the predict slice. Note this imports
+:mod:`schemas.assessment` (a Pydantic enum module with no DB dependency), not an
+ORM model — importing the enum rather than restating its four strings is what
+keeps the mapping from silently going stale if the internal vocabulary changes.
+
+**What** ``job_id`` **refers to: the id of the resource served at the poll URL.**
+``job_id`` and the ``{id}`` segment of the ``Location`` header are always the same
+value. There is no separate job registry and ``job_id`` is *not* defined as "a row
+in a jobs table". Checked against all three consumers:
+
+* **Assessments** — poll ``GET /v4/assessments/{id}``, ``job_id = str(assessment.id)``.
+  The job *is* the resource, as the guide specifies.
+* **Predict** — poll ``GET /v4/predict/jobs/{id}``, ``job_id = predict_job.id``.
+  The client never submitted a "predict job", but the ``predict_jobs`` row is
+  nonetheless the resource at the poll URL, so the rule holds unchanged.
+* **Training** — poll ``GET /v4/training-jobs/{id}``, ``job_id = str(training_job.id)``.
+
+Training is where the rule earns its wording: a ``TrainingJob`` stores no state,
+so ``job_id`` identifies the pollable resource while the state is read from a
+*different* row (``training_job.assessment``). The rule holds; the adapter seam
+absorbs the indirection. Two consequences the training slice must handle rather
+than inherit silently:
+
+1. A training run is observable under **two** ids — its training-job id and its
+   underlying assessment id — and both envelopes report the same state. They are
+   one job seen twice, not two jobs. Do not treat ``assessment_id`` as a job id
+   on the training surface.
+2. ``training_job.assessment_id`` is nullable (``ondelete="SET NULL"``), so a
+   training row can exist with **no state carrier at all**. That is a
+   data-integrity fault, not a job state; this module offers no ``UNKNOWN`` state
+   to launder it into.
+
+**Wire type is** ``str`` **, uniformly.** ``Assessment.id`` and ``TrainingJob.id``
+are integer primary keys and ``PredictJob.id`` is an opaque ``prj_…`` string. The
+envelope stringifies, so a client parses one type across the whole surface
+instead of switching per endpoint. The cost is real and worth reviewing: for
+assessments the envelope reports ``"job_id": "42"`` while the resource body for
+the same row reports ``"id": 42``. The rejected alternative — an ``int | str``
+union — pushes that same inconsistency onto every client as a runtime type check.
+
+**A failed job reuses** :class:`~api_v4.errors.V4ErrorDetail` **rather than
+inventing a second error shape.** Per the guide's table a ``FAILED`` poll is an
+HTTP **200** — the request to read job state succeeded; it is the *job* that
+failed. So the failure cannot travel through the #828 exception handler, and
+raising :class:`~api_v4.errors.V4APIError` for it would be wrong twice over: it
+would turn a successful poll into a 4xx/5xx, and it would discard ``job_id`` and
+``state``. But the client should not have to parse two different error objects
+depending on *where* the failure happened, so ``JobEnvelope.error`` is literally
+``V4ErrorDetail`` — the same ``{code, message, details}`` object, with the same
+"``code`` is the stable thing you branch on, ``details`` is machine-readable
+context, prose lives in ``message``" rules. Only the surrounding envelope differs:
+a transport error is ``{"error": {...}}`` at the top level, a job failure is the
+``error`` *field* of the job envelope, alongside ``job_id`` and ``state``.
+
+**All four envelope keys are always present, including** ``"error": null``. This
+diverges from the error envelope, which uses ``exclude_none`` to drop an absent
+``details``. Here a fixed four-key shape lets a client read ``body["error"]`` and
+``body["result"]`` unconditionally, which is what a polling loop actually does on
+every tick; it also matches the envelope printed in #827 verbatim. So do **not**
+add ``response_model_exclude_none=True`` to a poll route.
+
+**Illegal state/payload combinations are rejected at construction.**
+:class:`JobEnvelope` enforces that ``FAILED`` carries an ``error`` and no other
+state does, and that ``result`` is present only on ``SUCCEEDED``. Encoding the
+invariants in the model (rather than trusting each slice) means a client can rely
+on "``state == "SUCCEEDED"`` implies ``result`` is usable" without defensive
+checks. The ``result``-only-on-``SUCCEEDED`` half is the stricter, more arguable
+one: it means partial or in-progress output cannot be published through
+``result``. That is deliberate — ``result`` is the job's *outcome*, and progress
+(``Assessment.percent_complete``, ``status_detail``) is a different concept that
+should arrive as its own field if and when a slice needs it, not as a
+half-populated ``result`` that clients cannot distinguish from a finished one.
+
+
+Where v4 deliberately diverges from v3's predict jobs
+-----------------------------------------------------
+
+v3 already implements a version of this at ``predict_routes/v3/predict_routes.py``
+(``_JOB_POLL_INTERVAL_S``, ``PredictJobHandle.poll_url``, and the ``Retry-After``
+set at line 372). v4 keeps its instincts and changes four things:
+
+1. **202 + ``Location``, not 200 + a URL in the body.** v3 returns ``200`` and
+   puts the poll URL in the payload (``PredictJobHandle.poll_url``), so a client
+   must know the response shape to find out where to poll. v4 returns
+   ``202 Accepted`` with the poll URL in the ``Location`` header, which any
+   generic HTTP client can follow without parsing the body.
+2. **``Retry-After`` on the submit, not only on the poll.** v3 sets it only on a
+   still-running *poll* response, so a client's very first poll happens at a
+   cadence it invented. v4 advertises the cadence with the 202 itself, then keeps
+   re-advertising it on every non-terminal poll (:func:`set_poll_headers`).
+3. **The cadence is a required argument, with no shared default.** v3's
+   ``_JOB_POLL_INTERVAL_S = 10`` is module-private to one route file, tuned for
+   translation jobs that finish in 30–120s. Exporting that as a v4-wide default
+   would silently apply a 10-second cadence to an assessment that runs for forty
+   minutes — 240 pointless polls per hour per job, which is the exact load
+   ``Retry-After`` exists to prevent. So :func:`job_accepted_response` requires
+   ``retry_after_s`` and each slice states its own cadence out loud.
+4. **``Location`` points at the concrete ``/v4`` path, not the floating
+   ``/latest`` alias.** v3 builds ``/latest/predict/jobs/{id}``, so a client that
+   deliberately pinned v3 gets handed a URL that will one day mean v4. v4 hands
+   back the version the caller actually called. Build it with
+   ``str(request.url_for("route_name", ...))`` so the path cannot drift from the
+   route it names.
+
+One v3 behavior is *not* carried over as a divergence but as a warning: v3's poll
+handler advances job state as a side effect of being polled (it calls Modal,
+flips ``status``, and commits — lines 344-387). That is a pragmatic design for a
+``Function.spawn`` with no callback, and this module neither requires nor forbids
+it. But a slice that does it must ensure the transition it writes is legal for
+its own vocabulary; ``JobEnvelope`` validates the shape of what you report, never
+the legality of a transition (``ASSESSMENT_VALID_TRANSITIONS`` in
+``schemas/assessment.py`` owns that for assessments).
+
+
+Not in this module
+------------------
+
+**Idempotency keys (#827, mitigating #722) are not implemented.** Honoring
+``Idempotency-Key`` needs a persistence table, so it lands as a follow-up PR with
+its own migration. Until then ``job_accepted_response`` does not read the header,
+and a client that retries after a dropped 202 **will** enqueue a second Modal run.
+Do not document the header as supported on any v4 endpoint before that PR lands.
+
+**The** ``results_push_*`` **callback surface is untouched.** It stays an
+explicitly internal, separately authenticated surface (#827); nothing here is
+meant for it.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Generic, TypeVar
+
+from fastapi import Response, status
+from fastapi.responses import JSONResponse
+from pydantic import Field, model_validator
+
+from api_v4.errors import V4ErrorDetail
+from api_v4.schemas.base import V4BaseModel
+from schemas.assessment import AssessmentStatus
+
+
+class JobState(str, Enum):
+    """The public, closed state vocabulary for every v4 async job.
+
+    Uppercase on the wire (``"SUCCEEDED"``), deliberately distinct from the
+    lowercase internal vocabularies it is translated from. See the module
+    docstring for why the set is exactly these four and why ``CANCELED`` is not
+    among them.
+    """
+
+    #: Accepted and queued; no work has started yet. Polls as HTTP 202.
+    PENDING = "PENDING"
+    #: Work is under way.
+    RUNNING = "RUNNING"
+    #: Terminal success; ``result`` carries the outcome.
+    SUCCEEDED = "SUCCEEDED"
+    #: Terminal failure; ``error`` carries the reason.
+    FAILED = "FAILED"
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether no further state change is possible.
+
+        A polling client stops on a terminal state, which is also why
+        :func:`set_poll_headers` emits ``Retry-After`` only when this is false.
+        """
+        return self in TERMINAL_JOB_STATES
+
+
+#: The states from which nothing further happens. Kept as data (not just the
+#: property) so a slice can use it in a query filter or an ``in`` check.
+TERMINAL_JOB_STATES = frozenset({JobState.SUCCEEDED, JobState.FAILED})
+
+
+#: Internal assessment vocabulary -> public state (migration guide §7). Total
+#: over :class:`~schemas.assessment.AssessmentStatus` — a test pins that, so
+#: adding an internal status fails loudly here instead of silently falling
+#: through at runtime. Shared by the assessments and training slices (training
+#: reads status off its linked ``Assessment``); see the module docstring for why
+#: this one mapping lives in the shared module and predict's does not.
+ASSESSMENT_STATE_MAP: dict[AssessmentStatus, JobState] = {
+    AssessmentStatus.queued: JobState.PENDING,
+    AssessmentStatus.running: JobState.RUNNING,
+    AssessmentStatus.finished: JobState.SUCCEEDED,
+    AssessmentStatus.failed: JobState.FAILED,
+}
+
+
+def state_for_assessment_status(status: AssessmentStatus | str | None) -> JobState:
+    """Translate an internal assessment status into its public :class:`JobState`.
+
+    Accepts either the enum or the raw string, because ``Assessment.status`` is an
+    unconstrained ``Text`` column and the ORM hands back a plain ``str``.
+
+    Raises :class:`ValueError` on anything outside the four internal statuses
+    (including ``None``). That is deliberate and it is the caller's decision what
+    to do with it — this module will not invent a state for data it does not
+    understand. Mapping an unrecognized value to ``FAILED`` would tell a client a
+    job failed when the truth is that the server cannot read its own row, and
+    mapping it to ``PENDING`` would make a dead job look alive forever. Letting it
+    surface as an ``INTERNAL_ERROR`` 500 is the honest signal that a row is
+    inconsistent; a slice that would rather degrade gracefully must catch this
+    explicitly and say so at its own call site.
+    """
+    try:
+        return ASSESSMENT_STATE_MAP[AssessmentStatus(status)]
+    except ValueError as exc:
+        raise ValueError(
+            f"{status!r} is not a known internal assessment status "
+            f"({', '.join(s.value for s in AssessmentStatus)})."
+        ) from exc
+
+
+ResultT = TypeVar("ResultT")
+
+
+class JobEnvelope(V4BaseModel, Generic[ResultT]):
+    """The poll body for every v4 async job: ``{job_id, state, result, error}``.
+
+    Declare it as a poll route's ``response_model=JobEnvelope[SomeResult]`` so the
+    result payload is typed in OpenAPI (FastAPI renders the parametrized model
+    under a generated name like ``JobEnvelope_AssessmentSummary_``; clients read
+    the ``$ref``, not the name). The bare ``JobEnvelope`` leaves ``result``
+    untyped, which is fine for a slice whose result shape is genuinely open.
+
+    All four keys are always emitted, including ``"error": null`` — do not add
+    ``response_model_exclude_none=True`` to a poll route (module docstring).
+
+    Construction is plain for the three non-failure states::
+
+        JobEnvelope(job_id="42", state=JobState.RUNNING)
+        JobEnvelope[Summary](job_id="42", state=JobState.SUCCEEDED, result=summary)
+
+    and goes through :meth:`failed` for the fourth, which is the only case that
+    has to build a :class:`~api_v4.errors.V4ErrorDetail`.
+    """
+
+    job_id: str = Field(
+        description=(
+            "Identifier of the job, equal to the resource id in the poll URL "
+            "(the Location header returned by the submit). Always a string, even "
+            "where the underlying primary key is an integer."
+        ),
+    )
+    state: JobState = Field(
+        description="The job's current public state; branch on this.",
+    )
+    result: ResultT | None = Field(
+        default=None,
+        description=(
+            "The job's outcome. Non-null only when state is SUCCEEDED; null in "
+            "every other state (progress is not reported here)."
+        ),
+    )
+    error: V4ErrorDetail | None = Field(
+        default=None,
+        description=(
+            "Why the job failed — the same {code, message, details} object the v4 "
+            "error envelope uses. Non-null only when state is FAILED. Note that a "
+            "FAILED poll is still HTTP 200: reading the job succeeded, the job "
+            "did not."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _check_payload_matches_state(self) -> JobEnvelope[ResultT]:
+        """Reject envelopes whose payload contradicts their state.
+
+        Two invariants, both of which clients are then allowed to rely on without
+        defensive checks (see the module docstring for the rationale and for why
+        the ``result`` half is the stricter of the two):
+
+        * ``error`` is non-null if and only if ``state`` is ``FAILED``;
+        * ``result`` is null unless ``state`` is ``SUCCEEDED``.
+
+        A ``SUCCEEDED`` job with no result is *permitted* — plenty of jobs finish
+        with nothing to return, and a required-result rule would force slices to
+        invent filler payloads.
+        """
+        if self.state is JobState.FAILED and self.error is None:
+            raise ValueError(
+                "a FAILED job must carry an error; build it with "
+                "JobEnvelope.failed(...), which supplies a default message when "
+                "the source row records none"
+            )
+        if self.state is not JobState.FAILED and self.error is not None:
+            raise ValueError(f"state {self.state.value} must not carry an error")
+        if self.result is not None and self.state is not JobState.SUCCEEDED:
+            raise ValueError(
+                f"state {self.state.value} must not carry a result; result is the "
+                "job's outcome, not its progress"
+            )
+        return self
+
+    @classmethod
+    def failed(
+        cls,
+        *,
+        job_id: str,
+        message: str | None = None,
+        code: str = "JOB_FAILED",
+        details: dict | None = None,
+    ) -> JobEnvelope[ResultT]:
+        """Build the ``FAILED`` envelope.
+
+        ``message`` is optional and falls back to a generic sentence, because the
+        stored reason is routinely absent: ``predict_jobs.error`` is nullable, and
+        an assessment can reach ``failed`` with a null ``status_detail``. Without
+        the fallback every slice would have to write the same ``or "…"`` guard, and
+        forgetting it would trip the model validator and turn a legitimate failed
+        job into a 500.
+
+        ``code`` defaults to the generic ``JOB_FAILED``; a slice that can classify
+        its failures (a timeout, a missing model, a Modal container OOM) should
+        pass a more specific stable code, since ``code`` is what clients branch on.
+        """
+        return cls(
+            job_id=job_id,
+            state=JobState.FAILED,
+            error=V4ErrorDetail(
+                code=code,
+                message=message or "The job failed.",
+                details=details,
+            ),
+        )
+
+
+class JobSubmitAccepted(V4BaseModel):
+    """The 202 submit body: just ``{"job_id": "..."}``.
+
+    Deliberately minimal — the poll URL travels in the ``Location`` header, not in
+    here (see divergence 1 in the module docstring). Declare it on a submit route
+    as ``status_code=status.HTTP_202_ACCEPTED, responses={202: {"model":
+    JobSubmitAccepted}}`` so the 202 is documented; the body itself is built by
+    :func:`job_accepted_response`.
+    """
+
+    job_id: str = Field(
+        description=(
+            "Identifier of the newly accepted job. Poll it at the URL in the "
+            "Location header."
+        ),
+    )
+
+
+def job_accepted_response(
+    *,
+    job_id: str,
+    poll_url: str,
+    retry_after_s: int,
+    headers: dict[str, str] | None = None,
+) -> JSONResponse:
+    """Build the ``202 Accepted`` response every v4 submit endpoint returns.
+
+    Sets ``Location`` to ``poll_url`` and ``Retry-After`` to ``retry_after_s``,
+    with body ``{"job_id": job_id}``. The body is dumped from
+    :class:`JobSubmitAccepted` rather than hand-built, so the wire shape cannot
+    drift from the declared schema (same reasoning as
+    :func:`api_v4.errors._error_response`).
+
+    ``poll_url`` — the URL the client should poll, whose id segment must equal
+    ``job_id``. Pass ``str(request.url_for("route_name", …))`` so it cannot drift
+    from the route; a root-relative path (``/v4/assessments/42``) is equally valid
+    per RFC 9110 §10.2.2, so this helper passes through whatever it is given
+    without rewriting it.
+
+    ``retry_after_s`` — required on purpose; there is no v4-wide default cadence.
+    See divergence 3 in the module docstring.
+
+    ``headers`` — optional extras for the same response. The two contract headers
+    are applied last and win, so a caller cannot accidentally shadow them.
+
+    Because this returns a ``Response`` directly, FastAPI does not validate it
+    against the route's ``response_model``; declare the route as::
+
+        @router.post("", status_code=status.HTTP_202_ACCEPTED,
+                     responses={202: {"model": JobSubmitAccepted}})
+
+    so the 202 still shows up in ``/v4/openapi.json``.
+    """
+    if retry_after_s < 1:
+        # A zero or negative delta-seconds tells a client "poll immediately,
+        # forever". Fail at the call site rather than shipping a header that
+        # invites a hot loop.
+        raise ValueError(f"retry_after_s must be >= 1, got {retry_after_s}")
+    if not poll_url:
+        raise ValueError("poll_url is required: the 202 must say where to poll")
+
+    return JSONResponse(
+        status_code=status.HTTP_202_ACCEPTED,
+        content=JobSubmitAccepted(job_id=job_id).model_dump(mode="json"),
+        headers={
+            **(headers or {}),
+            "Location": poll_url,
+            "Retry-After": str(retry_after_s),
+        },
+    )
+
+
+def poll_status_code(state: JobState) -> int:
+    """The HTTP status a poll returns for ``state`` (migration guide §7 table).
+
+    ``PENDING`` -> ``202 Accepted``, everything else -> ``200 OK``. A 202 on a
+    ``GET`` is unusual, but it is what the guide specifies and it is useful: it
+    lets a client distinguish "accepted, not started" from "running" without
+    reading the body. An unknown job id is a ``404`` and never reaches here — it is
+    a transport error raised as :class:`~api_v4.errors.V4APIError`, so it gets the
+    ``{"error": {...}}`` envelope rather than a job envelope with a made-up state.
+    """
+    if state is JobState.PENDING:
+        return status.HTTP_202_ACCEPTED
+    return status.HTTP_200_OK
+
+
+def set_poll_headers(
+    response: Response,
+    *,
+    state: JobState,
+    retry_after_s: int,
+) -> None:
+    """Apply the poll-side contract to ``response``: status code and cadence hint.
+
+    Sets ``response.status_code`` from :func:`poll_status_code`, and sets
+    ``Retry-After`` only while ``state`` is non-terminal — a terminal job must not
+    invite another poll, matching v3's predict poll, which omits the header once
+    the job is done. Kept as a helper for the same reason
+    :meth:`api_v4.pagination.V4Page.create` exists: so the three job-bearing
+    slices cannot each drift on the details.
+
+    Usage in a poll handler that declares ``response: Response`` and
+    ``response_model=JobEnvelope[...]``::
+
+        envelope = JobEnvelope(job_id=str(row.id), state=state)
+        set_poll_headers(response, state=state, retry_after_s=30)
+        return envelope
+
+    ``retry_after_s`` is validated even when the state is terminal (and the header
+    consequently unused), so a bad constant is caught on the first poll rather
+    than on whichever poll happens to catch a running job.
+    """
+    if retry_after_s < 1:
+        raise ValueError(f"retry_after_s must be >= 1, got {retry_after_s}")
+
+    response.status_code = poll_status_code(state)
+    if not state.is_terminal:
+        response.headers["Retry-After"] = str(retry_after_s)
+
+
+# Re-exported so a slice needs one import line for the whole contract.
+__all__ = [
+    "ASSESSMENT_STATE_MAP",
+    "TERMINAL_JOB_STATES",
+    "JobEnvelope",
+    "JobState",
+    "JobSubmitAccepted",
+    "job_accepted_response",
+    "poll_status_code",
+    "set_poll_headers",
+    "state_for_assessment_status",
+]

--- a/api_v4/jobs.py
+++ b/api_v4/jobs.py
@@ -456,7 +456,13 @@ def job_accepted_response(
     See divergence 3 in the module docstring.
 
     ``headers`` — optional extras for the same response. The two contract headers
-    are applied last and win, so a caller cannot accidentally shadow them.
+    are **assigned** afterwards, so a caller cannot shadow them at any casing. They
+    must not be merged into the same dict: HTTP header names are case-insensitive
+    but Python dict keys are not, so ``{"location": ..., "Location": ...}`` keeps
+    both entries and Starlette emits *two* ``Location`` headers — of which lookups
+    return the caller's, because it was added first. Assigning through
+    ``response.headers`` instead goes via ``MutableHeaders.__setitem__``, which
+    matches case-insensitively and overwrites rather than appends.
 
     Because this returns a ``Response`` directly, FastAPI does not validate it
     against the route's ``response_model``; declare the route as::
@@ -474,15 +480,16 @@ def job_accepted_response(
     if not poll_url:
         raise ValueError("poll_url is required: the 202 must say where to poll")
 
-    return JSONResponse(
+    response = JSONResponse(
         status_code=status.HTTP_202_ACCEPTED,
         content=JobSubmitAccepted(job_id=job_id).model_dump(mode="json"),
-        headers={
-            **(headers or {}),
-            "Location": poll_url,
-            "Retry-After": str(retry_after_s),
-        },
+        headers=headers,
     )
+    # Assigned, not merged — see the docstring. This overwrites any casing of the
+    # same name the caller supplied instead of appending a duplicate.
+    response.headers["Location"] = poll_url
+    response.headers["Retry-After"] = str(retry_after_s)
+    return response
 
 
 def poll_status_code(state: JobState) -> int:
@@ -515,6 +522,13 @@ def set_poll_headers(
     :meth:`api_v4.pagination.V4Page.create` exists: so the three job-bearing
     slices cannot each drift on the details.
 
+    On a terminal state the header is *removed*, not merely left unset, so the
+    post-condition ("a terminal poll carries no ``Retry-After``") holds no matter
+    what state the response arrived in — e.g. a handler that set the header itself
+    before deciding the job was done. This function enforces the contract rather
+    than assuming a clean response. (It cannot police middleware, which runs after
+    the handler returns and mutates the finished response.)
+
     Usage in a poll handler that declares ``response: Response`` and
     ``response_model=JobEnvelope[...]``::
 
@@ -530,7 +544,11 @@ def set_poll_headers(
         raise ValueError(f"retry_after_s must be >= 1, got {retry_after_s}")
 
     response.status_code = poll_status_code(state)
-    if not state.is_terminal:
+    if state.is_terminal:
+        # MutableHeaders.__delitem__ matches case-insensitively and is a no-op
+        # when the header is absent, so this needs no membership guard.
+        del response.headers["Retry-After"]
+    else:
         response.headers["Retry-After"] = str(retry_after_s)
 
 

--- a/test/test_v4_jobs.py
+++ b/test/test_v4_jobs.py
@@ -314,10 +314,10 @@ def test_submit_body_is_only_the_job_id(client):
 def test_submit_location_id_matches_the_job_id(client):
     # The stated rule for what job_id refers to: it is the id of the resource
     # served at the poll URL, so the Location's last segment must equal it.
-    body = client.post("/_jobs").json()
-    assert (
-        client.post("/_jobs").headers["location"].rsplit("/", 1)[-1] == body["job_id"]
-    )
+    # One response, read twice — comparing a header from a *second* submit against
+    # the first submit's body would only work while job_id is a fixed constant.
+    response = client.post("/_jobs")
+    assert response.headers["location"].rsplit("/", 1)[-1] == response.json()["job_id"]
 
 
 def test_job_accepted_response_rejects_a_nonpositive_retry_after():
@@ -331,16 +331,58 @@ def test_job_accepted_response_requires_a_poll_url():
         job_accepted_response(job_id=JOB_ID, poll_url="", retry_after_s=RETRY_AFTER_S)
 
 
-def test_contract_headers_win_over_caller_supplied_extras():
+@pytest.mark.parametrize(
+    "location_key,retry_key",
+    [
+        ("Location", "Retry-After"),
+        # Lowercase (and mixed) casing is the regression case: HTTP header names
+        # are case-insensitive but dict keys are not, so merging the caller's
+        # extras into the contract headers used to keep BOTH entries — emitting
+        # two Location headers, with the caller's winning every lookup because it
+        # was added first. The contract headers must be assigned, not merged.
+        ("location", "retry-after"),
+        ("LOCATION", "RETRY-AFTER"),
+    ],
+)
+def test_contract_headers_win_over_caller_supplied_extras(location_key, retry_key):
     response = job_accepted_response(
         job_id=JOB_ID,
         poll_url=POLL_URL,
         retry_after_s=RETRY_AFTER_S,
-        headers={"Location": "/wrong", "Retry-After": "1", "X-Extra": "kept"},
+        headers={location_key: "/wrong", retry_key: "1", "X-Extra": "kept"},
     )
     assert response.headers["location"] == POLL_URL
     assert response.headers["retry-after"] == str(RETRY_AFTER_S)
+    # Unrelated extras still survive.
     assert response.headers["x-extra"] == "kept"
+    # And exactly one of each contract header reaches the wire — a duplicate
+    # Location is not just ambiguous for clients, some proxies reject it.
+    raw = [name for name, _ in response.raw_headers]
+    assert raw.count(b"location") == 1, response.raw_headers
+    assert raw.count(b"retry-after") == 1, response.raw_headers
+
+
+def test_terminal_poll_clears_a_preexisting_retry_after():
+    # set_poll_headers enforces the post-condition rather than assuming a clean
+    # response: a handler that set Retry-After before deciding the job was done
+    # must not leak it into a terminal poll.
+    for state in TERMINAL_JOB_STATES:
+        response = Response()
+        response.headers["Retry-After"] = "5"
+        set_poll_headers(response, state=state, retry_after_s=RETRY_AFTER_S)
+        assert "retry-after" not in response.headers, state
+
+
+def test_non_terminal_poll_overwrites_a_preexisting_retry_after():
+    # The mirror case: the helper's value wins, and does not append a second
+    # Retry-After alongside the stale one.
+    for state in (JobState.PENDING, JobState.RUNNING):
+        response = Response()
+        response.headers["retry-after"] = "5"
+        set_poll_headers(response, state=state, retry_after_s=RETRY_AFTER_S)
+        assert response.headers["retry-after"] == str(RETRY_AFTER_S)
+        raw = [name for name, _ in response.raw_headers]
+        assert raw.count(b"retry-after") == 1, response.raw_headers
 
 
 # --------------------------------------------------------------------------- #

--- a/test/test_v4_jobs.py
+++ b/test/test_v4_jobs.py
@@ -1,0 +1,476 @@
+"""Tests for the v4 async job contract (issue #827, epic #842).
+
+Pins the reusable pieces from :mod:`api_v4.jobs`:
+
+* :class:`~api_v4.jobs.JobState` is exactly the four public states, and
+  :data:`~api_v4.jobs.ASSESSMENT_STATE_MAP` is **total** over the internal
+  ``AssessmentStatus`` vocabulary (so adding an internal status fails here rather
+  than at runtime);
+* :class:`~api_v4.jobs.JobEnvelope` is exactly ``{job_id, state, result, error}``
+  with all four keys always present — including ``"error": null`` — and rejects
+  payloads that contradict the state;
+* a failed job's ``error`` is the **same** ``{code, message, details}`` object the
+  #828 error envelope uses, carried on an HTTP **200**;
+* :func:`~api_v4.jobs.job_accepted_response` returns 202 with the real
+  ``Location`` and ``Retry-After`` **response headers**, and
+  :func:`~api_v4.jobs.set_poll_headers` sets 202/200 and emits ``Retry-After``
+  only while the job is non-terminal;
+* both shapes render in the sub-app's OpenAPI schema.
+
+Throwaway submit/poll routes are attached to a freshly built /v4 sub-app
+(mirroring test_v4_pagination.py / test_v4_errors.py) so the headers and status
+codes are asserted as they actually leave the app. No DB is needed.
+"""
+
+import pytest
+from fastapi import Response, status
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from api_v4.app import create_v4_app
+from api_v4.jobs import (
+    ASSESSMENT_STATE_MAP,
+    TERMINAL_JOB_STATES,
+    JobEnvelope,
+    JobState,
+    JobSubmitAccepted,
+    job_accepted_response,
+    poll_status_code,
+    set_poll_headers,
+    state_for_assessment_status,
+)
+from api_v4.schemas.base import V4BaseModel
+from schemas.assessment import AssessmentStatus
+
+ENVELOPE_KEYS = {"job_id", "result", "state", "error"}
+ERROR_DETAIL_KEYS = {"code", "message", "details"}
+
+JOB_ID = "42"
+POLL_URL = "/v4/_jobs/42"
+RETRY_AFTER_S = 30
+
+
+class WidgetResult(V4BaseModel):
+    """A minimal result model, only so the generic ``JobEnvelope[WidgetResult]``
+    has a concrete type argument to render in OpenAPI."""
+
+    score: float
+    note: str
+
+
+WIDGET_RESULT = WidgetResult(score=0.75, note="done")
+
+
+@pytest.fixture
+def client():
+    """A /v4 sub-app with throwaway submit/poll routes using the job contract.
+
+    The poll route takes the state as a query param so one route can exercise all
+    four states through the real response cycle. CORS is a no-op so assertions
+    isolate the job contract from the CORS layer (its own concern, covered in
+    test_v4_subapp.py).
+    """
+    v4_app = create_v4_app(configure_cors=lambda _app: None)
+
+    @v4_app.post(
+        "/_jobs",
+        status_code=status.HTTP_202_ACCEPTED,
+        responses={202: {"model": JobSubmitAccepted}},
+    )
+    async def _submit_job():
+        # A real endpoint would create the row / spawn the Modal call and use its
+        # id here, and would build poll_url with request.url_for(...).
+        return job_accepted_response(
+            job_id=JOB_ID, poll_url=POLL_URL, retry_after_s=RETRY_AFTER_S
+        )
+
+    @v4_app.get("/_jobs/{job_id}", response_model=JobEnvelope[WidgetResult])
+    async def _poll_job(job_id: str, state: JobState, response: Response):
+        # Stands in for a slice's own `(row) -> JobState` adapter function; the
+        # real one reads its model's status column (see api_v4/jobs.py).
+        if state is JobState.FAILED:
+            envelope = JobEnvelope[WidgetResult].failed(
+                job_id=job_id,
+                code="ASSESSMENT_RUN_FAILED",
+                message="The runner exited before finishing.",
+                details={"attempt_count": 3},
+            )
+        elif state is JobState.SUCCEEDED:
+            envelope = JobEnvelope[WidgetResult](
+                job_id=job_id, state=state, result=WIDGET_RESULT
+            )
+        else:
+            envelope = JobEnvelope[WidgetResult](job_id=job_id, state=state)
+        set_poll_headers(response, state=state, retry_after_s=RETRY_AFTER_S)
+        return envelope
+
+    with TestClient(v4_app) as c:
+        yield c
+
+
+@pytest.fixture
+def openapi(client):
+    """The sub-app's generated OpenAPI document, built once for the OpenAPI tests
+    (generation walks every route/schema, so avoid regenerating per assertion)."""
+    return client.app.openapi()
+
+
+# --------------------------------------------------------------------------- #
+# JobState and the internal -> public mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_job_state_is_the_closed_four_state_vocabulary():
+    # The set is closed on purpose (module docstring): adding a state is a
+    # breaking change for clients that branch exhaustively, so a new member has
+    # to be a deliberate edit here too.
+    assert {s.value for s in JobState} == {
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED",
+    }
+    # Uppercase on the wire, deliberately distinct from the internal lowercase
+    # vocabularies it is translated from.
+    assert all(s.value == s.value.upper() for s in JobState)
+    assert all(s.value not in {a.value for a in AssessmentStatus} for s in JobState)
+
+
+def test_terminal_states_are_succeeded_and_failed():
+    assert TERMINAL_JOB_STATES == {JobState.SUCCEEDED, JobState.FAILED}
+    assert JobState.SUCCEEDED.is_terminal and JobState.FAILED.is_terminal
+    assert not JobState.PENDING.is_terminal and not JobState.RUNNING.is_terminal
+
+
+def test_assessment_state_map_is_total_over_the_internal_vocabulary():
+    # The guard that matters: if a fifth AssessmentStatus is ever added, this
+    # fails here instead of raising a ValueError on a live poll.
+    assert set(ASSESSMENT_STATE_MAP) == set(AssessmentStatus)
+
+
+def test_assessment_state_map_matches_the_guide_table():
+    # Migration guide §7 / issue #827: queued->PENDING, running->RUNNING,
+    # finished->SUCCEEDED, failed->FAILED.
+    assert ASSESSMENT_STATE_MAP == {
+        AssessmentStatus.queued: JobState.PENDING,
+        AssessmentStatus.running: JobState.RUNNING,
+        AssessmentStatus.finished: JobState.SUCCEEDED,
+        AssessmentStatus.failed: JobState.FAILED,
+    }
+
+
+@pytest.mark.parametrize(
+    "internal,expected",
+    [
+        ("queued", JobState.PENDING),
+        ("running", JobState.RUNNING),
+        ("finished", JobState.SUCCEEDED),
+        ("failed", JobState.FAILED),
+    ],
+)
+def test_state_for_assessment_status_accepts_raw_strings(internal, expected):
+    # Assessment.status is an unconstrained Text column, so the ORM hands back a
+    # plain str — the raw-string path is the one production actually uses.
+    assert state_for_assessment_status(internal) is expected
+    assert state_for_assessment_status(AssessmentStatus(internal)) is expected
+
+
+@pytest.mark.parametrize("bad", [None, "", "complete", "QUEUED", "unknown"])
+def test_state_for_assessment_status_rejects_unknown_values(bad):
+    # No state is invented for data the server cannot read — including
+    # predict's "complete", which belongs to a different vocabulary, and the
+    # correctly-spelled-but-wrong-case "QUEUED".
+    with pytest.raises(ValueError):
+        state_for_assessment_status(bad)
+
+
+# --------------------------------------------------------------------------- #
+# JobEnvelope invariants
+# --------------------------------------------------------------------------- #
+
+
+def test_envelope_emits_all_four_keys_including_null_error():
+    body = JobEnvelope(job_id=JOB_ID, state=JobState.RUNNING).model_dump(mode="json")
+    assert set(body) == ENVELOPE_KEYS
+    # Explicitly present-as-null, NOT omitted: a polling client reads
+    # body["error"] / body["result"] unconditionally on every tick.
+    assert body["result"] is None
+    assert body["error"] is None
+
+
+def test_failed_constructor_builds_the_shared_error_object():
+    envelope = JobEnvelope.failed(
+        job_id=JOB_ID,
+        code="ASSESSMENT_RUN_FAILED",
+        message="The runner exited before finishing.",
+        details={"attempt_count": 3},
+    )
+    assert envelope.state is JobState.FAILED
+    assert envelope.result is None
+    body = envelope.model_dump(mode="json")
+    # The same {code, message, details} object as the #828 envelope's inner error
+    # — no second error shape is invented for job failures.
+    assert set(body["error"]) == ERROR_DETAIL_KEYS
+    assert body["error"] == {
+        "code": "ASSESSMENT_RUN_FAILED",
+        "message": "The runner exited before finishing.",
+        "details": {"attempt_count": 3},
+    }
+
+
+def test_failed_constructor_defaults_message_and_code():
+    # predict_jobs.error is nullable and an assessment can reach `failed` with a
+    # null status_detail, so the no-recorded-reason path must produce a valid
+    # envelope rather than trip the validator into a 500.
+    envelope = JobEnvelope.failed(job_id=JOB_ID)
+    assert envelope.error is not None
+    assert envelope.error.code == "JOB_FAILED"
+    assert envelope.error.message
+    assert envelope.error.details is None
+
+
+def test_failed_state_without_an_error_is_rejected():
+    with pytest.raises(ValidationError, match="must carry an error"):
+        JobEnvelope(job_id=JOB_ID, state=JobState.FAILED)
+
+
+@pytest.mark.parametrize(
+    "state", [JobState.PENDING, JobState.RUNNING, JobState.SUCCEEDED]
+)
+def test_non_failed_state_with_an_error_is_rejected(state):
+    with pytest.raises(ValidationError, match="must not carry an error"):
+        JobEnvelope(
+            job_id=JOB_ID,
+            state=state,
+            error={"code": "NOPE", "message": "should not be here"},
+        )
+
+
+@pytest.mark.parametrize("state", [JobState.PENDING, JobState.RUNNING])
+def test_result_on_a_non_terminal_state_is_rejected(state):
+    # The stricter, more arguable invariant (see the module docstring): `result`
+    # is the outcome, not the progress, so a running job cannot publish one.
+    with pytest.raises(ValidationError, match="must not carry a result"):
+        JobEnvelope(job_id=JOB_ID, state=state, result={"partial": True})
+
+
+def test_result_on_failed_is_rejected():
+    with pytest.raises(ValidationError, match="must not carry a result"):
+        JobEnvelope(
+            job_id=JOB_ID,
+            state=JobState.FAILED,
+            result={"partial": True},
+            error={"code": "JOB_FAILED", "message": "nope"},
+        )
+
+
+def test_succeeded_without_a_result_is_allowed():
+    # Plenty of jobs finish with nothing to return; requiring a result would
+    # force slices to invent filler payloads.
+    envelope = JobEnvelope(job_id=JOB_ID, state=JobState.SUCCEEDED)
+    assert envelope.state is JobState.SUCCEEDED
+    assert envelope.result is None
+
+
+def test_parametrized_envelope_validates_its_result():
+    ok = JobEnvelope[WidgetResult](
+        job_id=JOB_ID, state=JobState.SUCCEEDED, result={"score": 0.5, "note": "x"}
+    )
+    assert isinstance(ok.result, WidgetResult)
+    with pytest.raises(ValidationError):
+        JobEnvelope[WidgetResult](
+            job_id=JOB_ID, state=JobState.SUCCEEDED, result={"score": "not-a-float"}
+        )
+
+
+def test_integer_ids_are_stringified_on_the_wire():
+    # The uniform-str decision: Assessment/TrainingJob have integer PKs, predict
+    # has an opaque string one, and clients parse one type across the surface.
+    envelope = JobEnvelope(job_id=str(42), state=JobState.RUNNING)
+    assert envelope.model_dump(mode="json")["job_id"] == "42"
+
+
+# --------------------------------------------------------------------------- #
+# The 202 submit response (real headers, through the app)
+# --------------------------------------------------------------------------- #
+
+
+def test_submit_returns_202_with_location_and_retry_after(client):
+    response = client.post("/_jobs")
+    assert response.status_code == 202
+    # The headers are the point of the contract — assert them as they actually
+    # leave the app, not just as helper return values.
+    assert response.headers["location"] == POLL_URL
+    assert response.headers["retry-after"] == str(RETRY_AFTER_S)
+    assert response.json() == {"job_id": JOB_ID}
+
+
+def test_submit_body_is_only_the_job_id(client):
+    # Deliberately minimal: the poll URL travels in Location, not in the body
+    # (v4's divergence from v3's PredictJobHandle.poll_url).
+    assert set(client.post("/_jobs").json()) == {"job_id"}
+
+
+def test_submit_location_id_matches_the_job_id(client):
+    # The stated rule for what job_id refers to: it is the id of the resource
+    # served at the poll URL, so the Location's last segment must equal it.
+    body = client.post("/_jobs").json()
+    assert (
+        client.post("/_jobs").headers["location"].rsplit("/", 1)[-1] == body["job_id"]
+    )
+
+
+def test_job_accepted_response_rejects_a_nonpositive_retry_after():
+    for bad in (0, -1):
+        with pytest.raises(ValueError, match="retry_after_s"):
+            job_accepted_response(job_id=JOB_ID, poll_url=POLL_URL, retry_after_s=bad)
+
+
+def test_job_accepted_response_requires_a_poll_url():
+    with pytest.raises(ValueError, match="poll_url"):
+        job_accepted_response(job_id=JOB_ID, poll_url="", retry_after_s=RETRY_AFTER_S)
+
+
+def test_contract_headers_win_over_caller_supplied_extras():
+    response = job_accepted_response(
+        job_id=JOB_ID,
+        poll_url=POLL_URL,
+        retry_after_s=RETRY_AFTER_S,
+        headers={"Location": "/wrong", "Retry-After": "1", "X-Extra": "kept"},
+    )
+    assert response.headers["location"] == POLL_URL
+    assert response.headers["retry-after"] == str(RETRY_AFTER_S)
+    assert response.headers["x-extra"] == "kept"
+
+
+# --------------------------------------------------------------------------- #
+# The poll response (status mapping + Retry-After, through the app)
+# --------------------------------------------------------------------------- #
+
+
+def test_poll_status_code_matches_the_guide_table():
+    assert poll_status_code(JobState.PENDING) == 202
+    assert poll_status_code(JobState.RUNNING) == 200
+    assert poll_status_code(JobState.SUCCEEDED) == 200
+    assert poll_status_code(JobState.FAILED) == 200
+
+
+def test_pending_poll_returns_202_with_retry_after(client):
+    response = client.get(f"/_jobs/{JOB_ID}", params={"state": "PENDING"})
+    assert response.status_code == 202
+    assert response.headers["retry-after"] == str(RETRY_AFTER_S)
+    assert response.json() == {
+        "job_id": JOB_ID,
+        "state": "PENDING",
+        "result": None,
+        "error": None,
+    }
+
+
+def test_running_poll_returns_200_with_retry_after(client):
+    response = client.get(f"/_jobs/{JOB_ID}", params={"state": "RUNNING"})
+    assert response.status_code == 200
+    assert response.headers["retry-after"] == str(RETRY_AFTER_S)
+    assert response.json()["state"] == "RUNNING"
+
+
+def test_succeeded_poll_returns_200_result_and_no_retry_after(client):
+    response = client.get(f"/_jobs/{JOB_ID}", params={"state": "SUCCEEDED"})
+    assert response.status_code == 200
+    # Terminal: the client must stop polling, so no cadence hint is emitted.
+    assert "retry-after" not in response.headers
+    assert response.json() == {
+        "job_id": JOB_ID,
+        "state": "SUCCEEDED",
+        "result": {"score": 0.75, "note": "done"},
+        "error": None,
+    }
+
+
+def test_failed_poll_returns_200_and_carries_the_error(client):
+    response = client.get(f"/_jobs/{JOB_ID}", params={"state": "FAILED"})
+    # The load-bearing assertion: reading the job succeeded, the job did not.
+    # A FAILED job is NOT an HTTP error and must not be reshaped into the #828
+    # transport envelope.
+    assert response.status_code == 200
+    assert "retry-after" not in response.headers
+    body = response.json()
+    assert set(body) == ENVELOPE_KEYS, "a failed poll is a job envelope, not {'error'}"
+    assert body["state"] == "FAILED"
+    assert body["result"] is None
+    assert body["error"] == {
+        "code": "ASSESSMENT_RUN_FAILED",
+        "message": "The runner exited before finishing.",
+        "details": {"attempt_count": 3},
+    }
+
+
+def test_unknown_state_query_value_is_a_422_error_envelope(client):
+    # JobState being a closed enum means an unrecognized value is rejected by
+    # FastAPI validation and surfaces through the #828 handler — this module
+    # introduces no new error shape.
+    response = client.get(f"/_jobs/{JOB_ID}", params={"state": "CANCELED"})
+    assert response.status_code == 422
+    body = response.json()
+    assert set(body) == {"error"}
+    assert body["error"]["code"] == "VALIDATION_ERROR"
+
+
+def test_set_poll_headers_rejects_a_nonpositive_retry_after():
+    # Validated even on a terminal state, where the header goes unused, so a bad
+    # constant is caught on the first poll rather than only on a running one.
+    for state in JobState:
+        with pytest.raises(ValueError, match="retry_after_s"):
+            set_poll_headers(Response(), state=state, retry_after_s=0)
+
+
+# --------------------------------------------------------------------------- #
+# OpenAPI
+# --------------------------------------------------------------------------- #
+
+
+def test_openapi_documents_the_202_submit(openapi):
+    submit = openapi["paths"]["/_jobs"]["post"]
+    accepted = submit["responses"]["202"]
+    ref = accepted["content"]["application/json"]["schema"]["$ref"]
+    assert ref == "#/components/schemas/JobSubmitAccepted", ref
+    props = openapi["components"]["schemas"]["JobSubmitAccepted"]["properties"]
+    assert set(props) == {"job_id"}
+
+
+def test_openapi_documents_the_job_envelope(openapi):
+    # Select the parametrized schema by its result type rather than pinning the
+    # exact generated identifier, whose format can shift across
+    # FastAPI/Pydantic versions (same approach as test_v4_pagination.py).
+    envelope_schemas = [
+        name
+        for name in openapi["components"]["schemas"]
+        if name.startswith("JobEnvelope") and "WidgetResult" in name
+    ]
+    assert len(envelope_schemas) == 1, envelope_schemas
+    envelope = envelope_schemas[0]
+
+    ok_content = openapi["paths"]["/_jobs/{job_id}"]["get"]["responses"]["200"][
+        "content"
+    ]
+    assert (
+        ok_content["application/json"]["schema"]["$ref"]
+        == f"#/components/schemas/{envelope}"
+    )
+
+    props = openapi["components"]["schemas"][envelope]["properties"]
+    assert set(props) == ENVELOPE_KEYS
+    # The closed state vocabulary must be discoverable from the schema, so a
+    # client can generate an exhaustive switch.
+    assert openapi["components"]["schemas"]["JobState"]["enum"] == [
+        "PENDING",
+        "RUNNING",
+        "SUCCEEDED",
+        "FAILED",
+    ]
+    # The failure object is the shared #828 V4ErrorDetail, not a job-local copy.
+    assert "V4ErrorDetail" in openapi["components"]["schemas"]
+    assert (
+        set(openapi["components"]["schemas"]["V4ErrorDetail"]["properties"])
+        == ERROR_DETAIL_KEYS
+    )


### PR DESCRIPTION
## Summary

Ships the **shared async-job contract** as `api_v4/jobs.py` — the third piece of reusable v4 infrastructure, following #828 (`api_v4/errors.py`) and #829 (`api_v4/pagination.py`), both of which landed as contracts *before* any real resource consumed them.

**Advances #827 and epic #842 — closes neither.** #827 does not close until the last job-bearing slice (assessments, training, predict) actually returns this envelope, and its idempotency-key checkbox is explicitly deferred (see below). Nothing here is wired into assessments, training, or predict; those are separate vertical slices that will consume this module the way the Versions slice (#883) consumed `V4Page` and `V4APIError`. No v3 code and no `results_push_*` callback is touched.

## What's in it

`api_v4/jobs.py`:

| Piece | Contract |
|---|---|
| `JobState` | Closed, uppercase, public enum: `PENDING` / `RUNNING` / `SUCCEEDED` / `FAILED`, plus `is_terminal` and `TERMINAL_JOB_STATES` |
| `ASSESSMENT_STATE_MAP`, `state_for_assessment_status()` | Internal `queued/running/finished/failed` (`schemas/assessment.py`) → public state, per the guide's §7 table |
| `JobEnvelope[ResultT]` | `{job_id, state, result, error}`; `error` is the #828 `V4ErrorDetail`; validates payload-vs-state; `JobEnvelope.failed(...)` constructor |
| `JobSubmitAccepted` + `job_accepted_response()` | `202 Accepted` with `Location` (poll URL) and `Retry-After` (cadence hint), body `{"job_id": "…"}` |
| `poll_status_code()`, `set_poll_headers()` | The poll half: `PENDING`→202, else 200; `Retry-After` only while non-terminal |

Every contract decision — including the ones deliberately *not* taken — is written into the module docstring, following #829's style.

### Where v4 deliberately diverges from v3's predict jobs

v3 already implements a version of this (`predict_routes/v3/predict_routes.py:315-372` — `_JOB_POLL_INTERVAL_S`, `PredictJobHandle.poll_url`, the `Retry-After` at :372). v4 keeps its instincts and changes four things, all documented in the module docstring:

1. **202 + `Location`**, not 200 with the poll URL in the body — a generic HTTP client can follow the header without parsing the payload.
2. **`Retry-After` on the submit**, not only on a still-running poll, so a client's *first* poll uses the server's cadence instead of one it invented.
3. **No shared default cadence.** v3's `_JOB_POLL_INTERVAL_S = 10` is module-private and tuned for 30–120s translation jobs; exporting it v4-wide would silently apply a 10s cadence to a 40-minute assessment (240 pointless polls/hour/job). `retry_after_s` is a **required** keyword arg.
4. **`Location` points at the concrete `/v4` path**, not v3's floating `/latest/predict/jobs/{id}` alias, which hands a v3-pinned client a URL that will one day mean v4.

Also flagged, not changed: v3's poll handler advances job state as a *side effect of being polled* (:344-387). This module neither requires nor forbids that — it validates the shape of what you report, never the legality of a transition (`ASSESSMENT_VALID_TRANSITIONS` still owns that).

## Design question (a) — the adapter seam for heterogeneous backing models

The three future consumers genuinely do not share a shape:

| Model | Status source | Vocabulary |
|---|---|---|
| `Assessment` (`database/models.py:132`) | `assessment.status` (unconstrained `Text`) | queued/running/finished/failed |
| `TrainingJob` (`:179`) | **none of its own** — `training_job.assessment.status` | borrowed |
| `PredictJob` (`:1379`) | `predict_jobs.status` (`ck_predict_jobs_status`) | running/**complete**/failed |

**Chosen seam: a per-slice mapping function.** Each slice writes its own total `(row) -> JobState` function and builds the envelope itself. `api_v4/jobs.py` imports **nothing** from `database.models`; the dependency direction is always slice → infrastructure.

Rejected, with reasons in the docstring:
- **A `Protocol` with `status: str`.** All three would satisfy it structurally and it would guarantee nothing — the whole difficulty is that the three `status` values mean different things. Worse, `TrainingJob` has *no* `status` column (metadata only; status/timing/progress live on the linked `Assessment` — aqua-api#584/#593), so the model that most needs the seam would fail the protocol.
- **A `JobEnvelope.from_model(row)` classmethod.** That is exactly the import this module must not have — shared infra would depend on three ORM models and grow an `isinstance` ladder every new job-bearing resource must edit.
- **A registry slices register adapters into.** Runtime indirection with one implementation each, plus a half-populated-registry failure mode invisible until a request arrives.

**The one asymmetry, stated on purpose:** the *assessment* mapping ships here, predict's does not. `AssessmentStatus` is the shared internal vocabulary of **two** of the three consumers (assessments directly; training through `TrainingJob.assessment`) and the guide's §7 table is written in it — a vocabulary two slices must agree on belongs in the shared module. Predict's is private to its own CHECK-constrained table. This imports `schemas.assessment` (a pure-Pydantic enum module, no DB dependency), not an ORM model; importing the enum rather than restating its four strings is what keeps the mapping from going stale, and a test pins the map **total** over `AssessmentStatus` so adding a fifth internal status fails at test time rather than on a live poll.

## Design question (b) — is `job_id` the resource id?

**Rule: `job_id` is the id of the resource served at the poll URL.** `job_id` and the `{id}` segment of `Location` are always the same value. There is no separate job registry, and `job_id` is *not* defined as "a row in a jobs table".

It holds for all three:

- **Assessments** — `GET /v4/assessments/{id}`, `job_id = str(assessment.id)`. The job *is* the resource, as the guide specifies.
- **Predict** — `GET /v4/predict/jobs/{id}`, `job_id = predict_job.id`. The client never submitted a "predict job", but the `predict_jobs` row is nonetheless the resource at the poll URL, so the rule is unchanged.
- **Training** — `GET /v4/training-jobs/{id}`, `job_id = str(training_job.id)`.

Training is where the wording earns its keep: a `TrainingJob` stores no state, so `job_id` identifies the *pollable resource* while state is read from a **different row**. The rule holds; the adapter seam absorbs the indirection. Two consequences the training slice must handle explicitly rather than inherit silently, both written into the docstring:

1. A training run is observable under **two** ids — its training-job id and its underlying assessment id — and both envelopes report the same state. **One job seen twice, not two jobs.** The training slice must not treat `assessment_id` as a job id.
2. `training_job.assessment_id` is **nullable** (`ondelete="SET NULL"`), so a training row can exist with no state carrier at all. That is a data-integrity fault, not a job state, and this module offers no `UNKNOWN` state to launder it into.

## Design decisions reviewers should push back on

1. **`job_id` is a uniform `str`, so `"job_id": "42"` sits next to `"id": 42`.** `Assessment.id`/`TrainingJob.id` are integer PKs; `PredictJob.id` is an opaque `prj_…` string. Stringifying means a client parses one type across the whole surface — but for assessments the envelope reports `"job_id": "42"` while the *resource* body for the same row reports `"id": 42`. The rejected alternative (`int | str`) pushes the same inconsistency onto every client as a runtime type check. This is the decision I'd most like a second opinion on.
2. **`result` is rejected on any non-`SUCCEEDED` state.** The stricter half of the model validator: partial/in-progress output cannot be published through `result`. Deliberate — `result` is the job's *outcome*, and progress (`percent_complete`, `status_detail`) is a different concept that should arrive as its own field if a slice needs it, not as a half-populated `result` clients can't distinguish from a finished one. If we'd rather allow partial results, it's a two-line change here.
3. **`state_for_assessment_status()` raises on an unrecognized status rather than degrading.** `Assessment.status` is an unconstrained `Text` column, so a legacy or corrupt row will produce an `INTERNAL_ERROR` 500. Mapping the unknown to `FAILED` would tell a client the job failed when the truth is the server can't read its own row; mapping it to `PENDING` would make a dead job look alive forever. A 500 is the honest signal — but it *is* a 500 on real data, so worth a decision now rather than at rollout.
4. **`poll_status_code()` returns 202 on a `GET`.** Unusual, but it's what the guide's table specifies, and it lets a client distinguish "accepted, not started" from "running" without reading the body.
5. **`set_poll_headers()` / `poll_status_code()` are slightly beyond the stated "202-submit helper" scope.** I added them because the poll side is half the §7 contract, and without a shared helper the three slices will each drift on "does a terminal poll emit `Retry-After`?". Easy to drop if you'd rather keep this PR to exactly the submit helper.
6. **All four envelope keys are always emitted, including `"error": null`** — deliberately unlike the error envelope's `exclude_none` treatment of `details`. A fixed shape lets a polling loop read `body["error"]`/`body["result"]` unconditionally, and it matches the envelope printed in #827 verbatim. Consequence for future slices: do **not** add `response_model_exclude_none=True` to a poll route.

## Deferred to a follow-up PR: idempotency-key storage (#827, mitigating #722)

Persisting `Idempotency-Key` needs a new table, and I write Alembic migrations by hand — **no migration is generated here.** Until that PR lands, `job_accepted_response()` does not read the header and a client retrying after a dropped 202 **will** enqueue a second Modal run; the docstring says so, and no v4 endpoint should document the header as supported before then.

Proposed design, for review now so the follow-up is mechanical:

```sql
CREATE TABLE idempotency_key (
    id                  SERIAL       PRIMARY KEY,
    key                 TEXT         NOT NULL,   -- client-supplied Idempotency-Key
    owner_id            INTEGER      NOT NULL REFERENCES users(id) ON DELETE CASCADE,
    endpoint            TEXT         NOT NULL,   -- e.g. 'POST /v4/assessments'
    request_fingerprint TEXT         NOT NULL,   -- sha256 of the canonicalized body
    job_id              TEXT         NULL,       -- NULL until the enqueue commits
    response_status     SMALLINT     NULL,
    created_at          TIMESTAMPTZ  NOT NULL DEFAULT now(),
    completed_at        TIMESTAMPTZ  NULL,
    expires_at          TIMESTAMPTZ  NOT NULL,
    CONSTRAINT uq_idempotency_owner_endpoint_key UNIQUE (owner_id, endpoint, key)
);
CREATE INDEX ix_idempotency_key_expires_at ON idempotency_key (expires_at);
```

**Scoping — `(owner_id, endpoint, key)`, per #827.** Per user so two clients can't collide on a guessable key value (and so one user can't probe another's keys); per endpoint so a client reusing one key across `POST /v4/assessments` and `POST /v4/training-jobs` doesn't get the wrong job back.

**The constraint that actually prevents #722's duplicate-enqueue race** is the unique constraint *combined with insert-before-spawn*, not the constraint alone:

1. `INSERT` the reservation row (`job_id` NULL) and **commit** — before any Modal `spawn`.
2. A concurrent duplicate submit hits `uq_idempotency_owner_endpoint_key`, the handler catches the `IntegrityError` and re-reads the existing row instead of enqueueing.
3. If that row still has `job_id IS NULL`, the winner is mid-enqueue: return **409** with `Retry-After`, **never** a 202 carrying a null `job_id`.
4. The winner spawns, then `UPDATE`s `job_id`/`response_status`/`completed_at`. A replay after that returns the original `job_id` with the original 202.

This is why the reservation commit must be its own transaction, separate from the job-row insert — with a single transaction the row isn't visible to the concurrent request until after the spawn, which is precisely the window #722 lives in. A `request_fingerprint` mismatch on a replayed key is a **422** (key reused with a different body).

**TTL/retention: `expires_at = created_at + 24h`**, swept by the same cron surface as #727's timeout sweep, using the `expires_at` index. 24h comfortably outlives any client's retry budget while keeping the table small; a row past `expires_at` is deleted, so the same key becomes reusable rather than permanently poisoned.

## v3 freeze snapshot: green, no regen

`/v4` is a mounted sub-app, so nothing here enters the main app's `/openapi.json`. `test/test_openapi_contract.py` passes **unchanged, with no snapshot regeneration**.

## Tests

**`test/test_v4_jobs.py`** (new, 45 cases) — throwaway submit/poll routes on a `create_v4_app` instance, so the status codes and headers are asserted as they actually leave the app (following `test_v4_pagination.py` / `test_v4_errors.py`; no DB needed):

- `JobState` is exactly the four states, uppercase, and disjoint from the internal vocabulary; terminal set is `{SUCCEEDED, FAILED}`.
- `ASSESSMENT_STATE_MAP` is **total** over `AssessmentStatus` and matches the guide's table exactly; `state_for_assessment_status()` accepts raw strings (the path production uses, since the column is `Text`) and rejects `None`, `""`, `"unknown"`, `"QUEUED"`, and predict's `"complete"`.
- The envelope emits all four keys including `"error": null`; `FAILED` without an error, a non-`FAILED` state *with* an error, and a `result` on any non-`SUCCEEDED` state are all rejected; `SUCCEEDED` with no result is allowed; the parametrized `JobEnvelope[WidgetResult]` validates its result.
- Submit → **202** with real `Location`/`Retry-After` response headers and a body of exactly `{"job_id"}`; `Location`'s last segment equals `job_id` (the design-(b) rule, asserted); non-positive `retry_after_s` and an empty `poll_url` raise; caller-supplied `Location`/`Retry-After` extras cannot shadow the contract headers.
- Poll → `PENDING` **202 + `Retry-After`**; `RUNNING` 200 + `Retry-After`; `SUCCEEDED` 200 + result + **no** `Retry-After`; `FAILED` **200** carrying the shared `{code, message, details}` object and *not* reshaped into the #828 `{"error": …}` transport envelope. An unrecognized state value surfaces as the #828 `VALIDATION_ERROR` 422 — this module introduces no new error shape.
- OpenAPI documents the 202 `JobSubmitAccepted`, the parametrized envelope (selected by result type, not by pinning the generated identifier), the `JobState` enum values, and that the failure object is the shared `V4ErrorDetail` rather than a job-local copy.

Actual results on this branch:

- `test/test_v4_jobs.py` — **45 passed**
- `test_v4_jobs.py test_v4_errors.py test_v4_pagination.py test_v4_base_model.py test_v4_subapp.py test_openapi_contract.py test_app_versioning.py test_version_routes_v4.py` — **109 passed** (v3 freeze guard green, no regen)
- `make linting` (Black + isort + **Flake8**, the exact CI target) — clean

## Review round 2 (Copilot, addressed in `73b863d`)

Three comments, all fixed; the second Copilot pass left none.

1. **Real bug — `Location` could be silently overridden.** `job_accepted_response` merged caller-supplied `headers` into the same dict as the contract headers. HTTP header names are case-insensitive but dict keys are not, so `headers={"location": "/wrong"}` kept **both** entries: Starlette emitted two `Location` headers and every lookup returned the *caller's*, because it was added first — pointing the client's polling at the wrong URL, the exact opposite of the documented guarantee. Now assigned via `response.headers[...]` (case-insensitive overwrite). The original test passed only because it used exact `"Location"` casing; it is now parametrized over three casings and asserts exactly one of each header reaches the wire.
2. **`set_poll_headers` now deletes `Retry-After` on a terminal state** rather than only declining to set it, so the post-condition holds even if the handler set it before deciding the job was done. (Verified `MutableHeaders.__delitem__` is case-insensitive and a no-op when absent.) It cannot police middleware, which mutates the response after the handler returns — noted in the docstring.
3. **`test_submit_location_id_matches_the_job_id` reads one response twice** instead of POSTing twice; the old form compared response B's header against response A's body and only worked while `job_id` was a fixed constant.

The fixes were confirmed to be real regression coverage by stashing the `jobs.py` change and re-running: the two new casing variants and the terminal-clear test fail against the pre-fix code.

None of the design decisions flagged above were touched — Copilot stayed on mechanics, so those remain open for a human call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
