### PR TITLE
feat(v4): Auth/Users/Groups slice — read half; typed /users/me closes the password-hash leak (#859)

### DIFF
--- a/api_v4/app.py
+++ b/api_v4/app.py
@@ -61,6 +61,9 @@ from api_v4.errors import register_exception_handlers
 from api_v4.meta_routes import router as meta_router
 from bible_routes.v4.version_routes import router as version_router
 from security_routes.auth_routes import get_current_user
+from security_routes.v4.group_routes import router as group_router
+from security_routes.v4.token_routes import router as token_router
+from security_routes.v4.user_routes import router as user_router
 
 
 def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
@@ -95,14 +98,23 @@ def create_v4_app(*, configure_cors) -> fastapi.FastAPI:
     # token, so do NOT attach auth here.
     v4_app.include_router(meta_router)
 
+    # The token router is likewise PUBLIC, and for the same class of reason: it is
+    # the endpoint that *issues* tokens, so attaching the router-level auth
+    # dependency below would be a deadlock (a token would be required to obtain a
+    # token). This is why it is a separate router from /v4/users — router-level
+    # dependencies apply to every route on the router, so a single auth-protected
+    # router could not carry an exempt path. See security_routes/v4/token_routes.py.
+    v4_app.include_router(token_router)
+
     # Domain routers are auth-protected at the router level (#831): a
     # ``dependencies=[Depends(get_current_user)]`` here makes "protected by
     # default" the failure mode, so a handler that forgets its own auth
     # dependency still cannot ship unauthenticated. Handlers that need the user
     # re-declare ``current_user: UserModel = Depends(get_current_user)`` — FastAPI
     # dedupes the dependency, so it runs once per request.
-    v4_app.include_router(
-        version_router, dependencies=[fastapi.Depends(get_current_user)]
-    )
+    for domain_router in (version_router, user_router, group_router):
+        v4_app.include_router(
+            domain_router, dependencies=[fastapi.Depends(get_current_user)]
+        )
 
     return v4_app

--- a/api_v4/schemas/security.py
+++ b/api_v4/schemas/security.py
@@ -1,0 +1,104 @@
+"""v4 auth / user / group response schemas (issues #830/#859, epic #842).
+
+The read-side wire contract for the Auth-Users-Groups slice. Three models, all
+snake_case (#830) and all **explicit field allowlists** — which is the entire
+point of :class:`UserOut`.
+
+Why these do not reuse ``schemas/security.py``: that module is the frozen v3
+contract and still declares Pydantic v1 ``class Config: orm_mode = True``, which
+is deprecated in Pydantic v2 (it emits a ``UserWarning`` on import today). v4
+uses ``ConfigDict(from_attributes=True)`` instead. v3's ``schemas/security.py``
+is deliberately left untouched.
+
+``from_attributes=True`` lets these be built straight from an ORM row with
+``UserOut.model_validate(user_db_row)``. Note that ``V4BaseModel``'s own
+``populate_by_name=True`` survives the subclass ``model_config`` — Pydantic v2
+merges config across the MRO (verified), so declaring ``from_attributes`` here
+does not drop the v4-wide alias policy.
+
+**The #859 fix.** v3's ``GET /users/me`` (``security_routes/auth_routes.py:107``)
+declares **no** ``response_model`` and returns the ``UserDB`` ORM object
+directly, so FastAPI serializes whatever attributes it happens to find. Measured
+against the live v3 route, that is::
+
+    ['email', 'groups', 'hashed_password', 'id', 'is_admin', 'username']
+
+— the bcrypt hash of the user's password on every call, plus the whole ``groups``
+relationship. :class:`UserOut` lists four fields and nothing else, and because
+FastAPI filters the response *against the declared model*, no future column added
+to ``UserDB`` can leak through this endpoint either. That is the durable part of
+the fix: the allowlist is closed by construction, not by remembering to exclude
+things. ``groups`` is also deliberately absent — group membership has its own
+endpoint (``GET /v4/users/me/groups``), so it is a paginated resource rather than
+an unbounded nested blob on every profile read.
+"""
+
+from pydantic import ConfigDict, EmailStr, Field, field_validator
+
+from api_v4.schemas.base import V4BaseModel
+
+
+class TokenOut(V4BaseModel):
+    """The ``POST /v4/token`` response body.
+
+    Field names are OAuth2's (``access_token`` / ``token_type``), which are
+    already snake_case, so v4 emits the same two keys v3 did — a v4 client's
+    token handling needs no changes.
+    """
+
+    access_token: str = Field(
+        description="The bearer token to send as `Authorization: Bearer <token>`."
+    )
+    token_type: str = Field(description='Always `"bearer"`.')
+
+
+class UserOut(V4BaseModel):
+    """A user, as an explicit allowlist of four fields (#859).
+
+    Never add a field here without deciding it is safe to return to the user
+    themselves — this model is the only thing standing between ``UserDB`` and the
+    wire. In particular ``hashed_password`` must never appear.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(description="The user's numeric id.")
+    username: str = Field(description="The user's login name.")
+    email: EmailStr | None = Field(
+        default=None, description="The user's email address, if one is recorded."
+    )
+    is_admin: bool = Field(
+        default=False, description="Whether the user has administrator privileges."
+    )
+
+    @field_validator("is_admin", mode="before")
+    @classmethod
+    def _null_is_not_admin(cls, value):
+        """Coerce a NULL ``is_admin`` to ``False``.
+
+        ``UserDB.is_admin`` is ``Column(Boolean, default=False)`` — nullable, with
+        only a *Python-side* default, so any row written outside the ORM (or before
+        the default existed) can hold NULL. A plain ``bool`` field rejects ``None``
+        outright (verified: ``ValidationError``), which would turn a legacy row into
+        a 500 on this endpoint. Coercing here fails **closed** — an indeterminate
+        flag means "not an admin" — and mirrors how the Versions slice coerces its
+        nullable booleans with ``bool(...)``.
+        """
+        return False if value is None else value
+
+
+class GroupOut(V4BaseModel):
+    """A group, as returned by ``GET /v4/groups`` and ``GET /v4/users/me/groups``.
+
+    Deliberately excludes the ``users`` and ``bible_versions_access``
+    relationships: membership and version access are their own resources, and
+    nesting them here would make a list endpoint's payload grow without bound.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int = Field(description="The group's numeric id.")
+    name: str = Field(description="The group's unique name.")
+    description: str | None = Field(
+        default=None, description="Free-text description of the group."
+    )

--- a/security_routes/v4/__init__.py
+++ b/security_routes/v4/__init__.py
@@ -1,0 +1,11 @@
+"""v4 auth / users / groups routers and services (epic #842).
+
+New package rather than edits to the flat ``security_routes/`` modules beside it:
+``auth_routes.py`` and ``admin_routes.py`` are shared, version-agnostic infra —
+``get_current_user`` is imported by :mod:`api_v4.app` for router-level auth and by
+16 v3 route modules — so v4 *adds* here instead of fork-editing them.
+
+There is deliberately no sibling ``security_routes/v3/``: the flat modules *are*
+v3 and moving them would break every one of those imports. That asymmetry with
+``bible_routes/`` (which does have ``v3/`` and ``v4/``) is intentional.
+"""

--- a/security_routes/v4/dependencies.py
+++ b/security_routes/v4/dependencies.py
@@ -1,0 +1,62 @@
+"""v4 authorization dependencies (issues #828/#831, epic #842).
+
+One dependency today: :func:`require_admin`, the v4 admin gate.
+
+**Why this is not** ``admin_routes.get_current_admin``. v3 has a working admin
+dependency, and reusing it would have been fewer lines — but it is the wrong
+building block for v4 on three counts, and per the epic's standing disciplines v4
+*adds* rather than fork-edits shared v3 infra:
+
+1. **It raises a bare** ``HTTPException(403)``. That reaches the client through the
+   #828 ``HTTPException`` handler, which derives the machine ``code`` from the
+   status name — so every v4 403 would arrive as the generic ``FORBIDDEN`` with no
+   way for a client to distinguish "you are not an admin" from any other refusal.
+   Raising :class:`~api_v4.errors.V4APIError` with a stable ``ADMIN_REQUIRED``
+   code is the whole point of the #828 contract.
+2. **It re-implements token decoding.** ``get_current_admin`` decodes the JWT and
+   loads the user itself, in a second copy of the logic in
+   ``auth_routes.get_current_user`` — and a subtly different one: it does not
+   ``selectinload(UserDB.groups)``. Building on ``get_current_user`` means v4 has
+   exactly one authentication path, and FastAPI dedupes the dependency so the
+   router-level ``Depends(get_current_user)`` in :mod:`api_v4.app` and this
+   function's own use of it resolve to a single call per request.
+3. **It conflates 401 and 403.** ``get_current_admin`` returns 403 for a *missing*
+   user as well as a non-admin one. Layering on ``get_current_user`` keeps
+   "unauthenticated" a 401 (with ``WWW-Authenticate``) and "authenticated but not
+   an admin" a 403, which is what the two statuses mean.
+
+Neither ``auth_routes.py`` nor ``admin_routes.py`` is modified; this module only
+imports ``get_current_user`` from the former, as :mod:`api_v4.app` already does.
+"""
+
+from fastapi import Depends, status
+
+from api_v4.errors import V4APIError
+from database.models import UserDB as UserModel
+from security_routes.auth_routes import get_current_user
+
+
+async def require_admin(
+    current_user: UserModel = Depends(get_current_user),
+) -> UserModel:
+    """Resolve the caller and require that they are an administrator.
+
+    Returns the :class:`~database.models.UserDB` row on success so a handler can
+    depend on this *instead of* ``get_current_user`` and still have the user —
+    there is no reason to declare both.
+
+    Raises :class:`~api_v4.errors.V4APIError` (403, ``ADMIN_REQUIRED``) for an
+    authenticated non-admin. An unauthenticated request never reaches this check:
+    ``get_current_user`` resolves first and raises its own 401.
+
+    Fails **closed** on a NULL flag: ``UserDB.is_admin`` is nullable, and
+    ``not None`` is ``True``, so a row with an indeterminate flag is treated as a
+    non-admin rather than being waved through.
+    """
+    if not current_user.is_admin:
+        raise V4APIError(
+            status_code=status.HTTP_403_FORBIDDEN,
+            code="ADMIN_REQUIRED",
+            message="This endpoint requires administrator privileges.",
+        )
+    return current_user

--- a/security_routes/v4/dependencies.py
+++ b/security_routes/v4/dependencies.py
@@ -50,8 +50,11 @@ async def require_admin(
     ``get_current_user`` resolves first and raises its own 401.
 
     Fails **closed** on a NULL flag: ``UserDB.is_admin`` is nullable, and
-    ``not None`` is ``True``, so a row with an indeterminate flag is treated as a
-    non-admin rather than being waved through.
+    ``not None`` is ``True`` (``None`` is falsy), so a row with an indeterminate
+    flag takes the raise branch and is treated as a non-admin rather than being
+    waved through. Pinned by ``TestRequireAdminFailsClosed`` in
+    ``test/test_security_routes/test_auth_routes_v4.py`` — do **not** "tighten"
+    this to ``is False``, which would invert the NULL case into a silent pass.
     """
     if not current_user.is_admin:
         raise V4APIError(

--- a/security_routes/v4/group_routes.py
+++ b/security_routes/v4/group_routes.py
@@ -1,0 +1,60 @@
+"""v4 Groups router — read half (issues #825/#829/#830/#831/#833, epic #842).
+
+One endpoint: ``GET /v4/groups`` — the full group catalog, paginated, admin-only.
+
+Auth is applied at the router level in :func:`api_v4.app.create_v4_app` (#831), so
+an unauthenticated request is a 401 before this handler runs. The admin check is
+:func:`security_routes.v4.dependencies.require_admin`, which adds a 403 with the
+stable ``ADMIN_REQUIRED`` code for an authenticated non-admin.
+
+**Admin-only is v3 parity, and it is a decision worth challenging.** v3's
+``GET /groups`` (``security_routes/admin_routes.py:108``) is gated by
+``get_current_admin``, so a non-admin gets a 403 and never sees the catalog. v4
+keeps that rather than converting it to a scoped list (admins see all, non-admins
+see their own) the way ``version_service.list_versions`` works — because a scoped
+version of this endpoint would return exactly what ``GET /v4/users/me/groups``
+already returns, leaving two endpoints with one behavior and a confusing choice
+for clients. Instead the two stay distinct: ``/v4/groups`` is the admin catalog,
+``/v4/users/me/groups`` is the self-service view. If we would rather have one
+scoped endpoint, that is a small change here — but it is a v3 authorization
+change, so it should be a deliberate decision rather than a side effect.
+
+The write half (``POST /v4/groups``, the ``groups/{id}/members/{user_id}``
+membership sub-resource, ``DELETE /v4/groups/{id}``) is a separate PR.
+"""
+
+__version__ = "v4"
+
+import fastapi
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_v4.pagination import PaginationParams, V4Page
+from api_v4.schemas.security import GroupOut
+from database.dependencies import get_db
+from database.models import UserDB as UserModel
+from security_routes.v4 import user_service
+from security_routes.v4.dependencies import require_admin
+
+router = fastapi.APIRouter(prefix="/groups", tags=["Groups"])
+
+
+@router.get("", response_model=V4Page[GroupOut])
+async def list_groups(
+    page: PaginationParams = Depends(),
+    db: AsyncSession = Depends(get_db),
+    _admin: UserModel = Depends(require_admin),
+) -> V4Page[GroupOut]:
+    """List every group, ordered by id, paginated. Administrators only.
+
+    ``_admin`` is named with a leading underscore because the handler does not use
+    the user — the dependency is here for its authorization side effect. It
+    replaces (rather than accompanies) ``get_current_user``: ``require_admin``
+    depends on it internally, and FastAPI dedupes, so authentication still happens
+    exactly once.
+    """
+    groups, total = await user_service.list_groups(
+        db, limit=page.limit, offset=page.offset
+    )
+    items = [GroupOut.model_validate(group) for group in groups]
+    return V4Page[GroupOut].create(items=items, total=total, pagination=page)

--- a/security_routes/v4/token_routes.py
+++ b/security_routes/v4/token_routes.py
@@ -1,0 +1,84 @@
+"""v4 token router — ``POST /v4/token`` (issues #826/#828/#831, epic #842).
+
+Its own module, and its own router, for one structural reason: :mod:`api_v4.app`
+registers domain routers with ``dependencies=[Depends(get_current_user)]` so v4 is
+protected-by-default (#831), and **the token endpoint cannot inherit that** — it
+is the endpoint that issues the token, so requiring one would be a deadlock (you
+would need a token to get a token). Keeping it in a separate router means it is
+registered without the auth dependency, the same way ``meta_router`` already is.
+Putting it on the ``/v4/users`` router and trying to exempt one path would not
+work: router-level dependencies apply to every route on the router.
+
+**Exempt from the JSON-body rule (#826).** v4 standardizes writes on JSON bodies;
+this endpoint deliberately keeps OAuth2's
+``application/x-www-form-urlencoded`` password form, as the migration guide §15.6
+specifies. It is what ``OAuth2PasswordBearer`` clients, the FastAPI ``/docs``
+"Authorize" button, and every existing v3 client already send, and the grant
+shape is defined by RFC 6749, not by us.
+
+**No** ``WWW-Authenticate`` **header on a bad-credentials 401** — a deliberate,
+small divergence from v3 (``auth_routes.py:96``), and one reviewers may want to
+push back on. Two reasons. First, :class:`~api_v4.errors.V4APIError` carries no
+``headers`` field, and it is the only sanctioned way for a v4 endpoint to signal a
+4xx (#828); emitting the header would mean either raising a bare
+``HTTPException`` here (abandoning the stable ``code``) or widening #828's shared
+error type from inside this slice. Second, the header is not called for:
+RFC 6749 §5.2 asks for ``WWW-Authenticate`` on a token-endpoint 401 only when the
+*client* authenticated with an HTTP auth scheme, and in the password grant the
+credentials arrive in the form body. Protected v4 routes still emit it — that
+comes from ``get_current_user``'s ``HTTPException``, which the #828 handler
+re-emits headers for.
+
+**Tokens are byte-compatible with v3's.** The payload is built by the shared
+``auth_routes.create_access_token`` with the same ``{"sub", "is_admin"}`` claims,
+so a token minted at ``/v4/token`` works on v3 routes and vice versa. That
+includes carrying the redundant ``is_admin`` claim: it is real debt (#732 —
+nothing reads it; both ``get_current_user`` and ``get_current_admin`` load the
+flag from the database), but dropping it here would fork the token format between
+the two surfaces for no gain. #732 removes it from both at once.
+"""
+
+__version__ = "v4"
+
+from datetime import timedelta
+
+import fastapi
+from fastapi import Depends, status
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_v4.errors import V4APIError
+from api_v4.schemas.security import TokenOut
+from database.dependencies import get_db
+from security_routes.auth_routes import authenticate_user, create_access_token
+from security_routes.utilities import ACCESS_TOKEN_EXPIRE_MINUTES
+
+router = fastapi.APIRouter(tags=["Auth"])
+
+
+@router.post("/token", response_model=TokenOut)
+async def login_for_access_token(
+    form_data: OAuth2PasswordRequestForm = Depends(),
+    db: AsyncSession = Depends(get_db),
+) -> TokenOut:
+    """Exchange a username and password for a bearer token.
+
+    Send ``application/x-www-form-urlencoded`` with ``username`` and ``password``
+    (see the module docstring for why this endpoint keeps the form body).
+    """
+    user = await authenticate_user(form_data.username, form_data.password, db)
+    if not user:
+        # One code and one message for both "no such user" and "wrong password":
+        # distinguishing them would let an unauthenticated caller enumerate valid
+        # usernames. v3 collapses them the same way.
+        raise V4APIError(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            code="INVALID_CREDENTIALS",
+            message="Incorrect username or password.",
+        )
+
+    access_token = create_access_token(
+        data={"sub": user.username, "is_admin": user.is_admin},
+        expires_delta=timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES),
+    )
+    return TokenOut(access_token=access_token, token_type="bearer")

--- a/security_routes/v4/user_routes.py
+++ b/security_routes/v4/user_routes.py
@@ -1,0 +1,82 @@
+"""v4 Users router (issues #825/#829/#830/#831/#833/#859, epic #842).
+
+The read half of the Users resource:
+
+* ``GET /v4/users/me``        — the authenticated user, as a typed allowlist.
+* ``GET /v4/users/me/groups`` — the caller's groups, paginated ``V4Page[GroupOut]``.
+
+Auth is applied at the router level in :func:`api_v4.app.create_v4_app` (#831,
+protected-by-default), so these handlers re-declare ``current_user`` only because
+they need the value; FastAPI dedupes the dependency.
+
+This module owns HTTP concerns only — :mod:`security_routes.v4.user_service` does
+the data access, following the Versions slice template. Neither of these two
+endpoints can produce a domain error (the user is proven to exist by the bearer
+token, and an empty group list is a valid result), so unlike
+``bible_routes/v4/version_routes.py`` there are no signal-to-``V4APIError``
+mappings here. The write half (#831's ``POST /v4/users``, the password split) is a
+separate PR and will need them.
+
+**#859 — this is the fix.** v3's ``GET /users/me`` declares no ``response_model``
+and returns the ORM object, which measurably serializes
+``['email', 'groups', 'hashed_password', 'id', 'is_admin', 'username']``: the
+user's bcrypt hash on every call. The v4 route declares
+``response_model=UserOut``, so FastAPI filters the body down to that model's four
+fields. See :mod:`api_v4.schemas.security` for why the allowlist is closed by
+construction rather than by an exclude list.
+
+``/v4/users/me`` before ``/v4/users/{id}``: the write-half PR adds id-addressed
+user routes, and FastAPI matches routes in registration order — a ``/users/{id}``
+declared first would swallow ``/users/me`` and try to parse ``"me"`` as an int.
+Registering the literal path first (as this module does by construction, since it
+is the only one here) is what keeps that from happening later.
+"""
+
+__version__ = "v4"
+
+import fastapi
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api_v4.pagination import PaginationParams, V4Page
+from api_v4.schemas.security import GroupOut, UserOut
+from database.dependencies import get_db
+from database.models import UserDB as UserModel
+from security_routes.auth_routes import get_current_user
+from security_routes.v4 import user_service
+
+router = fastapi.APIRouter(prefix="/users", tags=["Users"])
+
+
+@router.get("/me", response_model=UserOut)
+async def read_current_user(
+    current_user: UserModel = Depends(get_current_user),
+) -> UserOut:
+    """Return the authenticated user's own profile.
+
+    ``response_model=UserOut`` is load-bearing, not decoration — it is the #859
+    fix. Do not remove it, and do not widen ``UserOut`` without re-reading why it
+    is an allowlist.
+    """
+    return UserOut.model_validate(current_user)
+
+
+@router.get("/me/groups", response_model=V4Page[GroupOut])
+async def list_current_user_groups(
+    page: PaginationParams = Depends(),
+    db: AsyncSession = Depends(get_db),
+    current_user: UserModel = Depends(get_current_user),
+) -> V4Page[GroupOut]:
+    """List the groups the caller belongs to, ordered by group id, paginated.
+
+    Replaces v3's unbounded ``GET /groups/me``. Self-scoped: there is no id in the
+    path and no way to ask about another user, so no authorization check beyond
+    being authenticated. An account in no groups gets an empty page (``total: 0``),
+    not a 404 — which is the normal state for an admin, since admins are not
+    automatically members of anything.
+    """
+    groups, total = await user_service.list_user_groups(
+        db, current_user, limit=page.limit, offset=page.offset
+    )
+    items = [GroupOut.model_validate(group) for group in groups]
+    return V4Page[GroupOut].create(items=items, total=total, pagination=page)

--- a/security_routes/v4/user_service.py
+++ b/security_routes/v4/user_service.py
@@ -58,7 +58,9 @@ def _user_groups_query(user: UserDB):
     )
 
 
-async def _page(db: AsyncSession, stmt, *, limit: int, offset: int):
+async def _page(
+    db: AsyncSession, stmt, *, limit: int, offset: int, order_by
+) -> tuple[list, int]:
     """Run ``stmt`` as one page plus its unpaginated total.
 
     ``total`` counts *all* matching rows ignoring ``limit``/``offset`` (what the
@@ -68,14 +70,26 @@ async def _page(db: AsyncSession, stmt, *, limit: int, offset: int):
     offset-pagination skew between ``total`` and ``len(items)`` — the same
     documented caveat as ``version_service.list_versions``.
 
-    Ordered by ``Group.id`` so paging is stable: without a deterministic
-    ``ORDER BY``, Postgres may return rows in a different order per query and a
-    client walking ``offset`` could see the same group twice or skip one.
+    ``order_by`` is **required**, not defaulted, so the helper's behavior matches
+    its signature: it accepts an arbitrary ``stmt``, so hard-coding (or defaulting
+    to) a ``Group`` column would break the moment the write half adds a list over
+    a different table. That is not a hypothetical — the ordering column would not
+    be in the statement's FROM clause, producing
+    ``SELECT users.* FROM users ORDER BY groups.id``, which Postgres rejects with
+    *missing FROM-clause entry for table "groups"* — a request-time 500 through the
+    #828 catch-all rather than anything caught in review. A default would leave the
+    same trap, just sprung less often, so callers state their ordering explicitly
+    (the same reasoning as ``retry_after_s`` in :mod:`api_v4.jobs`).
+
+    Ordering is required at all rather than optional because paging without a
+    deterministic ``ORDER BY`` is unstable: Postgres may return rows in a different
+    order per query, so a client walking ``offset`` could see one row twice and
+    miss another.
     """
     total = (
         await db.execute(select(func.count()).select_from(stmt.subquery()))
     ).scalar_one()
-    result = await db.execute(stmt.order_by(GroupDB.id).limit(limit).offset(offset))
+    result = await db.execute(stmt.order_by(order_by).limit(limit).offset(offset))
     return list(result.scalars().all()), total
 
 
@@ -88,7 +102,13 @@ async def list_user_groups(
     no id parameter to authorize and no way to ask about another user. Replaces
     v3 ``GET /groups/me``, which returned an unbounded list.
     """
-    return await _page(db, _user_groups_query(user), limit=limit, offset=offset)
+    return await _page(
+        db,
+        _user_groups_query(user),
+        limit=limit,
+        offset=offset,
+        order_by=GroupDB.id,
+    )
 
 
 async def list_groups(
@@ -100,4 +120,6 @@ async def list_groups(
     having gated the route to admins (``require_admin``); this function does not
     re-check, exactly as v3's ``GET /groups`` body did not.
     """
-    return await _page(db, select(GroupDB), limit=limit, offset=offset)
+    return await _page(
+        db, select(GroupDB), limit=limit, offset=offset, order_by=GroupDB.id
+    )

--- a/security_routes/v4/user_service.py
+++ b/security_routes/v4/user_service.py
@@ -1,0 +1,103 @@
+"""User / group data-access service for the v4 surface (issue #833, epic #842).
+
+Follows the pattern the Versions slice established
+(:mod:`bible_routes.v4.version_service`): functions take an
+:class:`~sqlalchemy.ext.asyncio.AsyncSession` plus plain data, return ORM rows or
+plain values, and know nothing about HTTP status codes or the v4 error envelope.
+
+Unlike the Versions service this one declares **no domain-signal exceptions**,
+because the read half has no not-found paths to signal:
+
+* ``GET /v4/users/me`` resolves its user from the bearer token, so by the time a
+  handler runs the user provably exists — the missing/unknown case is already a
+  401 from ``get_current_user``, not a 404 from here.
+* Both list endpoints legitimately return an empty page (a user in no groups, or
+  a deployment with no groups at all). Empty is a valid result, not an error.
+
+The write half (create user / create group / membership sub-resource / deletes)
+is a separate PR and *will* need signals — name collisions and unknown ids.
+
+Authorization semantics preserved from v3:
+
+* ``GET /v4/users/me/groups`` mirrors v3 ``GET /groups/me``
+  (``security_routes/auth_routes.py:112``): the caller's own groups, joined
+  through ``user_groups``. Self-scoped, so there is no admin branch — an admin
+  asking for *their own* groups gets their own groups, which for an account in no
+  groups is an empty page.
+* ``GET /v4/groups`` mirrors v3 ``GET /groups``
+  (``security_routes/admin_routes.py:108``): the full catalog, unscoped, gated to
+  admins. The gate lives in the router's ``require_admin`` dependency rather than
+  in here, so this function stays a plain query and the authorization decision
+  stays visible at the route (see :mod:`security_routes.v4.dependencies`).
+"""
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from database.models import Group as GroupDB
+from database.models import UserDB, UserGroup
+
+
+def _user_groups_query(user: UserDB):
+    """Base ``SELECT Group`` scoped to the groups ``user`` belongs to.
+
+    No ``limit``/``offset``/``order_by`` — callers add those and the count query
+    wraps this as a subquery, so the join/scoping logic lives in one place (same
+    structure as ``version_service._visible_versions_query``).
+
+    ``distinct()`` guards against duplicate ``user_groups`` rows: the table has an
+    index on ``user_id`` but **no unique constraint** on ``(user_id, group_id)``, so
+    a user linked to the same group twice would otherwise appear to be in it twice
+    — inflating ``total`` and repeating the group in ``items``.
+    """
+    return (
+        select(GroupDB)
+        .distinct()
+        .join(UserGroup, GroupDB.id == UserGroup.group_id)
+        .where(UserGroup.user_id == user.id)
+    )
+
+
+async def _page(db: AsyncSession, stmt, *, limit: int, offset: int):
+    """Run ``stmt`` as one page plus its unpaginated total.
+
+    ``total`` counts *all* matching rows ignoring ``limit``/``offset`` (what the
+    #829 envelope needs), computed from the same statement as the page so the two
+    can never drift in their filtering. They remain two statements, so a
+    concurrent insert or delete between them can still cause the usual (rare)
+    offset-pagination skew between ``total`` and ``len(items)`` — the same
+    documented caveat as ``version_service.list_versions``.
+
+    Ordered by ``Group.id`` so paging is stable: without a deterministic
+    ``ORDER BY``, Postgres may return rows in a different order per query and a
+    client walking ``offset`` could see the same group twice or skip one.
+    """
+    total = (
+        await db.execute(select(func.count()).select_from(stmt.subquery()))
+    ).scalar_one()
+    result = await db.execute(stmt.order_by(GroupDB.id).limit(limit).offset(offset))
+    return list(result.scalars().all()), total
+
+
+async def list_user_groups(
+    db: AsyncSession, user: UserDB, *, limit: int, offset: int
+) -> tuple[list[GroupDB], int]:
+    """Return one page of the groups ``user`` belongs to, plus the total count.
+
+    Self-scoped — the caller can only ever see their own memberships, so there is
+    no id parameter to authorize and no way to ask about another user. Replaces
+    v3 ``GET /groups/me``, which returned an unbounded list.
+    """
+    return await _page(db, _user_groups_query(user), limit=limit, offset=offset)
+
+
+async def list_groups(
+    db: AsyncSession, *, limit: int, offset: int
+) -> tuple[list[GroupDB], int]:
+    """Return one page of *all* groups, plus the total count.
+
+    Unscoped by design: this is the admin catalog. The caller is responsible for
+    having gated the route to admins (``require_admin``); this function does not
+    re-check, exactly as v3's ``GET /groups`` body did not.
+    """
+    return await _page(db, select(GroupDB), limit=limit, offset=offset)

--- a/test/test_security_routes/test_auth_routes_v4.py
+++ b/test/test_security_routes/test_auth_routes_v4.py
@@ -1,0 +1,358 @@
+"""Tests for the v4 Auth / Users / Groups slice — read half (closes #859).
+
+Mounted at ``/v4`` on the same app as v3, so these reuse the shared fixtures
+(``client``, ``regular_token1/2``, ``admin_token``, ``test_db_session``). Fixture users:
+``testuser1`` (non-admin, in Group1), ``testuser2`` (non-admin, in Group2),
+``admin`` (admin, in **no** group).
+
+What each assertion is pinning down:
+
+* **#859** — ``GET /v4/users/me`` returns a closed four-field allowlist and never
+  ``hashed_password``. Verified during development to *fail* against the v3 route:
+  ``GET /latest/users/me`` returns
+  ``['email', 'groups', 'hashed_password', 'id', 'is_admin', 'username']``.
+* ``POST /v4/token`` answers **without** a bearer token (the protected-by-default
+  exemption) while ``GET /v4/groups`` still 401s — the deadlock trap.
+* bad credentials produce the #828 ``{"error": {...}}`` envelope, not v3's
+  ``{"detail": ...}``.
+* both list endpoints return the #829 ``V4Page`` envelope and honor limit/offset.
+* ``GET /v4/groups`` is admin-only (403 ``ADMIN_REQUIRED`` for a non-admin), and
+  ``GET /v4/users/me/groups`` is self-scoped — the two endpoints are genuinely
+  different, which the admin's empty self-groups page demonstrates.
+"""
+
+PREFIX = "/v4"
+
+#: The complete, closed set of fields UserOut may ever emit (#859). Asserting
+#: equality (not just "hashed_password not in body") is what makes this test catch
+#: a *future* column added to UserDB, not only today's known leak.
+USER_FIELDS = {"id", "username", "email", "is_admin"}
+GROUP_FIELDS = {"id", "name", "description"}
+PAGE_KEYS = {"items", "total", "limit", "offset"}
+
+
+def _auth(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+class TestTokenEndpointIsPublic:
+    """The trap: /v4/token must not inherit router-level auth (#831)."""
+
+    def test_token_succeeds_without_a_bearer_token(self, client, test_db_session):
+        resp = client.post(
+            f"{PREFIX}/token",
+            data={"username": "testuser1", "password": "password1"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert set(body) == {"access_token", "token_type"}
+        assert body["token_type"] == "bearer"
+        assert body["access_token"]
+
+    def test_protected_route_still_401s_without_a_token(self, client):
+        """The other half of the same proof: the exemption is scoped to /v4/token
+        and did not accidentally unprotect the rest of the surface."""
+        resp = client.get(f"{PREFIX}/groups")
+        assert resp.status_code == 401, resp.text
+        assert resp.json()["error"]["code"] == "UNAUTHORIZED"
+        assert resp.headers.get("www-authenticate") == "Bearer"
+
+    def test_users_me_also_401s_without_a_token(self, client):
+        resp = client.get(f"{PREFIX}/users/me")
+        assert resp.status_code == 401, resp.text
+        assert resp.json()["error"]["code"] == "UNAUTHORIZED"
+
+    def test_v4_token_is_accepted_by_v4_routes(self, client, test_db_session):
+        """A token minted at /v4/token authenticates a protected v4 route —
+        proving the v4 endpoint issues a real, equivalent token rather than a
+        differently-shaped one."""
+        token = client.post(
+            f"{PREFIX}/token",
+            data={"username": "testuser1", "password": "password1"},
+        ).json()["access_token"]
+        resp = client.get(f"{PREFIX}/users/me", headers=_auth(token))
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["username"] == "testuser1"
+
+    def test_v4_token_is_accepted_by_v3_routes(self, client, test_db_session):
+        """Token format is unchanged from v3 (the #732 is_admin claim is retained
+        on purpose), so a v4-issued token works on the frozen v3 surface."""
+        token = client.post(
+            f"{PREFIX}/token",
+            data={"username": "testuser1", "password": "password1"},
+        ).json()["access_token"]
+        resp = client.get("/latest/users/me", headers=_auth(token))
+        assert resp.status_code == 200, resp.text
+
+
+class TestTokenErrors:
+    def test_bad_password_returns_the_v4_error_envelope(self, client, test_db_session):
+        resp = client.post(
+            f"{PREFIX}/token",
+            data={"username": "testuser1", "password": "wrong-password"},
+        )
+        assert resp.status_code == 401, resp.text
+        body = resp.json()
+        # The #828 envelope, NOT v3's {"detail": "Incorrect username or password"}.
+        assert set(body) == {"error"}, f"expected the #828 envelope, got {set(body)}"
+        assert body["error"]["code"] == "INVALID_CREDENTIALS"
+        assert "detail" not in body
+
+    def test_unknown_username_is_indistinguishable_from_a_bad_password(
+        self, client, test_db_session
+    ):
+        """Same status, code, and message for both — otherwise an unauthenticated
+        caller could enumerate valid usernames."""
+        unknown = client.post(
+            f"{PREFIX}/token",
+            data={"username": "no-such-user", "password": "password1"},
+        )
+        bad_pw = client.post(
+            f"{PREFIX}/token",
+            data={"username": "testuser1", "password": "wrong-password"},
+        )
+        assert unknown.status_code == bad_pw.status_code == 401
+        assert unknown.json() == bad_pw.json()
+
+    def test_missing_form_fields_return_the_422_envelope(self, client):
+        resp = client.post(f"{PREFIX}/token", data={"username": "testuser1"})
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["error"]["code"] == "VALIDATION_ERROR"
+
+    def test_v3_token_error_shape_is_unchanged(self, client, test_db_session):
+        """Freeze guard: v4's error contract must not have altered v3's /token."""
+        resp = client.post(
+            "/latest/token",
+            data={"username": "testuser1", "password": "wrong-password"},
+        )
+        assert resp.status_code == 401
+        assert resp.json() == {"detail": "Incorrect username or password"}
+
+
+class TestUsersMe:
+    """#859: the typed response model and its closed field allowlist."""
+
+    def test_no_hashed_password_in_the_response(
+        self, client, regular_token1, test_db_session
+    ):
+        """The #859 assertion. This exact check FAILS against v3's
+        GET /latest/users/me, which serializes the ORM object and includes the
+        bcrypt hash — verified before writing the fix."""
+        resp = client.get(f"{PREFIX}/users/me", headers=_auth(regular_token1))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "hashed_password" not in body
+        # Belt and braces: no value in the body may look like a bcrypt hash, in
+        # case a future field carries it under a different name.
+        assert not any(
+            isinstance(v, str) and v.startswith("$2b$") for v in body.values()
+        ), body
+
+    def test_response_is_exactly_the_declared_allowlist(
+        self, client, regular_token1, test_db_session
+    ):
+        """Stronger than the leak check: pins the field set, so a new UserDB column
+        cannot silently start appearing here."""
+        body = client.get(f"{PREFIX}/users/me", headers=_auth(regular_token1)).json()
+        assert set(body) == USER_FIELDS, f"unexpected fields: {set(body)}"
+
+    def test_groups_relationship_is_not_nested_in_the_profile(
+        self, client, regular_token1, test_db_session
+    ):
+        """v3 leaked the whole `groups` relationship too; v4 exposes membership as
+        its own paginated resource instead."""
+        body = client.get(f"{PREFIX}/users/me", headers=_auth(regular_token1)).json()
+        assert "groups" not in body
+
+    def test_returns_the_authenticated_user(
+        self, client, regular_token1, test_db_session
+    ):
+        body = client.get(f"{PREFIX}/users/me", headers=_auth(regular_token1)).json()
+        assert body["username"] == "testuser1"
+        assert body["email"] == "testuser1@example.com"
+        assert body["is_admin"] is False
+        assert isinstance(body["id"], int)
+
+    def test_admin_sees_is_admin_true(self, client, admin_token, test_db_session):
+        body = client.get(f"{PREFIX}/users/me", headers=_auth(admin_token)).json()
+        assert body["username"] == "admin"
+        assert body["is_admin"] is True
+
+    def test_two_users_get_their_own_profiles(
+        self, client, regular_token1, regular_token2, test_db_session
+    ):
+        """Self-scoped: the response follows the token, not a path parameter."""
+        one = client.get(f"{PREFIX}/users/me", headers=_auth(regular_token1)).json()
+        two = client.get(f"{PREFIX}/users/me", headers=_auth(regular_token2)).json()
+        assert one["username"] == "testuser1"
+        assert two["username"] == "testuser2"
+        assert one["id"] != two["id"]
+
+
+class TestUsersMeGroups:
+    def test_returns_the_page_envelope(self, client, regular_token1, test_db_session):
+        resp = client.get(f"{PREFIX}/users/me/groups", headers=_auth(regular_token1))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert set(body) == PAGE_KEYS, f"unexpected envelope keys: {set(body)}"
+        assert body["limit"] == 20 and body["offset"] == 0
+
+    def test_scoped_to_the_callers_own_groups(
+        self, client, regular_token1, regular_token2, test_db_session
+    ):
+        one = client.get(
+            f"{PREFIX}/users/me/groups", headers=_auth(regular_token1)
+        ).json()
+        two = client.get(
+            f"{PREFIX}/users/me/groups", headers=_auth(regular_token2)
+        ).json()
+        assert [g["name"] for g in one["items"]] == ["Group1"]
+        assert [g["name"] for g in two["items"]] == ["Group2"]
+        assert one["total"] == two["total"] == 1
+
+    def test_group_items_have_exactly_the_declared_fields(
+        self, client, regular_token1, test_db_session
+    ):
+        items = client.get(
+            f"{PREFIX}/users/me/groups", headers=_auth(regular_token1)
+        ).json()["items"]
+        assert items, "expected testuser1 to be in at least one group"
+        for item in items:
+            assert set(item) == GROUP_FIELDS, f"unexpected group fields: {set(item)}"
+
+    def test_admin_with_no_memberships_gets_an_empty_page(
+        self, client, admin_token, test_db_session
+    ):
+        """The clearest demonstration that /users/me/groups and /groups are
+        different endpoints: the admin sees every group on /v4/groups but has no
+        memberships of their own. Empty is a 200 with total 0, not a 404."""
+        resp = client.get(f"{PREFIX}/users/me/groups", headers=_auth(admin_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["items"] == []
+        assert body["total"] == 0
+
+    def test_pagination_is_honored(self, client, regular_token1, test_db_session):
+        body = client.get(
+            f"{PREFIX}/users/me/groups",
+            params={"limit": 1, "offset": 0},
+            headers=_auth(regular_token1),
+        ).json()
+        assert body["limit"] == 1 and body["offset"] == 0
+        assert len(body["items"]) <= 1
+
+    def test_offset_past_the_end_returns_an_empty_page_with_real_total(
+        self, client, regular_token1, test_db_session
+    ):
+        """`total` is the unpaginated match count, so it stays non-zero even when
+        the requested page is empty."""
+        body = client.get(
+            f"{PREFIX}/users/me/groups",
+            params={"offset": 500},
+            headers=_auth(regular_token1),
+        ).json()
+        assert body["items"] == []
+        assert body["total"] >= 1
+
+    def test_out_of_range_limit_is_the_422_envelope(
+        self, client, regular_token1, test_db_session
+    ):
+        resp = client.get(
+            f"{PREFIX}/users/me/groups",
+            params={"limit": 101},
+            headers=_auth(regular_token1),
+        )
+        assert resp.status_code == 422
+        assert resp.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+class TestGroupsCatalog:
+    def test_admin_sees_all_groups_in_the_page_envelope(
+        self, client, admin_token, test_db_session
+    ):
+        resp = client.get(f"{PREFIX}/groups", headers=_auth(admin_token))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert set(body) == PAGE_KEYS
+        names = {g["name"] for g in body["items"]}
+        # Both fixture groups are visible to an admin, including Group2, which the
+        # admin is not a member of — this is the catalog, not a membership view.
+        assert {"Group1", "Group2"} <= names, names
+        assert body["total"] >= 2
+
+    def test_non_admin_is_forbidden_with_a_stable_code(
+        self, client, regular_token1, test_db_session
+    ):
+        """v3 parity (admin-only), surfaced through the #828 contract with a
+        specific code rather than a generic FORBIDDEN."""
+        resp = client.get(f"{PREFIX}/groups", headers=_auth(regular_token1))
+        assert resp.status_code == 403, resp.text
+        body = resp.json()
+        assert set(body) == {"error"}
+        assert body["error"]["code"] == "ADMIN_REQUIRED"
+
+    def test_non_admin_learns_nothing_about_the_catalog(
+        self, client, regular_token1, test_db_session
+    ):
+        """The 403 body must not carry group data as a consolation payload."""
+        body = client.get(f"{PREFIX}/groups", headers=_auth(regular_token1)).json()
+        assert "items" not in body
+        assert "Group2" not in str(body)
+
+    def test_group_items_have_exactly_the_declared_fields(
+        self, client, admin_token, test_db_session
+    ):
+        items = client.get(f"{PREFIX}/groups", headers=_auth(admin_token)).json()[
+            "items"
+        ]
+        for item in items:
+            assert set(item) == GROUP_FIELDS, f"unexpected group fields: {set(item)}"
+
+    def test_pagination_slices_the_catalog(self, client, admin_token, test_db_session):
+        full = client.get(f"{PREFIX}/groups", headers=_auth(admin_token)).json()
+        first = client.get(
+            f"{PREFIX}/groups",
+            params={"limit": 1, "offset": 0},
+            headers=_auth(admin_token),
+        ).json()
+        second = client.get(
+            f"{PREFIX}/groups",
+            params={"limit": 1, "offset": 1},
+            headers=_auth(admin_token),
+        ).json()
+        assert len(first["items"]) == 1 and len(second["items"]) == 1
+        # Stable ordering by id means consecutive pages don't repeat a row.
+        assert first["items"][0]["id"] != second["items"][0]["id"]
+        # total is the unpaginated count, identical across pages.
+        assert first["total"] == second["total"] == full["total"]
+
+    def test_ordering_is_by_id(self, client, admin_token, test_db_session):
+        items = client.get(f"{PREFIX}/groups", headers=_auth(admin_token)).json()[
+            "items"
+        ]
+        ids = [g["id"] for g in items]
+        assert ids == sorted(ids), ids
+
+
+class TestOpenAPI:
+    def test_v4_schema_documents_the_slice(self, client):
+        """The v4 sub-app's own schema (at /v4/openapi.json) advertises the new
+        routes; the main app's schema must not (covered by the freeze test)."""
+        schema = client.get(f"{PREFIX}/openapi.json").json()
+        for path in ("/token", "/users/me", "/users/me/groups", "/groups"):
+            assert path in schema["paths"], f"{path} missing from v4 schema"
+
+    def test_user_schema_has_no_password_field(self, client):
+        """The allowlist is visible in the contract, not just in the runtime body —
+        a client reading /v4/openapi.json can see there is no password field."""
+        schema = client.get(f"{PREFIX}/openapi.json").json()
+        props = schema["components"]["schemas"]["UserOut"]["properties"]
+        assert set(props) == USER_FIELDS
+        assert not any("password" in name.lower() for name in props)
+
+    def test_token_endpoint_declares_a_form_body(self, client):
+        """#826 exemption: the token endpoint documents form-encoding, not JSON."""
+        schema = client.get(f"{PREFIX}/openapi.json").json()
+        content = schema["paths"]["/token"]["post"]["requestBody"]["content"]
+        assert "application/x-www-form-urlencoded" in content
+        assert "application/json" not in content

--- a/test/test_security_routes/test_auth_routes_v4.py
+++ b/test/test_security_routes/test_auth_routes_v4.py
@@ -21,6 +21,14 @@ What each assertion is pinning down:
   different, which the admin's empty self-groups page demonstrates.
 """
 
+import asyncio
+import types
+
+import pytest
+
+from api_v4.errors import V4APIError
+from security_routes.v4.dependencies import require_admin
+
 PREFIX = "/v4"
 
 #: The complete, closed set of fields UserOut may ever emit (#859). Asserting
@@ -264,6 +272,40 @@ class TestUsersMeGroups:
         )
         assert resp.status_code == 422
         assert resp.json()["error"]["code"] == "VALIDATION_ERROR"
+
+
+class TestRequireAdminFailsClosed:
+    """`require_admin` must reject anything that is not positively an admin.
+
+    Exercised directly rather than over HTTP because the interesting input — a
+    ``users.is_admin`` of NULL — cannot be produced by the shared fixtures without
+    inserting a row that other test modules would see. The function body is a
+    single branch, so calling it with a stand-in user covers the logic exactly.
+
+    ``is_admin`` is ``Column(Boolean, default=False)``: nullable, with only a
+    Python-side default, so a row written outside the ORM can hold NULL. The gate
+    must treat that as "not an admin".
+    """
+
+    @staticmethod
+    def _call(is_admin):
+        user = types.SimpleNamespace(id=1, username="probe", is_admin=is_admin)
+        return asyncio.run(require_admin(current_user=user))
+
+    def test_admin_passes(self):
+        user = self._call(True)
+        assert user.username == "probe"
+
+    @pytest.mark.parametrize("flag", [False, None])
+    def test_non_admin_and_null_are_both_rejected(self, flag):
+        """NULL is the case worth pinning: `not None` is True in Python, so the
+        existing `if not current_user.is_admin` branch already fails closed. This
+        test is what keeps a later "simplification" (e.g. `is False`) from quietly
+        turning a NULL into a pass."""
+        with pytest.raises(V4APIError) as exc_info:
+            self._call(flag)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.code == "ADMIN_REQUIRED"
 
 
 class TestGroupsCatalog:


### PR DESCRIPTION
## Summary

The **Auth / Users / Groups** vertical slice on `/v4` — read half. Follows the template the Versions slice (#883) established: an HTTP-agnostic service, a router that maps domain signals onto `V4APIError`, and reuse of `V4Page` / `PaginationParams` / `V4BaseModel`.

**Closes #859.** **Advances #825, #826, #829, #830, #831, #833 and epic #842 — closes none of those**, since they are cross-cutting dimensions of every endpoint (URL shape, body shape, pagination, field canon, auth, service layer) and only close when the last resource lands.

### Endpoints

| Method | Path | v3 source | Notes |
|---|---|---|---|
| `POST` | `/v4/token` | `auth_routes.py:87` | OAuth2 password **form** retained — explicitly exempt from the JSON-body rule (#826). **Public** — see the trap below |
| `GET` | `/v4/users/me` | `auth_routes.py:107` | **Closes #859** — typed `UserOut`, closed four-field allowlist |
| `GET` | `/v4/users/me/groups` | `GET /groups/me`, `auth_routes.py:112` | Now paginated `V4Page[GroupOut]` |
| `GET` | `/v4/groups` | `admin_routes.py:108` | Paginated; admin-only (v3 parity) |

The admin write half (`POST /v4/users`, `POST /v4/groups`, the `groups/{id}/members/{user_id}` membership sub-resource, the deletes, and the `change-password` self/admin split) is a **second PR**. API keys stay out of scope under #831 — they need a new table, and this PR adds **no migration and no new table**.

## #859 is the point of this PR

v3's `GET /users/me` declares **no** `response_model` and returns the `UserDB` ORM object, so FastAPI serializes whatever attributes it finds. I measured it against the live v3 route before writing the fix:

```
v3 GET /latest/users/me -> 200
body keys: ['email', 'groups', 'hashed_password', 'id', 'is_admin', 'username']
```

So v3 returns **the user's bcrypt password hash on every call**, plus the entire `groups` relationship. `GET /v4/users/me` declares `response_model=UserOut` — four fields, nothing else — and FastAPI filters the response body against the declared model.

The durable part of the fix is that the allowlist is **closed by construction**, not by an exclude list: no column added to `UserDB` in future can start appearing on this endpoint. The test asserts `set(body) == {"id", "username", "email", "is_admin"}` rather than merely `"hashed_password" not in body`, so it catches tomorrow's leak as well as today's.

**The leak test has teeth — verified, not assumed.** As requested, I pointed the exact v4 assertion at the v3 route first. It fails:

```
>       assert "hashed_password" not in resp.json(), "v3 LEAKS hashed_password"
E       AssertionError: v3 LEAKS hashed_password
```

That probe was a throwaway and is **not** in the PR — codifying a live v3 vulnerability as an expected-to-fail test would be worse than not testing it. v3 stays frozen; the leak is fixed v4-only, consistent with how the other v3 data-exposure findings were handled.

## What's in it

- **`api_v4/schemas/security.py`** — `TokenOut`, `UserOut`, `GroupOut` on `V4BaseModel` + `ConfigDict(from_attributes=True)`. Verified that Pydantic v2 merges `model_config` across the MRO, so `V4BaseModel`'s `populate_by_name=True` survives. Does **not** copy v3's Pydantic-v1 `class Config: orm_mode = True`; `schemas/security.py` itself is untouched.
- **`security_routes/v4/`** (new package) — `user_service.py` (HTTP-agnostic queries), `dependencies.py` (`require_admin`), and `token_routes.py` / `user_routes.py` / `group_routes.py`. **No edit to `auth_routes.py` or `admin_routes.py`**: they are shared version-agnostic infra (`get_current_user` is imported by `api_v4/app.py` and 16 v3 route modules), so v4 adds rather than fork-edits. There is deliberately no sibling `security_routes/v3/` — the flat modules *are* v3, and moving them would break every one of those imports.
- **`api_v4/app.py`** — registers the token router **without** auth and the user/group routers with it.

### Two behaviors worth noting

- **`total` is the unpaginated match count**, computed from the same scoped statement as the page, so a page past the end returns `items: []` with a real non-zero `total` (tested). Same two-statement drift caveat as `version_service.list_versions`.
- **`user_groups` has no unique constraint** on `(user_id, group_id)`, so `list_user_groups` uses `distinct()` — without it a doubly-linked user would inflate `total` and repeat the group in `items`.

## The protected-by-default trap

`api_v4/app.py` registers domain routers with `dependencies=[Depends(get_current_user)]`, so v4 is protected-by-default (#831). **`POST /v4/token` must not inherit that** — requiring a token to obtain a token is a deadlock. It is therefore its own router, registered without the dependency, following the `meta_router` precedent. Putting it on the `/v4/users` router and exempting one path would not work: router-level dependencies apply to every route on the router.

Tested from both sides: `/v4/token` answers with no bearer token, while `/v4/groups` and `/v4/users/me` still return `401 UNAUTHORIZED` with `WWW-Authenticate: Bearer`. Also tested that a token minted at `/v4/token` authenticates both a v4 route and a v3 route — the format is unchanged (see #732 below).

## Design decisions reviewers should push back on

1. **`GET /v4/groups` stays admin-only (403 for non-admins) rather than becoming a scoped list.** v3 gates it with `get_current_admin`, so this is parity. I did *not* convert it to the `list_versions` pattern (admins see all, non-admins see their own) because a scoped version would return exactly what `GET /v4/users/me/groups` already returns — two endpoints, one behavior, and a confusing choice for clients. Instead the two stay distinct: `/v4/groups` is the admin catalog, `/v4/users/me/groups` is the self-service view. Changing this is a few lines, but it *is* a v3 authorization change, so it should be a deliberate call. **This is the decision I'd most like a second opinion on.**
2. **No `WWW-Authenticate` header on a bad-credentials `401` from `/v4/token`** — a small, deliberate divergence from v3 (`auth_routes.py:96`). `V4APIError` carries no `headers` field and it is the only sanctioned way to signal a 4xx (#828), so emitting the header would mean either raising a bare `HTTPException` (abandoning the stable `code`) or widening #828's shared error type from inside this slice. It also is not required: RFC 6749 §5.2 asks for the header only when the *client* authenticated with an HTTP auth scheme, and in the password grant the credentials are in the form body. Protected v4 routes still emit it. If you'd rather have parity, the clean fix is adding `headers` to `V4APIError` in its own PR.
3. **`require_admin` is new rather than reusing `admin_routes.get_current_admin`.** Three reasons: `get_current_admin` raises a bare `HTTPException(403)` so every v4 403 would arrive as a generic `FORBIDDEN` with no distinguishing code; it re-implements token decoding in a second, subtly different copy (no `selectinload(UserDB.groups)`); and it returns 403 for a *missing* user where 401 is correct. Building on `get_current_user` gives v4 one authentication path, and FastAPI dedupes so auth still runs once per request. The cost is a fourth admin-check implementation in the repo until v3 is retired.
4. **`UserOut.email` is `EmailStr | None`, not `str | None`.** Matches v3's declared type and documents `format: email` in OpenAPI, but it means a malformed stored address would 500 this endpoint — where `str` could not. Writes go through v3's `User` schema (which also uses `EmailStr`), so stored values should already be valid; flagging it because the failure-mode asymmetry arguably favors `str` on a read path whose whole job is not to blow up.
5. **`is_admin` gets a `None` → `False` coercion.** `UserDB.is_admin` is nullable with only a Python-side default, and a plain `bool` field rejects `None` outright (verified: `ValidationError`), which would turn a legacy NULL row into a 500. The coercion fails **closed**. Mirrors the Versions slice's `bool(...)` treatment of its nullable booleans.
6. **The `is_admin` JWT claim is retained** (#732). It is real debt — nothing reads it, both `get_current_user` and `get_current_admin` load the flag from the database — but dropping it here would fork the token format between v3 and v4 for no gain. #732 removes it from both at once.

## v3 freeze snapshot: green, no regen

`/v4` is a mounted sub-app, so its routes live at `/v4/openapi.json` and never enter the main app's `/openapi.json`. `test/test_openapi_contract.py` passes unchanged with **no snapshot regeneration**. Two extra guards in this PR's own tests pin v3 behavior directly: v3's `/token` still returns `{"detail": "Incorrect username or password"}` (not the v4 envelope), and all pre-existing `test/test_security_routes/` tests pass untouched.

## Tests

**`test/test_security_routes/test_auth_routes_v4.py`** (new, 34 cases), following `test_version_routes_v4.py`:

- **Token is public** (4): `/v4/token` succeeds with no bearer token; `/v4/groups` and `/v4/users/me` still `401` with `WWW-Authenticate: Bearer`; a v4-minted token works on both a v4 and a v3 route.
- **Token errors** (4): bad password → the #828 `{"error": {"code": "INVALID_CREDENTIALS"}}` envelope with no `detail` key; unknown username is byte-identical to a bad password (no username enumeration); a missing form field → `VALIDATION_ERROR` 422; v3's `/token` error shape unchanged.
- **`/v4/users/me`** (6): no `hashed_password`; no value in the body looks like a bcrypt hash; the body is *exactly* the declared allowlist; no nested `groups`; correct user returned; `is_admin` true for the admin; two tokens get two different profiles.
- **`/v4/users/me/groups`** (7): the `V4Page` envelope; scoped per caller (testuser1 → Group1, testuser2 → Group2); item fields pinned; **the admin's page is empty with `total: 0`** — the clearest proof the two group endpoints differ; limit/offset honored; offset past the end → empty page with a real `total`; `limit=101` → `VALIDATION_ERROR`.
- **`/v4/groups`** (6): admin sees both fixture groups (including one they are not a member of) in the page envelope; non-admin → `403 ADMIN_REQUIRED`; the 403 body carries no group data; item fields pinned; consecutive `limit=1` pages don't repeat a row and share one `total`; ordering is by id.
- **`require_admin` fails closed** (3): `is_admin=True` passes; both `False` and **`None`** are rejected with `403 ADMIN_REQUIRED`. Called directly rather than over HTTP — a NULL `is_admin` row can't be created without polluting the shared module-scoped fixtures, and the function body is a single branch.
- **OpenAPI** (3): the four paths appear in `/v4/openapi.json`; `UserOut`'s properties are exactly the allowlist with no password-ish field name (the allowlist is visible in the *contract*, not just the runtime body); `/token` documents `application/x-www-form-urlencoded` and **not** `application/json` (the #826 exemption).

Actual results on this branch:

- `test/test_security_routes/test_auth_routes_v4.py` — **34 passed**
- `test_security_routes/` + `test_openapi_contract.py` + all `test_v4_*` + `test_app_versioning.py` + `test_version_routes_v4.py` — **152 passed**, 0 failed (v3 freeze guard green, no regen)
- `make linting` (Black + isort + Flake8, the exact CI target) — clean

## Review round 2 (Copilot, addressed in `d88d9ff`)

One comment, on `require_admin`. **Its premise is factually inverted, so no behavior change was needed — but it exposed a genuine test gap, which is now closed.**

Copilot wrote: *"in Python `not None` is `False`, so `if not current_user.is_admin:` will not raise for NULLs"*, and called it a privilege-escalation risk. `None` is falsy, so:

```
not None       = True
bool(None)     = False
branch taken?   RAISES (fails closed)
```

The gate already took the raise branch for a NULL `is_admin`; the docstring already said so, and Copilot read it as claiming the opposite. Its suggested fixes are also no-ops: `if not bool(x)` is identical to `if not x`, and `x is not True` is behaviorally identical for real booleans — and marginally worse, since it would reject a truthy non-bool (integer `1`) and lock out a legitimate admin.

What *was* missing is that nothing pinned the fail-closed property. A reviewer misreading this branch is itself an argument for a test rather than a comment, so:

- **`TestRequireAdminFailsClosed`** (3 new cases): `True` passes; `False` and `None` both → `403 ADMIN_REQUIRED`. Called directly rather than over HTTP because a NULL `is_admin` row cannot be created without inserting into the shared module-scoped fixtures that other test modules see; the function body is one branch, so a stand-in user covers it exactly.
- The docstring now says explicitly **not** to "tighten" the check to `is False` — which is the form that *would* invert the NULL case into a silent pass:

```
is_admin= True -> PASSES GATE
is_admin=False -> rejected
is_admin= None -> PASSES GATE   <- the actual escalation
```

That is the bug Copilot described, except it is the one its own suggestion would have introduced rather than one the code had.

None of the six design decisions above were touched.

## Review round 3 (Copilot, addressed in `973a8ca`)

One comment, and this one is a fair hit: `_page` in `user_service.py` accepted an arbitrary `stmt` but hard-coded `order_by(GroupDB.id)`, so its behavior did not match its signature.

No bug today — both callers pass `Group` statements — but the write half adds list endpoints over other tables, so the trap is imminent rather than hypothetical. The consequence is also more specific than the comment guessed ("incorrect ordering or even a SQL error"): the ordering column would not be in the statement's FROM clause, producing

```sql
SELECT users.id, users.username, ... FROM users ORDER BY groups.id
```

which Postgres rejects with *missing FROM-clause entry for table "groups"* — a **request-time 500** through the #828 catch-all, not silently wrong data. Loud, but only at request time in whatever endpoint the next PR adds.

Fixed by making `order_by` a **required keyword-only argument** rather than a defaulted one. Copilot suggested "with a default"; a default leaves exactly the same trap, just sprung less often, so callers state their ordering explicitly — the same reasoning as `retry_after_s` in `api_v4/jobs.py`. Verified: `order_by` is keyword-only with no default, and omitting it is an immediate `TypeError` rather than a runtime surprise. Both call sites pass `GroupDB.id`; the existing ordering and pagination tests still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

