### PR TITLE
perf(v3/textsearch): fix random-ordering pool exhaustion + raise DB pool/timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,10 +25,13 @@ AQUA_DB=postgresql+asyncpg://dbuser:dbpassword@localhost:5432/dbname
 # Set AQUA_DB_POOLCLASS=null to force SQLAlchemy's NullPool (the test suite
 # does this). Leave unset in production to use the pooled engine below.
 # AQUA_DB_POOLCLASS=null
-AQUA_DB_POOL_SIZE=2
-AQUA_DB_MAX_OVERFLOW=3
-AQUA_DB_POOL_TIMEOUT=10
+AQUA_DB_POOL_SIZE=5
+AQUA_DB_MAX_OVERFLOW=10
+AQUA_DB_POOL_TIMEOUT=30
 AQUA_DB_POOL_RECYCLE=1800
+# Server-side statement_timeout in ms, applied per pooled connection so one
+# runaway query can't pin a connection for the whole pool. 0 disables.
+AQUA_DB_STATEMENT_TIMEOUT_MS=60000
 
 # --- Auth (required) ------------------------------------------------------
 # Secret used to sign JWTs. Must be non-empty (whitespace-only counts as

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -558,30 +558,56 @@ async def search_revision_text(
     SQL_LIMIT_ABS_CAP = 10_000
     sql_limit = min(limit * 10 * len(pieces), SQL_LIMIT_ABS_CAP)
 
-    # Randomise + cap on the *main* side before the comparison lateral.
-    # `ORDER BY random()` can't be pushed below the join, so randomising on
-    # the outer (joined) query forces the per-row comp lookup to run once per
-    # term match — thousands of LATERAL invocations for a common term, only to
-    # keep sql_limit of them. Capping the main side first bounds the lateral
-    # to sql_limit invocations. The comparison join stays INNER, so main
-    # verses with no comp coverage are still dropped (they just no longer
-    # cost a lateral probe each). The non-random path keeps its outer
-    # ORDER BY book/chapter/verse: main_sub already emits rows in that order,
-    # so the lateral early-stops at the LIMIT without a full materialise.
+    # For random ordering, randomise + cap on the *main* side before the
+    # comparison lateral. `ORDER BY random()` can't be pushed below the join,
+    # so randomising the joined query would run the per-row comp lookup once
+    # per term match (thousands of LATERAL invocations for a common term) just
+    # to keep sql_limit of them. Capping the main side first bounds the lateral
+    # to sql_limit invocations.
+    #
+    # When a comparison side is present the join below is INNER — it drops main
+    # verses the comparison version doesn't cover. Sampling *before* that filter
+    # would let the cap under-fill: with sparse comparison coverage the
+    # sql_limit random draw could yield far fewer than `limit` covered rows even
+    # when plenty exist. So restrict the draw to covered vrefs first, via a
+    # semi-join against the set of vrefs the comparison side actually has (one
+    # covered-vref scan Postgres can hash, not a per-row probe). Existence is
+    # enough here — the per-row lateral below still fetches the latest
+    # comparison *text* for the already-covered, already-capped rows.
+    #
+    # The non-random path keeps its outer ORDER BY book/chapter/verse: main_sub
+    # already emits rows in that order, so the lateral early-stops at the LIMIT
+    # without a full materialise, and no under-fill is possible.
     if random:
-        base = (
-            select(
-                main_sub.c.id.label("id"),
-                main_sub.c.book.label("book"),
-                main_sub.c.chapter.label("chapter"),
-                main_sub.c.verse.label("verse"),
-                main_sub.c.verse_reference.label("verse_reference"),
-                main_sub.c.text.label("text"),
+        base_cols = [
+            main_sub.c.id.label("id"),
+            main_sub.c.book.label("book"),
+            main_sub.c.chapter.label("chapter"),
+            main_sub.c.verse.label("verse"),
+            main_sub.c.text.label("text"),
+        ]
+        if use_comparison:
+            base_cols.append(main_sub.c.verse_reference.label("verse_reference"))
+        base_select = select(*base_cols)
+        if use_comparison:
+            comp_auth = _authorized_revisions_select(
+                current_user,
+                version_id=comparison_version_id,
+                revision_id=comparison_revision_id,
             )
-            .order_by(func.random())
-            .limit(sql_limit)
-            .subquery()
-        )
+            covered_vrefs = (
+                select(VerseText.verse_reference)
+                .where(
+                    VerseText.revision_id.in_(comp_auth),
+                    VerseText.text != "",
+                    VerseText.verse_reference.is_not(None),
+                )
+                .distinct()
+            )
+            base_select = base_select.where(
+                main_sub.c.verse_reference.in_(covered_vrefs)
+            )
+        base = base_select.order_by(func.random()).limit(sql_limit).subquery()
     else:
         base = main_sub
 
@@ -609,13 +635,13 @@ async def search_revision_text(
             base.c.text.label("main_text"),
         ).select_from(base)
 
-    search_query = search_query.limit(sql_limit)
-    # Per-side dedup is already handled inside main_sub (and the comp lateral
-    # picks at most one row per main row); the random case is already ordered
-    # and capped on the main side above, so only the non-random case needs an
-    # outer ORDER BY.
+    # The random branch already ordered + capped on the main side (and its comp
+    # join only ever removes rows); only the non-random branch needs the outer
+    # ORDER BY + LIMIT.
     if not random:
-        search_query = search_query.order_by(base.c.book, base.c.chapter, base.c.verse)
+        search_query = search_query.order_by(
+            base.c.book, base.c.chapter, base.c.verse
+        ).limit(sql_limit)
 
     main_auth_select = _authorized_revisions_select(
         current_user, version_id=version_id, revision_id=revision_id

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -635,10 +635,15 @@ async def search_revision_text(
             base.c.text.label("main_text"),
         ).select_from(base)
 
-    # The random branch already ordered + capped on the main side (and its comp
-    # join only ever removes rows); only the non-random branch needs the outer
-    # ORDER BY + LIMIT.
-    if not random:
+    # The random branch is already capped on the main side (and its comp join
+    # only ever removes rows), so it needs no outer LIMIT — but it does need an
+    # outer ORDER BY random(): the main-side cap picks *which* rows, and this
+    # shuffles the (<= sql_limit) survivors so the `limit` the Python filter
+    # keeps below is a random subset rather than planner order. It only sorts
+    # the already-capped set, so the comparison lateral stays bounded.
+    if random:
+        search_query = search_query.order_by(func.random())
+    else:
         search_query = search_query.order_by(
             base.c.book, base.c.chapter, base.c.verse
         ).limit(sql_limit)

--- a/assessment_routes/v3/search_routes.py
+++ b/assessment_routes/v3/search_routes.py
@@ -545,29 +545,6 @@ async def search_revision_text(
     use_comparison = (
         comparison_revision_id is not None or comparison_version_id is not None
     )
-    if use_comparison:
-        comp_lat = _comp_lateral(
-            current_user,
-            version_id=comparison_version_id,
-            revision_id=comparison_revision_id,
-            main_vref_col=main_sub.c.verse_reference,
-        )
-        search_query = select(
-            main_sub.c.id.label("id"),
-            main_sub.c.book.label("book"),
-            main_sub.c.chapter.label("chapter"),
-            main_sub.c.verse.label("verse"),
-            main_sub.c.text.label("main_text"),
-            comp_lat.c.text.label("comparison_text"),
-        ).select_from(main_sub.join(comp_lat, true()))
-    else:
-        search_query = select(
-            main_sub.c.id.label("id"),
-            main_sub.c.book.label("book"),
-            main_sub.c.chapter.label("chapter"),
-            main_sub.c.verse.label("verse"),
-            main_sub.c.text.label("main_text"),
-        ).select_from(main_sub)
 
     # Cap the DB result set. The Python-side whole-word filter may discard
     # ilike matches that aren't whole words, so we overfetch to give enough
@@ -580,18 +557,65 @@ async def search_revision_text(
     # value so pathological `limit=1000` queries can't pull 50k rows.
     SQL_LIMIT_ABS_CAP = 10_000
     sql_limit = min(limit * 10 * len(pieces), SQL_LIMIT_ABS_CAP)
-    search_query = search_query.limit(sql_limit)
 
-    # Apply ordering on the outer query. Per-side dedup is already handled
-    # inside main_sub (and the comp lateral picks at most one row per main
-    # row), so the outer query is free to randomize without violating
-    # DISTINCT ON's leading-column rule.
+    # Randomise + cap on the *main* side before the comparison lateral.
+    # `ORDER BY random()` can't be pushed below the join, so randomising on
+    # the outer (joined) query forces the per-row comp lookup to run once per
+    # term match — thousands of LATERAL invocations for a common term, only to
+    # keep sql_limit of them. Capping the main side first bounds the lateral
+    # to sql_limit invocations. The comparison join stays INNER, so main
+    # verses with no comp coverage are still dropped (they just no longer
+    # cost a lateral probe each). The non-random path keeps its outer
+    # ORDER BY book/chapter/verse: main_sub already emits rows in that order,
+    # so the lateral early-stops at the LIMIT without a full materialise.
     if random:
-        search_query = search_query.order_by(func.random())
-    else:
-        search_query = search_query.order_by(
-            main_sub.c.book, main_sub.c.chapter, main_sub.c.verse
+        base = (
+            select(
+                main_sub.c.id.label("id"),
+                main_sub.c.book.label("book"),
+                main_sub.c.chapter.label("chapter"),
+                main_sub.c.verse.label("verse"),
+                main_sub.c.verse_reference.label("verse_reference"),
+                main_sub.c.text.label("text"),
+            )
+            .order_by(func.random())
+            .limit(sql_limit)
+            .subquery()
         )
+    else:
+        base = main_sub
+
+    if use_comparison:
+        comp_lat = _comp_lateral(
+            current_user,
+            version_id=comparison_version_id,
+            revision_id=comparison_revision_id,
+            main_vref_col=base.c.verse_reference,
+        )
+        search_query = select(
+            base.c.id.label("id"),
+            base.c.book.label("book"),
+            base.c.chapter.label("chapter"),
+            base.c.verse.label("verse"),
+            base.c.text.label("main_text"),
+            comp_lat.c.text.label("comparison_text"),
+        ).select_from(base.join(comp_lat, true()))
+    else:
+        search_query = select(
+            base.c.id.label("id"),
+            base.c.book.label("book"),
+            base.c.chapter.label("chapter"),
+            base.c.verse.label("verse"),
+            base.c.text.label("main_text"),
+        ).select_from(base)
+
+    search_query = search_query.limit(sql_limit)
+    # Per-side dedup is already handled inside main_sub (and the comp lateral
+    # picks at most one row per main row); the random case is already ordered
+    # and capped on the main side above, so only the non-random case needs an
+    # outer ORDER BY.
+    if not random:
+        search_query = search_query.order_by(base.c.book, base.c.chapter, base.c.verse)
 
     main_auth_select = _authorized_revisions_select(
         current_user, version_id=version_id, revision_id=revision_id
@@ -622,6 +646,15 @@ async def search_revision_text(
         # query running in the same transaction, which AsyncSession does by
         # default; would silently no-op under autocommit-style execution.
         await db.execute(text("SET LOCAL enable_bitmapscan = off"))
+
+        # The DISTINCT ON dedup sorts the version's full verse set (~10 MB for
+        # a whole Bible), which spills to a temp file under the pooled default
+        # work_mem. During the overnight batch, dozens of concurrent searches
+        # spilling at once make temp-file I/O the bottleneck. Give the sort
+        # enough memory to stay in RAM. SET LOCAL scopes it to this
+        # transaction, so the pooled connection isn't left with a raised
+        # work_mem for other callers.
+        await db.execute(text("SET LOCAL work_mem = '32MB'"))
 
         result = await db.execute(search_query)
         rows = result.all()

--- a/config.py
+++ b/config.py
@@ -64,16 +64,21 @@ class Settings(BaseSettings):
     # TestClient spawns a fresh event loop per request). Anything else uses the
     # pooled engine configured below.
     aqua_db_poolclass: Optional[str] = None
-    aqua_db_pool_size: int = 2
-    aqua_db_max_overflow: int = 3
-    aqua_db_pool_timeout: int = 10
+    aqua_db_pool_size: int = 5
+    aqua_db_max_overflow: int = 10
+    aqua_db_pool_timeout: int = 30
     aqua_db_pool_recycle: int = 1800
+    # Server-side per-statement cap (ms) applied to every pooled connection.
+    # A single runaway query can't then pin a connection for the whole pool;
+    # it fails its own request instead. 0 disables (Postgres default).
+    aqua_db_statement_timeout_ms: int = 60000
 
     @field_validator(
         "aqua_db_pool_size",
         "aqua_db_max_overflow",
         "aqua_db_pool_timeout",
         "aqua_db_pool_recycle",
+        "aqua_db_statement_timeout_ms",
         mode="before",
     )
     @classmethod

--- a/database/dependencies.py
+++ b/database/dependencies.py
@@ -26,16 +26,21 @@ DATABASE_URL = settings.aqua_db
 # get_db, surfacing as 500 "QueuePool limit of size 2 overflow 3 reached".
 # Pair the bigger pool with a server-side statement_timeout so one slow query
 # can't pin a pooled connection indefinitely.
+# statement_timeout applies per physical connection, so wire it on both engine
+# branches — otherwise AQUA_DB_POOLCLASS=null (NullPool) would drop the runaway-
+# query safety net exactly when it removes the pool ceiling too.
+connect_args = {}
+if settings.aqua_db_statement_timeout_ms > 0:
+    connect_args["server_settings"] = {
+        "statement_timeout": str(settings.aqua_db_statement_timeout_ms)
+    }
 if settings.aqua_db_poolclass and settings.aqua_db_poolclass.lower() == "null":
     from sqlalchemy.pool import NullPool
 
-    engine = create_async_engine(DATABASE_URL, poolclass=NullPool)
+    engine = create_async_engine(
+        DATABASE_URL, poolclass=NullPool, connect_args=connect_args
+    )
 else:
-    connect_args = {}
-    if settings.aqua_db_statement_timeout_ms > 0:
-        connect_args["server_settings"] = {
-            "statement_timeout": str(settings.aqua_db_statement_timeout_ms)
-        }
     engine = create_async_engine(
         DATABASE_URL,
         pool_size=settings.aqua_db_pool_size,

--- a/database/dependencies.py
+++ b/database/dependencies.py
@@ -13,18 +13,29 @@ DATABASE_URL = settings.aqua_db
 # Production runs a single persistent loop per worker and benefits from
 # pooling — avoids the asyncpg+TLS handshake on every request.
 #
-# Default sizing: with 8 uvicorn workers, steady-state is ~16 conns per
-# container (8 × pool_size 2) and the burst ceiling is 40 (8 × (2 + 3)).
-# RDS default max_connections is LEAST({DBInstanceClassMemory/9531392},
-# 5000) — roughly 170 on db.t3.small, 340 on db.t3.medium, 675 on
-# db.m5.large — so 40/container leaves comfortable headroom even on
-# small instance classes. Tune the env vars if running many containers
-# or if other consumers (alembic, batch jobs, replicas) eat the budget.
+# Default sizing: with 8 uvicorn workers, steady-state is ~40 conns per
+# container (8 × pool_size 5) and the burst ceiling is 120 (8 × (5 + 10)).
+# The shared RDS instance reports max_connections=829, so even a handful of
+# containers (staging + prod share it) stay well under budget. Tune the env
+# vars if running many more containers or if other consumers (alembic, batch
+# jobs, replicas) eat the budget.
+#
+# An earlier 2+3 default (5 conns/worker) starved /v3/textsearch under the
+# overnight batch: a few multi-second searches consumed a worker's whole
+# pool and the next request — even just the auth lookup — timed out at 10s in
+# get_db, surfacing as 500 "QueuePool limit of size 2 overflow 3 reached".
+# Pair the bigger pool with a server-side statement_timeout so one slow query
+# can't pin a pooled connection indefinitely.
 if settings.aqua_db_poolclass and settings.aqua_db_poolclass.lower() == "null":
     from sqlalchemy.pool import NullPool
 
     engine = create_async_engine(DATABASE_URL, poolclass=NullPool)
 else:
+    connect_args = {}
+    if settings.aqua_db_statement_timeout_ms > 0:
+        connect_args["server_settings"] = {
+            "statement_timeout": str(settings.aqua_db_statement_timeout_ms)
+        }
     engine = create_async_engine(
         DATABASE_URL,
         pool_size=settings.aqua_db_pool_size,
@@ -32,6 +43,7 @@ else:
         pool_timeout=settings.aqua_db_pool_timeout,
         pool_recycle=settings.aqua_db_pool_recycle,
         pool_pre_ping=True,
+        connect_args=connect_args,
     )
 AsyncSessionLocal = sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,14 +14,16 @@ services:
       - GRAPHQL_URL=${GRAPHQL_URL}
       - GRAPHQL_SECRET=${GRAPHQL_SECRET}
       - AQUA_DB=postgresql+asyncpg://dbuser:dbpassword@db:5432/dbname
-      # DB connection pool tuning (defaults: pool_size=2, max_overflow=3,
-      # timeout=10, recycle=1800). Set AQUA_DB_POOLCLASS=null to disable
-      # pooling entirely (one connection per request).
+      # DB connection pool tuning (defaults: pool_size=5, max_overflow=10,
+      # timeout=30, recycle=1800, statement_timeout=60000ms). Set
+      # AQUA_DB_POOLCLASS=null to disable pooling entirely (one connection per
+      # request).
       - AQUA_DB_POOLCLASS=${AQUA_DB_POOLCLASS:-}
       - AQUA_DB_POOL_SIZE=${AQUA_DB_POOL_SIZE:-}
       - AQUA_DB_MAX_OVERFLOW=${AQUA_DB_MAX_OVERFLOW:-}
       - AQUA_DB_POOL_TIMEOUT=${AQUA_DB_POOL_TIMEOUT:-}
       - AQUA_DB_POOL_RECYCLE=${AQUA_DB_POOL_RECYCLE:-}
+      - AQUA_DB_STATEMENT_TIMEOUT_MS=${AQUA_DB_STATEMENT_TIMEOUT_MS:-}
       - TEST_KEY=${TEST_KEY}
       - FAIL_KEY=${FAIL_KEY}
       - KEY_VAULT=${KEY_VAULT}

--- a/test/test_assessment_routes/test_search_routes.py
+++ b/test/test_assessment_routes/test_search_routes.py
@@ -1603,6 +1603,139 @@ def test_search_comparison_drops_main_rows_with_no_comp_coverage(
     )
 
 
+def test_search_random_comparison_fills_to_limit_despite_sparse_coverage(
+    client, regular_token1, test_db_session
+):
+    """random=true + comparison must still fill to `limit` when the comparison
+    version covers only a small fraction of the main-side term matches.
+
+    Regression guard for the pool-exhaustion perf fix. The fix caps the random
+    draw on the *main* side (before the INNER comparison join) to bound the
+    per-row LATERAL. If that draw isn't restricted to comp-covered vrefs first,
+    a sparse comparison side drops most sampled rows *after* the cap, so the
+    result silently under-fills `limit` even though far more covered pairs
+    exist. Here M (matches) >> sql_limit and exactly `limit` vrefs are covered:
+    the query must return all `limit` covered pairs, every call.
+    """
+    import csv
+
+    user1 = test_db_session.query(UserDB).filter(UserDB.username == "testuser1").first()
+    group1 = test_db_session.query(Group).filter(Group.name == "Group1").first()
+    if (
+        test_db_session.query(IsoLanguage).filter(IsoLanguage.iso639 == "swh").first()
+        is None
+    ):
+        test_db_session.add(IsoLanguage(iso639="swh", name="Swahili"))
+        test_db_session.commit()
+
+    # 250 real GEN vrefs so main-side matches (M) far exceed sql_limit
+    # (limit*10 = 100); anything <= sql_limit wouldn't exercise the under-fill.
+    with open("fixtures/verse_reference.txt") as f:
+        gen_vrefs = [
+            row["full_verse_id"]
+            for row in csv.DictReader(f, delimiter="\t")
+            if row["full_verse_id"].startswith("GEN ")
+        ][:250]
+
+    def _parse(vref):
+        book, cv = vref.split(" ", 1)
+        chapter, verse = cv.split(":")
+        return book, int(chapter), int(verse)
+
+    eng_version = BibleVersion(
+        name="Sparse Coverage Eng",
+        iso_language="eng",
+        iso_script="Latn",
+        abbreviation="SCE",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    swh_version = BibleVersion(
+        name="Sparse Coverage Swh",
+        iso_language="swh",
+        iso_script="Latn",
+        abbreviation="SCS",
+        owner_id=user1.id,
+        is_reference=False,
+    )
+    test_db_session.add_all([eng_version, swh_version])
+    test_db_session.commit()
+    test_db_session.refresh(eng_version)
+    test_db_session.refresh(swh_version)
+
+    eng_rev = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=eng_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    swh_rev = BibleRevision(
+        date=date(2024, 1, 1),
+        bible_version_id=swh_version.id,
+        published=True,
+        machine_translation=False,
+    )
+    test_db_session.add_all([eng_rev, swh_rev])
+    test_db_session.commit()
+    test_db_session.refresh(eng_rev)
+    test_db_session.refresh(swh_rev)
+
+    # Every main verse matches "God"; the comparison side covers only the first
+    # 10 vrefs (C == limit), so a correct query returns exactly those 10.
+    for vref in gen_vrefs:
+        book, chapter, verse = _parse(vref)
+        test_db_session.add(
+            VerseText(
+                text="God is here.",
+                revision_id=eng_rev.id,
+                verse_reference=vref,
+                book=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        )
+    covered = gen_vrefs[:10]
+    for vref in covered:
+        book, chapter, verse = _parse(vref)
+        test_db_session.add(
+            VerseText(
+                text="Mungu yuko hapa.",
+                revision_id=swh_rev.id,
+                verse_reference=vref,
+                book=book,
+                chapter=chapter,
+                verse=verse,
+            )
+        )
+    for version in (eng_version, swh_version):
+        test_db_session.add(
+            BibleVersionAccess(bible_version_id=version.id, group_id=group1.id)
+        )
+    test_db_session.commit()
+
+    covered_refs = {_parse(v) for v in covered}
+    for _ in range(8):
+        response = client.get(
+            "/v3/textsearch",
+            params={
+                "version_id": eng_version.id,
+                "comparison_version_id": swh_version.id,
+                "term": "God",
+                "limit": 10,
+                "random": True,
+            },
+            headers={"Authorization": f"Bearer {regular_token1}"},
+        )
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert (
+            len(results) == 10
+        ), f"random+comparison under-filled: got {len(results)} of 10 covered pairs"
+        refs = {(r["book"], r["chapter"], r["verse"]) for r in results}
+        assert refs <= covered_refs, f"returned uncovered vrefs: {refs - covered_refs}"
+        assert all(r["comparison_text"] for r in results)
+
+
 def test_search_by_version_id_with_comparison_revision_id(
     client, regular_token1, test_db_session
 ):

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -58,6 +58,7 @@ _VALID_DB = "postgresql+asyncpg://u:p@localhost:5432/db"
         "AQUA_DB_MAX_OVERFLOW",
         "AQUA_DB_POOL_TIMEOUT",
         "AQUA_DB_POOL_RECYCLE",
+        "AQUA_DB_STATEMENT_TIMEOUT_MS",
     ],
 )
 def test_non_numeric_pool_config_rejected_at_boot(settings_cls, monkeypatch, env_name):
@@ -74,12 +75,13 @@ def test_non_numeric_pool_config_rejected_at_boot(settings_cls, monkeypatch, env
         settings_cls()
 
 
-# (env var, field name, declared default) for the four pooled int settings.
+# (env var, field name, declared default) for the pooled int settings.
 _POOL_FIELDS = [
-    ("AQUA_DB_POOL_SIZE", "aqua_db_pool_size", 2),
-    ("AQUA_DB_MAX_OVERFLOW", "aqua_db_max_overflow", 3),
-    ("AQUA_DB_POOL_TIMEOUT", "aqua_db_pool_timeout", 10),
+    ("AQUA_DB_POOL_SIZE", "aqua_db_pool_size", 5),
+    ("AQUA_DB_MAX_OVERFLOW", "aqua_db_max_overflow", 10),
+    ("AQUA_DB_POOL_TIMEOUT", "aqua_db_pool_timeout", 30),
     ("AQUA_DB_POOL_RECYCLE", "aqua_db_pool_recycle", 1800),
+    ("AQUA_DB_STATEMENT_TIMEOUT_MS", "aqua_db_statement_timeout_ms", 60000),
 ]
 
 


### PR DESCRIPTION
## Why

The overnight aqua-agent batch drove **1,277 `500 QueuePool limit of size 2 overflow 3 reached`** on aqua-api (2026-07-31 00:00–01:00Z), an escalating recurrence (07-24: 57 → 07-25: 296 → 1,277). All on `environment=main` (staging), but staging + prod share **one** RDS, so the DB load is real.

Root cause, confirmed with `EXPLAIN ANALYZE` on the shared RDS: `GET /v3/textsearch` (version-vs-version, `random=true`) holds its DB connection for the whole query (p50 ~7s, p99 20–26s under the batch). With only 5 conns/worker, a handful of slow searches starved the pool and the next request timed out at 10s in `get_db`.

## Changes

**1. `perf(v3/textsearch)` — bound the comparison `LATERAL`, keep the dedup sort in RAM**
- `ORDER BY random()` can't push the `LIMIT` below the comparison `LATERAL`, so the per-row comp lookup ran **once per term match** (2,122 loops to return 50). Now randomise + cap on the **main** side first, before the inner `LATERAL` join, bounding it to `sql_limit` probes. The join stays **INNER**, so drop-missing-comp semantics are preserved (covered by `test_search_comparison_drops_main_rows_with_no_comp_coverage`). Only the `random=true` path changes; non-random already early-stops at the LIMIT.
- `SET LOCAL work_mem='32MB'` keeps the `DISTINCT ON` dedup sort in memory instead of an external-merge temp-file spill (~9.5MB), which becomes the bottleneck when dozens of batch searches spill concurrently.

**2. `fix(db)` — raise pool defaults + add a statement_timeout safety net**
- Pool defaults `2/3/10` → `5/10/30`. The shared RDS reports `max_connections=829` (~84 in use), so `8×(5+10)=120` conns/container across staging+prod stays well within budget.
- New `AQUA_DB_STATEMENT_TIMEOUT_MS` (default 60000) applied via asyncpg `server_settings`, so one runaway query can't pin a pooled connection indefinitely.

## Proof (prod `EXPLAIN ANALYZE`, single query, no concurrency)

| Term | Before | After | comp `LATERAL` loops | Main dedup sort |
|---|---|---|---|---|
| `الله` (common) | **2,655 ms** | **596 ms** | 2,122 → **50** | external-merge disk → **in-memory** |
| `شريعة` (selective) | 628 ms | 593 ms | never runs | disk → in-memory |

## Test plan

- `test/test_assessment_routes/test_search_routes.py` — 74 passed (incl. random + comparison + drop-missing-comp semantics)
- `test/test_config.py` — updated pool defaults + new `AQUA_DB_STATEMENT_TIMEOUT_MS`; 41 passed
- `test/test_agent_routes/test_tokenizer_routes.py` — search/comparison paths pass
- Full combined suite: 146 passed on a fresh DB

## Not addressed (follow-up)

The residual ~0.5s floor is the unindexed `NORMALIZE(text,NFC) ILIKE` scan over ~31k deduped rows — the trgm GIN is deliberately disabled (`enable_bitmapscan=off`) to avoid a 91s multi-revision plan. Re-enabling it for selective terms is a separate, trickier change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)